### PR TITLE
Time alias group order by

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.12.6
+
+Fix - Time series builder - use time alias when grouping/ordering
+
 ## 0.12.5
 
 Chore - dashboards

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clickhouse-datasource",
-  "version": "0.12.5",
+  "version": "0.12.6",
   "description": "Clickhouse Datasource",
   "scripts": {
     "build": "grafana-toolkit plugin:build",

--- a/src/components/queryBuilder/utils.ts
+++ b/src/components/queryBuilder/utils.ts
@@ -186,9 +186,9 @@ const getGroupBy = (groupBy: string[] = [], timeField?: string): string => {
     return clause;
   }
   if (groupBy.length === 0) {
-    return ` GROUP BY ${timeField}`;
+    return ` GROUP BY time`;
   }
-  return `${clause}, ${timeField}`;
+  return `${clause}, time`;
 };
 
 const getOrderBy = (orderBy?: OrderBy[], prefix = true): string => {
@@ -245,7 +245,7 @@ export const getSQLFromQueryOptions = (options: SqlBuilderOptions): string => {
       }
   }
   if (options.mode === BuilderMode.Trend) {
-    query += ` ORDER BY ${options.timeField} ASC`;
+    query += ` ORDER BY time ASC`;
     const orderBy = getOrderBy(options.orderBy, false);
     if (orderBy.trim() !== '') {
       query += `, ${orderBy}`;


### PR DESCRIPTION
Fixes #99 

time field is always aliased by time in the builder, use that alias when grouping and ordering