### PR TITLE
Ignore clickhouse go driver update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,5 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: "github.com/ClickHouse/clickhouse-go/v2"


### PR DESCRIPTION
Dependabot tries to downgrade the CH go driver. This will just ignore any updates for the driver