### PR TITLE
Use date.UnixMilli in newTimeFilter func

### DIFF
--- a/pkg/macros/macros.go
+++ b/pkg/macros/macros.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"math"
 	"strings"
-	"time"
 
 	"github.com/grafana/sqlds/v2"
 )
@@ -27,10 +26,7 @@ func newTimeFilter(queryType timeQueryType, query *sqlds.Query) (string, error) 
 	if queryType == timeQueryTypeTo {
 		date = query.TimeRange.To
 	}
-	millis := date.UnixNano() / int64(time.Millisecond)
-	// TODO - when drone pipeline supports go 1.17
-	// return fmt.Sprintf("toDateTime(intDiv(%d,1000))", date.UnixMilli()), nil
-	return fmt.Sprintf("toDateTime(intDiv(%d,1000))", millis), nil
+	return fmt.Sprintf("toDateTime(intDiv(%d,1000))", date.UnixMilli()), nil
 }
 
 // FromTimeFilter return time filter query based on grafana's timepicker's from time


### PR DESCRIPTION
Saw this in the code:

```
TODO - when drone pipeline supports go 1.17
```

As the pipeline supports 1.20, we can now safely fix this code.