### PR TITLE
anything starting with date can be used for time field

### DIFF
--- a/src/components/queryBuilder/TimeField.tsx
+++ b/src/components/queryBuilder/TimeField.tsx
@@ -14,7 +14,7 @@ interface TimeFieldEditorProps {
 export const TimeFieldEditor = (props: TimeFieldEditorProps) => {
   const { label, tooltip } = selectors.components.QueryEditor.QueryBuilder.TIME_FIELD;
   const columns: SelectableValue[] = (props.fieldsList || [])
-    .filter((f) => f.type.toLowerCase() === 'datetime' || f.type.toLowerCase() === 'date')
+    .filter((f) => f.type.toLowerCase().startsWith('date'))
     .map((f) => ({ label: f.label, value: f.name }));
   const getColumnType = (columnName: string): string => {
     const matchedColumn = props.fieldsList.find((f) => f.name === columnName);


### PR DESCRIPTION
fixes #118 
This will also make [Date32](https://clickhouse.com/docs/en/sql-reference/data-types/date32) usable for the time field.
I am using `startsWith()` instead of exact matching because the `DateTime64` includes its precision level in the `type` like this: `DateTime64(3)`