### PR TITLE
Allow for converting data returned from `SimpleAggregateFunction`

### DIFF
--- a/pkg/converters/converters.go
+++ b/pkg/converters/converters.go
@@ -42,6 +42,8 @@ var mapMatch, _ = regexp.Compile(`^Map\(.*\)`)
 
 var fixedStringMatch, _ = regexp.Compile(`^Nullable\(FixedString\(.*\)\)`)
 
+var simpleAggMatch, _ = regexp.Compile(`^SimpleAggregateFunction\(.*\)`)
+
 var Converters = map[string]Converter{
 	"Bool": {
 		scanType:  reflect.PtrTo(reflect.TypeOf(true)),
@@ -241,6 +243,12 @@ var Converters = map[string]Converter{
 		scanType:   reflect.PtrTo(reflect.PtrTo(reflect.TypeOf(net.IP{}))),
 		convert:    ipNullConverter,
 		matchRegex: ipNullableMatch,
+	},
+	"SimpleAggregateFunction()": {
+		fieldType:  data.FieldTypeNullableJSON,
+		scanType:   reflect.TypeOf((*interface{})(nil)).Elem(),
+		matchRegex: simpleAggMatch,
+		convert:    jsonConverter,
 	},
 }
 

--- a/pkg/converters/converters_test.go
+++ b/pkg/converters/converters_test.go
@@ -3,14 +3,15 @@ package converters_test
 import (
 	"encoding/json"
 	"errors"
-	"github.com/grafana/clickhouse-datasource/pkg/converters"
-	"github.com/shopspring/decimal"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"math/big"
 	"net"
 	"testing"
 	"time"
+
+	"github.com/grafana/clickhouse-datasource/pkg/converters"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDate(t *testing.T) {
@@ -572,4 +573,14 @@ func TestNullableIPv6ShouldBeNull(t *testing.T) {
 	v, err := ipConverter.FrameConverter.ConverterFunc(&value)
 	assert.Nil(t, err)
 	require.Nil(t, v)
+}
+
+func TestSimpleAggregateFunction(t *testing.T) {
+	value := [][]int{{1, 2, 3}, {1, 2, 3}}
+	aggConverter := converters.GetConverter("SimpleAggregateFunction()")
+	v, err := aggConverter.FrameConverter.ConverterFunc(&value)
+	assert.Nil(t, err)
+	msg, err := toJson(value)
+	assert.Nil(t, err)
+	assert.Equal(t, msg, *v.(*json.RawMessage))
 }

--- a/pkg/plugin/driver.go
+++ b/pkg/plugin/driver.go
@@ -263,7 +263,8 @@ func (h *Clickhouse) MutateQuery(ctx context.Context, req backend.DataQuery) (co
 // MutateResponse For any view other than traces we convert FieldTypeNullableJSON to string
 func (h *Clickhouse) MutateResponse(ctx context.Context, res data.Frames) (data.Frames, error) {
 	for _, frame := range res {
-		if frame.Meta.PreferredVisualization != data.VisType(data.VisTypeTrace) {
+		if frame.Meta.PreferredVisualization != data.VisType(data.VisTypeTrace) &&
+			frame.Meta.PreferredVisualization != data.VisType(data.VisTypeTable) {
 			var fields []*data.Field
 			for _, field := range frame.Fields {
 				values := make([]*string, field.Len())


### PR DESCRIPTION
Fixes #277.

This PR adds the ability to handle arrays of arrays returned by `SimpleAggregateFunction()`. It also modified the conditions for response mutation that was originally introduced in #332 to exclude tables.