### PR TITLE
fix: quote table names with dots

### DIFF
--- a/src/components/queryBuilder/utils.spec.ts
+++ b/src/components/queryBuilder/utils.spec.ts
@@ -82,27 +82,34 @@ describe('isNumberType', () => {
 });
 
 describe('Utils: getSQLFromQueryOptions and getQueryOptionsFromSql', () => {
-  testCondition('handles a table without a database', 'SELECT name FROM foo', {
+  testCondition('handles a table without a database', 'SELECT name FROM "foo"', {
     mode: BuilderMode.List,
     table: 'foo',
     fields: ['name'],
   });
 
-  testCondition('handles a database and a table', 'SELECT name FROM db.foo', {
+  testCondition('handles a database and a table', 'SELECT name FROM db."foo"', {
     mode: BuilderMode.List,
     database: 'db',
     table: 'foo',
     fields: ['name'],
   });
 
-  testCondition('handles 2 fields', 'SELECT field1, field2 FROM db.foo', {
+  testCondition('handles a database and a table with a dot', 'SELECT name FROM db."foo.bar"', {
+    mode: BuilderMode.List,
+    database: 'db',
+    table: 'foo.bar',
+    fields: ['name'],
+  });
+
+  testCondition('handles 2 fields', 'SELECT field1, field2 FROM db."foo"', {
     mode: BuilderMode.List,
     database: 'db',
     table: 'foo',
     fields: ['field1', 'field2'],
   });
 
-  testCondition('handles a limit', 'SELECT field1, field2 FROM db.foo LIMIT 20', {
+  testCondition('handles a limit', 'SELECT field1, field2 FROM db."foo" LIMIT 20', {
     mode: BuilderMode.List,
     database: 'db',
     table: 'foo',
@@ -112,7 +119,7 @@ describe('Utils: getSQLFromQueryOptions and getQueryOptionsFromSql', () => {
 
   testCondition(
     'handles empty orderBy array',
-    'SELECT field1, field2 FROM db.foo LIMIT 20',
+    'SELECT field1, field2 FROM db."foo" LIMIT 20',
     {
       mode: BuilderMode.List,
       database: 'db',
@@ -124,7 +131,7 @@ describe('Utils: getSQLFromQueryOptions and getQueryOptionsFromSql', () => {
     false
   );
 
-  testCondition('handles order by', 'SELECT field1, field2 FROM db.foo ORDER BY field1 ASC LIMIT 20', {
+  testCondition('handles order by', 'SELECT field1, field2 FROM db."foo" ORDER BY field1 ASC LIMIT 20', {
     mode: BuilderMode.List,
     database: 'db',
     table: 'foo',
@@ -146,7 +153,7 @@ describe('Utils: getSQLFromQueryOptions and getQueryOptionsFromSql', () => {
     false
   );
 
-  testCondition('handles aggregation function', 'SELECT sum(field1) FROM db.foo', {
+  testCondition('handles aggregation function', 'SELECT sum(field1) FROM db."foo"', {
     mode: BuilderMode.Aggregate,
     database: 'db',
     table: 'foo',
@@ -154,7 +161,7 @@ describe('Utils: getSQLFromQueryOptions and getQueryOptionsFromSql', () => {
     metrics: [{ field: 'field1', aggregation: BuilderMetricFieldAggregation.Sum }],
   });
 
-  testCondition('handles aggregation with alias', 'SELECT sum(field1) total_records FROM db.foo', {
+  testCondition('handles aggregation with alias', 'SELECT sum(field1) total_records FROM db."foo"', {
     mode: BuilderMode.Aggregate,
     database: 'db',
     table: 'foo',
@@ -164,7 +171,7 @@ describe('Utils: getSQLFromQueryOptions and getQueryOptionsFromSql', () => {
 
   testCondition(
     'handles 2 aggregations',
-    'SELECT sum(field1) total_records, count(field2) total_records2 FROM db.foo',
+    'SELECT sum(field1) total_records, count(field2) total_records2 FROM db."foo"',
     {
       mode: BuilderMode.Aggregate,
       table: 'foo',
@@ -179,7 +186,7 @@ describe('Utils: getSQLFromQueryOptions and getQueryOptionsFromSql', () => {
 
   testCondition(
     'handles aggregation with groupBy',
-    'SELECT field3, sum(field1) total_records, count(field2) total_records2 FROM db.foo GROUP BY field3',
+    'SELECT field3, sum(field1) total_records, count(field2) total_records2 FROM db."foo" GROUP BY field3',
     {
       mode: BuilderMode.Aggregate,
       table: 'foo',
@@ -196,7 +203,7 @@ describe('Utils: getSQLFromQueryOptions and getQueryOptionsFromSql', () => {
 
   testCondition(
     'handles aggregation with groupBy with fields having group by value',
-    'SELECT field3, sum(field1) total_records, count(field2) total_records2 FROM db.foo GROUP BY field3',
+    'SELECT field3, sum(field1) total_records, count(field2) total_records2 FROM db."foo" GROUP BY field3',
     {
       mode: BuilderMode.Aggregate,
       table: 'foo',
@@ -212,7 +219,7 @@ describe('Utils: getSQLFromQueryOptions and getQueryOptionsFromSql', () => {
 
   testCondition(
     'handles aggregation with group by and order by',
-    'SELECT StageName, Type, count(Id) count_of, sum(Amount) FROM db.foo GROUP BY StageName, Type ORDER BY count(Id) DESC, StageName ASC',
+    'SELECT StageName, Type, count(Id) count_of, sum(Amount) FROM db."foo" GROUP BY StageName, Type ORDER BY count(Id) DESC, StageName ASC',
     {
       mode: BuilderMode.Aggregate,
       database: 'db',
@@ -233,7 +240,7 @@ describe('Utils: getSQLFromQueryOptions and getQueryOptionsFromSql', () => {
 
   testCondition(
     'handles aggregation with a IN filter',
-    `SELECT count(id) FROM db.foo WHERE   ( stagename IN ('Deal Won', 'Deal Lost' ) )`,
+    `SELECT count(id) FROM db."foo" WHERE   ( stagename IN ('Deal Won', 'Deal Lost' ) )`,
     {
       mode: BuilderMode.Aggregate,
       database: 'db',
@@ -253,7 +260,7 @@ describe('Utils: getSQLFromQueryOptions and getQueryOptionsFromSql', () => {
 
   testCondition(
     'handles aggregation with a NOT IN filter',
-    `SELECT count(id) FROM db.foo WHERE   ( stagename NOT IN ('Deal Won', 'Deal Lost' ) )`,
+    `SELECT count(id) FROM db."foo" WHERE   ( stagename NOT IN ('Deal Won', 'Deal Lost' ) )`,
     {
       mode: BuilderMode.Aggregate,
       database: 'db',
@@ -273,7 +280,7 @@ describe('Utils: getSQLFromQueryOptions and getQueryOptionsFromSql', () => {
 
   testCondition(
     'handles aggregation with datetime filter',
-    `SELECT count(id) FROM db.foo WHERE   ( createddate  >= $__fromTime AND createddate <= $__toTime )`,
+    `SELECT count(id) FROM db."foo" WHERE   ( createddate  >= $__fromTime AND createddate <= $__toTime )`,
     {
       mode: BuilderMode.Aggregate,
       database: 'db',
@@ -292,7 +299,7 @@ describe('Utils: getSQLFromQueryOptions and getQueryOptionsFromSql', () => {
 
   testCondition(
     'handles aggregation with date filter',
-    `SELECT count(id) FROM db.foo WHERE   (  NOT ( closedate  >= $__fromTime AND closedate <= $__toTime ) )`,
+    `SELECT count(id) FROM db."foo" WHERE   (  NOT ( closedate  >= $__fromTime AND closedate <= $__toTime ) )`,
     {
       mode: BuilderMode.Aggregate,
       database: 'db',
@@ -311,7 +318,7 @@ describe('Utils: getSQLFromQueryOptions and getQueryOptionsFromSql', () => {
 
   testCondition(
     'handles timeseries function with "timeFieldType: DateType"',
-    'SELECT $__timeInterval(time) as time FROM db.foo WHERE $__timeFilter(time) GROUP BY time ORDER BY time ASC',
+    'SELECT $__timeInterval(time) as time FROM db."foo" WHERE $__timeFilter(time) GROUP BY time ORDER BY time ASC',
     {
       mode: BuilderMode.Trend,
       database: 'db',
@@ -327,7 +334,7 @@ describe('Utils: getSQLFromQueryOptions and getQueryOptionsFromSql', () => {
 
   testCondition(
     'handles timeseries function with "timeFieldType: DateType" with a filter',
-    'SELECT $__timeInterval(time) as time FROM db.foo WHERE $__timeFilter(time) AND   ( base IS NOT NULL ) GROUP BY time ORDER BY time ASC',
+    'SELECT $__timeInterval(time) as time FROM db."foo" WHERE $__timeFilter(time) AND   ( base IS NOT NULL ) GROUP BY time ORDER BY time ASC',
     {
       mode: BuilderMode.Trend,
       database: 'db',

--- a/src/components/queryBuilder/utils.ts
+++ b/src/components/queryBuilder/utils.ts
@@ -74,9 +74,9 @@ export const isMultiFilter = (filter: Filter): filter is MultiFilter => {
 };
 
 const getListQuery = (database = '', table = '', fields: string[] = []): string => {
-  const sep = database === '' || table === '' ? '' : '.';
+  const sep = database === ''  || table === '' ? '' : '.';
   fields = fields && fields.length > 0 ? fields : [''];
-  return `SELECT ${fields.join(', ')} FROM ${database}${sep}${table}`;
+  return `SELECT ${fields.join(', ')} FROM ${database}${sep}${escapedTableName(table)}`;
 };
 
 const getAggregationQuery = (
@@ -99,7 +99,7 @@ const getAggregationQuery = (
   const sep = database === '' || table === '' ? '' : '.';
   return `SELECT ${selected}${selected && (groupByQuery || metricsQuery) ? ', ' : ''}${groupByQuery}${
     metricsQuery && groupByQuery ? ', ' : ''
-  }${metricsQuery} FROM ${database}${sep}${table}`;
+  }${metricsQuery} FROM ${database}${sep}${escapedTableName(table)}`;
 };
 
 const getTrendByQuery = (
@@ -129,7 +129,7 @@ const getTrendByQuery = (
   }
 
   const sep = database === '' || table === '' ? '' : '.';
-  return `SELECT ${metricsQuery} FROM ${database}${sep}${table}`;
+  return `SELECT ${metricsQuery} FROM ${database}${sep}${escapedTableName(table)}`;
 };
 
 const getFilters = (filters: Filter[]): string => {
@@ -569,6 +569,10 @@ function formatStringValue(currentFilter: string): string {
     return ` ${currentFilter || ''}`;
   }
   return ` '${currentFilter || ''}'`;
+}
+
+function escapedTableName(table: string) {
+  return table === '' ? '' : `"${table}"`;
 }
 
 export const operMap = new Map<string, FilterOperator>([

--- a/src/components/queryBuilder/utils.ts
+++ b/src/components/queryBuilder/utils.ts
@@ -74,7 +74,7 @@ export const isMultiFilter = (filter: Filter): filter is MultiFilter => {
 };
 
 const getListQuery = (database = '', table = '', fields: string[] = []): string => {
-  const sep = database === ''  || table === '' ? '' : '.';
+  const sep = database === '' || table === '' ? '' : '.';
   fields = fields && fields.length > 0 ? fields : [''];
   return `SELECT ${fields.join(', ')} FROM ${database}${sep}${escapedTableName(table)}`;
 };

--- a/src/data/CHDatasource.test.ts
+++ b/src/data/CHDatasource.test.ts
@@ -225,7 +225,7 @@ describe('ClickHouseDatasource', () => {
       const spyOnQuery = jest.spyOn(ds, 'query').mockImplementation((request) => of({ data: [frame] }));
 
       await ds.fetchFieldsFull('db_name', 'table_name');
-      const expected = { rawSql: 'DESC TABLE db_name.table_name' };
+      const expected = { rawSql: 'DESC TABLE db_name."table_name"' };
 
       expect(spyOnQuery).toHaveBeenCalledWith(
         expect.objectContaining({ targets: expect.arrayContaining([expect.objectContaining(expected)]) })
@@ -238,7 +238,20 @@ describe('ClickHouseDatasource', () => {
       const spyOnQuery = jest.spyOn(ds, 'query').mockImplementation((request) => of({ data: [frame] }));
 
       await ds.fetchFieldsFull('', 'table_name');
-      const expected = { rawSql: 'DESC TABLE table_name' };
+      const expected = { rawSql: 'DESC TABLE "table_name"' };
+
+      expect(spyOnQuery).toHaveBeenCalledWith(
+        expect.objectContaining({ targets: expect.arrayContaining([expect.objectContaining(expected)]) })
+      );
+    });
+
+    it('sends a correct query when table name contains a dot', async () => {
+      const ds = cloneDeep(mockDatasource);
+      const frame = new ArrayDataFrame([{ name: 'foo', type: 'string', table: 'table' }]);
+      const spyOnQuery = jest.spyOn(ds, 'query').mockImplementation((_) => of({ data: [frame] }));
+
+      await ds.fetchFieldsFull('', 'table.name');
+      const expected = { rawSql: 'DESC TABLE "table.name"' };
 
       expect(spyOnQuery).toHaveBeenCalledWith(
         expect.objectContaining({ targets: expect.arrayContaining([expect.objectContaining(expected)]) })

--- a/src/data/CHDatasource.ts
+++ b/src/data/CHDatasource.ts
@@ -160,12 +160,12 @@ export class Datasource extends DataSourceWithBackend<CHQuery, CHConfig> {
   }
 
   async fetchFields(database: string, table: string): Promise<string[]> {
-    return this.fetchData(`DESC TABLE ${database}.${table}`);
+    return this.fetchData(`DESC TABLE ${database}."${table}"`);
   }
 
   async fetchFieldsFull(database: string | undefined, table: string): Promise<FullField[]> {
     const prefix = Boolean(database) ? `${database}.` : '';
-    const rawSql = `DESC TABLE ${prefix}${table}`;
+    const rawSql = `DESC TABLE ${prefix}"${table}"`;
     const frame = await this.runQuery({ rawSql });
     if (frame.fields?.length === 0) {
       return [];

--- a/src/data/ast.ts
+++ b/src/data/ast.ts
@@ -6,7 +6,7 @@ export function sqlToStatement(sql: string): Statement {
     name: string;
     replacementName: string;
   }> = [];
-  //default is a key word in this grammar but it can be used in CH
+  //default is a key word in this grammar, but it can be used in CH
   const re = /(\$__|\$|default)/gi;
   let regExpArray: RegExpExecArray | null;
   while ((regExpArray = re.exec(sql)) !== null) {
@@ -69,7 +69,7 @@ export function getTable(sql: string): string {
     case 'table': {
       const table = stm.from![0];
       const tableName = `${table.name.schema ? `${table.name.schema}.` : ''}${table.name.name}`;
-      // clickhouse table names are case sensitive and pgsql parser removes casing,
+      // clickhouse table names are case-sensitive and pgsql parser removes casing,
       // so we need to get the casing from the raw sql
       const s = new RegExp(`\\b${tableName}\\b`, 'gi').exec(sql);
       return s ? s[0] : tableName;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "@grafana/toolkit/src/config/tsconfig.plugin.json",
   "include": ["src", "types"],
   "compilerOptions": {
+    "jsx": "react",
     "rootDir": "./src",
     "baseUrl": "./src",
     "typeRoots": ["./node_modules/@types"]


### PR DESCRIPTION
* Resolves https://github.com/grafana/clickhouse-datasource/issues/232 - table names with dots work correctly now, as they are quoted with `""` now;
* Adds `"jsx": "react"` to `compilerOptions` in `tsconfig.json`, fixing WebStorm syntax highlighting issues.

I used @chenlujjj's [commit](https://github.com/chenlujjj/clickhouse-datasource/commit/c82391af7526b6adb039e7b5b267340790e6f7f8) as an example, though I opted for double-quote instead of a backtick to be compatible with `pgsql-ast-parser` library that is used in `ast.ts`, and added a couple more unit tests.