### PR TITLE
Add a predefined TimeRange filter if there is at least one DateTime* column

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,3 +14,14 @@ services:
       - TERM=linux
       - GF_DEFAULT_APP_MODE=development
       - GF_ENTERPRISE_LICENSE_TEXT=$GF_ENTERPRISE_LICENSE_TEXT
+
+  clickhouse:
+    image: 'clickhouse/clickhouse-server:${CLICKHOUSE_VERSION-23.1-alpine}'
+    container_name: 'grafana-clickhouse-server'
+    ports:
+      - '8123:8123'
+      - '9000:9000'
+    ulimits:
+      nofile:
+        soft: 262144
+        hard: 262144

--- a/src/components/queryBuilder/Filters.test.tsx
+++ b/src/components/queryBuilder/Filters.test.tsx
@@ -1,15 +1,12 @@
 import React from 'react';
-import { fireEvent, render, RenderResult } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { defaultNewFilter, FilterEditor, FiltersEditor, FilterValueEditor } from './Filters';
-import { selectors } from '../../selectors';
+import { selectors } from './../../selectors';
 import { BooleanFilter, DateFilter, Filter, FilterOperator, MultiFilter, NumberFilter, StringFilter } from 'types';
 
 describe('FiltersEditor', () => {
   describe('FiltersEditor', () => {
-    beforeAll(() => {
-      jest.resetAllMocks();
-    });
     it('renders correctly', () => {
       const onFiltersChange = jest.fn();
       const result = render(<FiltersEditor fieldsList={[]} filters={[]} onFiltersChange={onFiltersChange} />);
@@ -39,7 +36,12 @@ describe('FiltersEditor', () => {
         },
       ];
       const result = render(<FiltersEditor fieldsList={[]} filters={filters} onFiltersChange={() => {}} />);
-      assertRenderResultWithFilters(result, filters);
+      expect(result.container.firstChild).not.toBeNull();
+      expect(result.getAllByText(selectors.components.QueryEditor.QueryBuilder.WHERE.label).length).toBe(1);
+      expect(result.queryByTestId('query-builder-filters-add-button')).not.toBeInTheDocument();
+      expect(result.getByTestId('query-builder-filters-inline-add-button')).toBeInTheDocument();
+      expect(result.getAllByTestId('query-builder-filters-inline-add-button').length).toBe(1);
+      expect(result.getAllByTestId('query-builder-filters-remove-button').length).toBe(filters.length);
     });
     it('should call the onFiltersChange with correct args', () => {
       const filters: Filter[] = [
@@ -60,7 +62,12 @@ describe('FiltersEditor', () => {
       ];
       const onFiltersChange = jest.fn();
       const result = render(<FiltersEditor fieldsList={[]} filters={filters} onFiltersChange={onFiltersChange} />);
-      assertRenderResultWithFilters(result, filters);
+      expect(result.container.firstChild).not.toBeNull();
+      expect(result.getAllByText(selectors.components.QueryEditor.QueryBuilder.WHERE.label).length).toBe(1);
+      expect(result.queryByTestId('query-builder-filters-add-button')).not.toBeInTheDocument();
+      expect(result.getByTestId('query-builder-filters-inline-add-button')).toBeInTheDocument();
+      expect(result.getAllByTestId('query-builder-filters-inline-add-button').length).toBe(1);
+      expect(result.getAllByTestId('query-builder-filters-remove-button').length).toBe(filters.length);
       userEvent.click(result.getByTestId('query-builder-filters-inline-add-button'));
       expect(onFiltersChange).toBeCalledTimes(1);
       expect(onFiltersChange).toHaveBeenNthCalledWith(1, [...filters, defaultNewFilter]);
@@ -68,15 +75,6 @@ describe('FiltersEditor', () => {
       expect(onFiltersChange).toBeCalledTimes(2);
       expect(onFiltersChange).toHaveBeenNthCalledWith(2, [filters[1]]);
     });
-
-    function assertRenderResultWithFilters(result: RenderResult, filters: Filter[]) {
-      expect(result.container.firstChild).not.toBeNull();
-      expect(result.getAllByText(selectors.components.QueryEditor.QueryBuilder.WHERE.label).length).toBe(1);
-      expect(result.queryByTestId('query-builder-filters-add-button')).not.toBeInTheDocument();
-      expect(result.getByTestId('query-builder-filters-inline-add-button')).toBeInTheDocument();
-      expect(result.getAllByTestId('query-builder-filters-inline-add-button').length).toBe(1);
-      expect(result.getAllByTestId('query-builder-filters-remove-button').length).toBe(filters.length);
-    }
   });
   describe('FilterEditor', () => {
     it('renders correctly', () => {

--- a/src/components/queryBuilder/Filters.test.tsx
+++ b/src/components/queryBuilder/Filters.test.tsx
@@ -1,21 +1,18 @@
 import React from 'react';
 import { fireEvent, render, RenderResult } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { defaultNewFilter, FilterEditor, FiltersEditor, FilterValueEditor, PredefinedFilter } from './Filters';
+import { defaultNewFilter, FilterEditor, FiltersEditor, FilterValueEditor } from './Filters';
 import { selectors } from '../../selectors';
 import { BooleanFilter, DateFilter, Filter, FilterOperator, MultiFilter, NumberFilter, StringFilter } from 'types';
 
 describe('FiltersEditor', () => {
   describe('FiltersEditor', () => {
-    const tableName = 'my_table';
     beforeAll(() => {
       jest.resetAllMocks();
     });
     it('renders correctly', () => {
       const onFiltersChange = jest.fn();
-      const result = render(
-        <FiltersEditor fieldsList={[]} filters={[]} onFiltersChange={onFiltersChange} tableName={tableName} />
-      );
+      const result = render(<FiltersEditor fieldsList={[]} filters={[]} onFiltersChange={onFiltersChange} />);
       expect(result.container.firstChild).not.toBeNull();
       expect(result.getAllByText(selectors.components.QueryEditor.QueryBuilder.WHERE.label).length).toBe(1);
       expect(result.getByTestId('query-builder-filters-add-button')).toBeInTheDocument();
@@ -41,9 +38,7 @@ describe('FiltersEditor', () => {
           operator: FilterOperator.IsNotNull,
         },
       ];
-      const result = render(
-        <FiltersEditor fieldsList={[]} filters={filters} onFiltersChange={() => {}} tableName={tableName} />
-      );
+      const result = render(<FiltersEditor fieldsList={[]} filters={filters} onFiltersChange={() => {}} />);
       assertRenderResultWithFilters(result, filters);
     });
     it('should call the onFiltersChange with correct args', () => {
@@ -64,9 +59,7 @@ describe('FiltersEditor', () => {
         },
       ];
       const onFiltersChange = jest.fn();
-      const result = render(
-        <FiltersEditor fieldsList={[]} filters={filters} onFiltersChange={onFiltersChange} tableName={tableName} />
-      );
+      const result = render(<FiltersEditor fieldsList={[]} filters={filters} onFiltersChange={onFiltersChange} />);
       assertRenderResultWithFilters(result, filters);
       userEvent.click(result.getByTestId('query-builder-filters-inline-add-button'));
       expect(onFiltersChange).toBeCalledTimes(1);
@@ -74,38 +67,6 @@ describe('FiltersEditor', () => {
       userEvent.click(result.getAllByTestId('query-builder-filters-remove-button')[0]);
       expect(onFiltersChange).toBeCalledTimes(2);
       expect(onFiltersChange).toHaveBeenNthCalledWith(2, [filters[1]]);
-    });
-    it('should add a predefined TimeRange filter if we have at least one datetime column', async () => {
-      const onFiltersChange = jest.fn();
-      jest.useFakeTimers();
-      jest.spyOn(global, 'setTimeout');
-      const dateTimeField = { label: 'Created', name: 'created', type: 'datetime', picklistValues: [] };
-      const result = render(
-        <FiltersEditor
-          fieldsList={[
-            { label: 'col1', name: 'col1', type: 'string', picklistValues: [] },
-            { label: 'col2', name: 'col2', type: 'string', picklistValues: [] },
-            dateTimeField,
-          ]}
-          filters={[]}
-          onFiltersChange={onFiltersChange}
-          tableName={tableName}
-        />
-      );
-      const filters: Array<Filter & PredefinedFilter> = [
-        {
-          filterType: 'custom',
-          condition: 'AND',
-          key: 'created',
-          type: 'datetime',
-          operator: FilterOperator.WithInGrafanaTimeRange,
-          restrictToFields: [dateTimeField],
-        },
-      ];
-      jest.runAllTimers();
-      assertRenderResultWithFilters(result, filters);
-      expect(onFiltersChange).toBeCalledTimes(1);
-      expect(onFiltersChange).toHaveBeenNthCalledWith(1, [...filters]);
     });
 
     function assertRenderResultWithFilters(result: RenderResult, filters: Filter[]) {

--- a/src/components/queryBuilder/Filters.test.tsx
+++ b/src/components/queryBuilder/Filters.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { fireEvent, render, RenderResult } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { defaultNewFilter, FilterEditor, FiltersEditor, FilterValueEditor, RestrictedFilter } from './Filters';
+import { defaultNewFilter, FilterEditor, FiltersEditor, FilterValueEditor, PredefinedFilter } from './Filters';
 import { selectors } from '../../selectors';
 import { BooleanFilter, DateFilter, Filter, FilterOperator, MultiFilter, NumberFilter, StringFilter } from 'types';
 
@@ -92,7 +92,7 @@ describe('FiltersEditor', () => {
           tableName={tableName}
         />
       );
-      const filters: Array<Filter & RestrictedFilter> = [
+      const filters: Array<Filter & PredefinedFilter> = [
         {
           filterType: 'custom',
           condition: 'AND',
@@ -100,7 +100,6 @@ describe('FiltersEditor', () => {
           type: 'datetime',
           operator: FilterOperator.WithInGrafanaTimeRange,
           restrictToFields: [dateTimeField],
-          restrictToOperators: [FilterOperator.WithInGrafanaTimeRange],
         },
       ];
       jest.runAllTimers();

--- a/src/components/queryBuilder/Filters.tsx
+++ b/src/components/queryBuilder/Filters.tsx
@@ -45,9 +45,8 @@ export const defaultNewFilter: NullFilter = {
   type: 'id',
   operator: FilterOperator.IsNotNull,
 };
-export interface RestrictedFilter {
+export interface PredefinedFilter {
   restrictToFields?: FullField[];
-  restrictToOperators?: FilterOperator[];
 }
 
 const FilterValueNumberItem = (props: { value: number; onChange: (value: number) => void }) => {
@@ -169,7 +168,7 @@ export const FilterValueEditor = (props: {
 export const FilterEditor = (props: {
   fieldsList: FullField[];
   index: number;
-  filter: Filter & RestrictedFilter;
+  filter: Filter & PredefinedFilter;
   onFilterChange: (index: number, filter: Filter) => void;
 }) => {
   const { index, filter, fieldsList, onFilterChange } = props;
@@ -185,9 +184,7 @@ export const FilterEditor = (props: {
     return values;
   };
   const getFilterOperatorsByType = (type = 'string'): Array<SelectableValue<FilterOperator>> => {
-    if (filter.restrictToOperators !== undefined) {
-      return filterOperators.filter((f) => filter.restrictToOperators!.includes(f.value!));
-    } else if (utils.isBooleanType(type)) {
+    if (utils.isBooleanType(type)) {
       return filterOperators.filter((f) => [FilterOperator.Equals, FilterOperator.NotEquals].includes(f.value!));
     } else if (utils.isNumberType(type)) {
       return filterOperators.filter((f) =>
@@ -272,17 +269,16 @@ export const FilterEditor = (props: {
       return;
     }
 
-    let newFilter: Filter & RestrictedFilter;
+    let newFilter: Filter & PredefinedFilter;
     console.log('Composing new filter');
     // this is an auto-generated TimeRange filter
-    if (filter.restrictToFields && filter.restrictToOperators) {
+    if (filter.restrictToFields) {
       newFilter = {
         filterType: 'custom',
         key: filterData.key,
         type: 'datetime',
         condition: filter.condition || 'AND',
         operator: FilterOperator.WithInGrafanaTimeRange,
-        restrictToOperators: filter.restrictToOperators,
         restrictToFields: filter.restrictToFields,
       };
     } else if (utils.isBooleanType(filterData.type)) {
@@ -402,14 +398,13 @@ export const FiltersEditor = (props: {
   if (!timeRangeFilterState.wasSetOnce && filters.length === 0 && fieldsList.length > 0) {
     const dateTimeFields = fieldsList.filter((f) => isDateTimeType(f.type));
     if (dateTimeFields.length > 0) {
-      const filter: Filter & RestrictedFilter = {
+      const filter: Filter & PredefinedFilter = {
         operator: FilterOperator.WithInGrafanaTimeRange,
         filterType: 'custom',
         key: dateTimeFields[0].name,
         type: 'datetime',
         condition: 'AND',
         restrictToFields: dateTimeFields,
-        restrictToOperators: [FilterOperator.WithInGrafanaTimeRange],
       };
       filters.push(filter);
       updateTimeRangeFilterState({

--- a/src/components/queryBuilder/Filters.tsx
+++ b/src/components/queryBuilder/Filters.tsx
@@ -230,7 +230,6 @@ export const FilterEditor = (props: {
     }
   };
   const onFilterNameChange = (fieldName: string) => {
-    console.log(fieldName);
     setIsOpen(false);
     const matchingField = fieldsList.find((f) => f.name === fieldName);
     let filterData: { key: string; type: string } | null = null;
@@ -270,7 +269,6 @@ export const FilterEditor = (props: {
     }
 
     let newFilter: Filter & PredefinedFilter;
-    console.log('Composing new filter');
     // this is an auto-generated TimeRange filter
     if (filter.restrictToFields) {
       newFilter = {

--- a/src/components/queryBuilder/QueryBuilder.tsx
+++ b/src/components/queryBuilder/QueryBuilder.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import defaultsDeep from 'lodash/defaultsDeep';
 import { Datasource } from '../../data/CHDatasource';
 import { TableSelect } from './TableSelect';
@@ -8,18 +8,18 @@ import { MetricsEditor } from './Metrics';
 import { TimeFieldEditor } from './TimeField';
 import { FiltersEditor } from './Filters';
 import { GroupByEditor } from './GroupBy';
-import { OrderByEditor, getOrderByFields } from './OrderBy';
+import { getOrderByFields, OrderByEditor } from './OrderBy';
 import { LimitEditor } from './Limit';
 import {
-  SqlBuilderOptions,
-  defaultCHBuilderQuery,
-  OrderBy,
-  BuilderMode,
-  FullField,
-  Filter,
-  SqlBuilderOptionsTrend,
   BuilderMetricField,
-} from './../../types';
+  BuilderMode,
+  defaultCHBuilderQuery,
+  Filter,
+  FullField,
+  OrderBy,
+  SqlBuilderOptions,
+  SqlBuilderOptionsTrend,
+} from '../../types';
 import { DatabaseSelect } from './DatabaseSelect';
 import { isDateType } from './utils';
 
@@ -192,7 +192,12 @@ export const QueryBuilder = (props: QueryBuilderProps) => {
       {(builder.mode === BuilderMode.Aggregate || builder.mode === BuilderMode.Trend) && (
         <MetricsEditor metrics={builder.metrics || []} onMetricsChange={onMetricsChange} fieldsList={fieldsList} />
       )}
-      <FiltersEditor filters={builder.filters || []} onFiltersChange={onFiltersChange} fieldsList={fieldsList} />
+      <FiltersEditor
+        filters={builder.filters || []}
+        onFiltersChange={onFiltersChange}
+        fieldsList={fieldsList}
+        tableName={builder.table}
+      />
       {(builder.mode === BuilderMode.Aggregate || builder.mode === BuilderMode.Trend) && (
         <GroupByEditor groupBy={builder.groupBy || []} onGroupByChange={onGroupByChange} fieldsList={fieldsList} />
       )}

--- a/src/components/queryBuilder/utils.spec.ts
+++ b/src/components/queryBuilder/utils.spec.ts
@@ -1,5 +1,5 @@
 import { BuilderMetricFieldAggregation, BuilderMode, FilterOperator, OrderByDirection } from 'types';
-import { getQueryOptionsFromSql, getSQLFromQueryOptions, isDateType, isNumberType } from './utils';
+import { getQueryOptionsFromSql, getSQLFromQueryOptions, isDateTimeType, isDateType, isNumberType } from './utils';
 
 describe('isDateType', () => {
   it('returns true for Date type', () => {
@@ -39,6 +39,41 @@ describe('isDateType', () => {
   it('returns false for other types', () => {
     expect(isDateType('boolean')).toBe(false);
     expect(isDateType('Boolean')).toBe(false);
+  });
+});
+
+describe('isDateTimeType', () => {
+  it('returns true for DateTime type', () => {
+    expect(isDateTimeType('DateTime')).toBe(true);
+    expect(isDateTimeType('datetime')).toBe(true);
+  });
+  it('returns true for Nullable(DateTime) type', () => {
+    expect(isDateTimeType('Nullable(DateTime)')).toBe(true);
+  });
+  it('returns true for DateTime64 type', () => {
+    expect(isDateTimeType('DateTime64(3)')).toBe(true);
+    expect(isDateTimeType('datetime64(3)')).toBe(true);
+    expect(isDateTimeType("Datetime64(3, 'Asia/Istanbul')")).toBe(true);
+  });
+  it('returns true for Nullable(DateTime64(3)) type', () => {
+    expect(isDateTimeType('Nullable(DateTime64(3))')).toBe(true);
+    expect(isDateTimeType("Nullable(DateTime64(3, 'Asia/Istanbul'))")).toBe(true);
+  });
+  it('returns false for Date type', () => {
+    expect(isDateTimeType('Date')).toBe(false);
+    expect(isDateTimeType('date')).toBe(false);
+    expect(isDateTimeType('Date32')).toBe(false);
+    expect(isDateTimeType('date32')).toBe(false);
+  });
+  it('returns false for Nullable(Date) type', () => {
+    expect(isDateTimeType('Nullable(Date)')).toBe(false);
+    expect(isDateTimeType('Nullable(Date32)')).toBe(false);
+    expect(isDateTimeType('nullable(date)')).toBe(false);
+    expect(isDateTimeType('nullable(date32)')).toBe(false);
+  });
+  it('returns false for other types', () => {
+    expect(isDateTimeType('boolean')).toBe(false);
+    expect(isDateTimeType('String')).toBe(false);
   });
 });
 

--- a/src/components/queryBuilder/utils.ts
+++ b/src/components/queryBuilder/utils.ts
@@ -1,34 +1,34 @@
 import {
   astVisitor,
   Expr,
-  FromTable,
-  ExprRef,
-  SelectedColumn,
-  ExprString,
   ExprBinary,
-  ExprInteger,
-  ExprUnary,
   ExprCall,
+  ExprInteger,
   ExprList,
+  ExprRef,
+  ExprString,
+  ExprUnary,
+  FromTable,
+  SelectedColumn,
 } from 'pgsql-ast-parser';
 import { isString } from 'lodash';
 import {
+  BooleanFilter,
   BuilderMetricField,
+  BuilderMetricFieldAggregation,
   BuilderMode,
+  DateFilter,
+  DateFilterWithoutValue,
+  Filter,
+  FilterOperator,
+  MultiFilter,
+  NullFilter,
+  NumberFilter,
   OrderBy,
   SqlBuilderOptions,
-  Filter,
-  NullFilter,
-  BooleanFilter,
-  NumberFilter,
-  DateFilter,
-  StringFilter,
-  MultiFilter,
-  FilterOperator,
-  DateFilterWithoutValue,
-  BuilderMetricFieldAggregation,
   SqlBuilderOptionsAggregate,
   SqlBuilderOptionsTrend,
+  StringFilter,
 } from 'types';
 import { sqlToStatement } from 'data/ast';
 
@@ -44,7 +44,10 @@ export const isDateType = (type: string): boolean => {
   const normalizedName = type?.toLowerCase();
   return normalizedName?.startsWith('date') || normalizedName?.startsWith('nullable(date');
 };
-
+export const isDateTimeType = (type: string): boolean => {
+  const normalizedName = type?.toLowerCase();
+  return normalizedName?.startsWith('datetime') || normalizedName?.startsWith('nullable(datetime');
+};
 export const isStringType = (type: string): boolean => {
   return !(isBooleanType(type) || isNumberType(type) || isDateType(type));
 };


### PR DESCRIPTION
Demo: 

https://user-images.githubusercontent.com/3175289/220785466-ddedb45e-b80a-4f26-88af-dfc1f2236c83.mov

Full description:

There was a request from our users to restrict the query to the dashboard range automatically.

After some consideration, we decided to add a (removable) pre-defined filter that appears when we switch the tables if and only if we have at least one DateTime column. If we find some, the first DateTime column is picked, and we add the `WithInGrafanaTimeRange` filter automatically. 

What is interesting about this filter is that the column selection there is restricted to DateTime (could be also *64 or Nullable) types only, so it is convenient to switch to another column if we failed to pick the right one, and the type of the filter is `WithInGrafanaTimeRange` by default.

If a user does not need this type of filter, they can delete it and just add another one.

I also added a convenience ClickHouse container to the `docker-compose.yml`.
