### PR TITLE
use gzip for http

### DIFF
--- a/pkg/plugin/driver.go
+++ b/pkg/plugin/driver.go
@@ -105,6 +105,10 @@ func (h *Clickhouse) Connect(config backend.DataSourceInstanceSettings, message 
 	if settings.Protocol == "http" {
 		protocol = clickhouse.HTTP
 	}
+	compression := clickhouse.CompressionLZ4
+	if protocol == clickhouse.HTTP {
+		compression = clickhouse.CompressionGZIP
+	}
 	db := clickhouse.OpenDB(&clickhouse.Options{
 		TLS:  tlsConfig,
 		Addr: []string{fmt.Sprintf("%s:%d", settings.Server, settings.Port)},
@@ -114,7 +118,7 @@ func (h *Clickhouse) Connect(config backend.DataSourceInstanceSettings, message 
 			Database: settings.DefaultDatabase,
 		},
 		Compression: &clickhouse.Compression{
-			Method: clickhouse.CompressionLZ4,
+			Method: compression,
 		},
 		DialTimeout: time.Duration(t) * time.Second,
 		ReadTimeout: time.Duration(qt) * time.Second,


### PR DESCRIPTION
closes https://github.com/grafana/clickhouse-datasource/issues/217
closes https://github.com/grafana/clickhouse-datasource/issues/206

Currently, we use lz4 compression irrespective of the protocol. There is an issue in the go client (which ill PR) which means errors over HTTP aren't decompressed if they are compressed with LZ4 - preventing them from being shown to the user. Whilst we'll fix this in the client, we should really use gzip over HTTP - its a standard and is more likely to be proxy friendly.