### PR TITLE
Fix auto formatting by reverting to table correctly

### DIFF
--- a/src/components/editor.ts
+++ b/src/components/editor.ts
@@ -8,7 +8,7 @@ export const getFormat = (sql: string, selectedFormat: Format): Format => {
     // first field as "time" alias and requires at least 2 fields (time and metric)
     const selectList = getFields(sql);
     // if there are more than 2 fields, index 1 will be a ','
-    if (selectList.length > 2 && isString(selectList[0])) {
+    if (selectList.length >= 2 && isString(selectList[0])) {
       const firstProjection = selectList[0].trim().toLowerCase();
       if (firstProjection.endsWith('as time')) {
         return Format.TIMESERIES;

--- a/src/data/ast.test.ts
+++ b/src/data/ast.test.ts
@@ -1,0 +1,10 @@
+import { getFields } from './ast';
+
+describe('ast', () => {
+  describe('getFields', () => {
+    it('return 1 expression if statement does not have an alias', () => {
+      const stm = getFields(`select foo from bar`);
+      expect(stm.length).toBe(1)
+    });
+  });
+});

--- a/src/data/ast.ts
+++ b/src/data/ast.ts
@@ -1,4 +1,4 @@
-import { parseFirst, Statement, SelectFromStatement, astMapper, toSql } from 'pgsql-ast-parser';
+import { parseFirst, Statement, SelectFromStatement, astMapper, toSql, ExprRef } from 'pgsql-ast-parser';
 
 export function sqlToStatement(sql: string): Statement {
   const replaceFuncs: Array<{
@@ -87,5 +87,14 @@ export function getFields(sql: string): string[] {
   if (stm.type !== 'select' || !stm.columns?.length || stm.columns?.length <= 0) {
     return [];
   }
-  return stm.columns.map((x) => `${x.expr} as ${x.alias?.name}`);
+  
+  return stm.columns.map((x) => {
+    const exprName = (x.expr as ExprRef).name
+
+    if (x.alias !== undefined) {
+      return `${exprName} as ${x.alias?.name}`;
+    } else {
+      return `${exprName}`;
+    }
+  });
 }

--- a/src/views/CHQueryEditor.tsx
+++ b/src/views/CHQueryEditor.tsx
@@ -81,6 +81,14 @@ const CHEditorByType = (props: CHQueryEditorProps) => {
 export const CHQueryEditor = (props: CHQueryEditorProps) => {
   const { query, onChange, onRunQuery } = props;
 
+  React.useEffect(() => {
+    if (typeof query.selectedFormat === 'undefined' && query.queryType === QueryType.SQL) {
+      const selectedFormat = Format.AUTO;
+      const format = getFormat(query.rawSql, selectedFormat);
+      onChange({ ...query, selectedFormat, format });
+    }
+  }, [query, onChange]);
+
   const runQuery = () => {
     if (query.queryType === QueryType.SQL) {
       const format = getFormat(query.rawSql, query.selectedFormat);


### PR DESCRIPTION
The browser would crash if auto format was selected and a large query was run. We would incorrectly coerce the resulting data into a time-series and graph it even if it wasn't actually a timeseries query. 

This also fixes differences in execution between the Grafana run query button and the clickhouse run query button.

Fixes #467 