### PR TITLE
multi-line handle selects with functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.9.8
+
+Fix - Detect Multi-line time series. Handle cases with functions.
+
 ## 0.9.7
 
 Feature - Multi-line time series.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Time series visualization options are selectable after adding a `datetime` field
 
 #### Multi-line time series
 
-To create multi-line time series, the query must return at least 3 fields.
+To create multi-line time series, the query must return at least 3 fields in the following order:
 - field 1:  `datetime` field with an alias of `time`
 - field 2:  value to group by
 - field 3+: the metric values

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clickhouse-datasource",
-  "version": "0.9.7",
+  "version": "0.9.8",
   "description": "Clickhouse Datasource",
   "scripts": {
     "build": "grafana-toolkit plugin:build",

--- a/src/components/SQLEditor.tsx
+++ b/src/components/SQLEditor.tsx
@@ -21,7 +21,9 @@ export const SQLEditor = (props: SQLEditorProps) => {
     const ast = sqlToAST(sql);
     const select = ast.get('SELECT');
     if (isString(select)) {
-      const fields = select.split(',');
+      // remove function parms that may contain commas
+      const cleanSelect = select.replace(/\((?:[^)(]+|\((?:[^)(]+|\([^)(]*\))*\))*\)/, '');
+      const fields = cleanSelect.split(',');
       if (fields.length > 1) {
         return fields[0].toLowerCase().endsWith('as time') ? Format.TIMESERIES : Format.TABLE;
       }


### PR DESCRIPTION
remove function params that might contain commas, so splitting on commas will give an accurate field list