### PR TITLE
Bump Go version used in CI to 1.20

### DIFF
--- a/.github/workflows/run-backend-tests.yml
+++ b/.github/workflows/run-backend-tests.yml
@@ -10,7 +10,7 @@ on:
       - v1
       - main
   schedule:
-    - cron: "0 9 1 * *"
+    - cron: '0 9 1 * *'
 
 jobs:
   run:
@@ -19,7 +19,7 @@ jobs:
       fail-fast: true
       matrix:
         go:
-          - 1.19
+          - '1.20.x'
         clickhouse:
           - 22.3
           - 22.8
@@ -34,7 +34,6 @@ jobs:
       - name: Install Go ${{ matrix.go }}
         uses: actions/setup-go@v4.0.0
         with:
-          stable: false
           go-version: ${{ matrix.go }}
 
       - name: Build

--- a/.github/workflows/run-frontend-tests.yml
+++ b/.github/workflows/run-frontend-tests.yml
@@ -10,7 +10,7 @@ on:
       - v1
       - main
   schedule:
-    - cron: "0 9 1 * *"
+    - cron: '0 9 1 * *'
 
 jobs:
   run:
@@ -19,7 +19,7 @@ jobs:
       fail-fast: true
       matrix:
         go:
-          - 1.18.3 #pin to 1.18.3 for now due to https://github.com/ClickHouse/ch-go/issues/160
+          - '1.20.x'
 
     steps:
       - uses: actions/checkout@v3
@@ -38,13 +38,12 @@ jobs:
       - name: Install Go ${{ matrix.go }}
         uses: actions/setup-go@v4.0.0
         with:
-          stable: false
           go-version: ${{ matrix.go }}
 
       - name: Install yarn dependencies
         run: yarn install
         env:
-          NODE_OPTIONS: "--max_old_space_size=4096"
+          NODE_OPTIONS: '--max_old_space_size=4096'
 
       - name: Build
         run: go build -v ./...
@@ -52,4 +51,4 @@ jobs:
       - name: Build Frontend
         run: yarn build
         env:
-          NODE_OPTIONS: "--max_old_space_size=4096"
+          NODE_OPTIONS: '--max_old_space_size=4096'


### PR DESCRIPTION
This PR fixes an issue surfaced in #455, whereby the CI pipeline was failing due to using a mixture of Go 1.18/1.19. Dependency `grafana-plugin-sdk-go` now requires 1.20 due to the usage of `unsafe.StringData`.

This also fixes formatting inconsistencies, as well as removing the `stable: false` option, which does nothing.