### PR TITLE
Query Editor refactor

### DIFF
--- a/src/components/FormatSelect.tsx
+++ b/src/components/FormatSelect.tsx
@@ -1,48 +1,40 @@
 import React from 'react';
-import { InlineFormLabel, Select } from '@grafana/ui';
 import { selectors } from './../selectors';
 import { Format } from '../types';
-import { styles } from '../styles';
+import { InlineSelect } from '@grafana/experimental';
 
 export type Props = { format: Format; value?: string; onChange: (format: Format) => void };
 
 export const FormatSelect = (props: Props) => {
   const { onChange, format } = props;
-  const { label, tooltip, options: formatLabels } = selectors.components.QueryEditor.Format;
+  const { options: formatLabels } = selectors.components.QueryEditor.Format;
   return (
-    <div className="gf-form">
-      <InlineFormLabel width={8} className="query-keyword" tooltip={tooltip}>
-        {label}
-      </InlineFormLabel>
-      <Select<Format>
-        className={`width-8 ${styles.Common.inlineSelect}`}
-        onChange={(e) => onChange(e.value!)}
-        options={[
-          {
-            label: formatLabels.AUTO,
-            value: Format.AUTO,
-          },
-          {
-            label: formatLabels.TABLE,
-            value: Format.TABLE,
-          },
-          {
-            label: formatLabels.TIME_SERIES,
-            value: Format.TIMESERIES,
-          },
-          {
-            label: formatLabels.LOGS,
-            value: Format.LOGS,
-          },
-          {
-            label: formatLabels.TRACE,
-            value: Format.TRACE,
-          },
-        ]}
-        value={format}
-        menuPlacement={'bottom'}
-        allowCustomValue={false}
-      />
-    </div>
+    <InlineSelect
+      label="Format as"
+      options={[
+        {
+          label: formatLabels.AUTO,
+          value: Format.AUTO,
+        },
+        {
+          label: formatLabels.TABLE,
+          value: Format.TABLE,
+        },
+        {
+          label: formatLabels.TIME_SERIES,
+          value: Format.TIMESERIES,
+        },
+        {
+          label: formatLabels.LOGS,
+          value: Format.LOGS,
+        },
+        {
+          label: formatLabels.TRACE,
+          value: Format.TRACE,
+        },
+      ]}
+      value={format}
+      onChange={(e) => onChange(e.value!)}
+    />
   );
 };

--- a/src/components/QueryHeader.tsx
+++ b/src/components/QueryHeader.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { BuilderMode, CHQuery, Format, QueryType, CHBuilderQuery } from '../types';
+import { QueryTypeSwitcher } from 'components/QueryTypeSwitcher';
+import { FormatSelect } from '../components/FormatSelect';
+import { Button } from '@grafana/ui';
+import { getFormat } from 'components/editor';
+import { EditorHeader, FlexItem } from '@grafana/experimental';
+
+interface QueryHeaderProps {
+  query: CHQuery;
+  onChange: (query: CHQuery) => void;
+  onRunQuery: () => void;
+}
+
+export const QueryHeader = ({ query, onChange, onRunQuery }: QueryHeaderProps) => {
+  React.useEffect(() => {
+    if (typeof query.selectedFormat === 'undefined' && query.queryType === QueryType.SQL) {
+      const selectedFormat = Format.AUTO;
+      const format = getFormat(query.rawSql, selectedFormat);
+      onChange({ ...query, selectedFormat, format });
+    }
+  }, [query, onChange]);
+
+  const runQuery = () => {
+    if (query.queryType === QueryType.SQL) {
+      const format = getFormat(query.rawSql, query.selectedFormat);
+      if (format !== query.format) {
+        onChange({ ...query, format });
+      }
+    }
+    onRunQuery();
+  };
+
+  const onFormatChange = (selectedFormat: Format) => {
+    switch (query.queryType) {
+      case QueryType.SQL:
+        onChange({ ...query, format: getFormat(query.rawSql, selectedFormat), selectedFormat });
+      case QueryType.Builder:
+      default:
+        if (selectedFormat === Format.AUTO) {
+          let builderOptions = (query as CHBuilderQuery).builderOptions;
+          const format = builderOptions && builderOptions.mode === BuilderMode.Trend ? Format.TIMESERIES : Format.TABLE;
+          onChange({ ...query, format, selectedFormat });
+        } else {
+          onChange({ ...query, format: selectedFormat, selectedFormat });
+        }
+    }
+  };
+
+  return (
+    <EditorHeader>
+      <QueryTypeSwitcher query={query} onChange={onChange} />
+      <FlexItem grow={1} />
+      <Button variant="primary" icon="play" size="sm" onClick={runQuery}>
+        Run query
+      </Button>
+      <FormatSelect format={query.selectedFormat ?? Format.AUTO} onChange={onFormatChange} />
+    </EditorHeader>
+  );
+};

--- a/src/components/QueryTypeSwitcher.test.tsx
+++ b/src/components/QueryTypeSwitcher.test.tsx
@@ -8,20 +8,14 @@ const { options } = selectors.components.QueryEditor.Types;
 
 describe('QueryTypeSwitcher', () => {
   it('renders default query', () => {
-    const result = render(
-      <QueryTypeSwitcher query={{ refId: 'A' } as CHQuery} onChange={() => {}} onRunQuery={() => {}} />
-    );
+    const result = render(<QueryTypeSwitcher query={{ refId: 'A' } as CHQuery} onChange={() => {}} />);
     expect(result.container.firstChild).not.toBeNull();
     expect(result.getByLabelText(options.SQLEditor)).not.toBeChecked();
     expect(result.getByLabelText(options.QueryBuilder)).toBeChecked();
   });
   it('renders legacy query (query without query type)', () => {
     const result = render(
-      <QueryTypeSwitcher
-        query={{ refId: 'A', rawSql: 'hello' } as CHSQLQuery}
-        onChange={() => {}}
-        onRunQuery={() => {}}
-      />
+      <QueryTypeSwitcher query={{ refId: 'A', rawSql: 'hello' } as CHSQLQuery} onChange={() => {}} />
     );
     expect(result.container.firstChild).not.toBeNull();
     expect(result.getByLabelText(options.SQLEditor)).toBeChecked();
@@ -32,7 +26,6 @@ describe('QueryTypeSwitcher', () => {
       <QueryTypeSwitcher
         query={{ refId: 'A', queryType: QueryType.SQL, rawSql: '', format: Format.TABLE, selectedFormat: Format.AUTO }}
         onChange={() => {}}
-        onRunQuery={() => {}}
       />
     );
     expect(result.container.firstChild).not.toBeNull();
@@ -44,7 +37,6 @@ describe('QueryTypeSwitcher', () => {
       <QueryTypeSwitcher
         query={{ refId: 'A', queryType: QueryType.Builder, rawSql: '' } as CHQuery}
         onChange={() => {}}
-        onRunQuery={() => {}}
       />
     );
     expect(result.container.firstChild).not.toBeNull();

--- a/src/components/QueryTypeSwitcher.tsx
+++ b/src/components/QueryTypeSwitcher.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { SelectableValue } from '@grafana/data';
-import { RadioButtonGroup, ConfirmModal, InlineFormLabel } from '@grafana/ui';
+import { RadioButtonGroup, ConfirmModal } from '@grafana/ui';
 import { getQueryOptionsFromSql, getSQLFromQueryOptions } from './queryBuilder/utils';
 import { selectors } from './../selectors';
 import { CHQuery, QueryType, defaultCHBuilderQuery, SqlBuilderOptions, CHSQLQuery } from 'types';
@@ -9,12 +9,10 @@ import { isString } from 'lodash';
 interface QueryTypeSwitcherProps {
   query: CHQuery;
   onChange: (query: CHQuery) => void;
-  onRunQuery: () => void;
 }
 
-export const QueryTypeSwitcher = (props: QueryTypeSwitcherProps) => {
-  const { query, onChange } = props;
-  const { label, tooltip, options: queryTypeLabels, switcher, cannotConvert } = selectors.components.QueryEditor.Types;
+export const QueryTypeSwitcher = ({ query, onChange }: QueryTypeSwitcherProps) => {
+  const { options: queryTypeLabels, switcher, cannotConvert } = selectors.components.QueryEditor.Types;
   let queryType: QueryType =
     query.queryType ||
     ((query as CHSQLQuery).rawSql && !(query as CHQuery).queryType ? QueryType.SQL : QueryType.Builder);
@@ -71,10 +69,7 @@ export const QueryTypeSwitcher = (props: QueryTypeSwitcherProps) => {
   };
   return (
     <>
-      <InlineFormLabel width={8} className="query-keyword" tooltip={tooltip}>
-        {label}
-      </InlineFormLabel>
-      <RadioButtonGroup options={options} value={editor} onChange={(e) => onQueryTypeChange(e!)} />
+      <RadioButtonGroup size="sm" options={options} value={editor} onChange={(e) => onQueryTypeChange(e!)} />
       <ConfirmModal
         isOpen={confirmModalState}
         title={switcher.title}

--- a/src/components/queryBuilder/DatabaseSelect.tsx
+++ b/src/components/queryBuilder/DatabaseSelect.tsx
@@ -1,9 +1,9 @@
 import React, { useState, useEffect } from 'react';
-import { InlineFormLabel, Select } from '@grafana/ui';
+import { Select } from '@grafana/ui';
 import { SelectableValue } from '@grafana/data';
 import { Datasource } from '../../data/CHDatasource';
 import { selectors } from './../../selectors';
-import { styles } from '../../styles';
+import { EditorField } from '@grafana/experimental';
 
 export type Props = { datasource: Datasource; value?: string; onChange: (value: string) => void };
 
@@ -27,18 +27,14 @@ export const DatabaseSelect = (props: Props) => {
   const defaultDatabase = datasource.settings.jsonData.defaultDatabase;
   const db = value ?? defaultDatabase;
   return (
-    <>
-      <InlineFormLabel width={8} className="query-keyword" tooltip={tooltip}>
-        {label}
-      </InlineFormLabel>
+    <EditorField tooltip={tooltip} label={label}>
       <Select
-        className={`width-15 ${styles.Common.inlineSelect}`}
         onChange={(e) => onChange(e.value!)}
         options={list}
         value={db}
-        menuPlacement={'bottom'}
         allowCustomValue={true}
+        width={25}
       ></Select>
-    </>
+    </EditorField>
   );
 };

--- a/src/components/queryBuilder/Fields.tsx
+++ b/src/components/queryBuilder/Fields.tsx
@@ -1,9 +1,9 @@
 import React, { useState, useEffect } from 'react';
-import { InlineFormLabel, MultiSelect } from '@grafana/ui';
+import { MultiSelect } from '@grafana/ui';
 import { SelectableValue } from '@grafana/data';
 import { FullField } from './../../types';
 import { selectors } from './../../selectors';
-import { styles } from '../../styles';
+import { EditorField } from '@grafana/experimental';
 
 interface FieldsEditorProps {
   fieldsList: FullField[];
@@ -54,24 +54,19 @@ export const FieldsEditor = (props: FieldsEditorProps) => {
   };
 
   return (
-    <div className="gf-form">
-      <InlineFormLabel width={8} className="query-keyword" tooltip={tooltipTable}>
-        {label}
-      </InlineFormLabel>
-      <div data-testid="query-builder-fields-multi-select-container" className={styles.Common.selectWrapper}>
-        <MultiSelect<string>
-          options={[...columns, ...defaultFields, ...custom]}
-          value={fields && fields.length > 0 ? fields : []}
-          isOpen={isOpen}
-          onOpenMenu={() => setIsOpen(true)}
-          onCloseMenu={() => setIsOpen(false)}
-          onChange={onChange}
-          onBlur={onUpdateField}
-          allowCustomValue={true}
-          menuPlacement={'bottom'}
-        />
-      </div>
-    </div>
+    <EditorField tooltip={tooltipTable} label={label} data-testid={'query-builder-fields-multi-select-container'}>
+      <MultiSelect<string>
+        options={[...columns, ...defaultFields, ...custom]}
+        value={fields && fields.length > 0 ? fields : []}
+        isOpen={isOpen}
+        onOpenMenu={() => setIsOpen(true)}
+        onCloseMenu={() => setIsOpen(false)}
+        onChange={onChange}
+        onBlur={onUpdateField}
+        allowCustomValue={true}
+        width={50}
+      />
+    </EditorField>
   );
 };
 

--- a/src/components/queryBuilder/Filters.test.tsx
+++ b/src/components/queryBuilder/Filters.test.tsx
@@ -38,9 +38,7 @@ describe('FiltersEditor', () => {
       const result = render(<FiltersEditor fieldsList={[]} filters={filters} onFiltersChange={() => {}} />);
       expect(result.container.firstChild).not.toBeNull();
       expect(result.getAllByText(selectors.components.QueryEditor.QueryBuilder.WHERE.label).length).toBe(1);
-      expect(result.queryByTestId('query-builder-filters-add-button')).not.toBeInTheDocument();
-      expect(result.getByTestId('query-builder-filters-inline-add-button')).toBeInTheDocument();
-      expect(result.getAllByTestId('query-builder-filters-inline-add-button').length).toBe(1);
+      expect(result.getByTestId('query-builder-filters-add-button')).toBeInTheDocument();
       expect(result.getAllByTestId('query-builder-filters-remove-button').length).toBe(filters.length);
     });
     it('should call the onFiltersChange with correct args', async () => {
@@ -64,11 +62,9 @@ describe('FiltersEditor', () => {
       const result = render(<FiltersEditor fieldsList={[]} filters={filters} onFiltersChange={onFiltersChange} />);
       expect(result.container.firstChild).not.toBeNull();
       expect(result.getAllByText(selectors.components.QueryEditor.QueryBuilder.WHERE.label).length).toBe(1);
-      expect(result.queryByTestId('query-builder-filters-add-button')).not.toBeInTheDocument();
-      expect(result.getByTestId('query-builder-filters-inline-add-button')).toBeInTheDocument();
-      expect(result.getAllByTestId('query-builder-filters-inline-add-button').length).toBe(1);
+      expect(result.getByTestId('query-builder-filters-add-button')).toBeInTheDocument();
       expect(result.getAllByTestId('query-builder-filters-remove-button').length).toBe(filters.length);
-      await userEvent.click(result.getByTestId('query-builder-filters-inline-add-button'));
+      await userEvent.click(result.getByTestId('query-builder-filters-add-button'));
       expect(onFiltersChange).toBeCalledTimes(1);
       expect(onFiltersChange).toHaveBeenNthCalledWith(1, [...filters, defaultNewFilter]);
       await userEvent.click(result.getAllByTestId('query-builder-filters-remove-button')[0]);

--- a/src/components/queryBuilder/Filters.tsx
+++ b/src/components/queryBuilder/Filters.tsx
@@ -1,10 +1,11 @@
 import React, { useState } from 'react';
 import { SelectableValue } from '@grafana/data';
-import { Button, InlineFormLabel, Input, MultiSelect, RadioButtonGroup, Select } from '@grafana/ui';
+import { Button, Input, MultiSelect, RadioButtonGroup, Select } from '@grafana/ui';
 import { Filter, FilterOperator, FullField, NullFilter } from '../../types';
 import * as utils from './utils';
 import { selectors } from '../../selectors';
 import { styles } from '../../styles';
+import { EditorField, EditorFieldGroup } from '@grafana/experimental';
 
 const boolValues: Array<SelectableValue<boolean>> = [
   { value: true, label: 'True' },
@@ -328,32 +329,28 @@ export const FilterEditor = (props: {
     onFilterChange(index, filter);
   };
   return (
-    <>
+    <EditorFieldGroup>
       {index !== 0 && (
         <RadioButtonGroup options={conditions} value={filter.condition} onChange={(e) => onFilterConditionChange(e!)} />
       )}
       <Select
         value={filter.key}
-        width={40}
-        className={styles.Common.inlineSelect}
+        width={30}
         options={getFields()}
         isOpen={isOpen}
         onOpenMenu={() => setIsOpen(true)}
         onCloseMenu={() => setIsOpen(false)}
         onChange={(e) => onFilterNameChange(e.value!)}
         allowCustomValue={true}
-        menuPlacement={'bottom'}
       />
       <Select
         value={filter.operator}
-        width={34}
-        className={styles.Common.inlineSelect}
+        width={30}
         options={getFilterOperatorsByType(filter.type)}
         onChange={(e) => onFilterOperatorChange(e.value!)}
-        menuPlacement={'bottom'}
       />
       <FilterValueEditor filter={filter} onFilterChange={onFilterValueChange} fieldsList={fieldsList} />
-    </>
+    </EditorFieldGroup>
   );
 };
 
@@ -378,63 +375,36 @@ export const FiltersEditor = (props: {
     onFiltersChange(newFilters);
   };
   return (
-    <>
-      {filters.length === 0 && (
-        <div className="gf-form">
-          <InlineFormLabel width={8} className="query-keyword" tooltip={tooltip}>
-            {label}
-          </InlineFormLabel>
-          <Button
-            data-testid="query-builder-filters-add-button"
-            icon="plus-circle"
-            variant="secondary"
-            size="sm"
-            className={styles.Common.smallBtn}
-            onClick={addFilter}
-          >
-            {AddLabel}
-          </Button>
-        </div>
-      )}
-      {filters.map((filter, index) => {
-        return (
-          <div className="gf-form" key={index}>
-            {index === 0 ? (
-              <InlineFormLabel width={8} className="query-keyword" tooltip={tooltip}>
-                {label}
-              </InlineFormLabel>
-            ) : (
-              <div className={`width-8 ${styles.Common.firstLabel}`}></div>
-            )}
-            <FilterEditor fieldsList={fieldsList} filter={filter} onFilterChange={onFilterChange} index={index} />
-            <Button
-              data-testid="query-builder-filters-remove-button"
-              icon="trash-alt"
-              variant="destructive"
-              size="sm"
-              className={styles.Common.smallBtn}
-              onClick={() => removeFilter(index)}
-            >
-              {RemoveLabel}
-            </Button>
-          </div>
-        );
-      })}
-      {filters.length !== 0 && (
-        <div className="gf-form">
-          <div className={`width-8 ${styles.Common.firstLabel}`}></div>
-          <Button
-            data-testid="query-builder-filters-inline-add-button"
-            icon="plus-circle"
-            variant="secondary"
-            size="sm"
-            className={styles.Common.smallBtn}
-            onClick={addFilter}
-          >
-            {AddLabel}
-          </Button>
-        </div>
-      )}
-    </>
+    <EditorField tooltip={tooltip} label={label}>
+      <EditorFieldGroup>
+        {filters.map((filter, index) => {
+          return (
+            <div className="gf-form" key={index}>
+              <FilterEditor fieldsList={fieldsList} filter={filter} onFilterChange={onFilterChange} index={index} />
+              <Button
+                data-testid="query-builder-filters-remove-button"
+                icon="trash-alt"
+                variant="destructive"
+                size="sm"
+                className={styles.Common.smallBtn}
+                onClick={() => removeFilter(index)}
+              >
+                {RemoveLabel}
+              </Button>
+            </div>
+          );
+        })}
+        <Button
+          data-testid="query-builder-filters-add-button"
+          icon="plus-circle"
+          variant="secondary"
+          size="sm"
+          className={styles.Common.smallBtn}
+          onClick={addFilter}
+        >
+          {AddLabel}
+        </Button>
+      </EditorFieldGroup>
+    </EditorField>
   );
 };

--- a/src/components/queryBuilder/GroupBy.tsx
+++ b/src/components/queryBuilder/GroupBy.tsx
@@ -1,9 +1,9 @@
 import React, { useState } from 'react';
-import { InlineFormLabel, MultiSelect } from '@grafana/ui';
+import { MultiSelect } from '@grafana/ui';
 import { SelectableValue } from '@grafana/data';
 import { FullField } from './../../types';
 import { selectors } from './../../selectors';
-import { styles } from '../../styles';
+import { EditorField } from '@grafana/experimental';
 
 interface GroupByEditorProps {
   fieldsList: FullField[];
@@ -22,24 +22,19 @@ export const GroupByEditor = (props: GroupByEditorProps) => {
   // Add selected value to the list if it does not exist.
   groupBy.filter((x) => !columns.some((y) => y.value === x)).forEach((x) => columns.push({ value: x, label: x }));
   return (
-    <div className="gf-form">
-      <InlineFormLabel width={8} className="query-keyword" tooltip={tooltip}>
-        {label}
-      </InlineFormLabel>
-      <div data-testid="query-builder-group-by-multi-select-container" className={styles.Common.selectWrapper}>
-        <MultiSelect
-          options={columns}
-          placeholder="(Optional) Click here to choose"
-          isOpen={isOpen}
-          onOpenMenu={() => setIsOpen(true)}
-          onCloseMenu={() => setIsOpen(false)}
-          onChange={onChange}
-          onBlur={() => props.onGroupByChange(groupBy)}
-          value={groupBy}
-          allowCustomValue={true}
-          menuPlacement={'bottom'}
-        />
-      </div>
-    </div>
+    <EditorField tooltip={tooltip} label={label}>
+      <MultiSelect
+        options={columns}
+        placeholder="Choose"
+        isOpen={isOpen}
+        onOpenMenu={() => setIsOpen(true)}
+        onCloseMenu={() => setIsOpen(false)}
+        onChange={onChange}
+        onBlur={() => props.onGroupByChange(groupBy)}
+        value={groupBy}
+        allowCustomValue={true}
+        width={25}
+      />
+    </EditorField>
   );
 };

--- a/src/components/queryBuilder/Limit.tsx
+++ b/src/components/queryBuilder/Limit.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
-import { InlineFormLabel, Input } from '@grafana/ui';
+import { Input } from '@grafana/ui';
 import { selectors } from './../../selectors';
+import { EditorField } from '@grafana/experimental';
 
 interface LimitEditorProps {
   limit: number;
@@ -10,10 +11,7 @@ export const LimitEditor = (props: LimitEditorProps) => {
   const [limit, setLimit] = useState(props.limit || 10);
   const { label, tooltip } = selectors.components.QueryEditor.QueryBuilder.LIMIT;
   return (
-    <div className="gf-form">
-      <InlineFormLabel width={8} className="query-keyword" tooltip={tooltip}>
-        {label}
-      </InlineFormLabel>
+    <EditorField tooltip={tooltip} label={label}>
       <Input
         width={10}
         value={limit}
@@ -22,6 +20,6 @@ export const LimitEditor = (props: LimitEditorProps) => {
         onChange={(e) => setLimit(e.currentTarget.valueAsNumber)}
         onBlur={() => props.onLimitChange(limit)}
       />
-    </div>
+    </EditorField>
   );
 };

--- a/src/components/queryBuilder/LogLevelField.tsx
+++ b/src/components/queryBuilder/LogLevelField.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import { SelectableValue } from '@grafana/data';
-import { InlineFormLabel, Select } from '@grafana/ui';
+import { Select } from '@grafana/ui';
 import { selectors } from './../../selectors';
 import { FullField } from 'types';
+import { EditorField } from '@grafana/experimental';
 
 interface LogLevelEditorProps {
   fieldsList: FullField[];
@@ -16,18 +17,14 @@ export const LogLevelFieldEditor = (props: LogLevelEditorProps) => {
     .filter((f) => f.name !== '*')
     .map((f) => ({ label: f.label, value: f.name }));
   return (
-    <div className="gf-form">
-      <InlineFormLabel width={8} className="query-keyword" tooltip={tooltip}>
-        {label}
-      </InlineFormLabel>
+    <EditorField tooltip={tooltip} label={label}>
       <Select
         options={columns}
-        width={20}
+        width={25}
         onChange={(e) => props.onLogLevelFieldChange(e?.value ?? e)}
-        menuPlacement={'bottom'}
         value={props.logLevelField}
         isClearable={true}
       />
-    </div>
+    </EditorField>
   );
 };

--- a/src/components/queryBuilder/Metrics.tsx
+++ b/src/components/queryBuilder/Metrics.tsx
@@ -4,6 +4,7 @@ import { InlineFormLabel, Select, Button, Input } from '@grafana/ui';
 import { BuilderMetricField, BuilderMetricFieldAggregation, FullField } from './../../types';
 import { selectors } from './../../selectors';
 import { styles } from '../../styles';
+import { EditorField, EditorFieldGroup } from '@grafana/experimental';
 
 const MetricEditor = (props: {
   fieldsList: FullField[];
@@ -46,17 +47,16 @@ const MetricEditor = (props: {
     onMetricsChange(newMetrics);
   };
   return (
-    <>
+    <EditorFieldGroup>
       <Select
-        width={20}
+        width={25}
         className={styles.Common.inlineSelect}
         options={aggregationTypes}
         onChange={(e) => onMetricAggregationChange(e.value!)}
         value={metric.aggregation}
-        menuPlacement={'bottom'}
       />
       <Select<string>
-        width={28}
+        width={25}
         className={styles.Common.inlineSelect}
         options={columns}
         isOpen={isOpen}
@@ -64,19 +64,18 @@ const MetricEditor = (props: {
         onCloseMenu={() => setIsOpen(false)}
         onChange={onMetricFieldChange}
         value={metric.field}
-        menuPlacement={'bottom'}
       />
       <InlineFormLabel width={2} className="query-keyword">
         {ALIAS.label}
       </InlineFormLabel>
       <Input
-        width={20}
+        width={25}
         value={alias}
         onChange={(e) => setAlias(e.currentTarget.value)}
         onBlur={onMetricAliasChange}
         placeholder="alias"
       />
-    </>
+    </EditorFieldGroup>
   );
 };
 
@@ -98,40 +97,32 @@ export const MetricsEditor = (props: MetricsEditorProps) => {
     onMetricsChange(newMetrics);
   };
   return (
-    <>
-      {metrics.map((metric, index) => {
-        return (
-          <div className="gf-form" key={index}>
-            {index === 0 ? (
-              <InlineFormLabel width={8} className="query-keyword" tooltip={tooltipAggregate}>
-                {label}
-              </InlineFormLabel>
-            ) : (
-              <div className={`width-8 ${styles.Common.firstLabel}`}></div>
-            )}
-            <MetricEditor
-              fieldsList={fieldsList}
-              index={index}
-              metric={metric}
-              metrics={metrics}
-              onMetricsChange={onMetricsChange}
-            />
-            {metrics.length > 1 && (
-              <Button
-                icon="trash-alt"
-                size="sm"
-                variant="destructive"
-                className={styles.Common.smallBtn}
-                onClick={() => onMetricRemove(index)}
-              >
-                {RemoveLabel}
-              </Button>
-            )}
-          </div>
-        );
-      })}
-      <div className="gf-form">
-        <div className={`width-8 ${styles.Common.firstLabel}`}></div>
+    <EditorField tooltip={tooltipAggregate} label={label}>
+      <EditorFieldGroup>
+        {metrics.map((metric, index) => {
+          return (
+            <div className="gf-form" key={index}>
+              <MetricEditor
+                fieldsList={fieldsList}
+                index={index}
+                metric={metric}
+                metrics={metrics}
+                onMetricsChange={onMetricsChange}
+              />
+              {metrics.length > 1 && (
+                <Button
+                  icon="trash-alt"
+                  size="sm"
+                  variant="destructive"
+                  className={styles.Common.smallBtn}
+                  onClick={() => onMetricRemove(index)}
+                >
+                  {RemoveLabel}
+                </Button>
+              )}
+            </div>
+          );
+        })}
         <Button
           icon="plus-circle"
           size="sm"
@@ -141,7 +132,7 @@ export const MetricsEditor = (props: MetricsEditorProps) => {
         >
           {AddLabel}
         </Button>
-      </div>
-    </>
+      </EditorFieldGroup>
+    </EditorField>
   );
 };

--- a/src/components/queryBuilder/ModeEditor.tsx
+++ b/src/components/queryBuilder/ModeEditor.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { RadioButtonGroup, InlineFormLabel } from '@grafana/ui';
+import { RadioButtonGroup } from '@grafana/ui';
 import { BuilderMode } from 'types';
 import { selectors } from './../../selectors';
+import { EditorField } from '@grafana/experimental';
 
 interface ModeEditorProps {
   mode: BuilderMode;
@@ -15,11 +16,8 @@ export const ModeEditor = (props: ModeEditorProps) => {
     { value: BuilderMode.Trend, label: options.TREND },
   ];
   return (
-    <>
-      <InlineFormLabel width={6} className="query-keyword" tooltip={tooltip}>
-        {label}
-      </InlineFormLabel>
+    <EditorField tooltip={tooltip} label={label}>
       <RadioButtonGroup<BuilderMode> options={modes} value={props.mode} onChange={(e) => props.onModeChange(e!)} />
-    </>
+    </EditorField>
   );
 };

--- a/src/components/queryBuilder/OrderBy.test.tsx
+++ b/src/components/queryBuilder/OrderBy.test.tsx
@@ -33,25 +33,9 @@ describe('OrderByEditor', () => {
       />
     );
     expect(result.container.firstChild).not.toBeNull();
-    expect(result.queryByTestId('query-builder-orderby-add-button')).not.toBeInTheDocument();
-    expect(result.getByTestId('query-builder-orderby-inline-add-button')).toBeInTheDocument();
+    expect(result.getByTestId('query-builder-orderby-add-button')).toBeInTheDocument();
     expect(result.getByTestId('query-builder-orderby-item-wrapper')).toBeInTheDocument();
     expect(result.getByTestId('query-builder-orderby-remove-button')).toBeInTheDocument();
-  });
-  it('should be only one inline add button when multiple orderby items passed', () => {
-    const result = render(
-      <OrderByEditor
-        fieldsList={[{ value: 'foo', sortable: true }]}
-        orderBy={[
-          { name: 'foo', dir: OrderByDirection.ASC },
-          { name: 'bar', dir: OrderByDirection.ASC },
-        ]}
-        onOrderByItemsChange={() => {}}
-      />
-    );
-    expect(result.container.firstChild).not.toBeNull();
-    expect(result.queryByTestId('query-builder-orderby-add-button')).not.toBeInTheDocument();
-    expect(result.getByTestId('query-builder-orderby-inline-add-button')).toBeInTheDocument();
   });
   it('should render add/remove buttons correctly when multiple orderby elements passed', () => {
     const result = render(
@@ -65,24 +49,9 @@ describe('OrderByEditor', () => {
       />
     );
     expect(result.container.firstChild).not.toBeNull();
-    expect(result.queryByTestId('query-builder-orderby-add-button')).not.toBeInTheDocument();
-    expect(result.getByTestId('query-builder-orderby-inline-add-button')).toBeInTheDocument();
+    expect(result.queryByTestId('query-builder-orderby-add-button')).toBeInTheDocument();
     expect(result.getAllByTestId('query-builder-orderby-item-wrapper').length).toBe(2);
     expect(result.getAllByTestId('query-builder-orderby-remove-button').length).toBe(2);
-  });
-  it('should render label only once', () => {
-    const result = render(
-      <OrderByEditor
-        fieldsList={[{ value: 'foo', sortable: true }]}
-        orderBy={[
-          { name: 'foo', dir: OrderByDirection.ASC },
-          { name: 'bar', dir: OrderByDirection.ASC },
-        ]}
-        onOrderByItemsChange={() => {}}
-      />
-    );
-    expect(result.container.firstChild).not.toBeNull();
-    expect(result.getByTestId('query-builder-orderby-item-label')).toBeInTheDocument();
   });
   it('should add default item when add button clicked', async () => {
     const onOrderByItemsChange = jest.fn();
@@ -122,7 +91,7 @@ describe('OrderByEditor', () => {
     expect(onOrderByItemsChange).toBeCalledTimes(0);
     await userEvent.click(result.getAllByTestId('query-builder-orderby-remove-button')[1]);
     await userEvent.click(result.getAllByTestId('query-builder-orderby-remove-button')[0]);
-    await userEvent.click(result.getAllByTestId('query-builder-orderby-inline-add-button')[0]);
+    await userEvent.click(result.getAllByTestId('query-builder-orderby-add-button')[0]);
     expect(onOrderByItemsChange).toBeCalledTimes(3);
     expect(onOrderByItemsChange).toHaveBeenNthCalledWith(1, [{ name: 'foo', dir: OrderByDirection.ASC }]);
     expect(onOrderByItemsChange).toHaveBeenNthCalledWith(2, [{ name: 'bar', dir: OrderByDirection.ASC }]);

--- a/src/components/queryBuilder/OrderBy.tsx
+++ b/src/components/queryBuilder/OrderBy.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { SelectableValue } from '@grafana/data';
-import { Button, InlineFormLabel, Select } from '@grafana/ui';
+import { Button, Select } from '@grafana/ui';
 import {
   OrderBy,
   OrderByDirection,
@@ -12,6 +12,7 @@ import {
 } from './../../types';
 import { selectors } from './../../selectors';
 import { styles } from '../../styles';
+import { EditorField, EditorFieldGroup, EditorRow } from '@grafana/experimental';
 
 const OrderByItem = (props: {
   index: number;
@@ -39,7 +40,7 @@ const OrderByItem = (props: {
     props.onOrderByItemsChange(orderByItems);
   };
   return (
-    <>
+    <EditorFieldGroup>
       <Select
         value={orderByItem.name}
         className={styles.Common.inlineSelect}
@@ -57,7 +58,7 @@ const OrderByItem = (props: {
         onChange={(e) => onOrderBySortDirectionUpdate(e.value!)}
         menuPlacement={'bottom'}
       />
-    </>
+    </EditorFieldGroup>
   );
 };
 
@@ -83,40 +84,12 @@ export const OrderByEditor = (props: OrderByEditorProps) => {
     props.onOrderByItemsChange(orderByItems);
   };
   return columns.length === 0 ? null : (
-    <>
-      {props.orderBy.length === 0 ? (
-        <div className="gf-form">
-          <InlineFormLabel width={8} className="query-keyword" tooltip={tooltip}>
-            {label}
-          </InlineFormLabel>
-          <Button
-            data-testid="query-builder-orderby-add-button"
-            icon="plus-circle"
-            variant="secondary"
-            size="sm"
-            onClick={onOrderByAdd}
-            className={styles.Common.smallBtn}
-          >
-            {AddLabel}
-          </Button>
-        </div>
-      ) : (
-        <>
+    <EditorRow>
+      <EditorField tooltip={tooltip} label={label}>
+        <EditorFieldGroup>
           {props.orderBy.map((o, index) => {
             return (
               <div className="gf-form" key={index} data-testid="query-builder-orderby-item-wrapper">
-                {index === 0 ? (
-                  <InlineFormLabel
-                    width={8}
-                    className="query-keyword"
-                    data-testid="query-builder-orderby-item-label"
-                    tooltip={tooltip}
-                  >
-                    {label}
-                  </InlineFormLabel>
-                ) : (
-                  <div className={`width-8 ${styles.Common.firstLabel}`}></div>
-                )}
                 <OrderByItem
                   index={index}
                   orderBy={props.orderBy}
@@ -137,22 +110,19 @@ export const OrderByEditor = (props: OrderByEditorProps) => {
               </div>
             );
           })}
-          <div className="gf-form">
-            <div className={`width-8 ${styles.Common.firstLabel}`}></div>
-            <Button
-              data-testid="query-builder-orderby-inline-add-button"
-              icon="plus-circle"
-              variant="secondary"
-              size="sm"
-              onClick={onOrderByAdd}
-              className={styles.Common.smallBtn}
-            >
-              {AddLabel}
-            </Button>
-          </div>
-        </>
-      )}
-    </>
+          <Button
+            data-testid="query-builder-orderby-add-button"
+            icon="plus-circle"
+            variant="secondary"
+            size="sm"
+            onClick={onOrderByAdd}
+            className={styles.Common.smallBtn}
+          >
+            {AddLabel}
+          </Button>
+        </EditorFieldGroup>
+      </EditorField>
+    </EditorRow>
   );
 };
 

--- a/src/components/queryBuilder/Preview.tsx
+++ b/src/components/queryBuilder/Preview.tsx
@@ -1,17 +1,16 @@
 import React from 'react';
-import { InlineFormLabel } from '@grafana/ui';
 import { selectors } from './../../selectors';
+import { EditorField, EditorRow } from '@grafana/experimental';
 interface PreviewProps {
   sql: string;
 }
 export const Preview = (props: PreviewProps) => {
   const { label, tooltip } = selectors.components.QueryEditor.QueryBuilder.PREVIEW;
   return (
-    <div className="gf-form">
-      <InlineFormLabel width={8} className="query-keyword" tooltip={tooltip}>
-        {label}
-      </InlineFormLabel>
-      <pre>{props.sql}</pre>
-    </div>
+    <EditorRow>
+      <EditorField tooltip={tooltip} label={label}>
+        <pre>{props.sql !== '' ? props.sql : 'Query SQL will show here'}</pre>
+      </EditorField>
+    </EditorRow>
   );
 };

--- a/src/components/queryBuilder/QueryBuilder.tsx
+++ b/src/components/queryBuilder/QueryBuilder.tsx
@@ -27,6 +27,7 @@ import { isDateTimeType, isDateType } from './utils';
 import { selectors } from '../../selectors';
 import { LogLevelFieldEditor } from './LogLevelField';
 import { CoreApp } from '@grafana/data';
+import { EditorFieldGroup, EditorRow, EditorRows } from '@grafana/experimental';
 
 interface QueryBuilderProps {
   builderOptions: SqlBuilderOptions;
@@ -204,68 +205,80 @@ export const QueryBuilder = (props: QueryBuilderProps) => {
   };
   const fieldsList = getFieldList();
   return builder ? (
-    <>
-      <div className="gf-form">
-        <DatabaseSelect datasource={props.datasource} value={builder.database} onChange={onDatabaseChange} />
-        <ModeEditor mode={builder.mode} onModeChange={onModeChange} />
-      </div>
-      <div className="gf-form">
-        <TableSelect
-          datasource={props.datasource}
-          database={builder.database}
-          table={builder.table}
-          onTableChange={onTableChange}
-        />
-      </div>
+    <EditorRows>
+      <EditorRow>
+        <EditorFieldGroup>
+          <DatabaseSelect datasource={props.datasource} value={builder.database} onChange={onDatabaseChange} />
+          <TableSelect
+            datasource={props.datasource}
+            database={builder.database}
+            table={builder.table}
+            onTableChange={onTableChange}
+          />
+          <ModeEditor mode={builder.mode} onModeChange={onModeChange} />
+        </EditorFieldGroup>
+      </EditorRow>
       {builder.mode === BuilderMode.Trend && (
-        <TimeFieldEditor
-          timeField={builder.timeField}
-          timeFieldType={builder.timeFieldType}
-          onTimeFieldChange={onTimeFieldChange}
-          fieldsList={fieldsList}
-          timeFieldTypeCheckFn={isDateType}
-          labelAndTooltip={selectors.components.QueryEditor.QueryBuilder.TIME_FIELD}
-        />
+        <EditorRow>
+          <TimeFieldEditor
+            timeField={builder.timeField}
+            timeFieldType={builder.timeFieldType}
+            onTimeFieldChange={onTimeFieldChange}
+            fieldsList={fieldsList}
+            timeFieldTypeCheckFn={isDateType}
+            labelAndTooltip={selectors.components.QueryEditor.QueryBuilder.TIME_FIELD}
+          />
+        </EditorRow>
       )}
       {
         // Time and LogLevel fields selection for Logs Volume histogram in the Explore mode
         builder.mode === BuilderMode.List && props.format === Format.LOGS && props.app === CoreApp.Explore && (
-          <>
-            <TimeFieldEditor
-              timeField={timeField}
-              timeFieldType={builder.timeFieldType}
-              onTimeFieldChange={onTimeFieldChange}
-              fieldsList={fieldsList}
-              timeFieldTypeCheckFn={isDateTimeType}
-              labelAndTooltip={selectors.components.QueryEditor.QueryBuilder.LOGS_VOLUME_TIME_FIELD}
-            />
-            <LogLevelFieldEditor
-              logLevelField={logLevelField}
-              fieldsList={fieldsList}
-              onLogLevelFieldChange={onLogLevelFieldChange}
-            />
-          </>
+          <EditorRow>
+            <EditorFieldGroup>
+              <TimeFieldEditor
+                timeField={timeField}
+                timeFieldType={builder.timeFieldType}
+                onTimeFieldChange={onTimeFieldChange}
+                fieldsList={fieldsList}
+                timeFieldTypeCheckFn={isDateTimeType}
+                labelAndTooltip={selectors.components.QueryEditor.QueryBuilder.LOGS_VOLUME_TIME_FIELD}
+              />
+              <LogLevelFieldEditor
+                logLevelField={logLevelField}
+                fieldsList={fieldsList}
+                onLogLevelFieldChange={onLogLevelFieldChange}
+              />
+            </EditorFieldGroup>
+          </EditorRow>
         )
       }
       {builder.mode !== BuilderMode.Trend && (
-        <FieldsEditor fields={builder.fields || []} onFieldsChange={onFieldsChange} fieldsList={fieldsList} />
+        <EditorRow>
+          <FieldsEditor fields={builder.fields || []} onFieldsChange={onFieldsChange} fieldsList={fieldsList} />
+        </EditorRow>
       )}
 
       {(builder.mode === BuilderMode.Aggregate || builder.mode === BuilderMode.Trend) && (
-        <MetricsEditor metrics={builder.metrics || []} onMetricsChange={onMetricsChange} fieldsList={fieldsList} />
+        <EditorRow>
+          <MetricsEditor metrics={builder.metrics || []} onMetricsChange={onMetricsChange} fieldsList={fieldsList} />
+        </EditorRow>
       )}
-      <FiltersEditor filters={builder.filters || []} onFiltersChange={onFiltersChange} fieldsList={fieldsList} />
+      <EditorRow>
+        <FiltersEditor filters={builder.filters || []} onFiltersChange={onFiltersChange} fieldsList={fieldsList} />
+      </EditorRow>
       {(builder.mode === BuilderMode.Aggregate || builder.mode === BuilderMode.Trend) && (
-        <GroupByEditor groupBy={builder.groupBy || []} onGroupByChange={onGroupByChange} fieldsList={fieldsList} />
+        <EditorRow>
+          <GroupByEditor groupBy={builder.groupBy || []} onGroupByChange={onGroupByChange} fieldsList={fieldsList} />
+        </EditorRow>
       )}
-      <>
-        <OrderByEditor
-          orderBy={builder.orderBy || []}
-          onOrderByItemsChange={onOrderByChange}
-          fieldsList={getOrderByFields(builder, fieldsList)}
-        />
+      <OrderByEditor
+        orderBy={builder.orderBy || []}
+        onOrderByItemsChange={onOrderByChange}
+        fieldsList={getOrderByFields(builder, fieldsList)}
+      />
+      <EditorRow>
         <LimitEditor limit={builder.limit || 20} onLimitChange={onLimitChange} />
-      </>
-    </>
+      </EditorRow>
+    </EditorRows>
   ) : null;
 };

--- a/src/components/queryBuilder/TableSelect.tsx
+++ b/src/components/queryBuilder/TableSelect.tsx
@@ -1,9 +1,9 @@
 import React, { useState, useEffect } from 'react';
-import { InlineFormLabel, Select } from '@grafana/ui';
+import { Select } from '@grafana/ui';
 import { SelectableValue } from '@grafana/data';
 import { Datasource } from '../../data/CHDatasource';
 import { selectors } from './../../selectors';
-import { styles } from '../../styles';
+import { EditorField } from '@grafana/experimental';
 
 export type Props = {
   datasource: Datasource;
@@ -36,18 +36,14 @@ export const TableSelect = (props: Props) => {
   };
 
   return (
-    <>
-      <InlineFormLabel width={8} className="query-keyword" tooltip={tooltip}>
-        {label}
-      </InlineFormLabel>
+    <EditorField tooltip={tooltip} label={label}>
       <Select
-        className={`width-15 ${styles.Common.inlineSelect}`}
         onChange={(e) => onChange(e.value ? e.value : '')}
         options={list}
         value={table}
-        menuPlacement={'bottom'}
         allowCustomValue={true}
+        width={25}
       ></Select>
-    </>
+    </EditorField>
   );
 };

--- a/src/components/queryBuilder/TimeField.tsx
+++ b/src/components/queryBuilder/TimeField.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import { SelectableValue } from '@grafana/data';
-import { InlineFormLabel, Select } from '@grafana/ui';
+import { Select } from '@grafana/ui';
 import { selectors } from './../../selectors';
 import { FullField } from 'types';
+import { EditorField } from '@grafana/experimental';
 
 interface TimeFieldEditorProps {
   fieldsList: FullField[];
@@ -23,17 +24,13 @@ export const TimeFieldEditor = (props: TimeFieldEditorProps) => {
     return matchedColumn ? matchedColumn.type : '';
   };
   return (
-    <div className="gf-form">
-      <InlineFormLabel width={8} className="query-keyword" tooltip={tooltip}>
-        {label}
-      </InlineFormLabel>
+    <EditorField tooltip={tooltip} label={label}>
       <Select
         options={columns}
-        width={20}
+        width={25}
         onChange={(e) => props.onTimeFieldChange(e.value, getColumnType(e.value))}
         value={props.timeField}
-        menuPlacement={'bottom'}
       />
-    </div>
+    </EditorField>
   );
 };

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -2,9 +2,6 @@ import { css } from '@emotion/css';
 
 export const styles = {
   Common: {
-    check: css`
-      margin-top: 5px;
-    `,
     wrapper: css`
       position: relative;
       width: 100%;
@@ -13,13 +10,7 @@ export const styles = {
       margin-top: 5px;
       margin-inline: 5px;
     `,
-    selectWrapper: css`
-      width: 100%;
-    `,
     inlineSelect: css`
-      margin-right: 5px;
-    `,
-    firstLabel: css`
       margin-right: 5px;
     `,
     expand: css`
@@ -30,36 +21,4 @@ export const styles = {
       color: gray;
     `,
   },
-  ConfigEditor: {
-    container: css`
-      justify-content: space-between;
-      h5 {
-        line-height: 34px;
-        margin-bottom: 5px;
-      }
-      button {
-        margin-right: 5px;
-      }
-    `,
-    wide: css`
-      width: 75%;
-    `,
-    subHeader: css`
-      padding: 5px 0 5px 0;
-    `,
-  },
-  QueryEditor: {
-    queryType: css`
-      justify-content: space-between;
-      span {
-        display: flex;
-      }
-    `,
-  },
-  FormatSelector: {
-    formatSelector: css`
-      display: flex;
-    `,
-  },
-  VariablesEditor: {},
 };

--- a/src/views/CHQueryEditor.tsx
+++ b/src/views/CHQueryEditor.tsx
@@ -15,11 +15,8 @@ import { SQLEditor } from 'components/SQLEditor';
 import { getSQLFromQueryOptions } from 'components/queryBuilder/utils';
 import { QueryBuilder } from 'components/queryBuilder/QueryBuilder';
 import { Preview } from 'components/queryBuilder/Preview';
-import { QueryTypeSwitcher } from 'components/QueryTypeSwitcher';
-import { FormatSelect } from '../components/FormatSelect';
-import { Button } from '@grafana/ui';
-import { styles } from 'styles';
 import { getFormat } from 'components/editor';
+import { QueryHeader } from 'components/QueryHeader';
 
 export type CHQueryEditorProps = QueryEditorProps<Datasource, CHQuery, CHConfig>;
 
@@ -89,41 +86,9 @@ export const CHQueryEditor = (props: CHQueryEditorProps) => {
     }
   }, [query, onChange]);
 
-  const runQuery = () => {
-    if (query.queryType === QueryType.SQL) {
-      const format = getFormat(query.rawSql, query.selectedFormat);
-      if (format !== query.format) {
-        onChange({ ...query, format });
-      }
-    }
-    onRunQuery();
-  };
-
-  const onFormatChange = (selectedFormat: Format) => {
-    switch (query.queryType) {
-      case QueryType.SQL:
-        onChange({ ...query, format: getFormat(query.rawSql, selectedFormat), selectedFormat });
-      case QueryType.Builder:
-      default:
-        if (selectedFormat === Format.AUTO) {
-          let builderOptions = (query as CHBuilderQuery).builderOptions;
-          const format = builderOptions && builderOptions.mode === BuilderMode.Trend ? Format.TIMESERIES : Format.TABLE;
-          onChange({ ...query, format, selectedFormat });
-        } else {
-          onChange({ ...query, format: selectedFormat, selectedFormat });
-        }
-    }
-  };
-
   return (
     <>
-      <div className={'gf-form ' + styles.QueryEditor.queryType}>
-        <span>
-          <QueryTypeSwitcher {...props} />
-        </span>
-        <Button onClick={() => runQuery()}>Run Query</Button>
-      </div>
-      <FormatSelect format={query.selectedFormat ?? Format.AUTO} onChange={onFormatChange} />
+      <QueryHeader query={query} onChange={onChange} onRunQuery={onRunQuery} />
       <CHEditorByType {...props} />
     </>
   );


### PR DESCRIPTION
Revamp query editor to use newer Grafana UI components. This switches `InlineField`/`InlineFormLabel` components to `EditorField`. A query header has been added as it seems to make sense stylistically (but I'm no design expert so we can always revert this change).

All tests have been updated and the styles that were unused have been removed. I've also slightly refactored some of the logic to simplify.

![ClickHouseQueryEditor mov](https://github.com/grafana/clickhouse-datasource/assets/15019026/64fe0df2-5481-4eb9-a677-c0ae589cc99a)

A part of grafana/grafana#6479 and grafana/oss-plugin-partnerships#225

Fixes grafana/oss-plugin-partnerships#273