### PR TITLE
Queries with SETTINGS clauses no longer get AST errors

### DIFF
--- a/src/data/ast.test.ts
+++ b/src/data/ast.test.ts
@@ -1,10 +1,19 @@
-import { getFields } from './ast';
+import { getFields, sqlToStatement } from './ast';
+import { toSql } from 'pgsql-ast-parser'
 
 describe('ast', () => {
   describe('getFields', () => {
     it('return 1 expression if statement does not have an alias', () => {
       const stm = getFields(`select foo from bar`);
       expect(stm.length).toBe(1);
+    });
+  });
+  describe('sqlToStatement', () => {
+    it('settings parse correctly', () => {
+      const sql = 'SELECT count(*) FROM mytable SETTINGS setting1=stuff setting2=stuff';
+      const stm = sqlToStatement(sql);
+      // this is formatted like this to match how pgsql generates its sql
+      expect(toSql.statement(stm)).toEqual('SELECT (count (*) )  FROM mytable');
     });
   });
 });

--- a/src/data/ast.ts
+++ b/src/data/ast.ts
@@ -7,10 +7,14 @@ export function sqlToStatement(sql: string): Statement {
     replacementName: string;
   }> = [];
   //default is a key word in this grammar, but it can be used in CH
-  const re = /(\$__|\$|default)/gi;
+  const re = /(\$__|\$|default|settings)/gi;
   let regExpArray: RegExpExecArray | null;
   while ((regExpArray = re.exec(sql)) !== null) {
-    replaceFuncs.push({ startIndex: regExpArray.index, name: regExpArray[0], replacementName: '' });
+    let n = regExpArray[0];
+    if (n.toLowerCase() === "settings") {
+      n = sql.substring(regExpArray.index)
+    }
+    replaceFuncs.push({ startIndex: regExpArray.index, name: n, replacementName: '' });
   }
 
   //need to process in reverse so starting positions aren't effected by replacing other things
@@ -18,6 +22,11 @@ export function sqlToStatement(sql: string): Statement {
     const si = replaceFuncs[i].startIndex;
     const replacementName = 'f' + (Math.random() + 1).toString(36).substring(7);
     replaceFuncs[i].replacementName = replacementName;
+    // settings do not parse and we do not need information from them so we will remove them
+    if (replaceFuncs[i].name.toLowerCase().includes("settings")) {
+      sql = sql.substring(0, si)
+      continue;
+    }
     sql = sql.substring(0, si) + replacementName + sql.substring(si + replaceFuncs[i].name.length);
   }
 
@@ -97,4 +106,8 @@ export function getFields(sql: string): string[] {
       return `${exprName}`;
     }
   });
+}
+
+export function statementToSql(stm: Statement): string {
+  return toSql.statement(stm);
 }

--- a/src/data/ast.ts
+++ b/src/data/ast.ts
@@ -11,9 +11,6 @@ export function sqlToStatement(sql: string): Statement {
   let regExpArray: RegExpExecArray | null;
   while ((regExpArray = re.exec(sql)) !== null) {
     let n = regExpArray[0];
-    if (n.toLowerCase() === "settings") {
-      n = sql.substring(regExpArray.index)
-    }
     replaceFuncs.push({ startIndex: regExpArray.index, name: n, replacementName: '' });
   }
 
@@ -23,7 +20,7 @@ export function sqlToStatement(sql: string): Statement {
     const replacementName = 'f' + (Math.random() + 1).toString(36).substring(7);
     replaceFuncs[i].replacementName = replacementName;
     // settings do not parse and we do not need information from them so we will remove them
-    if (replaceFuncs[i].name.toLowerCase().includes("settings")) {
+    if (replaceFuncs[i].name.toLowerCase() === "settings") {
       sql = sql.substring(0, si)
       continue;
     }
@@ -106,8 +103,4 @@ export function getFields(sql: string): string[] {
       return `${exprName}`;
     }
   });
-}
-
-export function statementToSql(stm: Statement): string {
-  return toSql.statement(stm);
 }

--- a/src/data/ast.ts
+++ b/src/data/ast.ts
@@ -10,8 +10,7 @@ export function sqlToStatement(sql: string): Statement {
   const re = /(\$__|\$|default|settings)/gi;
   let regExpArray: RegExpExecArray | null;
   while ((regExpArray = re.exec(sql)) !== null) {
-    let n = regExpArray[0];
-    replaceFuncs.push({ startIndex: regExpArray.index, name: n, replacementName: '' });
+    replaceFuncs.push({ startIndex: regExpArray.index, name: regExpArray[0], replacementName: '' });
   }
 
   //need to process in reverse so starting positions aren't effected by replacing other things


### PR DESCRIPTION
Settings are removed from the SQL before trying to make an ast. We do not need settings with the AST.

Solves https://github.com/grafana/clickhouse-datasource/issues/520