### PR TITLE
use timeInterval macro on timeseries date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.12.0
+
+Feature - Time series builder: use $__timeInterval macro on time field so buckets can be adjusted from query options.
+
 ## 0.11.0
 
 Feature - Time series: Hide fields, use group by in select, use time field in group by

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clickhouse-datasource",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Clickhouse Datasource",
   "scripts": {
     "build": "grafana-toolkit plugin:build",

--- a/pkg/macros/macros.go
+++ b/pkg/macros/macros.go
@@ -76,7 +76,7 @@ func TimeInterval(query *sqlds.Query, args []string) (string, error) {
 	}
 
 	seconds := query.Interval.Seconds()
-	return fmt.Sprintf("toStartOfInterval(%s, INTERVAL %d second)", args[0], int(seconds)), nil
+	return fmt.Sprintf("toStartOfInterval(toDateTime(%s), INTERVAL %d second)", args[0], int(seconds)), nil
 }
 
 func IntervalSeconds(query *sqlds.Query, args []string) (string, error) {

--- a/pkg/macros/macros_test.go
+++ b/pkg/macros/macros_test.go
@@ -81,7 +81,7 @@ func TestMacroTimeInterval(t *testing.T) {
 	}
 	got, err := macros.TimeInterval(&query, []string{"col"})
 	assert.Nil(t, err)
-	assert.Equal(t, "toStartOfInterval(col, INTERVAL 20 second)", got)
+	assert.Equal(t, "toStartOfInterval(toDateTime(col), INTERVAL 20 second)", got)
 }
 
 func TestMacroIntervalSeconds(t *testing.T) {

--- a/src/components/queryBuilder/utils.ts
+++ b/src/components/queryBuilder/utils.ts
@@ -100,13 +100,14 @@ const getTrendByQuery = (
       return `${m.aggregation}(${m.field})${alias}`;
     })
     .join(', ');
+  const time = `$__timeInterval(${timeField})`;
   if (metricsQuery !== '') {
     const group = groupBy.length > 0 ? `${groupBy.join(', ')},` : '';
-    metricsQuery = `${timeField}, ${group} ${metricsQuery}`;
+    metricsQuery = `${time}, ${group} ${metricsQuery}`;
   } else if (groupBy.length > 0) {
-    metricsQuery = `${timeField}, ${groupBy.join(', ')}`;
+    metricsQuery = `${time}, ${groupBy.join(', ')}`;
   } else {
-    metricsQuery = `${timeField}`;
+    metricsQuery = `${time}`;
   }
 
   const sep = database === '' || table === '' ? '' : '.';


### PR DESCRIPTION
Use timeInterval macro on time series date
- this will allow adjusting the bucket size from query options
![image](https://user-images.githubusercontent.com/6108819/153503410-db166019-17a7-4263-b85e-a723056dd23b.png)

Also make timeInterval macro support date types ( not just datetime )

Fixes #69 