### PR TITLE
removeConditionalAlls: apply value overrides from scoped variables

### DIFF
--- a/src/data/CHDatasource.ts
+++ b/src/data/CHDatasource.ts
@@ -58,7 +58,7 @@ export class Datasource extends DataSourceWithBackend<CHQuery, CHConfig> {
       rawQuery = this.adHocFilter.apply(rawQuery, adHocFilters);
     }
     this.skipAdHocFilter = false;
-    rawQuery = removeConditionalAlls(rawQuery, templateSrv.getVariables());
+    rawQuery = removeConditionalAlls(rawQuery, templateSrv.getVariables(), scoped);
     return {
       ...query,
       rawSql: this.replace(rawQuery, scoped) || '',

--- a/src/data/removeConditionalAlls.test.ts
+++ b/src/data/removeConditionalAlls.test.ts
@@ -1,4 +1,4 @@
-import { VariableModel } from '@grafana/data';
+import { ScopedVars, VariableModel } from '@grafana/data';
 import { removeConditionalAlls } from './removeConditionalAlls';
 
 describe('RemoveConditionalAlls', () => {
@@ -79,18 +79,23 @@ describe('RemoveConditionalAlls', () => {
   ];
   const tempVarsWithAll = [{ type: 'query', name: 'tempVar', label: '', current: { value: '$__all' } }];
   for (let t of testCasesWithAllTempVar) {
-    testCondition(t.name, t.input, t.expect, tempVarsWithAll);
+    testCondition(t.name, t.input, t.expect, tempVarsWithAll, {});
   }
 
   const tempVarsWithoutAll = [{ type: 'query', name: 'tempVar', label: '', current: { value: 'val' } }];
   for (let t of testCasesWithoutAllTempVar) {
-    testCondition(t.name, t.input, t.expect, tempVarsWithoutAll);
+    testCondition(t.name, t.input, t.expect, tempVarsWithoutAll, {});
+  }
+
+  const scopedVars = { tempVar: { text: 'val', value: 'val', selected: false } };
+  for (let t of testCasesWithoutAllTempVar) {
+    testCondition(t.name, t.input, t.expect, tempVarsWithAll, scopedVars);
   }
 });
 
-function testCondition(name: string, input: string, expected: string, tempVars: any) {
+function testCondition(name: string, input: string, expected: string, tempVars: any, scopedVars: ScopedVars) {
   it(name, () => {
-    const val = removeConditionalAlls(input, tempVars as VariableModel[]);
+    const val = removeConditionalAlls(input, tempVars as VariableModel[], scopedVars);
     expect(val).toEqual(expected);
   });
 }

--- a/src/data/removeConditionalAlls.ts
+++ b/src/data/removeConditionalAlls.ts
@@ -1,18 +1,19 @@
-import { VariableModel } from '@grafana/data';
+import { ScopedVars, VariableModel } from '@grafana/data';
 import sqlToAST, { astToSql, removeConditionalAllsFromAST } from './ast';
 
-export function removeConditionalAlls(sql: string, queryVars: VariableModel[]): string {
+export function removeConditionalAlls(sql: string, queryVars: VariableModel[], scopedVars?: ScopedVars): string {
   if (sql === '' || !queryVars || queryVars.length === 0) {
     return sql;
   }
 
   const varNames: string[] = [];
-  for (let v of queryVars) {
-    if (v.type !== 'query') {
+  for (let qv of queryVars) {
+    if (qv.type !== 'query') {
       continue;
     }
-    if ((v as any)?.current?.value?.toString() === '$__all') {
-      varNames.push(v.name);
+    const val = scopedVars?.[qv.name]?.value ?? (qv as any)?.current?.value;
+    if (val?.toString() === '$__all') {
+      varNames.push(qv.name);
     }
   }
   // Semicolons are not required and cause problems when building the SQL


### PR DESCRIPTION
If a variable is present in the scoped set for a query, that value
should take precedence over the "base" value known by the template
service. This matches the behavior of TemplateSrv.replace.

This fixes an issue with repeated panels getting their local filtering
condition stripped when the dashboard variable is set to "All" (#86).