### PR TITLE
Macros: Don't use 0 interval in $__timeInterval macro

### DIFF
--- a/pkg/macros/macros.go
+++ b/pkg/macros/macros.go
@@ -3,6 +3,7 @@ package macros
 import (
 	"errors"
 	"fmt"
+	"math"
 	"strings"
 	"time"
 
@@ -75,7 +76,7 @@ func TimeInterval(query *sqlds.Query, args []string) (string, error) {
 		return "", fmt.Errorf("%w: expected 1 argument, received %d", sqlds.ErrorBadArgumentCount, len(args))
 	}
 
-	seconds := query.Interval.Seconds()
+	seconds := math.Max(query.Interval.Seconds(), 1)
 	return fmt.Sprintf("toStartOfInterval(toDateTime(%s), INTERVAL %d second)", args[0], int(seconds)), nil
 }
 


### PR DESCRIPTION
Since we currently only support an integer number of seconds, the right solution is to always pick at least 1 second. The value 0 will never work.

Fixes https://github.com/grafana/clickhouse-datasource/issues/138