### PR TITLE
AST - comma bug

### DIFF
--- a/src/data/ast.ts
+++ b/src/data/ast.ts
@@ -190,12 +190,14 @@ function getASTBranches(sql: string): Clause[] {
     // add the phrase to the bracket phrase. The complete bracket phrase will be used to create a new AST branch
     if (bracket.count > 0) {
       bracket.phrase += phrase + foundSplitter;
-    } else {
+    } else if (bracket.lastCount <= 0) {
       completePhrase(clauses, phrase);
       clauses.push(foundSplitter);
     }
     if (bracket.count <= 0 && bracket.lastCount > 0) {
+      bracket.phrase += phrase;
       completePhrase(clauses, bracket.phrase);
+      clauses.push(foundSplitter);
       bracket.phrase = '';
     }
     bracket.lastCount = bracket.count;


### PR DESCRIPTION
The AST was adding phrases out of order because I was not checking the correct condition. This bug only occurred when using functions with multiple parameters.