### PR TITLE
Add vscode profile for debugging jest

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,9 +8,7 @@
       "mode": "auto",
       "program": "${workspaceFolder}/pkg/",
       "env": {},
-      "args": [
-        "--standalone=true"
-      ]
+      "args": ["--standalone=true"]
     },
     {
       "name": "Debug in Container",
@@ -23,5 +21,15 @@
       "apiVersion": 1,
       "trace": "verbose"
     },
-  ],
-} 
+    {
+      "name": "Debug Jest test",
+      "type": "node",
+      "request": "launch",
+      "runtimeExecutable": "yarn",
+      "runtimeArgs": ["run", "jest", "--runInBand", "${file}"],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "port": 9229
+    }
+  ]
+}


### PR DESCRIPTION
One aspect of this I'm not clear on is a way to debug individual tests that are built via `testCondition`. Calling out to `testCondition` obviously breaks Jest's regex for detecting what tests to individually debug. Is there a way to configure this?
