### PR TITLE
Fix: remove ad-hoc filter parsing for numeric fields

### DIFF
--- a/src/data/adHocFilter.test.ts
+++ b/src/data/adHocFilter.test.ts
@@ -9,7 +9,7 @@ describe('AdHocManager', () => {
       { key: 'keyNum', operator: '=', value: '123' },
     ] as AdHocVariableFilter[]);
     expect(val).toEqual(
-      `SELECT stuff FROM foo WHERE col = test settings additional_table_filters={'foo' : ' key = \\'val\\' AND keyNum = 123 '}`
+      `SELECT stuff FROM foo WHERE col = test settings additional_table_filters={'foo' : ' key = \\'val\\' AND keyNum = \\'123\\' '}`
     );
   });
   it('apply ad hoc filter with no inner query and no existing WHERE', () => {
@@ -20,7 +20,7 @@ describe('AdHocManager', () => {
       { key: 'keyNum', operator: '=', value: '123' },
     ] as AdHocVariableFilter[]);
     expect(val).toEqual(
-      `SELECT stuff FROM foo settings additional_table_filters={'foo' : ' key = \\'val\\' AND keyNum = 123 '}`
+      `SELECT stuff FROM foo settings additional_table_filters={'foo' : ' key = \\'val\\' AND keyNum = \\'123\\' '}`
     );
   });
   it('apply ad hoc filter with an inner query without existing WHERE', () => {
@@ -31,7 +31,7 @@ describe('AdHocManager', () => {
       { key: 'keyNum', operator: '=', value: '123' },
     ] as AdHocVariableFilter[]);
     expect(val).toEqual(
-      `SELECT stuff FROM (SELECT * FROM foo) as r , bar GROUP BY s ORDER BY s settings additional_table_filters={'foo' : ' key = \\'val\\' AND keyNum = 123 '}`
+      `SELECT stuff FROM (SELECT * FROM foo) as r , bar GROUP BY s ORDER BY s settings additional_table_filters={'foo' : ' key = \\'val\\' AND keyNum = \\'123\\' '}`
     );
   });
   it('apply ad hoc filter with an inner from query with existing WHERE', () => {
@@ -42,7 +42,7 @@ describe('AdHocManager', () => {
       { key: 'keyNum', operator: '=', value: '123' },
     ] as AdHocVariableFilter[]);
     expect(val).toEqual(
-      `SELECT stuff FROM (SELECT * FROM foo WHERE col = test) as r GROUP BY s ORDER BY s settings additional_table_filters={'foo' : ' key = \\'val\\' AND keyNum = 123 '}`
+      `SELECT stuff FROM (SELECT * FROM foo WHERE col = test) as r GROUP BY s ORDER BY s settings additional_table_filters={'foo' : ' key = \\'val\\' AND keyNum = \\'123\\' '}`
     );
   });
   it('apply ad hoc filter with an inner where query with existing WHERE', () => {

--- a/src/data/adHocFilter.ts
+++ b/src/data/adHocFilter.ts
@@ -38,7 +38,7 @@ export class AdHocFilter {
       })
       .map((f, i) => {
         const key = f.key.includes('.') ? f.key.split('.')[1] : f.key;
-        const value = isNaN(Number(f.value)) ? `\\'${f.value}\\'` : Number(f.value);
+        const value = `\\'${f.value}\\'`;
         const condition = i !== adHocFilters.length - 1 ? (f.condition ? f.condition : 'AND') : '';
         const operator = convertOperatorToClickHouseOperator(f.operator);
         return ` ${key} ${operator} ${value} ${condition}`;


### PR DESCRIPTION
This PR fixes issue [#502](https://github.com/Altinity/clickhouse-grafana/issues/502)
