### PR TITLE
Remove conditional alls

### DIFF
--- a/src/components/editor.ts
+++ b/src/components/editor.ts
@@ -1,11 +1,11 @@
-import SqlToAST from 'data/ast';
+import sqlToAST from 'data/ast';
 import { Format } from 'types';
 import { isString } from 'lodash';
 
 export const getFormat = (sql: string): Format => {
   // convention to format as time series
   // first field as "time" alias and requires at least 2 fields (time and metric)
-  const ast = SqlToAST(sql);
+  const ast = sqlToAST(sql);
   const selectList = ast.get('SELECT') || [];
   // if there are more than 2 fields, index 1 will be a ','
   if (selectList.length > 2 && isString(selectList[0])) {

--- a/src/components/editor.ts
+++ b/src/components/editor.ts
@@ -1,11 +1,11 @@
-import sqlToAST from 'data/ast';
+import SqlToAST from 'data/ast';
 import { Format } from 'types';
 import { isString } from 'lodash';
 
 export const getFormat = (sql: string): Format => {
   // convention to format as time series
   // first field as "time" alias and requires at least 2 fields (time and metric)
-  const ast = sqlToAST(sql);
+  const ast = SqlToAST(sql);
   const select = ast.get('SELECT');
   if (isString(select)) {
     // remove function parms that may contain commas

--- a/src/components/editor.ts
+++ b/src/components/editor.ts
@@ -7,6 +7,7 @@ export const getFormat = (sql: string): Format => {
   // first field as "time" alias and requires at least 2 fields (time and metric)
   const ast = SqlToAST(sql);
   const selectList = ast.get('SELECT') || [];
+  // if there are more than 2 fields, index 1 will be a ','
   if (selectList.length > 2 && isString(selectList[0])) {
     return selectList[0].trim().toLowerCase().endsWith('as time') ? Format.TIMESERIES : Format.TABLE;
   }

--- a/src/data/CHDatasource.test.ts
+++ b/src/data/CHDatasource.test.ts
@@ -7,7 +7,7 @@ interface InstanceConfig {
   queryResponse: {} | [];
 }
 
-const templateSrvMock = { replace: jest.fn() };
+const templateSrvMock = { replace: jest.fn(), getVariables: jest.fn() };
 jest.mock('@grafana/runtime', () => ({
   ...(jest.requireActual('@grafana/runtime') as unknown as object),
   getTemplateSrv: () => templateSrvMock,

--- a/src/data/CHDatasource.ts
+++ b/src/data/CHDatasource.ts
@@ -13,7 +13,7 @@ import { DataSourceWithBackend, getTemplateSrv, TemplateSrv } from '@grafana/run
 import { CHConfig, CHQuery, FullField, QueryType } from '../types';
 import { AdHocFilter } from './adHocFilter';
 import { isString } from 'lodash';
-import { RemoveConditionalAlls } from './removeConditionalAlls';
+import { removeConditionalAlls } from './removeConditionalAlls';
 
 export class Datasource extends DataSourceWithBackend<CHQuery, CHConfig> {
   // This enables default annotation support for 7.2+
@@ -59,7 +59,7 @@ export class Datasource extends DataSourceWithBackend<CHQuery, CHConfig> {
       rawQuery = this.adHocFilter.apply(rawQuery, (this.templateSrv as any)?.getAdhocFilters(this.name));
     }
     this.skipAdHocFilter = false;
-    rawQuery = RemoveConditionalAlls(rawQuery, getTemplateSrv().getVariables());
+    rawQuery = removeConditionalAlls(rawQuery, getTemplateSrv().getVariables());
     return {
       ...query,
       rawSql: this.replace(rawQuery, scoped) || '',

--- a/src/data/CHDatasource.ts
+++ b/src/data/CHDatasource.ts
@@ -13,7 +13,7 @@ import { DataSourceWithBackend, getTemplateSrv, TemplateSrv } from '@grafana/run
 import { CHConfig, CHQuery, FullField, QueryType } from '../types';
 import { AdHocFilter } from './adHocFilter';
 import { isString } from 'lodash';
-import { removeConditionalAlls } from './removeConditionalAlls';
+import { RemoveConditionalAlls } from './removeConditionalAlls';
 
 export class Datasource extends DataSourceWithBackend<CHQuery, CHConfig> {
   // This enables default annotation support for 7.2+
@@ -59,34 +59,11 @@ export class Datasource extends DataSourceWithBackend<CHQuery, CHConfig> {
       rawQuery = this.adHocFilter.apply(rawQuery, (this.templateSrv as any)?.getAdhocFilters(this.name));
     }
     this.skipAdHocFilter = false;
-    rawQuery = this.applyConditionalTest(rawQuery); // option use front end macro
-    rawQuery = removeConditionalAlls(rawQuery, getTemplateSrv().getVariables()); // option use AST to find where ALL is being used in where conditions
+    rawQuery = RemoveConditionalAlls(rawQuery, getTemplateSrv().getVariables());
     return {
       ...query,
       rawSql: this.replace(rawQuery, scoped) || '',
     };
-  }
-
-  applyConditionalTest(rawQuery: string): string {
-
-    if (!rawQuery) {
-      return rawQuery;
-    }
-
-    const paramsStr = rawQuery.split(/\b__conditionalTest\b/g, 2);
-    if (paramsStr.length === 1) {
-      return rawQuery;
-    }
-    const params = paramsStr[1].split(/\(|\)|,/g, 4);
-    const name = params[2].trim().substring(1, params[2].trim().length);
-    const key = getTemplateSrv().getVariables().find(x => x.name === name) as any;
-    const rw = `__conditionalTest(${params[1]},${params[2]})`;
-    let phrase = params[1];
-    if (key?.current.value.toString() === '$__all') {
-      phrase = '';
-    }
-    rawQuery = rawQuery.replace(rw, phrase);
-    return rawQuery;
   }
 
   replace(value?: string, scopedVars?: ScopedVars) {

--- a/src/data/adHocFilter.ts
+++ b/src/data/adHocFilter.ts
@@ -1,11 +1,11 @@
 import { isString } from 'lodash';
-import SqlToAST, { ASTToSql, AST, ApplyFiltersToAST } from './ast';
+import sqlToAST, { astToSql, AST, applyFiltersToAST } from './ast';
 
 export class AdHocFilter {
   private _targetTable = '';
 
   setTargetTable(query: string) {
-    const ast = SqlToAST(query);
+    const ast = sqlToAST(query);
     this.setTargetTableFroAST(ast);
   }
 
@@ -36,9 +36,9 @@ export class AdHocFilter {
     }
     // Semicolons are not required and cause problems when building the SQL
     sql = sql.replace(';', '');
-    const ast = SqlToAST(sql);
-    ApplyFiltersToAST(ast, whereClause, this._targetTable);
-    return ASTToSql(ast);
+    const ast = sqlToAST(sql);
+    applyFiltersToAST(ast, whereClause, this._targetTable);
+    return astToSql(ast);
   }
 }
 

--- a/src/data/adHocFilter.ts
+++ b/src/data/adHocFilter.ts
@@ -1,11 +1,11 @@
 import { isString } from 'lodash';
-import sqlToAST, { ASTToSql, AST, applyFiltersToAST } from './ast';
+import SqlToAST, { ASTToSql, AST, ApplyFiltersToAST } from './ast';
 
 export class AdHocFilter {
   private _targetTable = '';
 
   setTargetTable(query: string) {
-    const ast = sqlToAST(query);
+    const ast = SqlToAST(query);
     this.setTargetTableFroAST(ast);
   }
 
@@ -36,8 +36,8 @@ export class AdHocFilter {
     }
     // Semicolons are not required and cause problems when building the SQL
     sql = sql.replace(';', '');
-    const ast = sqlToAST(sql);
-    applyFiltersToAST(ast, whereClause, this._targetTable);
+    const ast = SqlToAST(sql);
+    ApplyFiltersToAST(ast, whereClause, this._targetTable);
     return ASTToSql(ast);
   }
 }

--- a/src/data/ast.ts
+++ b/src/data/ast.ts
@@ -83,7 +83,7 @@ export function ApplyFiltersToAST(ast: AST, whereClause: string, targetTable: st
         // first we get the remaining part of the FROM phrase. ") as r"
         const fromPhrase = ast.get('FROM');
         const fromPhraseAfterTableName = fromPhrase!
-        [fromPhrase!.length - 1]!.toString()
+          [fromPhrase!.length - 1]!.toString()
           .trim()
           .substring(targetTable.length);
         // apply the remaining part of the FROM phrase to the end of the new WHERE clause
@@ -118,7 +118,7 @@ export function RemoveConditionalAllsFromAST(ast: AST, queryVarNames: string[]):
   if (where) {
     for (let i = 0; i < where.length; i++) {
       const c = where[i];
-      if (isString(c) && queryVarNames.some(v => c.includes(v))) {
+      if (isString(c) && queryVarNames.some((v) => c.includes(v))) {
         where[i] = null;
         // remove AND/OR before this condition if this is the last condition
         if (i === where.length - 1) {
@@ -163,14 +163,11 @@ function movePhraseEnding(c: string, ast: AST) {
   // these are the logical places in priority to move the phrase ending
   if (ast.get('PREWHERE')?.length !== 0) {
     ast.get('PREWHERE')?.push(phraseEnding);
-  }
-  else if (ast.get('JOIN')?.length !== 0) {
+  } else if (ast.get('JOIN')?.length !== 0) {
     ast.get('JOIN')?.push(phraseEnding);
-  }
-  else if (ast.get('SAMPLE')?.length !== 0) {
+  } else if (ast.get('SAMPLE')?.length !== 0) {
     ast.get('SAMPLE')?.push(phraseEnding);
-  }
-  else if (ast.get('FROM')?.length !== 0) {
+  } else if (ast.get('FROM')?.length !== 0) {
     ast.get('FROM')?.push(phraseEnding);
   }
 }

--- a/src/data/ast.ts
+++ b/src/data/ast.ts
@@ -3,7 +3,7 @@ import { isString } from 'lodash';
 export type Clause = string | AST | null;
 export type AST = Map<string, Clause[]>;
 
-export default function SqlToAST(sql: string): AST {
+export default function sqlToAST(sql: string): AST {
   const ast = createStatement();
   const re =
     /\b(WITH|SELECT|DISTINCT|FROM|SAMPLE|JOIN|PREWHERE|WHERE|GROUP BY|LIMIT BY|HAVING|LIMIT|OFFSET|UNION|INTERSECT|EXCEPT|INTO OUTFILE|FORMAT)\b/gi;
@@ -38,7 +38,7 @@ export default function SqlToAST(sql: string): AST {
   return ast;
 }
 
-export function ASTToSql(ast: AST): string {
+export function astToSql(ast: AST): string {
   let r = '';
   ast.forEach((clauses: Clause[], key: string) => {
     let keyAndClauses = `${key} `;
@@ -46,7 +46,7 @@ export function ASTToSql(ast: AST): string {
       if (isString(c)) {
         keyAndClauses += `${c.trim()} `;
       } else if (c !== null) {
-        keyAndClauses += `${ASTToSql(c)} `;
+        keyAndClauses += `${astToSql(c)} `;
       }
     }
     // do not add the keys that do not have nodes
@@ -58,7 +58,7 @@ export function ASTToSql(ast: AST): string {
   return r.trim().replace(/\s+/g, ' ');
 }
 
-export function ApplyFiltersToAST(ast: AST, whereClause: string, targetTable: string): AST {
+export function applyFiltersToAST(ast: AST, whereClause: string, targetTable: string): AST {
   if (!ast || !ast.get('FROM')) {
     return ast;
   }
@@ -101,7 +101,7 @@ export function ApplyFiltersToAST(ast: AST, whereClause: string, targetTable: st
   ast.forEach((clauses: Clause[]) => {
     for (const c of clauses) {
       if (c !== null && !isString(c)) {
-        ApplyFiltersToAST(c, whereClause, targetTable);
+        applyFiltersToAST(c, whereClause, targetTable);
       }
     }
   });
@@ -109,7 +109,7 @@ export function ApplyFiltersToAST(ast: AST, whereClause: string, targetTable: st
   return ast;
 }
 
-export function RemoveConditionalAllsFromAST(ast: AST, queryVarNames: string[]): AST {
+export function removeConditionalAllsFromAST(ast: AST, queryVarNames: string[]): AST {
   if (!ast || !ast.get('FROM')) {
     return ast;
   }
@@ -138,7 +138,7 @@ export function RemoveConditionalAllsFromAST(ast: AST, queryVarNames: string[]):
   ast.forEach((clauses: Clause[]) => {
     for (const c of clauses) {
       if (c !== null && !isString(c)) {
-        RemoveConditionalAllsFromAST(c, queryVarNames);
+        removeConditionalAllsFromAST(c, queryVarNames);
       }
     }
   });
@@ -217,7 +217,7 @@ function completePhrase(clauses: Clause[], bracketPhrase: string) {
   // If it contains the keyword SELECT, build the AST for the phrase
   // If it does not, make a leaf node
   if (bracketPhrase.match(/\bSELECT\b/gi)) {
-    clauses.push(SqlToAST(bracketPhrase));
+    clauses.push(sqlToAST(bracketPhrase));
   } else {
     clauses.push(bracketPhrase);
   }

--- a/src/data/removeConditionalAlls.test.ts
+++ b/src/data/removeConditionalAlls.test.ts
@@ -1,5 +1,5 @@
-import { VariableModel } from "@grafana/data";
-import { RemoveConditionalAlls } from "./removeConditionalAlls";
+import { VariableModel } from '@grafana/data';
+import { RemoveConditionalAlls } from './removeConditionalAlls';
 
 describe('RemoveConditionalAlls', () => {
   const testCasesWithAllTempVar = [
@@ -51,12 +51,12 @@ describe('RemoveConditionalAlls', () => {
       expect: 'SELECT * FROM table WHERE col in ($tempVar)',
     },
   ];
-  const tempVarsWithAll = [{ type: 'query', name: 'tempVar', label: '', current: { value: '$__all' } },];
+  const tempVarsWithAll = [{ type: 'query', name: 'tempVar', label: '', current: { value: '$__all' } }];
   for (let t of testCasesWithAllTempVar) {
     testCondition(t.name, t.input, t.expect, tempVarsWithAll);
   }
 
-  const tempVarsWithoutAll = [{ type: 'query', name: 'tempVar', label: '', current: { value: 'val' } },];
+  const tempVarsWithoutAll = [{ type: 'query', name: 'tempVar', label: '', current: { value: 'val' } }];
   for (let t of testCasesWithoutAllTempVar) {
     testCondition(t.name, t.input, t.expect, tempVarsWithoutAll);
   }

--- a/src/data/removeConditionalAlls.test.ts
+++ b/src/data/removeConditionalAlls.test.ts
@@ -1,0 +1,80 @@
+import { VariableModel } from "@grafana/data";
+import { RemoveConditionalAlls } from "./removeConditionalAlls";
+
+describe('RemoveConditionalAlls', () => {
+  const testCases(name: string, input: string, expected: string) =[
+    {
+      name: 'removes template variable selecting ALL with one WHERE condition',
+      input: 'SELECT * FROM table WHERE col in ($tempVar)',
+      expect: 'SELECT * FROM table',
+    },
+    {
+      name: ,
+      input: ,
+      expect: ,
+    },
+    {
+      name: ,
+      input: ,
+      expect: ,
+    },
+    {
+      name: ,
+      input: ,
+      expect: ,
+    },
+  ];
+  it('removes template variable selecting ALL with one WHERE condition', () => {
+    const tempVars = [{ type: 'query', name: 'tempVar', label: '', current: { value: '$__all' } },];
+    const val = RemoveConditionalAlls('SELECT * FROM table WHERE col in ($tempVar)', tempVars as VariableModel[]);
+    expect(val).toEqual('SELECT * FROM table');
+  });
+  it('removes template variable selecting ALL with surrounding WHERE conditions', () => {
+    const tempVars = [{ type: 'query', name: 'tempVar', label: '', current: { value: '$__all' } },];
+    const val = RemoveConditionalAlls(`SELECT * FROM table WHERE date >= today AND col in ($tempVar) AND name = 'smith'`, tempVars as VariableModel[]);
+    expect(val).toEqual(`SELECT * FROM table WHERE date >= today AND name = 'smith'`);
+  });
+  it('removes template variable selecting ALL with a WHERE condition after', () => {
+    const tempVars = [{ type: 'query', name: 'tempVar', label: '', current: { value: '$__all' } },];
+    const val = RemoveConditionalAlls(`SELECT * FROM table WHERE col in ($tempVar) AND name = 'smith'`, tempVars as VariableModel[]);
+    expect(val).toEqual(`SELECT * FROM table WHERE name = 'smith'`);
+  });
+  it('removes template variable selecting ALL with a WHERE conditions before', () => {
+    const tempVars = [{ type: 'query', name: 'tempVar', label: '', current: { value: '$__all' } },];
+    const val = RemoveConditionalAlls(`SELECT * FROM table WHERE date >= today AND col in ($tempVar)`, tempVars as VariableModel[]);
+    expect(val).toEqual(`SELECT * FROM table WHERE date >= today`);
+  });
+  it('removes template variable selecting ALL with a WHERE conditions in an inline query in FROM', () => {
+    const tempVars = [{ type: 'query', name: 'tempVar', label: '', current: { value: '$__all' } },];
+    const val = RemoveConditionalAlls(`SELECT * FROM ( SELECT * FROM table WHERE col in ($tempVar) )`, tempVars as VariableModel[]);
+    expect(val).toEqual(`SELECT * FROM ( SELECT * FROM table )`);
+  });
+  it('removes template variable selecting ALL with a WHERE conditions in an inline query in WHERE', () => {
+    const tempVars = [{ type: 'query', name: 'tempVar', label: '', current: { value: '$__all' } },];
+    const val = RemoveConditionalAlls(`SELECT * FROM table WHERE col in ( SELECT * FROM table WHERE col in ($tempVar) )`, tempVars as VariableModel[]);
+    expect(val).toEqual(`SELECT * FROM table WHERE col in ( SELECT * FROM table )`);
+  });
+  it('removes template variable selecting ALL with a WHERE conditions in an inline query in WHERE with ending stuff', () => {
+    const tempVars = [{ type: 'query', name: 'tempVar', label: '', current: { value: '$__all' } },];
+    const val = RemoveConditionalAlls(`SELECT * FROM table WHERE col in (( SELECT * FROM table WHERE col in ($tempVar) )) by hello`, tempVars as VariableModel[]);
+    expect(val).toEqual(`SELECT * FROM table WHERE col in (( SELECT * FROM table )) by hello`);
+  });
+  it('does not removes template variable selecting ALL when not in where condition', () => {
+    const tempVars = [{ type: 'query', name: 'tempVar', label: '', current: { value: '$__all' } },];
+    const val = RemoveConditionalAlls(`SELECT * FROM $tempVar`, tempVars as VariableModel[]);
+    expect(val).toEqual(`SELECT * FROM $tempVar`);
+  });
+  it('does not removes template variable not selecting ALL', () => {
+    const tempVars = [{ type: 'query', name: 'tempVar', label: '', current: { value: 'val' } },];
+    const val = RemoveConditionalAlls('SELECT * FROM table WHERE col in ($tempVar)', tempVars as VariableModel[]);
+    expect(val).toEqual('SELECT * FROM table WHERE col in ($tempVar)');
+  });
+});
+
+function testCondition(name: string, input: string, expected: string) {
+  it(name, () => {
+    const tempVars = [{ type: 'query', name: 'tempVar', label: '', current: { value: '$__all' } },];
+    const val = RemoveConditionalAlls(input, tempVars as VariableModel[]);
+    expect(val).toEqual(expected);
+  });
+}

--- a/src/data/removeConditionalAlls.test.ts
+++ b/src/data/removeConditionalAlls.test.ts
@@ -2,78 +2,68 @@ import { VariableModel } from "@grafana/data";
 import { RemoveConditionalAlls } from "./removeConditionalAlls";
 
 describe('RemoveConditionalAlls', () => {
-  const testCases(name: string, input: string, expected: string) =[
+  const testCasesWithAllTempVar = [
     {
       name: 'removes template variable selecting ALL with one WHERE condition',
       input: 'SELECT * FROM table WHERE col in ($tempVar)',
       expect: 'SELECT * FROM table',
     },
     {
-      name: ,
-      input: ,
-      expect: ,
+      name: 'removes template variable selecting ALL with surrounding WHERE conditions',
+      input: `SELECT * FROM table WHERE date >= today AND col in ($tempVar) AND name = 'smith'`,
+      expect: `SELECT * FROM table WHERE date >= today AND name = 'smith'`,
     },
     {
-      name: ,
-      input: ,
-      expect: ,
+      name: 'removes template variable selecting ALL with a WHERE condition after',
+      input: `SELECT * FROM table WHERE col in ($tempVar) AND name = 'smith'`,
+      expect: `SELECT * FROM table WHERE name = 'smith'`,
     },
     {
-      name: ,
-      input: ,
-      expect: ,
+      name: 'removes template variable selecting ALL with a WHERE conditions before',
+      input: `SELECT * FROM table WHERE date >= today AND col in ($tempVar)`,
+      expect: `SELECT * FROM table WHERE date >= today`,
+    },
+    {
+      name: 'removes template variable selecting ALL with a WHERE conditions in an inline query in FROM',
+      input: `SELECT * FROM ( SELECT * FROM table WHERE col in ($tempVar) )`,
+      expect: `SELECT * FROM ( SELECT * FROM table )`,
+    },
+    {
+      name: 'removes template variable selecting ALL with a WHERE conditions in an inline query in WHERE',
+      input: `SELECT * FROM table WHERE col in ( SELECT * FROM table WHERE col in ($tempVar) )`,
+      expect: `SELECT * FROM table WHERE col in ( SELECT * FROM table )`,
+    },
+    {
+      name: 'removes template variable selecting ALL with a WHERE conditions in an inline query in WHERE with ending stuff',
+      input: `SELECT * FROM table WHERE col in (( SELECT * FROM table WHERE col in ($tempVar) )) by hello`,
+      expect: `SELECT * FROM table WHERE col in (( SELECT * FROM table )) by hello`,
+    },
+    {
+      name: 'does not removes template variable selecting ALL when not in where condition',
+      input: `SELECT * FROM $tempVar`,
+      expect: `SELECT * FROM $tempVar`,
     },
   ];
-  it('removes template variable selecting ALL with one WHERE condition', () => {
-    const tempVars = [{ type: 'query', name: 'tempVar', label: '', current: { value: '$__all' } },];
-    const val = RemoveConditionalAlls('SELECT * FROM table WHERE col in ($tempVar)', tempVars as VariableModel[]);
-    expect(val).toEqual('SELECT * FROM table');
-  });
-  it('removes template variable selecting ALL with surrounding WHERE conditions', () => {
-    const tempVars = [{ type: 'query', name: 'tempVar', label: '', current: { value: '$__all' } },];
-    const val = RemoveConditionalAlls(`SELECT * FROM table WHERE date >= today AND col in ($tempVar) AND name = 'smith'`, tempVars as VariableModel[]);
-    expect(val).toEqual(`SELECT * FROM table WHERE date >= today AND name = 'smith'`);
-  });
-  it('removes template variable selecting ALL with a WHERE condition after', () => {
-    const tempVars = [{ type: 'query', name: 'tempVar', label: '', current: { value: '$__all' } },];
-    const val = RemoveConditionalAlls(`SELECT * FROM table WHERE col in ($tempVar) AND name = 'smith'`, tempVars as VariableModel[]);
-    expect(val).toEqual(`SELECT * FROM table WHERE name = 'smith'`);
-  });
-  it('removes template variable selecting ALL with a WHERE conditions before', () => {
-    const tempVars = [{ type: 'query', name: 'tempVar', label: '', current: { value: '$__all' } },];
-    const val = RemoveConditionalAlls(`SELECT * FROM table WHERE date >= today AND col in ($tempVar)`, tempVars as VariableModel[]);
-    expect(val).toEqual(`SELECT * FROM table WHERE date >= today`);
-  });
-  it('removes template variable selecting ALL with a WHERE conditions in an inline query in FROM', () => {
-    const tempVars = [{ type: 'query', name: 'tempVar', label: '', current: { value: '$__all' } },];
-    const val = RemoveConditionalAlls(`SELECT * FROM ( SELECT * FROM table WHERE col in ($tempVar) )`, tempVars as VariableModel[]);
-    expect(val).toEqual(`SELECT * FROM ( SELECT * FROM table )`);
-  });
-  it('removes template variable selecting ALL with a WHERE conditions in an inline query in WHERE', () => {
-    const tempVars = [{ type: 'query', name: 'tempVar', label: '', current: { value: '$__all' } },];
-    const val = RemoveConditionalAlls(`SELECT * FROM table WHERE col in ( SELECT * FROM table WHERE col in ($tempVar) )`, tempVars as VariableModel[]);
-    expect(val).toEqual(`SELECT * FROM table WHERE col in ( SELECT * FROM table )`);
-  });
-  it('removes template variable selecting ALL with a WHERE conditions in an inline query in WHERE with ending stuff', () => {
-    const tempVars = [{ type: 'query', name: 'tempVar', label: '', current: { value: '$__all' } },];
-    const val = RemoveConditionalAlls(`SELECT * FROM table WHERE col in (( SELECT * FROM table WHERE col in ($tempVar) )) by hello`, tempVars as VariableModel[]);
-    expect(val).toEqual(`SELECT * FROM table WHERE col in (( SELECT * FROM table )) by hello`);
-  });
-  it('does not removes template variable selecting ALL when not in where condition', () => {
-    const tempVars = [{ type: 'query', name: 'tempVar', label: '', current: { value: '$__all' } },];
-    const val = RemoveConditionalAlls(`SELECT * FROM $tempVar`, tempVars as VariableModel[]);
-    expect(val).toEqual(`SELECT * FROM $tempVar`);
-  });
-  it('does not removes template variable not selecting ALL', () => {
-    const tempVars = [{ type: 'query', name: 'tempVar', label: '', current: { value: 'val' } },];
-    const val = RemoveConditionalAlls('SELECT * FROM table WHERE col in ($tempVar)', tempVars as VariableModel[]);
-    expect(val).toEqual('SELECT * FROM table WHERE col in ($tempVar)');
-  });
+  const testCasesWithoutAllTempVar = [
+    {
+      name: 'does not removes template variable not selecting ALL',
+      input: 'SELECT * FROM table WHERE col in ($tempVar)',
+      expect: 'SELECT * FROM table WHERE col in ($tempVar)',
+    },
+  ];
+  const tempVarsWithAll = [{ type: 'query', name: 'tempVar', label: '', current: { value: '$__all' } },];
+  for (let t of testCasesWithAllTempVar) {
+    testCondition(t.name, t.input, t.expect, tempVarsWithAll);
+  }
+
+  const tempVarsWithoutAll = [{ type: 'query', name: 'tempVar', label: '', current: { value: 'val' } },];
+  for (let t of testCasesWithoutAllTempVar) {
+    testCondition(t.name, t.input, t.expect, tempVarsWithoutAll);
+  }
 });
 
-function testCondition(name: string, input: string, expected: string) {
+function testCondition(name: string, input: string, expected: string, tempVars: any) {
   it(name, () => {
-    const tempVars = [{ type: 'query', name: 'tempVar', label: '', current: { value: '$__all' } },];
     const val = RemoveConditionalAlls(input, tempVars as VariableModel[]);
     expect(val).toEqual(expected);
   });

--- a/src/data/removeConditionalAlls.test.ts
+++ b/src/data/removeConditionalAlls.test.ts
@@ -1,5 +1,5 @@
 import { VariableModel } from '@grafana/data';
-import { RemoveConditionalAlls } from './removeConditionalAlls';
+import { removeConditionalAlls } from './removeConditionalAlls';
 
 describe('RemoveConditionalAlls', () => {
   const testCasesWithAllTempVar = [
@@ -64,7 +64,7 @@ describe('RemoveConditionalAlls', () => {
 
 function testCondition(name: string, input: string, expected: string, tempVars: any) {
   it(name, () => {
-    const val = RemoveConditionalAlls(input, tempVars as VariableModel[]);
+    const val = removeConditionalAlls(input, tempVars as VariableModel[]);
     expect(val).toEqual(expected);
   });
 }

--- a/src/data/removeConditionalAlls.ts
+++ b/src/data/removeConditionalAlls.ts
@@ -1,50 +1,24 @@
 import { VariableModel } from "@grafana/data";
-import { isString } from "lodash";
-import sqlToAST, { AST, ASTToSql, Clause } from "./ast";
+import SqlToAST, { ASTToSql, RemoveConditionalAllsFromAST } from "./ast";
 
-
-
-export function removeConditionalAlls(sql: string, queryVars: VariableModel[]): string {
-  if (sql === '' && queryVars.length === 0) {
+export function RemoveConditionalAlls(sql: string, queryVars: VariableModel[]): string {
+  if (sql === '' || !queryVars || queryVars.length === 0) {
     return sql;
   }
 
   const varNames: string[] = [];
   for (let v of queryVars) {
+    if (v.type !== 'query') {
+      continue;
+    }
     if ((v as any)?.current?.value?.toString() === '$__all') {
       varNames.push(v.name);
     }
   }
   // Semicolons are not required and cause problems when building the SQL
   sql = sql.replace(';', '');
-  const ast = sqlToAST(sql);
-  conditionalAllWhere(ast, varNames);
+  const ast = SqlToAST(sql);
+  RemoveConditionalAllsFromAST(ast, varNames);
   return ASTToSql(ast);
 }
 
-function conditionalAllWhere(ast: AST, queryVarNames: string[]): AST {
-  if (!ast || !ast.get('FROM')) {
-    return ast;
-  }
-
-  const where = ast.get('WHERE');
-  if (where) {
-    for (let i = 0; i < where.length; i++) {
-      const c = where[i];
-      if (isString(c) && queryVarNames.some(v => c.includes(v))) {
-        where[i] = null;
-      }
-    }
-  }
-
-  // Each node in the AST needs to be checked to see if ad hoc filters should be applied
-  ast.forEach((clauses: Clause[], key: string) => {
-    for (const c of clauses) {
-      if (c !== null && !isString(c)) {
-        conditionalAllWhere(ast, queryVarNames);
-      }
-    }
-  });
-
-  return ast;
-}

--- a/src/data/removeConditionalAlls.ts
+++ b/src/data/removeConditionalAlls.ts
@@ -1,0 +1,50 @@
+import { VariableModel } from "@grafana/data";
+import { isString } from "lodash";
+import sqlToAST, { AST, ASTToSql, Clause } from "./ast";
+
+
+
+export function removeConditionalAlls(sql: string, queryVars: VariableModel[]): string {
+  if (sql === '' && queryVars.length === 0) {
+    return sql;
+  }
+
+  const varNames: string[] = [];
+  for (let v of queryVars) {
+    if ((v as any)?.current?.value?.toString() === '$__all') {
+      varNames.push(v.name);
+    }
+  }
+  // Semicolons are not required and cause problems when building the SQL
+  sql = sql.replace(';', '');
+  const ast = sqlToAST(sql);
+  conditionalAllWhere(ast, varNames);
+  return ASTToSql(ast);
+}
+
+function conditionalAllWhere(ast: AST, queryVarNames: string[]): AST {
+  if (!ast || !ast.get('FROM')) {
+    return ast;
+  }
+
+  const where = ast.get('WHERE');
+  if (where) {
+    for (let i = 0; i < where.length; i++) {
+      const c = where[i];
+      if (isString(c) && queryVarNames.some(v => c.includes(v))) {
+        where[i] = null;
+      }
+    }
+  }
+
+  // Each node in the AST needs to be checked to see if ad hoc filters should be applied
+  ast.forEach((clauses: Clause[], key: string) => {
+    for (const c of clauses) {
+      if (c !== null && !isString(c)) {
+        conditionalAllWhere(ast, queryVarNames);
+      }
+    }
+  });
+
+  return ast;
+}

--- a/src/data/removeConditionalAlls.ts
+++ b/src/data/removeConditionalAlls.ts
@@ -1,5 +1,5 @@
-import { VariableModel } from "@grafana/data";
-import SqlToAST, { ASTToSql, RemoveConditionalAllsFromAST } from "./ast";
+import { VariableModel } from '@grafana/data';
+import SqlToAST, { ASTToSql, RemoveConditionalAllsFromAST } from './ast';
 
 export function RemoveConditionalAlls(sql: string, queryVars: VariableModel[]): string {
   if (sql === '' || !queryVars || queryVars.length === 0) {
@@ -21,4 +21,3 @@ export function RemoveConditionalAlls(sql: string, queryVars: VariableModel[]): 
   RemoveConditionalAllsFromAST(ast, varNames);
   return ASTToSql(ast);
 }
-

--- a/src/data/removeConditionalAlls.ts
+++ b/src/data/removeConditionalAlls.ts
@@ -1,7 +1,7 @@
 import { VariableModel } from '@grafana/data';
-import SqlToAST, { ASTToSql, RemoveConditionalAllsFromAST } from './ast';
+import sqlToAST, { astToSql, removeConditionalAllsFromAST } from './ast';
 
-export function RemoveConditionalAlls(sql: string, queryVars: VariableModel[]): string {
+export function removeConditionalAlls(sql: string, queryVars: VariableModel[]): string {
   if (sql === '' || !queryVars || queryVars.length === 0) {
     return sql;
   }
@@ -17,7 +17,7 @@ export function RemoveConditionalAlls(sql: string, queryVars: VariableModel[]): 
   }
   // Semicolons are not required and cause problems when building the SQL
   sql = sql.replace(';', '');
-  const ast = SqlToAST(sql);
-  RemoveConditionalAllsFromAST(ast, varNames);
-  return ASTToSql(ast);
+  const ast = sqlToAST(sql);
+  removeConditionalAllsFromAST(ast, varNames);
+  return astToSql(ast);
 }


### PR DESCRIPTION
When processing template variables, this will removes template variable conditionals from WHERE clauses when template variables have `All` selected.

Updated the AST to have each phrase separator, like `,` `AND` `OR`, to be placed in its own array element.
Here is an example:
Input: `SELECT time, data FROM table WHERE data = stuff AND time < today`
Old AST structure: 
```
SELECT: ['time, data'],
FROM: ['table'],
WHERE: ['data = stuff AND time < today']
```

New AST structure:
```
SELECT: ['time', ',', 'data'],
FROM: ['table'],
WHERE: ['data = stuff', 'AND', 'time < today']
```