### PR TITLE
validate sql

### DIFF
--- a/src/components/sqlProvider.ts
+++ b/src/components/sqlProvider.ts
@@ -39,13 +39,13 @@ export type Fetcher = {
   (text: string, range: Range): Promise<SuggestionResponse>;
 };
 
-export async function registerSQL(lang: string, editor: any, fetchSuggestions: Fetcher) {
+export function registerSQL(lang: string, editor: any, fetchSuggestions: Fetcher) {
   // so options are visible outside query editor
   editor.updateOptions({ fixedOverflowWidgets: true, scrollBeyondLastLine: false });
 
   const registeredLang = monaco.languages.getLanguages().find((l: Lang) => l.id === lang);
   if (registeredLang !== undefined) {
-    return;
+    return monaco.editor;
   }
 
   monaco.languages.register({ id: lang });
@@ -72,6 +72,8 @@ export async function registerSQL(lang: string, editor: any, fetchSuggestions: F
       return fetchSuggestions(textUntilPosition, range);
     },
   });
+
+  return monaco.editor;
 }
 
 export enum SchemaKind {

--- a/src/data/validate.test.ts
+++ b/src/data/validate.test.ts
@@ -1,0 +1,41 @@
+import { ParseError, validate } from './validate';
+
+let mockParser: any;
+
+jest.mock('js-sql-parser', () => {
+  const mock = {
+    parse: jest.fn(),
+  };
+  mockParser = mock;
+  return mock;
+});
+
+describe('Validate', () => {
+  it('should be valid', () => {
+    const sql = 'select foo from bar';
+    const v = validate(sql);
+    expect(v.valid).toBe(true);
+  });
+
+  it('should not be valid', () => {
+    const validationError: ParseError = {
+      message: 'foo\nbar\njunk\nexpected',
+      hash: {
+        loc: {
+          first_line: 1,
+          last_line: 1,
+          first_column: 1,
+          last_column: 3,
+        },
+      },
+    };
+    spyOn(mockParser, 'parse').and.callFake(() => {
+      throw validationError;
+    });
+
+    const sql = 'invalid sql';
+    const v = validate(sql);
+    expect(v.valid).toBe(false);
+    expect(v.error?.expected).toBe('expected');
+  });
+});

--- a/src/data/validate.ts
+++ b/src/data/validate.ts
@@ -1,0 +1,59 @@
+import * as parser from 'js-sql-parser';
+
+export interface Error {
+  startLine: number;
+  endLine: number;
+  startCol: number;
+  endCol: number;
+  message: string;
+  expected: string;
+}
+
+export interface Validation {
+  valid: boolean;
+  error?: Error;
+}
+
+export interface ParseError {
+  message: string;
+  hash: {
+    loc: {
+      first_line: number;
+      last_line: number;
+      first_column: number;
+      last_column: number;
+    };
+  };
+}
+
+// the sql parser only handles generic syntax, allow any clickhouse specific syntax
+const allow = ['INTERVAL'];
+
+export function validate(sql: string): Validation {
+  try {
+    parser.parse(sql);
+    return { valid: true };
+  } catch (e: any) {
+    const err = e as ParseError;
+    const parts = err.message.split('\n');
+    const loc = err.hash.loc;
+    const lines = sql.split('\n');
+    const line = lines[loc.first_line - 1];
+    const bad = line.substring(loc.first_column, loc.last_column);
+    if (allow.includes(bad.toUpperCase())) {
+      return { valid: true };
+    }
+
+    return {
+      valid: false,
+      error: {
+        startLine: loc.first_line,
+        endLine: loc.last_line,
+        startCol: loc.first_column + 1,
+        endCol: loc.last_column + 1,
+        message: e.message,
+        expected: parts[3],
+      },
+    };
+  }
+}

--- a/src/selectors.ts
+++ b/src/selectors.ts
@@ -54,6 +54,10 @@ export const Components = {
       label: 'Secure Connection',
       tooltip: 'Toggle on if the connection is secure',
     },
+    Validate: {
+      label: 'Validate SQL',
+      tooltip: 'Validate Sql in the editor.',
+    },
   },
   QueryEditor: {
     CodeEditor: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,7 @@ export interface CHConfig extends DataSourceJsonData {
   tlsAuth?: boolean;
   tlsAuthWithCACert?: boolean;
   secure?: boolean;
+  validate?: boolean;
 }
 
 export interface CHSecureConfig {

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -1,0 +1,1 @@
+declare module 'js-sql-parser';

--- a/src/views/CHConfigEditor.tsx
+++ b/src/views/CHConfigEditor.tsx
@@ -47,7 +47,7 @@ export const ConfigEditor: React.FC<Props> = (props) => {
       },
     });
   };
-  const onSwitchToggle = (key: keyof Pick<CHConfig, 'secure'>, value: boolean) => {
+  const onSwitchToggle = (key: keyof Pick<CHConfig, 'secure' | 'validate'>, value: boolean) => {
     onOptionsChange({
       ...options,
       jsonData: {
@@ -248,6 +248,19 @@ export const ConfigEditor: React.FC<Props> = (props) => {
             placeholder={Components.ConfigEditor.DefaultDatabase.placeholder}
             tooltip={Components.ConfigEditor.DefaultDatabase.tooltip}
           />
+        </div>
+        <div className="gf-form">
+          <InlineFormLabel width={12} tooltip={Components.ConfigEditor.Validate.tooltip}>
+            {Components.ConfigEditor.Validate.label}
+          </InlineFormLabel>
+          <div style={switchContainerStyle}>
+            <Switch
+              css={{}}
+              className="gf-form"
+              value={jsonData.validate || false}
+              onChange={(e) => onSwitchToggle('validate', e.currentTarget.checked)}
+            />
+          </div>
         </div>
       </div>
     </>


### PR DESCRIPTION
validate sql in editor
* this parser only supports generic sql - probably 80% of use cases
* for clickhouse specific sql that the parser doesn't recognize, it will just allow

ultimately, we may want to use:  [EXPLAIN SYNTAX](https://clickhouse.com/docs/en/sql-reference/statements/explain/#explain-syntax), though not sure if we want to do for every keystroke, maybe before running the query


