### PR TITLE
Upgrade grafana-plugin-sdk-go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/ClickHouse/clickhouse-go/v2 v2.10.0
 	github.com/docker/docker v23.0.1+incompatible
 	github.com/docker/go-units v0.5.0
-	github.com/grafana/grafana-plugin-sdk-go v0.161.0
+	github.com/grafana/grafana-plugin-sdk-go v0.171.0
 	github.com/grafana/sqlds/v2 v2.5.0
 	github.com/pkg/errors v0.9.1
 	github.com/shopspring/decimal v1.3.1
@@ -90,7 +90,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.14.0 // indirect
 	github.com/prometheus/client_model v0.3.0 // indirect
-	github.com/prometheus/common v0.40.0 // indirect
+	github.com/prometheus/common v0.42.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/segmentio/asm v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -234,8 +234,8 @@ github.com/gopherjs/gopherjs v0.0.0-20181103185306-d547d1d9531e h1:JKmoR8x90Iww1
 github.com/gopherjs/gopherjs v0.0.0-20181103185306-d547d1d9531e/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
-github.com/grafana/grafana-plugin-sdk-go v0.161.0 h1:UjVjRGQ5cuT4Ok30qUeLW2OhQhx9Whuz9Oz/1KsBvVM=
-github.com/grafana/grafana-plugin-sdk-go v0.161.0/go.mod h1:dPhljkVno3Bg/ZYafMrR/BfYjtCRJD2hU2719Nl3QzM=
+github.com/grafana/grafana-plugin-sdk-go v0.171.0 h1:f4W4sTgm3zJzh5EewTORMoKax4PorCmNeqINzIZ0mJw=
+github.com/grafana/grafana-plugin-sdk-go v0.171.0/go.mod h1:SvYXsAQWSuV9TtHqXZJdOFCaC8G0q02U+IHWMTKIGIQ=
 github.com/grafana/sqlds/v2 v2.5.0 h1:hcE6jiMfAysG0auBXOWMGrspC5kFdIsc6+5JljNeSXU=
 github.com/grafana/sqlds/v2 v2.5.0/go.mod h1:Ob8v+p/MOW0EShjqW63P+qmL52LJ6DwnDJsdKoN8U6s=
 github.com/grpc-ecosystem/go-grpc-middleware v1.4.0 h1:UH//fgunKIs4JdUbpDl1VZCDaL56wXCB/5+wF6uHfaI=
@@ -371,8 +371,8 @@ github.com/prometheus/client_golang v1.14.0/go.mod h1:8vpkKitgIVNcqrRBWh1C4TIUQg
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/client_model v0.3.0 h1:UBgGFHqYdG/TPFD1B1ogZywDqEkwp3fBMvqdiQ7Xew4=
 github.com/prometheus/client_model v0.3.0/go.mod h1:LDGWKZIo7rky3hgvBe+caln+Dr3dPggB5dvjtD7w9+w=
-github.com/prometheus/common v0.40.0 h1:Afz7EVRqGg2Mqqf4JuF9vdvp1pi220m55Pi9T2JnO4Q=
-github.com/prometheus/common v0.40.0/go.mod h1:L65ZJPSmfn/UBWLQIHV7dBrKFidB/wPlF1y5TlSt9OE=
+github.com/prometheus/common v0.42.0 h1:EKsfXEYo4JpWMHH5cg+KOUWeuJSov1Id8zGR8eeI1YM=
+github.com/prometheus/common v0.42.0/go.mod h1:xBwqVerjNdUDjgODMpudtOMwlOwf2SaTr1yjz4b7Zbc=
 github.com/prometheus/procfs v0.8.0 h1:ODq8ZFEaYeCaZOJlZZdJA2AbQR98dSHSM1KW/You5mo=
 github.com/prometheus/procfs v0.8.0/go.mod h1:z7EfXMXOkbkqb9IINtpCn86r/to3BnA0uaxHdg830/4=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=

--- a/pkg/plugin/driver.go
+++ b/pkg/plugin/driver.go
@@ -160,8 +160,8 @@ func (h *Clickhouse) Connect(config backend.DataSourceInstanceSettings, message 
 		Settings:    customSettings,
 	}
 
-	if sdkproxy.SecureSocksProxyEnabled(settings.ProxyOptions) {
-		dialer, err := sdkproxy.NewSecureSocksProxyContextDialer(settings.ProxyOptions)
+	if sdkproxy.Cli.SecureSocksProxyEnabled(settings.ProxyOptions) {
+		dialer, err := sdkproxy.Cli.NewSecureSocksProxyContextDialer(settings.ProxyOptions)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/plugin/settings.go
+++ b/pkg/plugin/settings.go
@@ -166,24 +166,9 @@ func LoadSettings(config backend.DataSourceInstanceSettings) (settings Settings,
 		settings.TlsClientKey = tlsClientKey
 	}
 
-	// secure socks proxy setup
-	// username defaults to the datasource UID
-	if proxy.SecureSocksProxyEnabledOnDS(jsonData) {
-		proxyUser := config.UID
-		if v, exists := jsonData["secureSocksProxyUsername"]; exists {
-			proxyUser = v.(string)
-		}
-		proxyPass := ""
-		if v, exists := config.DecryptedSecureJSONData["secureSocksProxyPassword"]; exists {
-			proxyPass = v
-		}
-		settings.ProxyOptions = &proxy.Options{
-			Enabled: true,
-			Auth: &proxy.AuthOptions{
-				Username: proxyUser,
-				Password: proxyPass,
-			},
-		}
+	proxyOpts, err := config.ProxyOptions()
+	if err == nil {
+		settings.ProxyOptions = proxyOpts
 	}
 
 	return settings, settings.isValid()


### PR DESCRIPTION
This PR upgrades the grafana-plugin-sdk-go to the latest version. This version had a breaking change in how the proxy client is called, so that has been updated. Additionally, there is now a new function in the sdk that can be used to parse the proxy options