### PR TITLE
Fix: Allow custom filter values for fields with Map type in query builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.4
+
+**Fix** - Query builder: allow custom filter values for fields with [`Map`](https://clickhouse.com/docs/en/sql-reference/data-types/map/) type
+
 ## 2.0.3
 
 **Chore** - Backend binaries compiled with latest go version 1.19.3

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clickhouse-datasource",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Clickhouse Datasource",
   "scripts": {
     "spellcheck": "cspell -c cspell.config.json \"**/*.{ts,tsx,js,go,md,mdx,yml,yaml,json,scss,css}\"",

--- a/src/components/queryBuilder/Filters.test.tsx
+++ b/src/components/queryBuilder/Filters.test.tsx
@@ -94,6 +94,87 @@ describe('FiltersEditor', () => {
       );
       expect(result.container.firstChild).not.toBeNull();
     });
+    it('should have all provided fields in the select', () => {
+      const result = render(
+        <FilterEditor
+          fieldsList={[
+            { label: 'col1', name: 'col1', type: 'string', picklistValues: [] },
+            { label: 'col2', name: 'col2', type: 'string', picklistValues: [] },
+            { label: 'col3', name: 'col3', type: 'string', picklistValues: [] },
+          ]}
+          filter={{
+            key: 'foo',
+            operator: FilterOperator.IsNotNull,
+            type: 'boolean',
+            condition: 'AND',
+            filterType: 'custom',
+          }}
+          index={0}
+          onFilterChange={() => {}}
+        />
+      );
+
+      // expand the `fieldName` select box
+      userEvent.type(result.getAllByRole('combobox')[0], '{ArrowDown}');
+
+      expect(result.getByText('col1')).toBeInTheDocument();
+      expect(result.getByText('col2')).toBeInTheDocument();
+      expect(result.getByText('col3')).toBeInTheDocument();
+    });
+    it('should call onFilterChange when user adds correct custom filter for the field with Map type', () => {
+      const onFilterChange = jest.fn();
+      const result = render(
+        <FilterEditor
+          fieldsList={[{ label: 'colName', name: 'colName', type: 'Map(String, UInt64)', picklistValues: [] }]}
+          filter={{
+            key: 'foo',
+            type: 'boolean',
+            operator: FilterOperator.IsNotNull,
+            condition: 'AND',
+            filterType: 'custom',
+          }}
+          index={0}
+          onFilterChange={onFilterChange}
+        />
+      );
+
+      // type into the `fieldName` select box
+      userEvent.type(result.getAllByRole('combobox')[0], `colName[['keyName']`);
+      userEvent.keyboard('{Enter}');
+
+      const expectedFilter: Filter = {
+        key: `colName['keyName']`,
+        type: 'UInt64',
+        operator: FilterOperator.IsNotNull,
+        condition: 'AND',
+        filterType: 'custom',
+      };
+
+      expect(onFilterChange).toHaveBeenCalledWith(0, expectedFilter);
+    });
+    it('should not call onFilterChange when user adds incorrect custom filter', async () => {
+      const onFilterChange = jest.fn();
+      const result = render(
+        <FilterEditor
+          fieldsList={[{ label: 'mapField', name: 'mapField', type: 'Map(String, UInt64)', picklistValues: [] }]}
+          filter={{
+            key: 'foo',
+            type: 'boolean',
+            operator: FilterOperator.IsNotNull,
+            condition: 'AND',
+            filterType: 'custom',
+          }}
+          index={0}
+          onFilterChange={onFilterChange}
+        />
+      );
+
+      // type into the `fieldName` select box
+      userEvent.type(result.getAllByRole('combobox')[0], `mapField__key`);
+      userEvent.keyboard('{Enter}');
+
+      expect(onFilterChange).not.toHaveBeenCalled();
+    });
   });
   describe('FilterValueEditor', () => {
     it('should render nothing for null operator', () => {


### PR DESCRIPTION
Fixes #156.
Because of the inner logic it was not possible to add a custom filter for the fields with [Map](https://clickhouse.com/docs/en/sql-reference/data-types/map/) type.

![image](https://user-images.githubusercontent.com/1436174/204479520-b421cf52-f816-43cd-980a-afd8401c4a2b.png)