### PR TITLE
limit $__interval_s to at least 1 second

### DIFF
--- a/pkg/macros/macros.go
+++ b/pkg/macros/macros.go
@@ -94,7 +94,7 @@ func TimeInterval(query *sqlds.Query, args []string) (string, error) {
 }
 
 func IntervalSeconds(query *sqlds.Query, args []string) (string, error) {
-	seconds := query.Interval.Seconds()
+	seconds := math.Max(query.Interval.Seconds(), 1)
 	return fmt.Sprintf("%d", int(seconds)), nil
 }
 


### PR DESCRIPTION
This is the same behaviour as $__timeInterval