### PR TITLE
fix: Allow default protocol toggle value when saving in settings

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,16 @@
+name: Add issue to project
+
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  add-to-project:
+    name: Add issue to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@main
+        with:
+          project-url: https://github.com/orgs/grafana/projects/55
+          github-token: ${{ secrets.GH_BOT_ACCESS_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.5
+
+**Fix** - fix: Allow default protocol toggle value when saving in settings
+
 ## 2.0.4
 
 **Fix** - Query builder: allow custom filter values for fields with [`Map`](https://clickhouse.com/docs/en/sql-reference/data-types/map/) type

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clickhouse-datasource",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Clickhouse Datasource",
   "scripts": {
     "spellcheck": "cspell -c cspell.config.json \"**/*.{ts,tsx,js,go,md,mdx,yml,yaml,json,scss,css}\"",

--- a/pkg/plugin/settings.go
+++ b/pkg/plugin/settings.go
@@ -51,6 +51,9 @@ func LoadSettings(config backend.DataSourceInstanceSettings) (settings Settings,
 	if strings.TrimSpace(settings.QueryTimeout) == "" {
 		settings.QueryTimeout = "60"
 	}
+	if settings.Protocol == "" {
+		settings.Protocol = "native"
+	}
 	val, ok := config.DecryptedSecureJSONData["password"]
 	if !ok {
 		return settings, settings.isValid()
@@ -67,9 +70,6 @@ func LoadSettings(config backend.DataSourceInstanceSettings) (settings Settings,
 	tlsClientKey, ok := config.DecryptedSecureJSONData["tlsClientKey"]
 	if ok {
 		settings.TlsClientKey = tlsClientKey
-	}
-	if settings.Protocol == "" {
-		settings.Protocol = "native"
 	}
 	return settings, settings.isValid()
 }

--- a/pkg/plugin/settings.go
+++ b/pkg/plugin/settings.go
@@ -34,9 +34,6 @@ func (settings *Settings) isValid() (err error) {
 	if settings.Port == 0 {
 		return ErrorMessageInvalidPort
 	}
-	if settings.Protocol != "http" && settings.Protocol != "native" {
-		return ErrorMessageInvalidProtocol
-	}
 	return nil
 }
 
@@ -51,14 +48,10 @@ func LoadSettings(config backend.DataSourceInstanceSettings) (settings Settings,
 	if strings.TrimSpace(settings.QueryTimeout) == "" {
 		settings.QueryTimeout = "60"
 	}
-	if settings.Protocol == "" {
-		settings.Protocol = "native"
+	password, ok := config.DecryptedSecureJSONData["password"]
+	if ok {
+		settings.Password = password
 	}
-	val, ok := config.DecryptedSecureJSONData["password"]
-	if !ok {
-		return settings, settings.isValid()
-	}
-	settings.Password = val
 	tlsCACert, ok := config.DecryptedSecureJSONData["tlsCACert"]
 	if ok {
 		settings.TlsCACert = tlsCACert

--- a/pkg/plugin/settings_test.go
+++ b/pkg/plugin/settings_test.go
@@ -43,7 +43,6 @@ func TestLoadSettings(t *testing.T) {
 					TlsClientKey:       "clientKey",
 					Timeout:            "10",
 					QueryTimeout:       "60",
-					Protocol:           "native",
 				},
 				wantErr: nil,
 			},


### PR DESCRIPTION
Fixes #245.

When creating data source, the default protocol toggle value is "Native". Allow user to keep it untouched (previously was needed to set to "HTTP" and then back to "Native" in order to make it work).

![image](https://user-images.githubusercontent.com/1436174/204834416-6a2af016-17ed-4f3e-a7e4-3e47fd0bdfc9.png)
