### PR TITLE
[2.x] Bump clickhouse-go (added ProxyFromEnvironment support)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/grafana/clickhouse-datasource
 go 1.19
 
 require (
-	github.com/ClickHouse/clickhouse-go/v2 v2.8.1
+	github.com/ClickHouse/clickhouse-go/v2 v2.9.2
 	github.com/docker/docker v23.0.1+incompatible
 	github.com/docker/go-units v0.5.0
 	github.com/grafana/grafana-plugin-sdk-go v0.156.0

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/BurntSushi/toml v1.2.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbi
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/ClickHouse/ch-go v0.52.1 h1:nucdgfD1BDSHjbNaG3VNebonxJzD8fX8jbuBpfo5VY0=
 github.com/ClickHouse/ch-go v0.52.1/go.mod h1:B9htMJ0hii/zrC2hljUKdnagRBuLqtRG/GrU3jqCwRk=
-github.com/ClickHouse/clickhouse-go/v2 v2.8.1 h1:61qllxbiWXQAxZ1vqpdp+1q57LhecTmubJ7whEc7ZSg=
-github.com/ClickHouse/clickhouse-go/v2 v2.8.1/go.mod h1:teXfZNM90iQ99Jnuht+dxQXCuhDZ8nvvMoTJOFrcmcg=
+github.com/ClickHouse/clickhouse-go/v2 v2.9.2 h1:P9az39xLJGwdL+Bq04Qrcq0lJspTgGT0VD7ESouFOYg=
+github.com/ClickHouse/clickhouse-go/v2 v2.9.2/go.mod h1:teXfZNM90iQ99Jnuht+dxQXCuhDZ8nvvMoTJOFrcmcg=
 github.com/Microsoft/go-winio v0.5.2 h1:a9IhgEQBCUEk6QCdml9CiJGhAws+YwffDHEMp1VMrpA=
 github.com/Microsoft/go-winio v0.5.2/go.mod h1:WpS1mjBmmwHBEWmogvA2mj8546UReBk4v8QkMxJ6pZY=
 github.com/Microsoft/hcsshim v0.9.7 h1:mKNHW/Xvv1aFH87Jb6ERDzXTJTLPlmzfZ28VBFD/bfg=


### PR DESCRIPTION
See https://github.com/ClickHouse/clickhouse-go/pull/987

> I was investigating the Grafana data source issue (Cloud cannot be accessed via proxy) that boiled down to ignored HTTP_PROXY and HTTPS_PROXY env variables in the CH data source.

Now, the underlying driver should correctly load the env settings.