### PR TITLE
change time macros names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.9.6
+
+Bug - Change time template variable names.
+
 ## 0.9.5
 
 Bug - Fix global template variables.

--- a/README.md
+++ b/README.md
@@ -92,8 +92,8 @@ WHERE $__timeFilter(date_time)
 | Macro example | Description |
 | -- | --|
 | *$__timeFilter(dataRow)* | Will be replaced by a time range filter using the specified name. |
-| *$__fromTime* | Will be replaced by the start of the currently active time range filter selection. |
-| *$__toTime* | Will be replaced by the end of the currently active time range filter selection. |
+| *$__fromTime* | Replaced by the start of time range in ms wrapped by toDateTime function. Example: toDateTime(intDiv(1415792726371,1000)) |
+| *$__toTime* | Replaced by the end of time range in ms wrapped by toDateTime function. Example: toDateTime(intDiv(1415792726371,1000)) |
 | *$__table* | Will be replaced by the table in use. |
 | *$__column* | Will be replaced by the column in use. |
 

--- a/README.md
+++ b/README.md
@@ -92,8 +92,8 @@ WHERE $__timeFilter(date_time)
 | Macro example | Description |
 | -- | --|
 | *$__timeFilter(dataRow)* | Will be replaced by a time range filter using the specified name. |
-| *$__from* | Will be replaced by the start of the currently active time range filter selection. |
-| *$__to* | Will be replaced by the end of the currently active time range filter selection. |
+| *$__fromTime* | Will be replaced by the start of the currently active time range filter selection. |
+| *$__toTime* | Will be replaced by the end of the currently active time range filter selection. |
 | *$__table* | Will be replaced by the table in use. |
 | *$__column* | Will be replaced by the column in use. |
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clickhouse-datasource",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "description": "Clickhouse Datasource",
   "scripts": {
     "build": "grafana-toolkit plugin:build",

--- a/pkg/macros/macros_test.go
+++ b/pkg/macros/macros_test.go
@@ -18,7 +18,7 @@ func TestMacroFromTimeFilter(t *testing.T) {
 			From: from,
 			To:   to,
 		},
-		RawSQL: "select foo from foo where bar > $__from",
+		RawSQL: "select foo from foo where bar > $__fromTime",
 	}
 	tests := []struct {
 		want    string
@@ -50,6 +50,7 @@ func TestMacroToTimeFilter(t *testing.T) {
 			From: from,
 			To:   to,
 		},
+		RawSQL: "select foo from foo where bar > $__toTime",
 	}
 	tests := []struct {
 		want    string

--- a/pkg/plugin/driver.go
+++ b/pkg/plugin/driver.go
@@ -116,8 +116,8 @@ func (h *Clickhouse) Converters() []sqlutil.Converter {
 // Macros returns list of macro functions convert the macros of raw query
 func (h *Clickhouse) Macros() sqlds.Macros {
 	return map[string]sqlds.MacroFunc{
-		"from":       macros.FromTimeFilter,
-		"to":         macros.ToTimeFilter,
+		"fromTime":   macros.FromTimeFilter,
+		"toTime":     macros.ToTimeFilter,
 		"timeFilter": macros.TimeFilter,
 		"table":      macros.Table,
 		"column":     macros.Column,


### PR DESCRIPTION
change names so they don't collide with global template variables