### PR TITLE
fix fetchFieldsFull when default database name is provided

### DIFF
--- a/src/data/CHDatasource.test.ts
+++ b/src/data/CHDatasource.test.ts
@@ -216,4 +216,32 @@ describe('ClickHouseDatasource', () => {
       expect(val).toEqual(`select stuff from table where fieldVal in ($fieldVal) and 1=1;`);
     });
   });
+
+  describe('fetchFieldsFull', () => {
+    it('sends a correct query when database and table names are provided', async () => {
+      const ds = cloneDeep(mockDatasource);
+      const frame = new ArrayDataFrame([{ name: 'foo', type: 'string', table: 'table' }]);
+      const spyOnQuery = jest.spyOn(ds, 'query').mockImplementation((request) => of({ data: [frame] }));
+
+      await ds.fetchFieldsFull('db_name', 'table_name');
+      const expected = { rawSql: 'DESC TABLE db_name.table_name' };
+
+      expect(spyOnQuery).toHaveBeenCalledWith(
+        expect.objectContaining({ targets: expect.arrayContaining([expect.objectContaining(expected)]) })
+      );
+    });
+
+    it('sends a correct query when only table name is provided', async () => {
+      const ds = cloneDeep(mockDatasource);
+      const frame = new ArrayDataFrame([{ name: 'foo', type: 'string', table: 'table' }]);
+      const spyOnQuery = jest.spyOn(ds, 'query').mockImplementation((request) => of({ data: [frame] }));
+
+      await ds.fetchFieldsFull('', 'table_name');
+      const expected = { rawSql: 'DESC TABLE table_name' };
+
+      expect(spyOnQuery).toHaveBeenCalledWith(
+        expect.objectContaining({ targets: expect.arrayContaining([expect.objectContaining(expected)]) })
+      );
+    });
+  });
 });

--- a/src/data/CHDatasource.ts
+++ b/src/data/CHDatasource.ts
@@ -161,9 +161,9 @@ export class Datasource extends DataSourceWithBackend<CHQuery, CHConfig> {
     return this.fetchData(`DESC TABLE ${database}.${table}`);
   }
 
-  async fetchFieldsFull(database: string, table: string): Promise<FullField[]> {
-    const sep = database === '' ? '' : '.';
-    const rawSql = `DESC TABLE ${database}${sep}${table}`;
+  async fetchFieldsFull(database: string | undefined, table: string): Promise<FullField[]> {
+    const prefix = Boolean(database) ? `${database}.` : '';
+    const rawSql = `DESC TABLE ${prefix}${table}`;
     const frame = await this.runQuery({ rawSql });
     if (frame.fields?.length === 0) {
       return [];


### PR DESCRIPTION
fix https://github.com/grafana/clickhouse-datasource/issues/155

builder doesn't have `database` field if no db was picked in UI https://github.com/grafana/clickhouse-datasource/blob/e4a63f48ce5a3a98e0ce577dc94fa913df2aa6a6/src/components/queryBuilder/QueryBuilder.tsx#L68

