### PR TITLE
Better macro docs wording. Fix unix milliseconds bug. Remove table and column macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,13 +96,11 @@ FROM test_data
 WHERE $__timeFilter(date_time)
 ```
 
-| Macro example | Description |
-| -- | --|
-| *$__timeFilter(dataRow)* | Will be replaced by a time range filter using the specified name. |
-| *$__fromTime* | Replaced by the start of time range in ms wrapped by toDateTime function. Example: toDateTime(intDiv(1415792726371,1000)) |
-| *$__toTime* | Replaced by the end of time range in ms wrapped by toDateTime function. Example: toDateTime(intDiv(1415792726371,1000)) |
-| *$__table* | Will be replaced by the table in use. |
-| *$__column* | Will be replaced by the column in use. |
+| Macro                       | Description                                                                                                      | Output example                                    |
+| --------------------------- | ---------------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
+| *$__timeFilter(columnName)* | Replaced by a conditional that filters the data (using the provided column) based on the time range of the panel | `time >= '1480001790' AND time <= '1482576232' )` |
+| *$__fromTime*               | Replaced by the starting time of the range of the panel casted to DateTime                                       | `toDateTime(intDiv(1415792726371,1000))`          |
+| *$__toTime*                 | Replaced by the ending time of the range of the panel casted to DateTime                                         | `toDateTime(intDiv(1415792726371,1000))`          |
 
 The plugin also supports notation using braces {}. Use this notation when queries are needed inside parameters.
 

--- a/README.md
+++ b/README.md
@@ -96,12 +96,12 @@ FROM test_data
 WHERE $__timeFilter(date_time)
 ```
 
-| Macro                            | Description                                                                                                                      | Output example                                          |
-| -------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
-| *$__timeFilter(columnName)*      | Replaced by a conditional that filters the data (using the provided column) based on the time range of the panel in seconds      | `time >= '1480001790' AND time <= '1482576232' )`       |
-| *$__timeFilterMilli(columnName)* | Replaced by a conditional that filters the data (using the provided column) based on the time range of the panel in milliseconds | `time >= '1480001790671' AND time <= '1482576232479' )` |
-| *$__fromTime*                    | Replaced by the starting time of the range of the panel casted to DateTime                                                       | `toDateTime(intDiv(1415792726371,1000))`                |
-| *$__toTime*                      | Replaced by the ending time of the range of the panel casted to DateTime                                                         | `toDateTime(intDiv(1415792726371,1000))`                |
+| Macro                          | Description                                                                                                                      | Output example                                          |
+| ------------------------------ | -------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
+| *$__timeFilter(columnName)*    | Replaced by a conditional that filters the data (using the provided column) based on the time range of the panel in seconds      | `time >= '1480001790' AND time <= '1482576232' )`       |
+| *$__timeFilter_ms(columnName)* | Replaced by a conditional that filters the data (using the provided column) based on the time range of the panel in milliseconds | `time >= '1480001790671' AND time <= '1482576232479' )` |
+| *$__fromTime*                  | Replaced by the starting time of the range of the panel casted to DateTime                                                       | `toDateTime(intDiv(1415792726371,1000))`                |
+| *$__toTime*                    | Replaced by the ending time of the range of the panel casted to DateTime                                                         | `toDateTime(intDiv(1415792726371,1000))`                |
 
 The plugin also supports notation using braces {}. Use this notation when queries are needed inside parameters.
 

--- a/README.md
+++ b/README.md
@@ -96,11 +96,12 @@ FROM test_data
 WHERE $__timeFilter(date_time)
 ```
 
-| Macro                       | Description                                                                                                      | Output example                                    |
-| --------------------------- | ---------------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
-| *$__timeFilter(columnName)* | Replaced by a conditional that filters the data (using the provided column) based on the time range of the panel | `time >= '1480001790' AND time <= '1482576232' )` |
-| *$__fromTime*               | Replaced by the starting time of the range of the panel casted to DateTime                                       | `toDateTime(intDiv(1415792726371,1000))`          |
-| *$__toTime*                 | Replaced by the ending time of the range of the panel casted to DateTime                                         | `toDateTime(intDiv(1415792726371,1000))`          |
+| Macro                            | Description                                                                                                                      | Output example                                          |
+| -------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
+| *$__timeFilter(columnName)*      | Replaced by a conditional that filters the data (using the provided column) based on the time range of the panel in seconds      | `time >= '1480001790' AND time <= '1482576232' )`       |
+| *$__timeFilterMilli(columnName)* | Replaced by a conditional that filters the data (using the provided column) based on the time range of the panel in milliseconds | `time >= '1480001790671' AND time <= '1482576232479' )` |
+| *$__fromTime*                    | Replaced by the starting time of the range of the panel casted to DateTime                                                       | `toDateTime(intDiv(1415792726371,1000))`                |
+| *$__toTime*                      | Replaced by the ending time of the range of the panel casted to DateTime                                                         | `toDateTime(intDiv(1415792726371,1000))`                |
 
 The plugin also supports notation using braces {}. Use this notation when queries are needed inside parameters.
 

--- a/pkg/macros/macros.go
+++ b/pkg/macros/macros.go
@@ -56,6 +56,20 @@ func TimeFilter(query *sqlds.Query, args []string) (string, error) {
 	return fmt.Sprintf("%s >= '%d' AND %s <= '%d'", column, from, column, to), nil
 }
 
+func TimeFilterMilli(query *sqlds.Query, args []string) (string, error) {
+	if len(args) != 1 {
+		return "", fmt.Errorf("%w: expected 1 argument, received %d", sqlds.ErrorBadArgumentCount, len(args))
+	}
+
+	var (
+		column = args[0]
+		from   = query.TimeRange.From.UTC().UnixMilli()
+		to     = query.TimeRange.To.UTC().UnixMilli()
+	)
+
+	return fmt.Sprintf("%s >= '%d' AND %s <= '%d'", column, from, column, to), nil
+}
+
 // RemoveQuotesInArgs remove all quotes from macro arguments and return
 func RemoveQuotesInArgs(args []string) []string {
 	updatedArgs := []string{}

--- a/pkg/macros/macros.go
+++ b/pkg/macros/macros.go
@@ -56,7 +56,7 @@ func TimeFilter(query *sqlds.Query, args []string) (string, error) {
 	return fmt.Sprintf("%s >= '%d' AND %s <= '%d'", column, from, column, to), nil
 }
 
-func TimeFilterMilli(query *sqlds.Query, args []string) (string, error) {
+func TimeFilterMs(query *sqlds.Query, args []string) (string, error) {
 	if len(args) != 1 {
 		return "", fmt.Errorf("%w: expected 1 argument, received %d", sqlds.ErrorBadArgumentCount, len(args))
 	}

--- a/pkg/macros/macros.go
+++ b/pkg/macros/macros.go
@@ -49,19 +49,11 @@ func TimeFilter(query *sqlds.Query, args []string) (string, error) {
 
 	var (
 		column = args[0]
-		from   = query.TimeRange.From.UTC().UnixMilli()
-		to     = query.TimeRange.To.UTC().UnixMilli()
+		from   = query.TimeRange.From.UTC().Unix()
+		to     = query.TimeRange.To.UTC().Unix()
 	)
 
 	return fmt.Sprintf("%s >= '%d' AND %s <= '%d'", column, from, column, to), nil
-}
-
-func Table(query *sqlds.Query, args []string) (string, error) {
-	return query.Table, nil
-}
-
-func Column(query *sqlds.Query, args []string) (string, error) {
-	return query.Column, nil
 }
 
 // RemoveQuotesInArgs remove all quotes from macro arguments and return

--- a/pkg/plugin/driver.go
+++ b/pkg/plugin/driver.go
@@ -116,8 +116,9 @@ func (h *Clickhouse) Converters() []sqlutil.Converter {
 // Macros returns list of macro functions convert the macros of raw query
 func (h *Clickhouse) Macros() sqlds.Macros {
 	return map[string]sqlds.MacroFunc{
-		"fromTime":   macros.FromTimeFilter,
-		"toTime":     macros.ToTimeFilter,
-		"timeFilter": macros.TimeFilter,
+		"fromTime":        macros.FromTimeFilter,
+		"toTime":          macros.ToTimeFilter,
+		"timeFilterMilli": macros.TimeFilterMilli,
+		"timeFilter":      macros.TimeFilter,
 	}
 }

--- a/pkg/plugin/driver.go
+++ b/pkg/plugin/driver.go
@@ -119,7 +119,5 @@ func (h *Clickhouse) Macros() sqlds.Macros {
 		"fromTime":   macros.FromTimeFilter,
 		"toTime":     macros.ToTimeFilter,
 		"timeFilter": macros.TimeFilter,
-		"table":      macros.Table,
-		"column":     macros.Column,
 	}
 }

--- a/pkg/plugin/driver.go
+++ b/pkg/plugin/driver.go
@@ -116,9 +116,9 @@ func (h *Clickhouse) Converters() []sqlutil.Converter {
 // Macros returns list of macro functions convert the macros of raw query
 func (h *Clickhouse) Macros() sqlds.Macros {
 	return map[string]sqlds.MacroFunc{
-		"fromTime":        macros.FromTimeFilter,
-		"toTime":          macros.ToTimeFilter,
-		"timeFilterMilli": macros.TimeFilterMilli,
-		"timeFilter":      macros.TimeFilter,
+		"fromTime":      macros.FromTimeFilter,
+		"toTime":        macros.ToTimeFilter,
+		"timeFilter_ms": macros.TimeFilterMs,
+		"timeFilter":    macros.TimeFilter,
 	}
 }


### PR DESCRIPTION
Added examples and better descriptions for macro docs
Fixed but that was converting from time range to milliseconds instead of seconds
Removed `$__table` and `$__column`. We currently are not setting them in the backend. These macros will be added back when there is a visual query editor.