### PR TITLE
Ensure databases, tables, and columns are escaped correctly 

### DIFF
--- a/src/components/queryBuilder/utils.spec.ts
+++ b/src/components/queryBuilder/utils.spec.ts
@@ -117,41 +117,41 @@ describe('isNumberType', () => {
 });
 
 describe('Utils: getSQLFromQueryOptions and getQueryOptionsFromSql', () => {
-  testCondition('handles a table without a database', 'SELECT name FROM "foo"', {
+  testCondition('handles a table without a database', 'SELECT "name" FROM "foo"', {
     mode: BuilderMode.List,
     table: 'foo',
     fields: ['name'],
   });
 
-  testCondition('handles a database with a special character', 'SELECT name FROM "foo-bar"."buzz"', {
+  testCondition('handles a database with a special character', 'SELECT "name" FROM "foo-bar"."buzz"', {
     mode: BuilderMode.List,
     database: 'foo-bar',
     table: 'buzz',
     fields: ['name'],
   });
 
-  testCondition('handles a database and a table', 'SELECT name FROM "db"."foo"', {
+  testCondition('handles a database and a table', 'SELECT "name" FROM "db"."foo"', {
     mode: BuilderMode.List,
     database: 'db',
     table: 'foo',
     fields: ['name'],
   });
 
-  testCondition('handles a database and a table with a dot', 'SELECT name FROM "db"."foo.bar"', {
+  testCondition('handles a database and a table with a dot', 'SELECT "name" FROM "db"."foo.bar"', {
     mode: BuilderMode.List,
     database: 'db',
     table: 'foo.bar',
     fields: ['name'],
   });
 
-  testCondition('handles 2 fields', 'SELECT field1, field2 FROM "db"."foo"', {
+  testCondition('handles 2 fields', 'SELECT "field1", "field2" FROM "db"."foo"', {
     mode: BuilderMode.List,
     database: 'db',
     table: 'foo',
     fields: ['field1', 'field2'],
   });
 
-  testCondition('handles a limit', 'SELECT field1, field2 FROM "db"."foo" LIMIT 20', {
+  testCondition('handles a limit', 'SELECT "field1", "field2" FROM "db"."foo" LIMIT 20', {
     mode: BuilderMode.List,
     database: 'db',
     table: 'foo',
@@ -161,7 +161,7 @@ describe('Utils: getSQLFromQueryOptions and getQueryOptionsFromSql', () => {
 
   testCondition(
     'handles empty orderBy array',
-    'SELECT field1, field2 FROM "db"."foo" LIMIT 20',
+    'SELECT "field1", "field2" FROM "db"."foo" LIMIT 20',
     {
       mode: BuilderMode.List,
       database: 'db',
@@ -173,7 +173,7 @@ describe('Utils: getSQLFromQueryOptions and getQueryOptionsFromSql', () => {
     false
   );
 
-  testCondition('handles order by', 'SELECT field1, field2 FROM "db"."foo" ORDER BY field1 ASC LIMIT 20', {
+  testCondition('handles order by', 'SELECT "field1", "field2" FROM "db"."foo" ORDER BY field1 ASC LIMIT 20', {
     mode: BuilderMode.List,
     database: 'db',
     table: 'foo',
@@ -190,6 +190,19 @@ describe('Utils: getSQLFromQueryOptions and getQueryOptionsFromSql', () => {
       database: 'db',
       table: '',
       fields: [],
+      metrics: [],
+    },
+    false
+  );
+
+  testCondition(
+    'does not escape * field',
+    'SELECT * FROM "db"',
+    {
+      mode: BuilderMode.Aggregate,
+      database: 'db',
+      table: '',
+      fields: ['*'],
       metrics: [],
     },
     false

--- a/src/components/queryBuilder/utils.spec.ts
+++ b/src/components/queryBuilder/utils.spec.ts
@@ -123,28 +123,35 @@ describe('Utils: getSQLFromQueryOptions and getQueryOptionsFromSql', () => {
     fields: ['name'],
   });
 
-  testCondition('handles a database and a table', 'SELECT name FROM db."foo"', {
+  testCondition('handles a database with a special character', 'SELECT name FROM "foo-bar"."buzz"', {
+    mode: BuilderMode.List,
+    database: 'foo-bar',
+    table: 'buzz',
+    fields: ['name'],
+  });
+
+  testCondition('handles a database and a table', 'SELECT name FROM "db"."foo"', {
     mode: BuilderMode.List,
     database: 'db',
     table: 'foo',
     fields: ['name'],
   });
 
-  testCondition('handles a database and a table with a dot', 'SELECT name FROM db."foo.bar"', {
+  testCondition('handles a database and a table with a dot', 'SELECT name FROM "db"."foo.bar"', {
     mode: BuilderMode.List,
     database: 'db',
     table: 'foo.bar',
     fields: ['name'],
   });
 
-  testCondition('handles 2 fields', 'SELECT field1, field2 FROM db."foo"', {
+  testCondition('handles 2 fields', 'SELECT field1, field2 FROM "db"."foo"', {
     mode: BuilderMode.List,
     database: 'db',
     table: 'foo',
     fields: ['field1', 'field2'],
   });
 
-  testCondition('handles a limit', 'SELECT field1, field2 FROM db."foo" LIMIT 20', {
+  testCondition('handles a limit', 'SELECT field1, field2 FROM "db"."foo" LIMIT 20', {
     mode: BuilderMode.List,
     database: 'db',
     table: 'foo',
@@ -154,7 +161,7 @@ describe('Utils: getSQLFromQueryOptions and getQueryOptionsFromSql', () => {
 
   testCondition(
     'handles empty orderBy array',
-    'SELECT field1, field2 FROM db."foo" LIMIT 20',
+    'SELECT field1, field2 FROM "db"."foo" LIMIT 20',
     {
       mode: BuilderMode.List,
       database: 'db',
@@ -166,7 +173,7 @@ describe('Utils: getSQLFromQueryOptions and getQueryOptionsFromSql', () => {
     false
   );
 
-  testCondition('handles order by', 'SELECT field1, field2 FROM db."foo" ORDER BY field1 ASC LIMIT 20', {
+  testCondition('handles order by', 'SELECT field1, field2 FROM "db"."foo" ORDER BY field1 ASC LIMIT 20', {
     mode: BuilderMode.List,
     database: 'db',
     table: 'foo',
@@ -177,7 +184,7 @@ describe('Utils: getSQLFromQueryOptions and getQueryOptionsFromSql', () => {
 
   testCondition(
     'handles no select',
-    'SELECT  FROM db',
+    'SELECT  FROM "db"',
     {
       mode: BuilderMode.Aggregate,
       database: 'db',
@@ -188,7 +195,7 @@ describe('Utils: getSQLFromQueryOptions and getQueryOptionsFromSql', () => {
     false
   );
 
-  testCondition('handles aggregation function', 'SELECT sum(field1) FROM db."foo"', {
+  testCondition('handles aggregation function', 'SELECT sum(field1) FROM "db"."foo"', {
     mode: BuilderMode.Aggregate,
     database: 'db',
     table: 'foo',
@@ -196,7 +203,7 @@ describe('Utils: getSQLFromQueryOptions and getQueryOptionsFromSql', () => {
     metrics: [{ field: 'field1', aggregation: BuilderMetricFieldAggregation.Sum }],
   });
 
-  testCondition('handles aggregation with alias', 'SELECT sum(field1) total_records FROM db."foo"', {
+  testCondition('handles aggregation with alias', 'SELECT sum(field1) total_records FROM "db"."foo"', {
     mode: BuilderMode.Aggregate,
     database: 'db',
     table: 'foo',
@@ -206,7 +213,7 @@ describe('Utils: getSQLFromQueryOptions and getQueryOptionsFromSql', () => {
 
   testCondition(
     'handles 2 aggregations',
-    'SELECT sum(field1) total_records, count(field2) total_records2 FROM db."foo"',
+    'SELECT sum(field1) total_records, count(field2) total_records2 FROM "db"."foo"',
     {
       mode: BuilderMode.Aggregate,
       table: 'foo',
@@ -221,7 +228,7 @@ describe('Utils: getSQLFromQueryOptions and getQueryOptionsFromSql', () => {
 
   testCondition(
     'handles aggregation with groupBy',
-    'SELECT field3, sum(field1) total_records, count(field2) total_records2 FROM db."foo" GROUP BY field3',
+    'SELECT field3, sum(field1) total_records, count(field2) total_records2 FROM "db"."foo" GROUP BY field3',
     {
       mode: BuilderMode.Aggregate,
       table: 'foo',
@@ -238,7 +245,7 @@ describe('Utils: getSQLFromQueryOptions and getQueryOptionsFromSql', () => {
 
   testCondition(
     'handles aggregation with groupBy with fields having group by value',
-    'SELECT field3, sum(field1) total_records, count(field2) total_records2 FROM db."foo" GROUP BY field3',
+    'SELECT field3, sum(field1) total_records, count(field2) total_records2 FROM "db"."foo" GROUP BY field3',
     {
       mode: BuilderMode.Aggregate,
       table: 'foo',
@@ -254,7 +261,7 @@ describe('Utils: getSQLFromQueryOptions and getQueryOptionsFromSql', () => {
 
   testCondition(
     'handles aggregation with group by and order by',
-    'SELECT StageName, Type, count(Id) count_of, sum(Amount) FROM db."foo" GROUP BY StageName, Type ORDER BY count(Id) DESC, StageName ASC',
+    'SELECT StageName, Type, count(Id) count_of, sum(Amount) FROM "db"."foo" GROUP BY StageName, Type ORDER BY count(Id) DESC, StageName ASC',
     {
       mode: BuilderMode.Aggregate,
       database: 'db',
@@ -275,7 +282,7 @@ describe('Utils: getSQLFromQueryOptions and getQueryOptionsFromSql', () => {
 
   testCondition(
     'handles aggregation with a IN filter',
-    `SELECT count(id) FROM db."foo" WHERE   ( stagename IN ('Deal Won', 'Deal Lost' ) )`,
+    `SELECT count(id) FROM "db"."foo" WHERE   ( stagename IN ('Deal Won', 'Deal Lost' ) )`,
     {
       mode: BuilderMode.Aggregate,
       database: 'db',
@@ -295,7 +302,7 @@ describe('Utils: getSQLFromQueryOptions and getQueryOptionsFromSql', () => {
 
   testCondition(
     'handles aggregation with a NOT IN filter',
-    `SELECT count(id) FROM db."foo" WHERE   ( stagename NOT IN ('Deal Won', 'Deal Lost' ) )`,
+    `SELECT count(id) FROM "db"."foo" WHERE   ( stagename NOT IN ('Deal Won', 'Deal Lost' ) )`,
     {
       mode: BuilderMode.Aggregate,
       database: 'db',
@@ -315,7 +322,7 @@ describe('Utils: getSQLFromQueryOptions and getQueryOptionsFromSql', () => {
 
   testCondition(
     'handles aggregation with datetime filter',
-    `SELECT count(id) FROM db."foo" WHERE   ( createddate  >= $__fromTime AND createddate <= $__toTime )`,
+    `SELECT count(id) FROM "db"."foo" WHERE   ( createddate  >= $__fromTime AND createddate <= $__toTime )`,
     {
       mode: BuilderMode.Aggregate,
       database: 'db',
@@ -334,7 +341,7 @@ describe('Utils: getSQLFromQueryOptions and getQueryOptionsFromSql', () => {
 
   testCondition(
     'handles aggregation with date filter',
-    `SELECT count(id) FROM db."foo" WHERE   (  NOT ( closedate  >= $__fromTime AND closedate <= $__toTime ) )`,
+    `SELECT count(id) FROM "db"."foo" WHERE   (  NOT ( closedate  >= $__fromTime AND closedate <= $__toTime ) )`,
     {
       mode: BuilderMode.Aggregate,
       database: 'db',
@@ -353,7 +360,7 @@ describe('Utils: getSQLFromQueryOptions and getQueryOptionsFromSql', () => {
 
   testCondition(
     'handles timeseries function with "timeFieldType: DateType"',
-    'SELECT $__timeInterval(time) as time FROM db."foo" WHERE $__timeFilter(time) GROUP BY time ORDER BY time ASC',
+    'SELECT $__timeInterval(time) as time FROM "db"."foo" WHERE $__timeFilter(time) GROUP BY time ORDER BY time ASC',
     {
       mode: BuilderMode.Trend,
       database: 'db',
@@ -369,7 +376,7 @@ describe('Utils: getSQLFromQueryOptions and getQueryOptionsFromSql', () => {
 
   testCondition(
     'handles timeseries function with "timeFieldType: DateType" with a filter',
-    'SELECT $__timeInterval(time) as time FROM db."foo" WHERE $__timeFilter(time) AND   ( base IS NOT NULL ) GROUP BY time ORDER BY time ASC',
+    'SELECT $__timeInterval(time) as time FROM "db"."foo" WHERE $__timeFilter(time) AND   ( base IS NOT NULL ) GROUP BY time ORDER BY time ASC',
     {
       mode: BuilderMode.Trend,
       database: 'db',

--- a/src/components/queryBuilder/utils.ts
+++ b/src/components/queryBuilder/utils.ts
@@ -79,7 +79,7 @@ export const isMultiFilter = (filter: Filter): filter is MultiFilter => {
 const getListQuery = (database = '', table = '', fields: string[] = []): string => {
   const sep = database === '' || table === '' ? '' : '.';
   fields = fields && fields.length > 0 ? fields : [''];
-  return `SELECT ${fields.join(', ')} FROM ${database}${sep}${escapedTableName(table)}`;
+  return `SELECT ${fields.join(', ')} FROM ${escaped(database)}${sep}${escaped(table)}`;
 };
 
 const getAggregationQuery = (
@@ -102,7 +102,7 @@ const getAggregationQuery = (
   const sep = database === '' || table === '' ? '' : '.';
   return `SELECT ${selected}${selected && (groupByQuery || metricsQuery) ? ', ' : ''}${groupByQuery}${
     metricsQuery && groupByQuery ? ', ' : ''
-  }${metricsQuery} FROM ${database}${sep}${escapedTableName(table)}`;
+  }${metricsQuery} FROM ${escaped(database)}${sep}${escaped(table)}`;
 };
 
 const getTrendByQuery = (
@@ -132,7 +132,7 @@ const getTrendByQuery = (
   }
 
   const sep = database === '' || table === '' ? '' : '.';
-  return `SELECT ${metricsQuery} FROM ${database}${sep}${escapedTableName(table)}`;
+  return `SELECT ${metricsQuery} FROM ${escaped(database)}${sep}${escaped(table)}`;
 };
 
 const getFilters = (filters: Filter[]): string => {
@@ -574,8 +574,8 @@ function formatStringValue(currentFilter: string): string {
   return ` '${currentFilter || ''}'`;
 }
 
-function escapedTableName(table: string) {
-  return table === '' ? '' : `"${table}"`;
+function escaped(object: string) {
+  return object === '' ? '' : `"${object}"`;
 }
 
 export const operMap = new Map<string, FilterOperator>([

--- a/src/components/queryBuilder/utils.ts
+++ b/src/components/queryBuilder/utils.ts
@@ -79,7 +79,7 @@ export const isMultiFilter = (filter: Filter): filter is MultiFilter => {
 const getListQuery = (database = '', table = '', fields: string[] = []): string => {
   const sep = database === '' || table === '' ? '' : '.';
   fields = fields && fields.length > 0 ? fields : [''];
-  return `SELECT ${fields.join(', ')} FROM ${escaped(database)}${sep}${escaped(table)}`;
+  return `SELECT ${escapedFields(fields).join(', ')} FROM ${escaped(database)}${sep}${escaped(table)}`;
 };
 
 const getAggregationQuery = (
@@ -576,6 +576,10 @@ function formatStringValue(currentFilter: string): string {
 
 function escaped(object: string) {
   return object === '' ? '' : `"${object}"`;
+}
+
+function escapedFields(fields: string[]) {
+  return fields.map((field) => (field === '*' ? field : escaped(field)));
 }
 
 export const operMap = new Map<string, FilterOperator>([

--- a/src/data/CHDatasource.test.ts
+++ b/src/data/CHDatasource.test.ts
@@ -245,7 +245,7 @@ describe('ClickHouseDatasource', () => {
       const frame = new ArrayDataFrame([{ name: 'foo', type: 'string', table: 'table' }]);
       const spyOnQuery = jest.spyOn(ds, 'query').mockImplementation((_request) => of({ data: [frame] }));
       await ds.fetchFieldsFull('db_name', 'table_name');
-      const expected = { rawSql: 'DESC TABLE db_name."table_name"' };
+      const expected = { rawSql: 'DESC TABLE "db_name"."table_name"' };
 
       expect(spyOnQuery).toHaveBeenCalledWith(
         expect.objectContaining({ targets: expect.arrayContaining([expect.objectContaining(expected)]) })
@@ -403,7 +403,7 @@ describe('ClickHouseDatasource', () => {
         });
         expect(result?.rawSql).toEqual(
           'SELECT toStartOfInterval("created_at", INTERVAL 1 DAY) AS time, count(*) logs ' +
-            'FROM default."logs" ' +
+            'FROM "default"."logs" ' +
             'GROUP BY toStartOfInterval("created_at", INTERVAL 1 DAY) AS time ' +
             'ORDER BY time ASC'
         );
@@ -423,7 +423,7 @@ describe('ClickHouseDatasource', () => {
             `sum(toString("level") IN ('trace','TRACE','Trace')) AS trace, ` +
             `sum(toString("level") IN ('unknown','UNKNOWN','Unknown')) AS unknown, ` +
             `toStartOfInterval("created_at", INTERVAL 1 DAY) AS time ` +
-            `FROM default."logs" ` +
+            `FROM "default"."logs" ` +
             `GROUP BY toStartOfInterval("created_at", INTERVAL 1 DAY) AS time ` +
             `ORDER BY time ASC`
         );

--- a/src/data/CHDatasource.ts
+++ b/src/data/CHDatasource.ts
@@ -361,7 +361,7 @@ export class Datasource
   }
 
   async fetchTables(db?: string): Promise<string[]> {
-    const rawSql = db ? `SHOW TABLES FROM ${db}` : 'SHOW TABLES';
+    const rawSql = db ? `SHOW TABLES FROM "${db}"` : 'SHOW TABLES';
     return this.fetchData(rawSql);
   }
 
@@ -370,11 +370,11 @@ export class Datasource
   }
 
   async fetchFields(database: string, table: string): Promise<string[]> {
-    return this.fetchData(`DESC TABLE ${database}."${table}"`);
+    return this.fetchData(`DESC TABLE "${database}"."${table}"`);
   }
 
   async fetchFieldsFull(database: string | undefined, table: string): Promise<FullField[]> {
-    const prefix = Boolean(database) ? `${database}.` : '';
+    const prefix = Boolean(database) ? `"${database}".` : '';
     const rawSql = `DESC TABLE ${prefix}"${table}"`;
     const frame = await this.runQuery({ rawSql });
     if (frame.fields?.length === 0) {


### PR DESCRIPTION
Databases, tables, or columns containing special characters must be escaped in order to be used correctly.

- Update tests

Fixes #450