### PR TITLE
Update go and dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.0.6
+
+**Chore** - Backend binaries compiled with latest go version 1.19.4
+**Chore** - Backend grafana dependencies updated
+
 ## 2.0.5
 
 **Chore** - update sqlds to 2.3.17 which fixes complex macro queries

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 **Chore** - Backend binaries compiled with latest go version 1.19.4
 **Chore** - Backend grafana dependencies updated to latest version
-**Chore** - Clickhouse dependency updated to latest version
+**Chore** - Clickhouse-go client updated to [v2.4.3](https://github.com/ClickHouse/clickhouse-go/blob/main/CHANGELOG.md#243-2022-11-30)
 
 ## 2.0.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 2.0.6
 
 **Chore** - Backend binaries compiled with latest go version 1.19.4
-**Chore** - Backend grafana dependencies updated
+**Chore** - Backend grafana dependencies updated to latest version
 
 ## 2.0.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 **Chore** - Backend binaries compiled with latest go version 1.19.4
 **Chore** - Backend grafana dependencies updated to latest version
+**Chore** - Clickhouse dependency updated to latest version
 
 ## 2.0.5
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/ClickHouse/clickhouse-go/v2 v2.4.3
 	github.com/docker/docker v20.10.21+incompatible
 	github.com/docker/go-units v0.5.0
-	github.com/grafana/grafana-plugin-sdk-go v0.145.0
+	github.com/grafana/grafana-plugin-sdk-go v0.147.0
 	github.com/grafana/sqlds/v2 v2.3.18
 	github.com/pkg/errors v0.9.1
 	github.com/shopspring/decimal v1.3.1

--- a/go.sum
+++ b/go.sum
@@ -560,8 +560,8 @@ github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB7
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
-github.com/grafana/grafana-plugin-sdk-go v0.145.0 h1:ZlRxxV3C6RA+wNWeGr+rLVD70pgsZwiLI9etzE0zu+Q=
-github.com/grafana/grafana-plugin-sdk-go v0.145.0/go.mod h1:dFof/7GenWBFTmrfcPRCpLau7tgIED0ykzupWAlB0o0=
+github.com/grafana/grafana-plugin-sdk-go v0.147.0 h1:VavvJOa/Ubs+wzalzWIl+FQmdaD4vEK8KVYU0a8rf+E=
+github.com/grafana/grafana-plugin-sdk-go v0.147.0/go.mod h1:NMgO3t2gR5wyLx8bWZ9CTmpDk5Txp4wYFccFLHdYn3Q=
 github.com/grafana/sqlds/v2 v2.3.18 h1:v1yE5Z4VOL51H2a6ahq22MW0QV8q9sBnwX1Hol6dMGo=
 github.com/grafana/sqlds/v2 v2.3.18/go.mod h1:RezQgHKaM4oBl95knI9f0bokhNaFYS0SMFOeNQWnEy8=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clickhouse-datasource",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "Clickhouse Datasource",
   "scripts": {
     "spellcheck": "cspell -c cspell.config.json \"**/*.{ts,tsx,js,go,md,mdx,yml,yaml,json,scss,css}\"",


### PR DESCRIPTION
Update go to the latest version (1.19.4) and update Grafana backend dependencies.