### PR TITLE
Sql editor to query builder

### DIFF
--- a/src/components/QueryTypeSwitcher.tsx
+++ b/src/components/QueryTypeSwitcher.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { SelectableValue } from '@grafana/data';
 import { RadioButtonGroup, ConfirmModal, InlineFormLabel } from '@grafana/ui';
-import { getSQLFromQueryOptions } from './queryBuilder/utils';
+import { getQueryOptionsFromSql, getSQLFromQueryOptions } from './queryBuilder/utils';
 import { selectors } from './../selectors';
 import { CHQuery, QueryType, defaultCHBuilderQuery, SqlBuilderOptions, CHSQLQuery, Format } from 'types';
 
@@ -34,7 +34,8 @@ export const QueryTypeSwitcher = (props: QueryTypeSwitcherProps) => {
           builderOptions = query.builderOptions;
           break;
         case QueryType.SQL:
-          builderOptions = query.meta?.builderOptions || defaultCHBuilderQuery.builderOptions;
+          builderOptions = getQueryOptionsFromSql(query.rawSql) || defaultCHBuilderQuery.builderOptions;
+          break;
         default:
           builderOptions = defaultCHBuilderQuery.builderOptions;
           break;

--- a/src/components/SQLEditor.tsx
+++ b/src/components/SQLEditor.tsx
@@ -39,6 +39,9 @@ export const SQLEditor = (props: SQLEditorProps) => {
     const icon = on ? 'minus' : 'plus';
     onChange({ ...sqlQuery, expand: on });
 
+    if (!codeEditor) {
+      return;
+    }
     if (on) {
       codeEditor.expanded = true;
       const height = getEditorHeight(codeEditor);

--- a/src/components/queryBuilder/DatabaseSelect.tsx
+++ b/src/components/queryBuilder/DatabaseSelect.tsx
@@ -22,7 +22,7 @@ export const DatabaseSelect = (props: Props) => {
       setList(values);
     }
     fetchList();
-  }, [datasource]);
+  }, [datasource, value]);
   return (
     <>
       <InlineFormLabel width={8} className="query-keyword" tooltip={tooltip}>

--- a/src/components/queryBuilder/DatabaseSelect.tsx
+++ b/src/components/queryBuilder/DatabaseSelect.tsx
@@ -8,13 +8,17 @@ import { styles } from '../../styles';
 export type Props = { datasource: Datasource; value?: string; onChange: (value: string) => void };
 
 export const DatabaseSelect = (props: Props) => {
-  const { datasource, onChange } = props;
+  const { datasource, onChange, value } = props;
   const [list, setList] = useState<Array<SelectableValue<string>>>([]);
   const { label, tooltip } = selectors.components.QueryEditor.QueryBuilder.DATABASE;
   useEffect(() => {
     async function fetchList() {
       const list = await datasource.fetchDatabases();
       const values = list.map((t) => ({ label: t, value: t }));
+      // Add selected value to the list if it does not exist.
+      if (value && !list.find(x => x === value)) {
+        values.push({ label: value!, value: value! });
+      }
       setList(values);
     }
     fetchList();
@@ -28,8 +32,9 @@ export const DatabaseSelect = (props: Props) => {
         className={`width-15 ${styles.Common.inlineSelect}`}
         onChange={(e) => onChange(e.value!)}
         options={list}
-        value={props.value}
+        value={value}
         menuPlacement={'auto'}
+        allowCustomValue={true}
       ></Select>
     </>
   );

--- a/src/components/queryBuilder/Fields.tsx
+++ b/src/components/queryBuilder/Fields.tsx
@@ -22,6 +22,7 @@ export const FieldsEditor = (props: FieldsEditorProps) => {
     if (props.fieldsList.length === 0) {
       return;
     }
+    setFields(props.fields);
     const customFields = getCustomFields(props.fields, props.fieldsList);
     setCustom(customFields);
   }, [props.fieldsList, props.fields]);

--- a/src/components/queryBuilder/Filters.tsx
+++ b/src/components/queryBuilder/Filters.tsx
@@ -173,9 +173,14 @@ export const FilterEditor = (props: {
   const { index, filter, fieldsList, onFilterChange } = props;
   const [isOpen, setIsOpen] = useState(false);
   const getFields = () => {
-    return fieldsList.map((f) => {
+    const values = fieldsList.map((f) => {
       return { label: f.label, value: f.name };
     });
+    // Add selected value to the list if it does not exist.
+    if (filter && filter.key && !values.find(x => x.value === filter.key )) {
+      values.push({ label: filter.key!, value: filter.key! });
+    }
+    return values;
   };
   const getFilterOperatorsByType = (type = 'string'): Array<SelectableValue<FilterOperator>> => {
     if (utils.isBooleanType(type)) {
@@ -293,6 +298,7 @@ export const FilterEditor = (props: {
         onOpenMenu={() => setIsOpen(true)}
         onCloseMenu={() => setIsOpen(false)}
         onChange={(e) => onFilterNameChange(e.value!)}
+        allowCustomValue={true}
       />
       <Select
         value={filter.operator}

--- a/src/components/queryBuilder/Filters.tsx
+++ b/src/components/queryBuilder/Filters.tsx
@@ -177,7 +177,7 @@ export const FilterEditor = (props: {
       return { label: f.label, value: f.name };
     });
     // Add selected value to the list if it does not exist.
-    if (filter && filter.key && !values.find((x) => x.value === filter.key)) {
+    if (filter?.key && !values.find((x) => x.value === filter.key)) {
       values.push({ label: filter.key!, value: filter.key! });
     }
     return values;

--- a/src/components/queryBuilder/GroupBy.tsx
+++ b/src/components/queryBuilder/GroupBy.tsx
@@ -19,6 +19,12 @@ export const GroupByEditor = (props: GroupByEditorProps) => {
     setIsOpen(false);
     setGroupBy(e.map((item) => item.value!));
   };
+  // Add selected value to the list if it does not exist.
+  groupBy.forEach(x => {
+    if (!columns.some(y => y.value === x)) {
+      columns.push({ value: x, label: x});
+    }
+  });
   return (
     <div className="gf-form">
       <InlineFormLabel width={8} className="query-keyword" tooltip={tooltip}>
@@ -34,6 +40,7 @@ export const GroupByEditor = (props: GroupByEditorProps) => {
           onChange={onChange}
           onBlur={() => props.onGroupByChange(groupBy)}
           value={groupBy}
+          allowCustomValue={true}
         />
       </div>
     </div>

--- a/src/components/queryBuilder/GroupBy.tsx
+++ b/src/components/queryBuilder/GroupBy.tsx
@@ -20,11 +20,7 @@ export const GroupByEditor = (props: GroupByEditorProps) => {
     setGroupBy(e.map((item) => item.value!));
   };
   // Add selected value to the list if it does not exist.
-  groupBy.forEach((x) => {
-    if (!columns.some((y) => y.value === x)) {
-      columns.push({ value: x, label: x });
-    }
-  });
+  groupBy.filter((x) => !columns.some((y) => y.value === x)).forEach((x) => columns.push({ value: x, label: x }));
   return (
     <div className="gf-form">
       <InlineFormLabel width={8} className="query-keyword" tooltip={tooltip}>

--- a/src/components/queryBuilder/OrderBy.tsx
+++ b/src/components/queryBuilder/OrderBy.tsx
@@ -8,6 +8,7 @@ import {
   FullField,
   BuilderMode,
   BuilderMetricField,
+  SqlBuilderOptionsAggregate,
 } from './../../types';
 import { selectors } from './../../selectors';
 import { styles } from '../../styles';
@@ -45,6 +46,7 @@ const OrderByItem = (props: {
         width={20}
         options={columns}
         onChange={(e) => onOrderBySortFieldUpdate(e.value!)}
+        allowCustomValue={true}
       ></Select>
       <Select<OrderByDirection>
         value={orderByItem.dir}
@@ -156,9 +158,10 @@ export const getOrderByFields = (
   builder: SqlBuilderOptions,
   fieldsList: FullField[]
 ): Array<SelectableValue<string>> => {
+  let values: SelectableValue<string>[] | { value: string; label: string; }[] = [];
   switch (builder.mode) {
     case BuilderMode.Aggregate:
-      return [
+      values =  [
         ...(builder.fields || []).map((g) => {
           return { value: g, label: g };
         }),
@@ -169,10 +172,18 @@ export const getOrderByFields = (
           return { value: g, label: g };
         }),
       ];
+      break;
     case BuilderMode.List:
     default:
-      return fieldsList.map((m) => {
+      values = fieldsList.map((m) => {
         return { value: m.name, label: m.label };
       });
   }
+  // Add selected value to the list if it does not exist.
+  (builder as SqlBuilderOptionsAggregate).orderBy?.forEach(x => {
+    if (!values.some(y => y.value === x.name)) {
+      values.push({ value: x.name, label: x.name });
+    }
+  });
+  return values;
 };

--- a/src/components/queryBuilder/OrderBy.tsx
+++ b/src/components/queryBuilder/OrderBy.tsx
@@ -182,10 +182,8 @@ export const getOrderByFields = (
       });
   }
   // Add selected value to the list if it does not exist.
-  (builder as SqlBuilderOptionsAggregate).orderBy?.forEach((x) => {
-    if (!values.some((y: { value: string; label: string } | SelectableValue<string>) => y.value === x.name)) {
-      values.push({ value: x.name, label: x.name });
-    }
-  });
+  (builder as SqlBuilderOptionsAggregate).orderBy
+    ?.filter((x) => !values.some((y: { value: string; label: string } | SelectableValue<string>) => y.value === x.name))
+    .forEach((x) => values.push({ value: x.name, label: x.name }));
   return values;
 };

--- a/src/components/queryBuilder/OrderBy.tsx
+++ b/src/components/queryBuilder/OrderBy.tsx
@@ -183,7 +183,7 @@ export const getOrderByFields = (
   }
   // Add selected value to the list if it does not exist.
   (builder as SqlBuilderOptionsAggregate).orderBy?.forEach((x) => {
-    if (!values.some((y) => y.value === x.name)) {
+    if (!values.some((y: { value: string; label: string } | SelectableValue<string>) => y.value === x.name)) {
       values.push({ value: x.name, label: x.name });
     }
   });

--- a/src/components/queryBuilder/OrderBy.tsx
+++ b/src/components/queryBuilder/OrderBy.tsx
@@ -160,7 +160,7 @@ export const getOrderByFields = (
   builder: SqlBuilderOptions,
   fieldsList: FullField[]
 ): Array<SelectableValue<string>> => {
-  let values: SelectableValue<string>[] | { value: string; label: string }[] = [];
+  let values: Array<SelectableValue<string>> | Array<{ value: string; label: string }> = [];
   switch (builder.mode) {
     case BuilderMode.Aggregate:
       values = [

--- a/src/components/queryBuilder/QueryBuilder.tsx
+++ b/src/components/queryBuilder/QueryBuilder.tsx
@@ -38,6 +38,24 @@ export const QueryBuilder = (props: QueryBuilderProps) => {
         .then(async (fields) => {
           fields.push({ name: '*', label: 'ALL', type: 'string', picklistValues: [] });
           setBaseFieldsList(fields);
+          
+          // When changing from SQL Editor to Query Builder, we need to find out if the
+          // first value is a datetime or date so we can change the mode to Time Series
+          if (builder.fields?.length > 0) {
+            const fieldName = builder.fields[0];
+            const timeFields = fields.filter((f) => f.type.toLowerCase() === 'datetime' || f.type.toLowerCase() === 'date');
+            const timeField = timeFields.find(x => x.name === fieldName);
+            if (timeField) {
+              const queryOptions: SqlBuilderOptions = {
+                ...builder,
+                timeField: timeField.name,
+                timeFieldType: timeField.type,
+                mode: BuilderMode.Trend,
+                fields: builder.fields.slice(1, builder.fields.length),
+              };
+              props.onBuilderOptionsChange(queryOptions);
+            }
+          }
         })
         .catch((ex: any) => {
           console.error(ex);

--- a/src/components/queryBuilder/QueryBuilder.tsx
+++ b/src/components/queryBuilder/QueryBuilder.tsx
@@ -38,13 +38,15 @@ export const QueryBuilder = (props: QueryBuilderProps) => {
         .then(async (fields) => {
           fields.push({ name: '*', label: 'ALL', type: 'string', picklistValues: [] });
           setBaseFieldsList(fields);
-          
+
           // When changing from SQL Editor to Query Builder, we need to find out if the
           // first value is a datetime or date so we can change the mode to Time Series
           if (builder.fields?.length > 0) {
             const fieldName = builder.fields[0];
-            const timeFields = fields.filter((f) => f.type.toLowerCase() === 'datetime' || f.type.toLowerCase() === 'date');
-            const timeField = timeFields.find(x => x.name === fieldName);
+            const timeFields = fields.filter(
+              (f) => f.type.toLowerCase() === 'datetime' || f.type.toLowerCase() === 'date'
+            );
+            const timeField = timeFields.find((x) => x.name === fieldName);
             if (timeField) {
               const queryOptions: SqlBuilderOptions = {
                 ...builder,

--- a/src/components/queryBuilder/TableSelect.tsx
+++ b/src/components/queryBuilder/TableSelect.tsx
@@ -29,7 +29,7 @@ export const TableSelect = (props: Props) => {
       setList(values);
     }
     fetchTables();
-  }, [datasource, database]);
+  }, [datasource, database, table]);
 
   const onChange = (value: string) => {
     onTableChange(value);

--- a/src/components/queryBuilder/TableSelect.tsx
+++ b/src/components/queryBuilder/TableSelect.tsx
@@ -20,6 +20,10 @@ export const TableSelect = (props: Props) => {
     async function fetchTables() {
       const tables = await datasource.fetchTables(database);
       const values = tables.map((t) => ({ label: t, value: t }));
+      // Add selected value to the list if it does not exist.
+      if (table && !tables.find(x => x === table)) {
+        values.push({ label: table!, value: table! });
+      }
       // TODO - can't seem to reset the select to unselected
       values.push({ label: '-- Choose --', value: '' });
       setList(values);
@@ -38,10 +42,11 @@ export const TableSelect = (props: Props) => {
       </InlineFormLabel>
       <Select
         className={`width-15 ${styles.Common.inlineSelect}`}
-        onChange={(e) => onChange(e.value!)}
+        onChange={(e) => onChange(e.value ? e.value : '')}
         options={list}
         value={table}
         menuPlacement={'auto'}
+        allowCustomValue={true}
       ></Select>
     </>
   );

--- a/src/components/queryBuilder/utils.spec.ts
+++ b/src/components/queryBuilder/utils.spec.ts
@@ -1,259 +1,227 @@
 import { BuilderMetricFieldAggregation, BuilderMode, FilterOperator, OrderByDirection } from 'types';
-import { getQueryOptionsFromSql, getSQLFromQueryOptions as convert } from './utils';
+import { getQueryOptionsFromSql, getSQLFromQueryOptions } from './utils';
 
-describe('Utils', () => {
-  it('getSQLFromQueryOptions', () => {
-    expect(convert({ mode: BuilderMode.List, database: 'db', table: '', fields: ['name'] })).toBe(
-      'SELECT name FROM db'
-    );
-    expect(convert({ mode: BuilderMode.List, database: 'db', table: 'foo', fields: ['name'] })).toBe(
-      'SELECT name FROM db.foo'
-    );
-    expect(convert({ mode: BuilderMode.List, database: 'db', table: 'foo', fields: ['field1', 'field2'] })).toBe(
-      'SELECT field1, field2 FROM db.foo'
-    );
-    expect(
-      convert({ mode: BuilderMode.List, database: 'db', table: 'foo', fields: ['field1', 'field2'], limit: 20 })
-    ).toBe('SELECT field1, field2 FROM db.foo LIMIT 20');
-    expect(
-      convert({
-        mode: BuilderMode.List,
-        database: 'db',
-        table: 'foo',
-        fields: ['field1', 'field2'],
-        orderBy: [],
-        limit: 20,
-      })
-    ).toBe('SELECT field1, field2 FROM db.foo LIMIT 20');
-    expect(
-      convert({
-        mode: BuilderMode.List,
-        database: 'db',
-        table: 'foo',
-        fields: ['field1', 'field2'],
-        orderBy: [{ name: 'field1', dir: OrderByDirection.ASC }],
-        limit: 20,
-      })
-    ).toBe('SELECT field1, field2 FROM db.foo ORDER BY field1 ASC LIMIT 20');
-    expect(convert({ mode: BuilderMode.Aggregate, database: 'db', table: '', fields: [], metrics: [] })).toBe(
-      'SELECT  FROM db'
-    );
-    expect(convert({ mode: BuilderMode.Aggregate, database: 'db', table: 'foo', fields: [], metrics: [] })).toBe(
-      'SELECT  FROM db.foo'
-    );
-    expect(
-      convert({
-        mode: BuilderMode.Aggregate,
-        database: 'db',
-        table: 'foo',
-        fields: [],
-        metrics: [{ field: 'field1', aggregation: BuilderMetricFieldAggregation.Sum }],
-      })
-    ).toBe('SELECT sum(field1) FROM db.foo');
-    expect(
-      convert({
-        mode: BuilderMode.Aggregate,
-        database: 'db',
-        table: 'foo',
-        fields: [],
-        metrics: [{ field: 'field1', aggregation: BuilderMetricFieldAggregation.Sum, alias: 'total_records' }],
-      })
-    ).toBe('SELECT sum(field1) total_records FROM db.foo');
-    expect(
-      convert({
-        mode: BuilderMode.Aggregate,
-        table: 'foo',
-        database: 'db',
-        fields: [],
-        metrics: [
-          { field: 'field1', aggregation: BuilderMetricFieldAggregation.Sum, alias: 'total_records' },
-          { field: 'field2', aggregation: BuilderMetricFieldAggregation.Count, alias: 'total_records2' },
-        ],
-      })
-    ).toBe('SELECT sum(field1) total_records, count(field2) total_records2 FROM db.foo');
-    expect(
-      convert({
-        mode: BuilderMode.Aggregate,
-        table: 'foo',
-        database: 'db',
-        fields: [],
-        metrics: [
-          { field: 'field1', aggregation: BuilderMetricFieldAggregation.Sum, alias: 'total_records' },
-          { field: 'field2', aggregation: BuilderMetricFieldAggregation.Count, alias: 'total_records2' },
-        ],
-        groupBy: [],
-      })
-    ).toBe('SELECT sum(field1) total_records, count(field2) total_records2 FROM db.foo');
-    expect(
-      convert({
-        mode: BuilderMode.Aggregate,
-        table: 'foo',
-        database: 'db',
-        fields: [],
-        metrics: [
-          { field: 'field1', aggregation: BuilderMetricFieldAggregation.Sum, alias: 'total_records' },
-          { field: 'field2', aggregation: BuilderMetricFieldAggregation.Count, alias: 'total_records2' },
-        ],
-        groupBy: ['field3'],
-      })
-    ).toBe('SELECT field3, sum(field1) total_records, count(field2) total_records2 FROM db.foo GROUP BY field3');
-    expect(
-      convert({
-        mode: BuilderMode.Aggregate,
-        database: 'db',
-        table: 'foo',
-        fields: [],
-        metrics: [
-          { field: 'Id', aggregation: BuilderMetricFieldAggregation.Count, alias: 'count_of' },
-          { field: 'Amount', aggregation: BuilderMetricFieldAggregation.Sum },
-        ],
-        groupBy: ['StageName', 'Type'],
-      })
-    ).toBe('SELECT StageName, Type, count(Id) count_of, sum(Amount) FROM db.foo GROUP BY StageName, Type');
-    expect(
-      convert({
-        mode: BuilderMode.Aggregate,
-        database: 'db',
-        table: 'foo',
-        fields: [],
-        metrics: [
-          { field: 'Id', aggregation: BuilderMetricFieldAggregation.Count, alias: 'count_of' },
-          { field: 'Amount', aggregation: BuilderMetricFieldAggregation.Sum },
-        ],
-        groupBy: ['StageName', 'Type'],
-        orderBy: [{ name: 'count(Id)', dir: OrderByDirection.DESC }],
-      })
-    ).toBe(
-      'SELECT StageName, Type, count(Id) count_of, sum(Amount) FROM db.foo GROUP BY StageName, Type ORDER BY count(Id) DESC'
-    );
-    expect(
-      convert({
-        mode: BuilderMode.Aggregate,
-        database: 'db',
-        table: 'foo',
-        fields: [],
-        metrics: [
-          { field: 'Id', aggregation: BuilderMetricFieldAggregation.Count, alias: 'count_of' },
-          { field: 'Amount', aggregation: BuilderMetricFieldAggregation.Sum },
-        ],
-        groupBy: ['StageName', 'Type'],
-        orderBy: [
-          { name: 'count(Id)', dir: OrderByDirection.DESC },
-          { name: 'StageName', dir: OrderByDirection.ASC },
-        ],
-      })
-    ).toBe(
-      'SELECT StageName, Type, count(Id) count_of, sum(Amount) FROM db.foo GROUP BY StageName, Type ORDER BY count(Id) DESC, StageName ASC'
-    );
-    expect(
-      convert({
-        mode: BuilderMode.Aggregate,
-        database: 'db',
-        table: 'foo',
-        fields: [],
-        metrics: [{ field: 'Id', aggregation: BuilderMetricFieldAggregation.Count }],
-      })
-    ).toBe('SELECT count(Id) FROM db.foo');
-    expect(
-      convert({
-        mode: BuilderMode.Aggregate,
-        database: 'db',
-        table: 'foo',
-        fields: [],
-        metrics: [{ field: 'Id', aggregation: BuilderMetricFieldAggregation.Count }],
-        filters: [
-          {
-            filterType: 'custom',
-            key: 'StageName',
-            operator: FilterOperator.In,
-            value: ['Deal Won', 'Deal Lost'],
-            type: 'string',
-            condition: 'AND',
-          },
-        ],
-      })
-    ).toBe(`SELECT count(Id) FROM db.foo WHERE   ( StageName IN ('Deal Won', 'Deal Lost' ) )`);
-    expect(
-      convert({
-        mode: BuilderMode.Aggregate,
-        database: 'db',
-        table: 'foo',
-        fields: [],
-        metrics: [{ field: 'Id', aggregation: BuilderMetricFieldAggregation.Count }],
-        filters: [
-          {
-            filterType: 'custom',
-            key: 'StageName',
-            operator: FilterOperator.NotIn,
-            value: ['Deal Won', 'Deal Lost'],
-            type: 'string',
-            condition: 'AND',
-          },
-        ],
-      })
-    ).toBe(`SELECT count(Id) FROM db.foo WHERE   ( StageName NOT IN ('Deal Won', 'Deal Lost' ) )`);
-    expect(
-      convert({
-        mode: BuilderMode.Aggregate,
-        database: 'db',
-        table: 'foo',
-        fields: [],
-        metrics: [{ field: 'Id', aggregation: BuilderMetricFieldAggregation.Count }],
-        filters: [
-          {
-            filterType: 'custom',
-            key: 'CreatedDate',
-            operator: FilterOperator.WithInGrafanaTimeRange,
-            type: 'datetime',
-            value: '',
-            condition: 'AND',
-          },
-        ],
-      })
-    ).toBe(`SELECT count(Id) FROM db.foo WHERE   ( CreatedDate  >= \${__from:date} AND CreatedDate <= \${__to:date} )`);
-    expect(
-      convert({
-        mode: BuilderMode.Aggregate,
-        database: 'db',
-        table: 'foo',
-        fields: [],
-        metrics: [{ field: 'Id', aggregation: BuilderMetricFieldAggregation.Count }],
-        filters: [
-          {
-            filterType: 'custom',
-            key: 'CloseDate',
-            operator: FilterOperator.OutsideGrafanaTimeRange,
-            type: 'date',
-            value: '',
-            condition: 'AND',
-          },
-        ],
-      })
-    ).toBe(
-      `SELECT count(Id) FROM db.foo WHERE   (  NOT ( CloseDate  >= \${__from:date:YYYY-MM-DD} AND CloseDate <= \${__to:date:YYYY-MM-DD} ) )`
-    );
+describe('Utils: getSQLFromQueryOptions and getQueryOptionsFromSql', () => {
+  testCondition('handles a database without a table', 'SELECT name FROM db', {
+    mode: BuilderMode.List,
+    database: 'db',
+    table: '',
+    fields: ['name'],
   });
-  it('getQueryOptionsFromSql', () => {
-    expect(
-      getQueryOptionsFromSql(
-        `SELECT count(Id) FROM db.foo WHERE   (  NOT ( CloseDate  >= \${__from:date:YYYY-MM-DD} AND CloseDate <= \${__to:date:YYYY-MM-DD} ) )`
-      )).toBe({
-        mode: BuilderMode.Aggregate,
-        database: 'db',
-        table: 'foo',
-        fields: [],
-        metrics: [{ field: 'Id', aggregation: BuilderMetricFieldAggregation.Count }],
-        filters: [
-          {
-            filterType: 'custom',
-            key: 'CloseDate',
-            operator: FilterOperator.OutsideGrafanaTimeRange,
-            type: 'date',
-            value: '',
-            condition: 'AND',
-          },
-        ],
-      }
-      );
+
+  testCondition('handles a database and a table', 'SELECT name FROM db.foo', {
+    mode: BuilderMode.List,
+    database: 'db',
+    table: 'foo',
+    fields: ['name'],
   });
+
+  testCondition('handles 2 fields', 'SELECT field1, field2 FROM db.foo', {
+    mode: BuilderMode.List,
+    database: 'db',
+    table: 'foo',
+    fields: ['field1', 'field2'],
+  });
+
+  testCondition('handles a limit', 'SELECT field1, field2 FROM db.foo LIMIT 20', {
+    mode: BuilderMode.List,
+    database: 'db',
+    table: 'foo',
+    fields: ['field1', 'field2'],
+    limit: 20,
+  });
+
+  testCondition('handles empty orderBy array', 'SELECT field1, field2 FROM db.foo LIMIT 20', {
+    mode: BuilderMode.List,
+    database: 'db',
+    table: 'foo',
+    fields: ['field1', 'field2'],
+    orderBy: [],
+    limit: 20,
+  }, false);
+
+  testCondition('handles order by', 'SELECT field1, field2 FROM db.foo ORDER BY field1 ASC LIMIT 20', {
+    mode: BuilderMode.List,
+    database: 'db',
+    table: 'foo',
+    fields: ['field1', 'field2'],
+    orderBy: [{ name: 'field1', dir: OrderByDirection.ASC }],
+    limit: 20,
+  });
+
+  testCondition('handles no select', 'SELECT  FROM db', {
+    mode: BuilderMode.Aggregate,
+    database: 'db',
+    table: '',
+    fields: [],
+    metrics: [],
+  }, false);
+
+  testCondition('handles aggregation function', 'SELECT sum(field1) FROM db.foo', {
+    mode: BuilderMode.Aggregate,
+    database: 'db',
+    table: 'foo',
+    fields: [],
+    metrics: [{ field: 'field1', aggregation: BuilderMetricFieldAggregation.Sum }],
+  });
+
+  testCondition('handles aggregation with alias', 'SELECT sum(field1) total_records FROM db.foo', {
+    mode: BuilderMode.Aggregate,
+    database: 'db',
+    table: 'foo',
+    fields: [],
+    metrics: [{ field: 'field1', aggregation: BuilderMetricFieldAggregation.Sum, alias: 'total_records' }],
+  });
+
+  testCondition('handles 2 aggregations', 'SELECT sum(field1) total_records, count(field2) total_records2 FROM db.foo', {
+    mode: BuilderMode.Aggregate,
+    table: 'foo',
+    database: 'db',
+    fields: [],
+    metrics: [
+      { field: 'field1', aggregation: BuilderMetricFieldAggregation.Sum, alias: 'total_records' },
+      { field: 'field2', aggregation: BuilderMetricFieldAggregation.Count, alias: 'total_records2' },
+    ],
+  });
+
+  testCondition(
+    'handles aggregation with groupBy',
+    'SELECT field3, sum(field1) total_records, count(field2) total_records2 FROM db.foo GROUP BY field3',
+    {
+      mode: BuilderMode.Aggregate,
+      table: 'foo',
+      database: 'db',
+      fields: [],
+      metrics: [
+        { field: 'field1', aggregation: BuilderMetricFieldAggregation.Sum, alias: 'total_records' },
+        { field: 'field2', aggregation: BuilderMetricFieldAggregation.Count, alias: 'total_records2' },
+      ],
+      groupBy: ['field3'],
+    },
+    false
+  );
+
+  testCondition(
+    'handles aggregation with groupBy with fields having group by value',
+    'SELECT field3, sum(field1) total_records, count(field2) total_records2 FROM db.foo GROUP BY field3',
+    {
+      mode: BuilderMode.Aggregate,
+      table: 'foo',
+      database: 'db',
+      fields: ['field3'],
+      metrics: [
+        { field: 'field1', aggregation: BuilderMetricFieldAggregation.Sum, alias: 'total_records' },
+        { field: 'field2', aggregation: BuilderMetricFieldAggregation.Count, alias: 'total_records2' },
+      ],
+      groupBy: ['field3'],
+    }
+  );
+
+  testCondition(
+    'handles aggregation with group by and order by',
+    'SELECT StageName, Type, count(Id) count_of, sum(Amount) FROM db.foo GROUP BY StageName, Type ORDER BY count(Id) DESC, StageName ASC',
+    {
+      mode: BuilderMode.Aggregate,
+      database: 'db',
+      table: 'foo',
+      fields: [],
+      metrics: [
+        { field: 'Id', aggregation: BuilderMetricFieldAggregation.Count, alias: 'count_of' },
+        { field: 'Amount', aggregation: BuilderMetricFieldAggregation.Sum },
+      ],
+      groupBy: ['StageName', 'Type'],
+      orderBy: [
+        { name: 'count(Id)', dir: OrderByDirection.DESC },
+        { name: 'StageName', dir: OrderByDirection.ASC },
+      ],
+    },
+    false
+  );
+
+  testCondition('handles aggregation with a IN filter', `SELECT count(Id) FROM db.foo WHERE   ( StageName IN ('Deal Won', 'Deal Lost' ) )`, {
+    mode: BuilderMode.Aggregate,
+    database: 'db',
+    table: 'foo',
+    fields: [],
+    metrics: [{ field: 'Id', aggregation: BuilderMetricFieldAggregation.Count }],
+    filters: [
+      {
+        filterType: 'custom',
+        key: 'StageName',
+        operator: FilterOperator.In,
+        value: ['Deal Won', 'Deal Lost'],
+        type: 'string',
+        condition: 'AND',
+      },
+    ],
+  });
+
+  testCondition('handles aggregation with a NOT IN filter', `SELECT count(Id) FROM db.foo WHERE   ( StageName NOT IN ('Deal Won', 'Deal Lost' ) )`, {
+    mode: BuilderMode.Aggregate,
+    database: 'db',
+    table: 'foo',
+    fields: [],
+    metrics: [{ field: 'Id', aggregation: BuilderMetricFieldAggregation.Count }],
+    filters: [
+      {
+        filterType: 'custom',
+        key: 'StageName',
+        operator: FilterOperator.NotIn,
+        value: ['Deal Won', 'Deal Lost'],
+        type: 'string',
+        condition: 'AND',
+      },
+    ],
+  });
+
+  testCondition(
+    'handles aggregation with datetime filter',
+    `SELECT count(Id) FROM db.foo WHERE   ( CreatedDate  >= \${__from:date} AND CreatedDate <= \${__to:date} )`,
+    {
+      mode: BuilderMode.Aggregate,
+      database: 'db',
+      table: 'foo',
+      fields: [],
+      metrics: [{ field: 'Id', aggregation: BuilderMetricFieldAggregation.Count }],
+      filters: [
+        {
+          filterType: 'custom',
+          key: 'CreatedDate',
+          operator: FilterOperator.WithInGrafanaTimeRange,
+          type: 'datetime',
+          value: '',
+          condition: 'AND',
+        },
+      ],
+    }
+  );
+
+  testCondition(
+    'handles aggregation with date filter',
+    `SELECT count(Id) FROM db.foo WHERE   (  NOT ( CloseDate  >= \${__from:date:YYYY-MM-DD} AND CloseDate <= \${__to:date:YYYY-MM-DD} ) )`,
+    {
+      mode: BuilderMode.Aggregate,
+      database: 'db',
+      table: 'foo',
+      fields: [],
+      metrics: [{ field: 'Id', aggregation: BuilderMetricFieldAggregation.Count }],
+      filters: [
+        {
+          filterType: 'custom',
+          key: 'CloseDate',
+          operator: FilterOperator.OutsideGrafanaTimeRange,
+          type: 'date',
+          value: '',
+          condition: 'AND',
+        },
+      ],
+    }
+  );
 });
+
+function testCondition(name: string, sql: string, builder: any, testQueryOptionsFromSql = true) {
+  it(name, () => {
+    expect(getSQLFromQueryOptions(builder)).toBe(sql);
+    testQueryOptionsFromSql ? expect(getQueryOptionsFromSql(sql)).toEqual(builder) : {};
+  });
+}

--- a/src/components/queryBuilder/utils.spec.ts
+++ b/src/components/queryBuilder/utils.spec.ts
@@ -31,14 +31,19 @@ describe('Utils: getSQLFromQueryOptions and getQueryOptionsFromSql', () => {
     limit: 20,
   });
 
-  testCondition('handles empty orderBy array', 'SELECT field1, field2 FROM db.foo LIMIT 20', {
-    mode: BuilderMode.List,
-    database: 'db',
-    table: 'foo',
-    fields: ['field1', 'field2'],
-    orderBy: [],
-    limit: 20,
-  }, false);
+  testCondition(
+    'handles empty orderBy array',
+    'SELECT field1, field2 FROM db.foo LIMIT 20',
+    {
+      mode: BuilderMode.List,
+      database: 'db',
+      table: 'foo',
+      fields: ['field1', 'field2'],
+      orderBy: [],
+      limit: 20,
+    },
+    false
+  );
 
   testCondition('handles order by', 'SELECT field1, field2 FROM db.foo ORDER BY field1 ASC LIMIT 20', {
     mode: BuilderMode.List,
@@ -49,13 +54,18 @@ describe('Utils: getSQLFromQueryOptions and getQueryOptionsFromSql', () => {
     limit: 20,
   });
 
-  testCondition('handles no select', 'SELECT  FROM db', {
-    mode: BuilderMode.Aggregate,
-    database: 'db',
-    table: '',
-    fields: [],
-    metrics: [],
-  }, false);
+  testCondition(
+    'handles no select',
+    'SELECT  FROM db',
+    {
+      mode: BuilderMode.Aggregate,
+      database: 'db',
+      table: '',
+      fields: [],
+      metrics: [],
+    },
+    false
+  );
 
   testCondition('handles aggregation function', 'SELECT sum(field1) FROM db.foo', {
     mode: BuilderMode.Aggregate,
@@ -73,16 +83,20 @@ describe('Utils: getSQLFromQueryOptions and getQueryOptionsFromSql', () => {
     metrics: [{ field: 'field1', aggregation: BuilderMetricFieldAggregation.Sum, alias: 'total_records' }],
   });
 
-  testCondition('handles 2 aggregations', 'SELECT sum(field1) total_records, count(field2) total_records2 FROM db.foo', {
-    mode: BuilderMode.Aggregate,
-    table: 'foo',
-    database: 'db',
-    fields: [],
-    metrics: [
-      { field: 'field1', aggregation: BuilderMetricFieldAggregation.Sum, alias: 'total_records' },
-      { field: 'field2', aggregation: BuilderMetricFieldAggregation.Count, alias: 'total_records2' },
-    ],
-  });
+  testCondition(
+    'handles 2 aggregations',
+    'SELECT sum(field1) total_records, count(field2) total_records2 FROM db.foo',
+    {
+      mode: BuilderMode.Aggregate,
+      table: 'foo',
+      database: 'db',
+      fields: [],
+      metrics: [
+        { field: 'field1', aggregation: BuilderMetricFieldAggregation.Sum, alias: 'total_records' },
+        { field: 'field2', aggregation: BuilderMetricFieldAggregation.Count, alias: 'total_records2' },
+      ],
+    }
+  );
 
   testCondition(
     'handles aggregation with groupBy',
@@ -138,41 +152,49 @@ describe('Utils: getSQLFromQueryOptions and getQueryOptionsFromSql', () => {
     false
   );
 
-  testCondition('handles aggregation with a IN filter', `SELECT count(Id) FROM db.foo WHERE   ( StageName IN ('Deal Won', 'Deal Lost' ) )`, {
-    mode: BuilderMode.Aggregate,
-    database: 'db',
-    table: 'foo',
-    fields: [],
-    metrics: [{ field: 'Id', aggregation: BuilderMetricFieldAggregation.Count }],
-    filters: [
-      {
-        filterType: 'custom',
-        key: 'StageName',
-        operator: FilterOperator.In,
-        value: ['Deal Won', 'Deal Lost'],
-        type: 'string',
-        condition: 'AND',
-      },
-    ],
-  });
+  testCondition(
+    'handles aggregation with a IN filter',
+    `SELECT count(Id) FROM db.foo WHERE   ( StageName IN ('Deal Won', 'Deal Lost' ) )`,
+    {
+      mode: BuilderMode.Aggregate,
+      database: 'db',
+      table: 'foo',
+      fields: [],
+      metrics: [{ field: 'Id', aggregation: BuilderMetricFieldAggregation.Count }],
+      filters: [
+        {
+          filterType: 'custom',
+          key: 'StageName',
+          operator: FilterOperator.In,
+          value: ['Deal Won', 'Deal Lost'],
+          type: 'string',
+          condition: 'AND',
+        },
+      ],
+    }
+  );
 
-  testCondition('handles aggregation with a NOT IN filter', `SELECT count(Id) FROM db.foo WHERE   ( StageName NOT IN ('Deal Won', 'Deal Lost' ) )`, {
-    mode: BuilderMode.Aggregate,
-    database: 'db',
-    table: 'foo',
-    fields: [],
-    metrics: [{ field: 'Id', aggregation: BuilderMetricFieldAggregation.Count }],
-    filters: [
-      {
-        filterType: 'custom',
-        key: 'StageName',
-        operator: FilterOperator.NotIn,
-        value: ['Deal Won', 'Deal Lost'],
-        type: 'string',
-        condition: 'AND',
-      },
-    ],
-  });
+  testCondition(
+    'handles aggregation with a NOT IN filter',
+    `SELECT count(Id) FROM db.foo WHERE   ( StageName NOT IN ('Deal Won', 'Deal Lost' ) )`,
+    {
+      mode: BuilderMode.Aggregate,
+      database: 'db',
+      table: 'foo',
+      fields: [],
+      metrics: [{ field: 'Id', aggregation: BuilderMetricFieldAggregation.Count }],
+      filters: [
+        {
+          filterType: 'custom',
+          key: 'StageName',
+          operator: FilterOperator.NotIn,
+          value: ['Deal Won', 'Deal Lost'],
+          type: 'string',
+          condition: 'AND',
+        },
+      ],
+    }
+  );
 
   testCondition(
     'handles aggregation with datetime filter',
@@ -222,6 +244,8 @@ describe('Utils: getSQLFromQueryOptions and getQueryOptionsFromSql', () => {
 function testCondition(name: string, sql: string, builder: any, testQueryOptionsFromSql = true) {
   it(name, () => {
     expect(getSQLFromQueryOptions(builder)).toBe(sql);
-    testQueryOptionsFromSql ? expect(getQueryOptionsFromSql(sql)).toEqual(builder) : {};
+    if (testQueryOptionsFromSql) {
+      expect(getQueryOptionsFromSql(sql)).toEqual(builder);
+    }
   });
 }

--- a/src/components/queryBuilder/utils.spec.ts
+++ b/src/components/queryBuilder/utils.spec.ts
@@ -2,10 +2,10 @@ import { BuilderMetricFieldAggregation, BuilderMode, FilterOperator, OrderByDire
 import { getQueryOptionsFromSql, getSQLFromQueryOptions } from './utils';
 
 describe('Utils: getSQLFromQueryOptions and getQueryOptionsFromSql', () => {
-  testCondition('handles a database without a table', 'SELECT name FROM db', {
+  testCondition('handles a table without a database', 'SELECT name FROM table', {
     mode: BuilderMode.List,
-    database: 'db',
-    table: '',
+    database: '',
+    table: 'table',
     fields: ['name'],
   });
 

--- a/src/components/queryBuilder/utils.spec.ts
+++ b/src/components/queryBuilder/utils.spec.ts
@@ -1,5 +1,5 @@
 import { BuilderMetricFieldAggregation, BuilderMode, FilterOperator, OrderByDirection } from 'types';
-import { getSQLFromQueryOptions as convert } from './utils';
+import { getQueryOptionsFromSql, getSQLFromQueryOptions as convert } from './utils';
 
 describe('Utils', () => {
   it('getSQLFromQueryOptions', () => {
@@ -232,5 +232,28 @@ describe('Utils', () => {
     ).toBe(
       `SELECT count(Id) FROM db.foo WHERE   (  NOT ( CloseDate  >= \${__from:date:YYYY-MM-DD} AND CloseDate <= \${__to:date:YYYY-MM-DD} ) )`
     );
+  });
+  it('getQueryOptionsFromSql', () => {
+    expect(
+      getQueryOptionsFromSql(
+        `SELECT count(Id) FROM db.foo WHERE   (  NOT ( CloseDate  >= \${__from:date:YYYY-MM-DD} AND CloseDate <= \${__to:date:YYYY-MM-DD} ) )`
+      )).toBe({
+        mode: BuilderMode.Aggregate,
+        database: 'db',
+        table: 'foo',
+        fields: [],
+        metrics: [{ field: 'Id', aggregation: BuilderMetricFieldAggregation.Count }],
+        filters: [
+          {
+            filterType: 'custom',
+            key: 'CloseDate',
+            operator: FilterOperator.OutsideGrafanaTimeRange,
+            type: 'date',
+            value: '',
+            condition: 'AND',
+          },
+        ],
+      }
+      );
   });
 });

--- a/src/components/queryBuilder/utils.ts
+++ b/src/components/queryBuilder/utils.ts
@@ -81,7 +81,6 @@ const getAggregationQuery = (
   if (groupBy && groupBy.length > 0) {
     metricsQuery =
       groupBy
-        .map((g) => `${g}`)
         .filter((x) => !fields.some((y) => y === x)) // not adding field if its already is selected
         .join(', ') + (metricsQuery ? `, ${metricsQuery}` : '');
   }
@@ -279,8 +278,8 @@ export function getQueryOptionsFromSql(sql: string): SqlBuilderOptions {
 
   let builder = {
     mode: fieldsAndMetrics.metrics.length > 0 ? BuilderMode.Aggregate : BuilderMode.List,
-    database: databaseAndTable[0].trim(),
-    table: databaseAndTable[1] ? databaseAndTable[1].trim() : '',
+    database: databaseAndTable[1] ? databaseAndTable[0].trim() : '',
+    table: databaseAndTable[1] ? databaseAndTable[1].trim() : databaseAndTable[0].trim(),
   } as SqlBuilderOptions;
 
   if (fieldsAndMetrics.fields) {
@@ -332,7 +331,7 @@ export function getQueryOptionsFromSql(sql: string): SqlBuilderOptions {
 function getFiltersFromAst(whereClauses: Clause[]): Filter[] {
   // first condition is always AND but is not used
   const filters: Filter[] = [{ condition: 'AND' } as Filter];
-  for (let c of whereClauses) {
+  for (const c of whereClauses) {
     if (!isString(c)) {
       continue;
     }
@@ -421,12 +420,12 @@ function isWithInTimeRangeFilter(phrases: string[]): boolean {
 function getMetricsFromAst(selectClauses: Clause[]): { metrics: BuilderMetricField[]; fields: string[] } {
   const metrics: BuilderMetricField[] = [];
   const fields: string[] = [];
-  for (let c of selectClauses) {
+  for (const c of selectClauses) {
     if (!isString(c) || !c.trim() || c.trim() === ',') {
       continue;
     }
     let isMetric = false;
-    for (let agg of Object.values(BuilderMetricFieldAggregation)) {
+    for (const agg of Object.values(BuilderMetricFieldAggregation)) {
       if (c.trim().toLowerCase().startsWith(`${agg}`)) {
         const phrases = c.match(/\w+|\$(\w+)/g);
         if (!phrases) {

--- a/src/components/queryBuilder/utils.ts
+++ b/src/components/queryBuilder/utils.ts
@@ -70,22 +70,20 @@ const getAggregationQuery = (
   metrics: BuilderMetricField[] = [],
   groupBy: string[] = []
 ): string => {
-  metrics = metrics && metrics.length > 0 ? metrics : [];
   let selected = fields.length > 0 ? fields.join(', ') : '';
   let metricsQuery = metrics
     .map((m) => {
-      const alias = m.alias ? ` ` + m.alias.replace(/ /g, '_') : '';
+      const alias = m.alias ? ` ${m.alias.replace(/ /g, '_')}` : '';
       return `${m.aggregation}(${m.field})${alias}`;
     })
     .join(', ');
-  if (groupBy && groupBy.length > 0) {
-    metricsQuery =
-      groupBy
-        .filter((x) => !fields.some((y) => y === x)) // not adding field if its already is selected
-        .join(', ') + (metricsQuery ? `, ${metricsQuery}` : '');
-  }
+  const groupByQuery = groupBy
+    .filter((x) => !fields.some((y) => y === x)) // not adding field if its already is selected
+    .join(', ');
   const sep = database === '' || table === '' ? '' : '.';
-  return `SELECT ${selected}${metricsQuery} FROM ${database}${sep}${table}`;
+  return `SELECT ${selected}${selected && (groupByQuery || metricsQuery) ? ', ' : ''}${groupByQuery}${
+    metricsQuery && groupByQuery ? ', ' : ''
+  }${metricsQuery} FROM ${database}${sep}${table}`;
 };
 
 const getTrendByQuery = (

--- a/src/data/adHocFilter.test.ts
+++ b/src/data/adHocFilter.test.ts
@@ -22,12 +22,12 @@ describe('AdHocManager', () => {
   it('apply ad hoc filter with an inner query without existing WHERE', () => {
     const ahm = new AdHocFilter();
     ahm.setTargetTable('SELECT * FROM table');
-    const val = ahm.apply(`SELECT stuff FROM (SELECT * FROM table) as r, table2 GROUP BY s ORDER BY s`, [
+    const val = ahm.apply(`SELECT stuff FROM (SELECT * FROM table) as r , table2 GROUP BY s ORDER BY s`, [
       { key: 'key', operator: '=', value: 'val' },
       { key: 'keyNum', operator: '=', value: '123' },
     ] as AdHocVariableFilter[]);
     expect(val).toEqual(
-      `SELECT stuff FROM ( SELECT * FROM table WHERE key = 'val' AND keyNum = 123 ) as r, table2 GROUP BY s ORDER BY s`
+      `SELECT stuff FROM ( SELECT * FROM table WHERE key = 'val' AND keyNum = 123 ) as r , table2 GROUP BY s ORDER BY s`
     );
   });
   it('apply ad hoc filter with an inner from query with existing WHERE', () => {
@@ -45,11 +45,11 @@ describe('AdHocManager', () => {
     const ahm = new AdHocFilter();
     ahm.setTargetTable('SELECT * FROM table');
     const val = ahm.apply(
-      `SELECT * FROM table WHERE (name = stuff) AND (name IN ( SELECT * FROM table WHERE (field = 'hello') GROUP BY name ORDER BY count() DESC LIMIT 10 )) GROUP BY name, time ORDER BY time`,
+      `SELECT * FROM table WHERE (name = stuff) AND (name IN ( SELECT * FROM table WHERE (field = 'hello') GROUP BY name ORDER BY count() DESC LIMIT 10 )) GROUP BY name , time ORDER BY time`,
       [{ key: 'key', operator: '=', value: 'val' }] as AdHocVariableFilter[]
     );
     expect(val).toEqual(
-      `SELECT * FROM table WHERE key = 'val' AND (name = stuff) AND (name IN ( SELECT * FROM table WHERE key = 'val' AND (field = 'hello') GROUP BY name ORDER BY count() DESC LIMIT 10 )) GROUP BY name, time ORDER BY time`
+      `SELECT * FROM table WHERE key = 'val' AND (name = stuff) AND (name IN ( SELECT * FROM table WHERE key = 'val' AND (field = 'hello') GROUP BY name ORDER BY count() DESC LIMIT 10 )) GROUP BY name , time ORDER BY time`
     );
   });
   it('does not apply ad hoc filter when the target table is not in the query', () => {

--- a/src/data/ast.ts
+++ b/src/data/ast.ts
@@ -6,7 +6,7 @@ export type AST = Map<string, Clause[]>;
 export default function sqlToAST(sql: string): AST {
   const ast = createStatement();
   const re =
-    /\b(WITH|SELECT|DISTINCT|FROM|SAMPLE|JOIN|PREWHERE|WHERE|GROUP BY|LIMIT BY|HAVING|LIMIT|OFFSET|UNION|INTERSECT|EXCEPT|INTO OUTFILE|FORMAT)\b/gi;
+    /\b(WITH|SELECT|DISTINCT|FROM|SAMPLE|JOIN|PREWHERE|WHERE|GROUP BY|LIMIT BY|HAVING|ORDER BY|LIMIT|OFFSET|UNION|INTERSECT|EXCEPT|INTO OUTFILE|FORMAT)\b/gi;
   const bracket = { count: 0, lastCount: 0, phrase: '' };
   let lastNode = '';
   let regExpArray: RegExpExecArray | null;
@@ -83,7 +83,7 @@ export function applyFiltersToAST(ast: AST, whereClause: string, targetTable: st
         // first we get the remaining part of the FROM phrase. ") as r"
         const fromPhrase = ast.get('FROM');
         const fromPhraseAfterTableName = fromPhrase!
-          [fromPhrase!.length - 1]!.toString()
+        [fromPhrase!.length - 1]!.toString()
           .trim()
           .substring(targetTable.length);
         // apply the remaining part of the FROM phrase to the end of the new WHERE clause
@@ -174,7 +174,7 @@ function movePhraseEnding(c: string, ast: AST) {
 
 function getASTBranches(sql: string): Clause[] {
   const clauses: Clause[] = [];
-  const re = /\b(AND|OR|,)\b/gi;
+  const re = /(\bAND\b|\bOR\b|,)/gi;
   const bracket = { count: 0, lastCount: 0, phrase: '' };
   let regExpArray: RegExpExecArray | null;
   let lastPhraseIndex = 0;
@@ -238,6 +238,7 @@ function createStatement(): AST {
   clauses.set('GROUP BY', []);
   clauses.set('LIMIT BY', []);
   clauses.set('HAVING', []);
+  clauses.set('ORDER BY', []);
   clauses.set('LIMIT', []);
   clauses.set('OFFSET', []);
   clauses.set('UNION', []);

--- a/src/data/ast.ts
+++ b/src/data/ast.ts
@@ -191,7 +191,7 @@ function getASTBranches(sql: string): Clause[] {
     if (bracket.count > 0) {
       bracket.phrase += phrase + foundSplitter;
     } else {
-      clauses.push(phrase);
+      completePhrase(clauses, phrase);
       clauses.push(foundSplitter);
     }
     if (bracket.count <= 0 && bracket.lastCount > 0) {

--- a/src/data/ast.ts
+++ b/src/data/ast.ts
@@ -119,14 +119,14 @@ export function removeConditionalAllsFromAST(ast: AST, queryVarNames: string[]):
     for (let i = 0; i < where.length; i++) {
       const c = where[i];
       if (isString(c) && queryVarNames.some((v) => c.includes(v))) {
-        where[i] = null;
         // remove AND/OR before this condition if this is the last condition
         if (i === where.length - 1) {
-          where[i - 1] = null;
+          where.splice(i - 1, 2);
         }
         // remove AND/OR after this condition
         if (where.length > 1) {
-          where[i + 1] = null;
+          where.splice(i, 2);
+          i--;
         }
         // moves the ending of the phrase, like ')', to the next logical place
         movePhraseEnding(c, ast);

--- a/src/data/ast.ts
+++ b/src/data/ast.ts
@@ -83,7 +83,7 @@ export function applyFiltersToAST(ast: AST, whereClause: string, targetTable: st
         // first we get the remaining part of the FROM phrase. ") as r"
         const fromPhrase = ast.get('FROM');
         const fromPhraseAfterTableName = fromPhrase!
-        [fromPhrase!.length - 1]!.toString()
+          [fromPhrase!.length - 1]!.toString()
           .trim()
           .substring(targetTable.length);
         // apply the remaining part of the FROM phrase to the end of the new WHERE clause

--- a/src/data/removeConditionalAlls.test.ts
+++ b/src/data/removeConditionalAlls.test.ts
@@ -43,6 +43,11 @@ describe('RemoveConditionalAlls', () => {
       input: `SELECT * FROM $tempVar`,
       expect: `SELECT * FROM $tempVar`,
     },
+    {
+      name: 'removes template variables when there are two in single WHERE statement',
+      input: `Select * from table WHERE active AND database IN (\${tempVar}) AND table IN (\${tempVar}) GROUP BY row`,
+      expect: `SELECT * FROM table WHERE active GROUP BY row`,
+    },
   ];
   const testCasesWithoutAllTempVar = [
     {

--- a/src/selectors.ts
+++ b/src/selectors.ts
@@ -70,7 +70,7 @@ export const Components = {
       },
       switcher: {
         title: 'Are you sure?',
-        body: 'You will lose manual changes done to the SQL if you go back to the query builder.',
+        body: 'Queries that are too complex for the Query Builder will be altered.',
         confirmText: 'Continue',
         dismissText: 'Cancel',
       },


### PR DESCRIPTION
When switching from SQL editor to the query builder it will try to convert the sql into a visual query.
This PR also fixes a bug with the AST not processing `,` correctly.