### PR TITLE
chore: update sqlds dependency to 2.3.18

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/docker/docker v20.10.20+incompatible
 	github.com/docker/go-units v0.5.0
 	github.com/grafana/grafana-plugin-sdk-go v0.144.0
-	github.com/grafana/sqlds/v2 v2.3.17
+	github.com/grafana/sqlds/v2 v2.3.18
 	github.com/pkg/errors v0.9.1
 	github.com/shopspring/decimal v1.3.1
 	github.com/stretchr/testify v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -561,8 +561,8 @@ github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoA
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/grafana/grafana-plugin-sdk-go v0.144.0 h1:NsuK9AKWeWBbuNREsF4hrLA3TnYPPpDJTqcPqm288aw=
 github.com/grafana/grafana-plugin-sdk-go v0.144.0/go.mod h1:dFof/7GenWBFTmrfcPRCpLau7tgIED0ykzupWAlB0o0=
-github.com/grafana/sqlds/v2 v2.3.17 h1:UAruTbnQn1oBpraRLDRcysCzGbTXTRvmeBnF8udpLx8=
-github.com/grafana/sqlds/v2 v2.3.17/go.mod h1:RezQgHKaM4oBl95knI9f0bokhNaFYS0SMFOeNQWnEy8=
+github.com/grafana/sqlds/v2 v2.3.18 h1:v1yE5Z4VOL51H2a6ahq22MW0QV8q9sBnwX1Hol6dMGo=
+github.com/grafana/sqlds/v2 v2.3.18/go.mod h1:RezQgHKaM4oBl95knI9f0bokhNaFYS0SMFOeNQWnEy8=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=


### PR DESCRIPTION
sqlds v2.3.18 contains this fix: https://github.com/grafana/sqlds/pull/79

Closes https://github.com/grafana/clickhouse-datasource/issues/253