### PR TITLE
add timezone to a query

### DIFF
--- a/src/data/CHDatasource.ts
+++ b/src/data/CHDatasource.ts
@@ -8,6 +8,8 @@ import {
   ScopedVars,
   VariableModel,
   vectorator,
+  getTimeZone,
+  getTimeZoneInfo,
 } from '@grafana/data';
 import { DataSourceWithBackend, getTemplateSrv } from '@grafana/runtime';
 import { Observable } from 'rxjs';
@@ -184,11 +186,32 @@ export class Datasource extends DataSourceWithBackend<CHQuery, CHConfig> {
     return this.values(frame);
   }
 
+  private getTimezone(request: DataQueryRequest<CHQuery>): string | undefined {
+    // timezone specified in the time picker
+    if(request.timezone) return request.timezone;
+    // fall back to the local timezone
+    const localTimezoneInfo = getTimeZoneInfo(getTimeZone(), Date.now());
+    return localTimezoneInfo?.ianaName;
+  }
+
   query(request: DataQueryRequest<CHQuery>): Observable<DataQueryResponse> {
+    const targets = request.targets
+      // filters out queries disabled in UI
+      .filter((t) => t.hide !== true)
+      // attach timezone information
+      .map(t => {
+        return {
+          ...t,
+          meta: {
+            ...t.meta,
+            timezone: this.getTimezone(request)
+          }
+        }
+      });
+
     return super.query({
       ...request,
-      // filters out queries disabled in UI
-      targets: request.targets.filter((t) => t.hide !== true),
+      targets
     });
   }
 

--- a/src/data/CHDatasource.ts
+++ b/src/data/CHDatasource.ts
@@ -188,7 +188,9 @@ export class Datasource extends DataSourceWithBackend<CHQuery, CHConfig> {
 
   private getTimezone(request: DataQueryRequest<CHQuery>): string | undefined {
     // timezone specified in the time picker
-    if(request.timezone) return request.timezone;
+    if (request.timezone) {
+      return request.timezone;
+    }
     // fall back to the local timezone
     const localTimezoneInfo = getTimeZoneInfo(getTimeZone(), Date.now());
     return localTimezoneInfo?.ianaName;
@@ -199,19 +201,19 @@ export class Datasource extends DataSourceWithBackend<CHQuery, CHConfig> {
       // filters out queries disabled in UI
       .filter((t) => t.hide !== true)
       // attach timezone information
-      .map(t => {
+      .map((t) => {
         return {
           ...t,
           meta: {
             ...t.meta,
-            timezone: this.getTimezone(request)
-          }
-        }
+            timezone: this.getTimezone(request),
+          },
+        };
       });
 
     return super.query({
       ...request,
-      targets
+      targets,
     });
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,6 +45,7 @@ export interface CHSQLQuery extends DataQuery {
   queryType: QueryType.SQL;
   rawSql: string;
   meta?: {
+    timezone?: string;
     // meta fields to be used just for building builder options when migrating  back to QueryType.Builder
     builderOptions?: SqlBuilderOptions;
   };
@@ -57,6 +58,9 @@ export interface CHBuilderQuery extends DataQuery {
   rawSql: string;
   builderOptions: SqlBuilderOptions;
   format: Format;
+  meta?: {
+    timezone?: string;
+  }
 }
 
 export type CHQuery = CHSQLQuery | CHBuilderQuery;

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,7 +60,7 @@ export interface CHBuilderQuery extends DataQuery {
   format: Format;
   meta?: {
     timezone?: string;
-  }
+  };
 }
 
 export type CHQuery = CHSQLQuery | CHBuilderQuery;


### PR DESCRIPTION
Attaches `iana` name of timezone  to each query.
Part of https://github.com/grafana/clickhouse-datasource/issues/295. The backend side of the plugin will use the timezone information to adjust the offset for `time.Time` value.
the timeonze is received from `request: DataQueryRequest`, if `request` doesn't provide one, fall back to the local timezone
