### PR TITLE
Custom HTTP Headers

### DIFF
--- a/pkg/plugin/driver.go
+++ b/pkg/plugin/driver.go
@@ -160,6 +160,7 @@ func (h *Clickhouse) Connect(config backend.DataSourceInstanceSettings, message 
 		Compression: &clickhouse.Compression{
 			Method: compression,
 		},
+		HttpHeaders: settings.HttpHeaders,
 		DialTimeout: time.Duration(t) * time.Second,
 		ReadTimeout: time.Duration(qt) * time.Second,
 		Protocol:    protocol,

--- a/pkg/plugin/settings.go
+++ b/pkg/plugin/settings.go
@@ -220,9 +220,10 @@ func loadHttpHeaders(jsonData map[string]interface{}, secureJsonData map[string]
 		httpHeadersRaw := jsonData["httpHeaders"].([]interface{})
 
 		for _, rawHeader := range httpHeadersRaw {
-			header := rawHeader.(map[string]interface{})
-			headerName := header["name"].(string)
-			headerValue := header["value"].(string)
+			header, _ := rawHeader.(map[string]interface{})
+			headerName, _ := header["name"].(string)
+			headerName = strings.TrimSpace(headerName)
+			headerValue, _ := header["value"].(string)
 			if headerName != "" && headerValue != "" {
 				httpHeaders[headerName] = headerValue
 			}
@@ -231,7 +232,7 @@ func loadHttpHeaders(jsonData map[string]interface{}, secureJsonData map[string]
 
 	for k, v := range secureJsonData {
 		if v != "" && strings.HasPrefix(k, secureHeaderKeyPrefix) {
-			headerName := k[len(secureHeaderKeyPrefix):]
+			headerName := strings.TrimSpace(k[len(secureHeaderKeyPrefix):])
 			httpHeaders[headerName] = v
 		}
 	}

--- a/pkg/plugin/settings_test.go
+++ b/pkg/plugin/settings_test.go
@@ -35,14 +35,14 @@ func TestLoadSettings(t *testing.T) {
 							"username": "baz",
 							"defaultDatabase":"example", "tlsSkipVerify": true, "tlsAuth" : true,
 							"tlsAuthWithCACert": true, "dialTimeout": "10", "enableSecureSocksProxy": true,
-							"httpHeaders": [{ "name": "test-plain-1", "value": "value-1", "secure": false }]
+							"httpHeaders": [{ "name": " test-plain-1 ", "value": "value-1", "secure": false }]
 						}`),
 						DecryptedSecureJSONData: map[string]string{
 							"password":  "bar",
 							"tlsCACert": "caCert", "tlsClientCert": "clientCert", "tlsClientKey": "clientKey",
-							"secureSocksProxyPassword":        "test",
-							"secureHttpHeaders.test-secure-2": "value-2",
-							"secureHttpHeaders.test-secure-3": "value-3",
+							"secureSocksProxyPassword":          "test",
+							"secureHttpHeaders. test-secure-2 ": "value-2",
+							"secureHttpHeaders.test-secure-3":   "value-3",
 						},
 					},
 				},

--- a/src/__mocks__/ConfigEditor.ts
+++ b/src/__mocks__/ConfigEditor.ts
@@ -12,7 +12,7 @@ export const mockConfigEditorProps = (overrides?: Partial<CHConfig>): ConfigEdit
       port: 443,
       path: '',
       username: 'user',
-      protocol: 'native',
+      protocol: 'http',
       ...overrides,
     },
   },

--- a/src/components/configEditor/HttpHeadersConfig.test.tsx
+++ b/src/components/configEditor/HttpHeadersConfig.test.tsx
@@ -1,0 +1,123 @@
+import React from 'react';
+import { render, fireEvent, renderHook } from '@testing-library/react';
+import { HttpHeadersConfig, useConfiguredSecureHttpHeaders } from './HttpHeadersConfig';
+import { selectors as allSelectors } from 'selectors';
+import { CHHttpHeader } from 'types/config';
+import { KeyValue } from '@grafana/data';
+
+describe('HttpHeadersConfig', () => {
+  const selectors = allSelectors.components.Config.HttpHeaderConfig;
+
+  it('should render', () => {
+    const result = render(<HttpHeadersConfig headers={[]} secureFields={{}} onHttpHeadersChange={() => {}} />);
+    expect(result.container.firstChild).not.toBeNull();
+  });
+
+  it('should not call onHttpHeadersChange when header is added', () => {
+    const onHttpHeadersChange = jest.fn();
+    const result = render(
+      <HttpHeadersConfig
+        headers={[]}
+        secureFields={{}}
+        onHttpHeadersChange={onHttpHeadersChange}
+      />
+    );
+    expect(result.container.firstChild).not.toBeNull();
+
+    const addHeaderButton = result.getByTestId(selectors.addHeaderButton);
+    expect(addHeaderButton).toBeInTheDocument();
+    fireEvent.click(addHeaderButton);
+    
+    expect(onHttpHeadersChange).toHaveBeenCalledTimes(0);
+  });
+
+  it('should call onHttpHeadersChange when header is updated', () => {
+    const onHttpHeadersChange = jest.fn();
+    const result = render(
+      <HttpHeadersConfig
+        headers={[]}
+        secureFields={{}}
+        onHttpHeadersChange={onHttpHeadersChange}
+      />
+    );
+    expect(result.container.firstChild).not.toBeNull();
+
+    const addHeaderButton = result.getByTestId(selectors.addHeaderButton);
+    expect(addHeaderButton).toBeInTheDocument();
+    fireEvent.click(addHeaderButton);
+    
+    const headerEditor = result.getByTestId(selectors.headerEditor);
+    expect(headerEditor).toBeInTheDocument();
+
+    const headerNameInput = result.getByTestId(selectors.headerNameInput);
+    expect(headerNameInput).toBeInTheDocument();
+    fireEvent.change(headerNameInput, { target: { value: 'x-test' } });
+    fireEvent.blur(headerNameInput);
+    expect(headerNameInput).toHaveValue('x-test');
+    expect(onHttpHeadersChange).toHaveBeenCalledTimes(1);
+
+    const headerValueInput = result.getByTestId(selectors.headerValueInput);
+    expect(headerValueInput).toBeInTheDocument();
+    fireEvent.change(headerValueInput, { target: { value: 'test value' } });
+    fireEvent.blur(headerValueInput);
+    expect(headerValueInput).toHaveValue('test value');
+    expect(onHttpHeadersChange).toHaveBeenCalledTimes(2);
+
+    const headerSecureSwitch = result.getByTestId(selectors.headerSecureSwitch);
+    expect(headerSecureSwitch).toBeInTheDocument();
+    fireEvent.click(headerSecureSwitch);
+    fireEvent.blur(headerSecureSwitch);
+    expect(onHttpHeadersChange).toHaveBeenCalledTimes(3);
+
+    const expected: CHHttpHeader[] = [
+      { name: 'x-test', value: 'test value', secure: true }
+    ];
+    expect(onHttpHeadersChange).toHaveBeenCalledWith(expect.objectContaining(expected));
+  });
+
+  it('should call onHttpHeadersChange when header is removed', () => {
+    const onHttpHeadersChange = jest.fn();
+    const result = render(
+      <HttpHeadersConfig
+        headers={[
+          { name: 'x-test', value: 'test value', secure: false },
+          { name: 'x-test-2', value: 'test value 2', secure: false }
+        ]}
+        secureFields={{}}
+        onHttpHeadersChange={onHttpHeadersChange}
+      />
+    );
+    expect(result.container.firstChild).not.toBeNull();
+
+    const removeHeaderButton = result.getAllByTestId(selectors.removeHeaderButton)[0]; // Get 1st
+    expect(removeHeaderButton).toBeInTheDocument();
+    fireEvent.click(removeHeaderButton);
+    
+    const expected: CHHttpHeader[] = [
+      { name: 'x-test-2', value: 'test value 2', secure: false }
+    ];
+    expect(onHttpHeadersChange).toHaveBeenCalledTimes(1);
+    expect(onHttpHeadersChange).toHaveBeenCalledWith(expect.objectContaining(expected));
+  });
+});
+
+
+describe('useConfiguredSecureHttpHeaders', () => {
+  it('returns unique set of secure header keys', async () => {
+    const fields: KeyValue<boolean> = {
+      'otherKey': true,
+      'otherOtherKey': false,
+      'secureHttpHeaders.a': true,
+      'secureHttpHeaders.b': true,
+      'secureHttpHeaders.c': false,
+    };
+
+    const hook = renderHook(() => useConfiguredSecureHttpHeaders(fields));
+    const result = hook.result.current;
+    
+    expect(result.size).toBe(2);
+    expect(result.has('a')).toBe(true);
+    expect(result.has('b')).toBe(true);
+    expect(result.has('c')).toBe(false);
+  });
+});

--- a/src/components/configEditor/HttpHeadersConfig.test.tsx
+++ b/src/components/configEditor/HttpHeadersConfig.test.tsx
@@ -51,9 +51,9 @@ describe('HttpHeadersConfig', () => {
 
     const headerNameInput = result.getByTestId(selectors.headerNameInput);
     expect(headerNameInput).toBeInTheDocument();
-    fireEvent.change(headerNameInput, { target: { value: 'x-test' } });
+    fireEvent.change(headerNameInput, { target: { value: 'x-test ' } }); // with space
     fireEvent.blur(headerNameInput);
-    expect(headerNameInput).toHaveValue('x-test');
+    expect(headerNameInput).toHaveValue('x-test'); // without space
     expect(onHttpHeadersChange).toHaveBeenCalledTimes(1);
 
     const headerValueInput = result.getByTestId(selectors.headerValueInput);

--- a/src/components/configEditor/HttpHeadersConfig.test.tsx
+++ b/src/components/configEditor/HttpHeadersConfig.test.tsx
@@ -51,9 +51,9 @@ describe('HttpHeadersConfig', () => {
 
     const headerNameInput = result.getByTestId(selectors.headerNameInput);
     expect(headerNameInput).toBeInTheDocument();
-    fireEvent.change(headerNameInput, { target: { value: 'x-test ' } }); // with space
+    fireEvent.change(headerNameInput, { target: { value: 'x-test ' } }); // with space in name
     fireEvent.blur(headerNameInput);
-    expect(headerNameInput).toHaveValue('x-test'); // without space
+    expect(headerNameInput).toHaveValue('x-test ');
     expect(onHttpHeadersChange).toHaveBeenCalledTimes(1);
 
     const headerValueInput = result.getByTestId(selectors.headerValueInput);
@@ -70,7 +70,7 @@ describe('HttpHeadersConfig', () => {
     expect(onHttpHeadersChange).toHaveBeenCalledTimes(3);
 
     const expected: CHHttpHeader[] = [
-      { name: 'x-test', value: 'test value', secure: true }
+      { name: 'x-test', value: 'test value', secure: true } // without space in name
     ];
     expect(onHttpHeadersChange).toHaveBeenCalledWith(expect.objectContaining(expected));
   });

--- a/src/components/configEditor/HttpHeadersConfig.tsx
+++ b/src/components/configEditor/HttpHeadersConfig.tsx
@@ -1,0 +1,174 @@
+import React, { ChangeEvent, useMemo, useState } from 'react';
+import { ConfigSection } from '@grafana/experimental';
+import { Input, Field, HorizontalGroup, Switch, SecretInput, Button } from '@grafana/ui';
+import { CHHttpHeader } from 'types/config';
+import allLabels from 'labels';
+import { styles } from 'styles';
+import { selectors as allSelectors } from 'selectors';
+import { KeyValue } from '@grafana/data';
+
+interface HttpHeadersConfigProps {
+  headers?: CHHttpHeader[];
+  secureFields: KeyValue<boolean>;
+  onHttpHeadersChange: (v: CHHttpHeader[]) => void;
+}
+
+export const HttpHeadersConfig = (props: HttpHeadersConfigProps) => {
+  const { secureFields, onHttpHeadersChange } = props;
+  const configuredSecureHeaders = useConfiguredSecureHttpHeaders(secureFields);
+  const [headers, setHeaders] = useState<CHHttpHeader[]>(props.headers || []);
+  const labels = allLabels.components.Config.HttpHeadersConfig;
+  const selectors = allSelectors.components.Config.HttpHeaderConfig;
+
+  const addHeader = () => setHeaders([...headers, { name: '', value: '', secure: false }]);
+  const removeHeader = (index: number) => {
+    const nextHeaders: CHHttpHeader[] = headers.slice();
+    nextHeaders.splice(index, 1);
+    setHeaders(nextHeaders);
+    onHttpHeadersChange(nextHeaders);
+  };
+  const updateHeader = (index: number, header: CHHttpHeader) => {
+    const nextHeaders: CHHttpHeader[] = headers.slice();
+    nextHeaders[index] = header;
+    setHeaders(nextHeaders);
+    onHttpHeadersChange(nextHeaders);
+  };
+
+  return (
+    <ConfigSection
+      title={labels.title}
+      description={labels.description}
+    >
+      {headers.map((header, index) => (
+        <HttpHeaderEditor
+          key={header.name + index}
+          name={header.name}
+          value={header.value}
+          secure={header.secure}
+          isSecureConfigured={configuredSecureHeaders.has(header.name)}
+          onHeaderChange={header => updateHeader(index, header)}
+          onRemove={() => removeHeader(index)}
+        />
+      ))}
+      <Button
+          data-testid={selectors.addHeaderButton}
+          icon="plus-circle"
+          variant="secondary"
+          size="sm"
+          onClick={addHeader}
+          className={styles.Common.smallBtn}
+        >
+          {labels.addHeaderLabel}
+      </Button>
+    </ConfigSection>
+  );
+}
+
+interface HttpHeaderEditorProps {
+  name: string;
+  value: string;
+  secure: boolean;
+  isSecureConfigured: boolean;
+  onHeaderChange: (v: CHHttpHeader) => void;
+  onRemove?: () => void;
+}
+
+const HttpHeaderEditor = (props: HttpHeaderEditorProps) => {
+  const { onHeaderChange, onRemove } = props;
+  const [name, setName] = useState<string>(props.name);
+  const [value, setValue] = useState<string>(props.value);
+  const [secure, setSecure] = useState<boolean>(props.secure);
+  const [isSecureConfigured, setSecureConfigured] = useState<boolean>(props.isSecureConfigured);
+  const labels = allLabels.components.Config.HttpHeadersConfig;
+  const selectors = allSelectors.components.Config.HttpHeaderConfig;
+
+  const onUpdate = () => {
+    onHeaderChange({
+      name,
+      value,
+      secure
+    });
+  }
+
+  let valueInput;
+  if (secure) {
+    valueInput = <SecretInput
+      data-testid={selectors.headerValueInput}
+      width={65}
+      label=""
+      aria-label=""
+      placeholder={labels.secureHeaderValueLabel}
+      value={value}
+      isConfigured={isSecureConfigured}
+      onReset={() => setSecureConfigured(false)}
+      onChange={(e: ChangeEvent<HTMLInputElement>) => setValue(e.target.value)}
+      onBlur={() => onUpdate()}
+    />;
+  } else {
+    valueInput = <Input
+      data-testid={selectors.headerValueInput}
+      width={65}
+      value={value}
+      placeholder={labels.insecureHeaderValueLabel}
+      onChange={(e: ChangeEvent<HTMLInputElement>) => setValue(e.target.value)}
+      onBlur={() => onUpdate()}
+    />;
+  }
+
+  const headerValueLabel = secure ? labels.secureHeaderValueLabel : labels.insecureHeaderValueLabel;
+  return (
+    <div data-testid={selectors.headerEditor}>
+      <HorizontalGroup>
+        <Field label={labels.headerNameLabel} aria-label={labels.headerNameLabel}>
+          <Input
+            data-testid={selectors.headerNameInput}
+            width={40}
+            value={name}
+            placeholder={labels.headerNamePlaceholder}
+            onChange={(e: ChangeEvent<HTMLInputElement>) => setName(e.target.value)}
+            onBlur={() => onUpdate()}
+          />
+        </Field>
+        <Field label={headerValueLabel} aria-label={headerValueLabel}>
+          {valueInput}
+        </Field>
+        { !isSecureConfigured &&
+          <Field label={labels.secureLabel}>
+            <Switch
+              data-testid={selectors.headerSecureSwitch}
+              className="gf-form"
+              value={secure}
+              onChange={e => setSecure(e.currentTarget.checked)}
+              onBlur={() => onUpdate()}
+            />
+          </Field>
+        }
+        { onRemove &&
+          <Button
+            data-testid={selectors.removeHeaderButton}
+            className={styles.Common.smallBtn}
+            variant="destructive"
+            size="sm"
+            icon="trash-alt"
+            onClick={onRemove}
+          />
+        }
+      </HorizontalGroup>
+    </div>
+  );
+}
+
+/**
+ * Returns a Set of all secured headers that are configured
+ */
+export const useConfiguredSecureHttpHeaders = (secureJsonFields: KeyValue<boolean>): Set<string> => {
+  return useMemo(() => {
+    const secureHeaders = new Set<string>();
+    for (let key in secureJsonFields) {
+      if (key.startsWith('secureHttpHeaders.') && secureJsonFields[key]) {
+        secureHeaders.add(key.substring(key.indexOf('.') + 1));
+      }
+    }
+    return secureHeaders;
+  }, [secureJsonFields]);
+};

--- a/src/components/configEditor/HttpHeadersConfig.tsx
+++ b/src/components/configEditor/HttpHeadersConfig.tsx
@@ -123,7 +123,6 @@ const HttpHeaderEditor = (props: HttpHeaderEditorProps) => {
         <Field label={labels.headerNameLabel} aria-label={labels.headerNameLabel}>
           <Input
             data-testid={selectors.headerNameInput}
-            width={40}
             value={name}
             disabled={isSecureConfigured}
             placeholder={labels.headerNamePlaceholder}

--- a/src/components/configEditor/HttpHeadersConfig.tsx
+++ b/src/components/configEditor/HttpHeadersConfig.tsx
@@ -124,6 +124,7 @@ const HttpHeaderEditor = (props: HttpHeaderEditorProps) => {
             data-testid={selectors.headerNameInput}
             width={40}
             value={name}
+            disabled={isSecureConfigured}
             placeholder={labels.headerNamePlaceholder}
             onChange={(e: ChangeEvent<HTMLInputElement>) => setName(e.target.value)}
             onBlur={() => onUpdate()}

--- a/src/components/configEditor/HttpHeadersConfig.tsx
+++ b/src/components/configEditor/HttpHeadersConfig.tsx
@@ -126,7 +126,7 @@ const HttpHeaderEditor = (props: HttpHeaderEditorProps) => {
             value={name}
             disabled={isSecureConfigured}
             placeholder={labels.headerNamePlaceholder}
-            onChange={(e: ChangeEvent<HTMLInputElement>) => setName(e.target.value)}
+            onChange={(e: ChangeEvent<HTMLInputElement>) => setName((e.target.value || '').trim())}
             onBlur={() => onUpdate()}
           />
         </Field>

--- a/src/components/configEditor/HttpHeadersConfig.tsx
+++ b/src/components/configEditor/HttpHeadersConfig.tsx
@@ -29,6 +29,7 @@ export const HttpHeadersConfig = (props: HttpHeadersConfigProps) => {
   };
   const updateHeader = (index: number, header: CHHttpHeader) => {
     const nextHeaders: CHHttpHeader[] = headers.slice();
+    header.name = header.name.trim();
     nextHeaders[index] = header;
     setHeaders(nextHeaders);
     onHttpHeadersChange(nextHeaders);
@@ -126,7 +127,7 @@ const HttpHeaderEditor = (props: HttpHeaderEditorProps) => {
             value={name}
             disabled={isSecureConfigured}
             placeholder={labels.headerNamePlaceholder}
-            onChange={(e: ChangeEvent<HTMLInputElement>) => setName((e.target.value || '').trim())}
+            onChange={(e: ChangeEvent<HTMLInputElement>) => setName(e.target.value)}
             onBlur={() => onUpdate()}
           />
         </Field>

--- a/src/labels.ts
+++ b/src/labels.ts
@@ -1,6 +1,84 @@
 export default {
   components: {
     Config: {
+      ConfigEditor: {
+        serverAddress: {
+          label: 'Server address',
+          placeholder: 'Server address',
+          tooltip: 'ClickHouse host address',
+          error: 'Server address required'
+        },
+        serverPort: {
+          label: 'Server port',
+          insecureNativePort: '9000',
+          insecureHttpPort: '8123',
+          secureNativePort: '9440',
+          secureHttpPort: '8443',
+          tooltip: 'ClickHouse server port',
+          error: 'Port is required'
+        },
+        path: {
+          label: 'HTTP URL Path',
+          tooltip: 'Additional URL path for HTTP requests',
+          placeholder: 'additional-path'
+        },
+        protocol: {
+          label: 'Protocol',
+          tooltip: 'Native or HTTP for server protocol',
+        },
+        username: {
+          label: 'Username',
+          placeholder: 'default',
+          tooltip: 'ClickHouse username',
+        },
+        password: {
+          label: 'Password',
+          placeholder: 'password',
+          tooltip: 'ClickHouse password',
+        },
+        tlsSkipVerify: {
+          label: 'Skip TLS Verify',
+          tooltip: 'Skip TLS Verify',
+        },
+        tlsClientAuth: {
+          label: 'TLS Client Auth',
+          tooltip: 'TLS Client Auth',
+        },
+        tlsAuthWithCACert: {
+          label: 'With CA Cert',
+          tooltip: 'Needed for verifying self-signed TLS Certs',
+        },
+        tlsCACert: {
+          label: 'CA Cert',
+          placeholder: 'CA Cert. Begins with -----BEGIN CERTIFICATE-----',
+        },
+        tlsClientCert: {
+          label: 'Client Cert',
+          placeholder: 'Client Cert. Begins with -----BEGIN CERTIFICATE-----',
+        },
+        tlsClientKey: {
+          label: 'Client Key',
+          placeholder: 'Client Key. Begins with -----BEGIN RSA PRIVATE KEY-----',
+        },
+        secure: {
+          label: 'Secure Connection',
+          tooltip: 'Toggle on if the connection is secure',
+        },
+        secureSocksProxy: {
+          label: 'Enable Secure Socks Proxy',
+          tooltip: 'Enable proxying the datasource connection through the secure socks proxy to a different network.',
+        },
+      },
+      HttpHeadersConfig: {
+        title: 'HTTP Headers',
+        description: 'Add HTTP headers when querying the database',
+        headerNameLabel: 'Header Name',
+        headerNamePlaceholder: 'X-Custom-Header',
+        insecureHeaderValueLabel: 'Header Value',
+        secureHeaderValueLabel: 'Secure Header Value',
+        secureLabel: 'Secure',
+        addHeaderLabel: 'Add Header'
+      },
       DefaultDatabaseTableConfig: {
         title: 'Default DB and table',
         database: {

--- a/src/selectors.ts
+++ b/src/selectors.ts
@@ -1,68 +1,5 @@
 import { E2ESelectors } from '@grafana/e2e-selectors';
 export const Components = {
-  ConfigEditor: {
-    ServerAddress: {
-      label: 'Server address',
-      placeholder: 'Server TCP address',
-      tooltip: 'ClickHouse native TCP server address',
-    },
-    ServerPort: {
-      label: 'Server port',
-      placeholder: (secure: string) => `Typically ${secure === 'true' ? '9440' : '9000'}`,
-      tooltip: 'ClickHouse native TCP port. Typically 9000 for unsecure, 9440 for secure',
-    },
-    Path: {
-      label: 'Path',
-      placeholder: 'Additional URL path for HTTP requests',
-      tooltip: 'Additional URL path for HTTP requests',
-    },
-    Protocol: {
-      label: 'Protocol',
-      tooltip: 'Native or HTTP for transport',
-    },
-    Username: {
-      label: 'Username',
-      placeholder: 'Username',
-      tooltip: 'ClickHouse username',
-    },
-    Password: {
-      label: 'Password',
-      placeholder: 'Password',
-      tooltip: 'ClickHouse password',
-    },
-    TLSSkipVerify: {
-      label: 'Skip TLS Verify',
-      tooltip: 'Skip TLS Verify',
-    },
-    TLSClientAuth: {
-      label: 'TLS Client Auth',
-      tooltip: 'TLS Client Auth',
-    },
-    TLSAuthWithCACert: {
-      label: 'With CA Cert',
-      tooltip: 'Needed for verifying self-signed TLS Certs',
-    },
-    TLSCACert: {
-      label: 'CA Cert',
-      placeholder: 'CA Cert. Begins with -----BEGIN CERTIFICATE-----',
-    },
-    TLSClientCert: {
-      label: 'Client Cert',
-      placeholder: 'Client Cert. Begins with -----BEGIN CERTIFICATE-----',
-    },
-    TLSClientKey: {
-      label: 'Client Key',
-      placeholder: 'Client Key. Begins with -----BEGIN RSA PRIVATE KEY-----',
-    },
-    Secure: {
-      label: 'Secure Connection',
-      tooltip: 'Toggle on if the connection is secure',
-    },
-    SecureSocksProxy: {
-      label: 'Enable Secure Socks Proxy',
-      tooltip: 'Enable proxying the datasource connection through the secure socks proxy to a different network.',
-    },
-  },
   QueryEditor: {
     CodeEditor: {
       input: () => '.monaco-editor textarea',
@@ -175,6 +112,16 @@ export const Components = {
         tooltip: 'SQL Preview. You can safely switch to SQL Editor to customize the generated query',
       },
     },
+  },
+  Config: {
+    HttpHeaderConfig: {
+      headerEditor: 'config__http-header-config__header-editor',
+      addHeaderButton: 'config__http-header-config__add-header-button',
+      removeHeaderButton: 'config__http-header-config__remove-header-button',
+      headerSecureSwitch: 'config__http-header-config__header-secure-switch',
+      headerNameInput: 'config__http-header-config__header-name-input',
+      headerValueInput: 'config__http-header-config__header-value-input'
+    }
   },
   QueryBuilder: {
     AggregateEditor: {

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -1,4 +1,4 @@
-import { DataSourceJsonData } from '@grafana/data';
+import { DataSourceJsonData, KeyValue } from '@grafana/data';
 
 export interface CHConfig extends DataSourceJsonData {
   host: string;
@@ -23,8 +23,25 @@ export interface CHConfig extends DataSourceJsonData {
   logs?: CHLogsConfig;
   traces?: CHTracesConfig;
 
+  httpHeaders?: CHHttpHeader[];
+
   customSettings?: CHCustomSetting[];
   enableSecureSocksProxy?: boolean;
+}
+
+interface CHSecureConfigProperties {
+  password?: string;
+
+  tlsCACert?: string;
+  tlsClientCert?: string;
+  tlsClientKey?: string;
+}
+export type CHSecureConfig = CHSecureConfigProperties | KeyValue<string>;
+
+export interface CHHttpHeader {
+  name: string;
+  value: string;
+  secure: boolean;
 }
 
 export interface CHCustomSetting {
@@ -32,12 +49,6 @@ export interface CHCustomSetting {
   value: string;
 }
 
-export interface CHSecureConfig {
-  password: string;
-  tlsCACert?: string;
-  tlsClientCert?: string;
-  tlsClientKey?: string;
-}
 
 export interface CHLogsConfig {
   defaultDatabase?: string;

--- a/src/views/CHConfigEditor.test.tsx
+++ b/src/views/CHConfigEditor.test.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { ConfigEditor } from './CHConfigEditor';
 import { mockConfigEditorProps } from '__mocks__/ConfigEditor';
-import { Components } from 'selectors';
 import '@testing-library/jest-dom';
 import { Protocol } from 'types/config';
+import allLabels from 'labels';
 
 jest.mock('@grafana/runtime', () => {
   const original = jest.requireActual('@grafana/runtime');
@@ -23,13 +23,15 @@ jest.mock('@grafana/runtime', () => {
 });
 
 describe('ConfigEditor', () => {
+  const labels = allLabels.components.Config.ConfigEditor;
+
   it('new editor', () => {
     render(<ConfigEditor {...mockConfigEditorProps()} />);
-    expect(screen.getByPlaceholderText(Components.ConfigEditor.ServerAddress.placeholder)).toBeInTheDocument();
-    expect(screen.getByPlaceholderText(Components.ConfigEditor.ServerPort.placeholder('false'))).toBeInTheDocument();
-    expect(screen.getByPlaceholderText(Components.ConfigEditor.Username.placeholder)).toBeInTheDocument();
-    expect(screen.getByPlaceholderText(Components.ConfigEditor.Password.placeholder)).toBeInTheDocument();
-    expect(screen.getByPlaceholderText(Components.ConfigEditor.Path.placeholder)).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(labels.serverAddress.placeholder)).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(labels.serverPort.insecureHttpPort)).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(labels.username.placeholder)).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(labels.password.placeholder)).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(labels.path.placeholder)).toBeInTheDocument();
   });
   it('with password', async () => {
     render(
@@ -42,9 +44,9 @@ describe('ConfigEditor', () => {
         }}
       />
     );
-    expect(screen.getByPlaceholderText(Components.ConfigEditor.ServerAddress.placeholder)).toBeInTheDocument();
-    expect(screen.getByPlaceholderText(Components.ConfigEditor.ServerPort.placeholder('false'))).toBeInTheDocument();
-    expect(screen.getByPlaceholderText(Components.ConfigEditor.Username.placeholder)).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(labels.serverAddress.placeholder)).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(labels.serverPort.insecureHttpPort)).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(labels.username.placeholder)).toBeInTheDocument();
     const a = screen.getByText('Reset');
     expect(a).toBeInTheDocument();
   });
@@ -55,11 +57,11 @@ describe('ConfigEditor', () => {
         {...mockConfigEditorProps()}
         options={{
           ...mockConfigEditorProps().options,
-          jsonData: { ...mockConfigEditorProps().options.jsonData, path },
+          jsonData: { ...mockConfigEditorProps().options.jsonData, path, protocol: Protocol.Http },
         }}
       />
     );
-    expect(screen.queryByPlaceholderText(Components.ConfigEditor.Path.placeholder)).toHaveValue(path);
+    expect(screen.queryByPlaceholderText(labels.path.placeholder)).toHaveValue(path);
   });
   it('with secure connection', async () => {
     render(
@@ -71,7 +73,7 @@ describe('ConfigEditor', () => {
         }}
       />
     );
-    expect(screen.queryByPlaceholderText(Components.ConfigEditor.ServerPort.placeholder('true'))).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText(labels.serverPort.secureHttpPort)).toBeInTheDocument();
   });
   it('with protocol', async () => {
     render(
@@ -88,7 +90,7 @@ describe('ConfigEditor', () => {
   });
   it('without tlsCACert', async () => {
     render(<ConfigEditor {...mockConfigEditorProps()} />);
-    expect(screen.queryByPlaceholderText(Components.ConfigEditor.TLSCACert.placeholder)).not.toBeInTheDocument();
+    expect(screen.queryByPlaceholderText(labels.tlsCACert.placeholder)).not.toBeInTheDocument();
   });
   it('with tlsCACert', async () => {
     render(
@@ -100,12 +102,12 @@ describe('ConfigEditor', () => {
         }}
       />
     );
-    expect(screen.getByPlaceholderText(Components.ConfigEditor.TLSCACert.placeholder)).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(labels.tlsCACert.placeholder)).toBeInTheDocument();
   });
   it('without tlsAuth', async () => {
     render(<ConfigEditor {...mockConfigEditorProps()} />);
-    expect(screen.queryByPlaceholderText(Components.ConfigEditor.TLSClientCert.placeholder)).not.toBeInTheDocument();
-    expect(screen.queryByPlaceholderText(Components.ConfigEditor.TLSClientKey.placeholder)).not.toBeInTheDocument();
+    expect(screen.queryByPlaceholderText(labels.tlsClientCert.placeholder)).not.toBeInTheDocument();
+    expect(screen.queryByPlaceholderText(labels.tlsClientKey.placeholder)).not.toBeInTheDocument();
   });
   it('with tlsAuth', async () => {
     render(
@@ -117,8 +119,8 @@ describe('ConfigEditor', () => {
         }}
       />
     );
-    expect(screen.getByPlaceholderText(Components.ConfigEditor.TLSClientCert.placeholder)).toBeInTheDocument();
-    expect(screen.getByPlaceholderText(Components.ConfigEditor.TLSClientKey.placeholder)).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(labels.tlsClientCert.placeholder)).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(labels.tlsClientKey.placeholder)).toBeInTheDocument();
   });
   it('with additional properties', async () => {
     const jsonDataOverrides = {
@@ -130,7 +132,7 @@ describe('ConfigEditor', () => {
       customSettings: [{ setting: 'test-setting', value: 'test-value' }],
     };
     render(<ConfigEditor {...mockConfigEditorProps(jsonDataOverrides)} />);
-    expect(screen.getByText(Components.ConfigEditor.SecureSocksProxy.label)).toBeInTheDocument();
+    expect(screen.getByText(labels.secureSocksProxy.label)).toBeInTheDocument();
     expect(screen.getByDisplayValue(jsonDataOverrides.customSettings[0].setting)).toBeInTheDocument();
     expect(screen.getByDisplayValue(jsonDataOverrides.customSettings[0].value)).toBeInTheDocument();
   });

--- a/src/views/CHConfigEditor.tsx
+++ b/src/views/CHConfigEditor.tsx
@@ -188,7 +188,7 @@ export const ConfigEditor: React.FC<ConfigEditorProps> = (props) => {
         >
           <Input
             name="host"
-            width={40}
+            width={80}
             value={jsonData.host || ''}
             onChange={onUpdateDatasourceJsonDataOption(props, 'host')}
             label={labels.serverAddress.label}
@@ -237,7 +237,7 @@ export const ConfigEditor: React.FC<ConfigEditorProps> = (props) => {
             <Input
               value={jsonData.path || ''}
               name="path"
-              width={40}
+              width={80}
               onChange={onUpdateDatasourceJsonDataOption(props, 'path')}
               label={labels.path.label}
               aria-label={labels.path.label}

--- a/src/views/CHConfigEditorHooks.test.ts
+++ b/src/views/CHConfigEditorHooks.test.ts
@@ -1,7 +1,7 @@
 import { DataSourceSettings } from "@grafana/data";
 import { renderHook } from "@testing-library/react";
-import { CHConfig } from "types/config";
-import { useMigrateV3Config } from "./CHConfigEditorHooks";
+import { CHConfig, CHHttpHeader, CHSecureConfig } from "types/config";
+import { onHttpHeadersChange, useMigrateV3Config } from "./CHConfigEditorHooks";
 
 describe('useMigrateV3Config', () => {
   it('should not call onOptionsChange if no v3 fields are present', async () => {
@@ -56,6 +56,91 @@ describe('useMigrateV3Config', () => {
       jsonData: {
         host: 'new',
         dialTimeout: '8'
+      }
+    };
+    expect(onOptionsChange).toHaveBeenCalledTimes(1);
+    expect(onOptionsChange).toHaveBeenCalledWith(expect.objectContaining(expectedOptions));
+  });
+});
+
+describe('onHttpHeadersChange', () => {
+  it('should properly sort headers into secure/plain config fields', async () => {
+    const onOptionsChange = jest.fn();
+    const headers: CHHttpHeader[] = [
+      {
+        name: 'X-Existing-Auth-Header',
+        value: '',
+        secure: true
+      },
+      {
+        name: 'X-Existing-Header',
+        value: 'existing value',
+        secure: false
+      },
+      {
+        name: 'Authorization',
+        value: 'secret1234',
+        secure: true
+      },
+      {
+        name: 'X-Custom-Header',
+        value: 'plain text value',
+        secure: false
+      },
+    ];
+    const opts = {
+      jsonData: {
+        httpHeaders: [
+          {
+            name: 'X-Existing-Auth-Header',
+            value: '',
+            secure: true
+          },
+          {
+            name: 'X-Existing-Header',
+            value: 'existing value',
+            secure: false
+          },
+        ]
+      },
+      secureJsonFields: {
+        'secureHttpHeaders.X-Existing-Auth-Header': true
+      },
+    } as any as DataSourceSettings<CHConfig, CHSecureConfig>;
+
+    onHttpHeadersChange(headers, opts, onOptionsChange);
+
+    const expectedOptions = {
+      jsonData: {
+        httpHeaders: [
+          {
+            name: 'X-Existing-Auth-Header',
+            value: '',
+            secure: true
+          },
+          {
+            name: 'X-Existing-Header',
+            value: 'existing value',
+            secure: false
+          },
+          {
+            name: 'Authorization',
+            value: '',
+            secure: true
+          },
+          {
+            name: 'X-Custom-Header',
+            value: 'plain text value',
+            secure: false
+          },
+        ]
+      },
+      secureJsonFields: {
+        'secureHttpHeaders.X-Existing-Auth-Header': true,
+        'secureHttpHeaders.Authorization': true
+      },
+      secureJsonData: {
+        'secureHttpHeaders.Authorization': 'secret1234'
       }
     };
     expect(onOptionsChange).toHaveBeenCalledTimes(1);

--- a/src/views/CHConfigEditorHooks.ts
+++ b/src/views/CHConfigEditorHooks.ts
@@ -1,13 +1,13 @@
-import { DataSourceSettings } from "@grafana/data";
+import { DataSourceSettings, KeyValue } from "@grafana/data";
 import { useEffect, useRef } from "react";
-import { CHConfig } from "types/config";
+import { CHConfig, CHHttpHeader, CHSecureConfig } from "types/config";
 
 /**
  * Migrates v3 config to latest config schema.
  * Copies and removes old "server" to "host" field
  * Copies and removes old "timeout" to "dialTimeout" field
  */
-export const useMigrateV3Config = (options: DataSourceSettings<CHConfig>, onOptionsChange: (opts: DataSourceSettings<CHConfig>) => void) => {
+export const useMigrateV3Config = (options: DataSourceSettings<CHConfig, CHSecureConfig>, onOptionsChange: (opts: DataSourceSettings<CHConfig, CHSecureConfig>) => void) => {
   const { jsonData } = options;
   const v3ServerField = (jsonData as any)['server'];
   const v3TimeoutField = (jsonData as any)['timeout'];
@@ -34,4 +34,60 @@ export const useMigrateV3Config = (options: DataSourceSettings<CHConfig>, onOpti
       migrated.current = true;
     }
   }, [v3ServerField, v3TimeoutField, options, onOptionsChange]);
+};
+
+/**
+ * Handles saving HTTP headers to Grafana config.
+ * 
+ * All header keys go to the unsecure config.
+ * If the header is marked as secure, its value goes to the
+ * secure json config where it is hidden.
+ */
+export const onHttpHeadersChange = (headers: CHHttpHeader[], options: DataSourceSettings<CHConfig, CHSecureConfig>, onOptionsChange: (opts: DataSourceSettings<CHConfig, CHSecureConfig>) => void) => {
+  const httpHeaders: CHHttpHeader[] = [];
+  const secureHttpHeaderKeys: KeyValue<boolean> = {};
+  const secureHttpHeaderValues: KeyValue<string> = {};
+
+  for (let header of headers) {
+    if (!header.name) {
+      continue;
+    }
+
+    if (header.secure) {
+      const key = `secureHttpHeaders.${header.name}`;
+      secureHttpHeaderKeys[key] = true;
+
+      if (header.value) {
+        secureHttpHeaderValues[key] = header.value;
+        header.value = '';
+      }
+    }
+
+    httpHeaders.push(header);
+  }
+
+  const currentSecureJsonFields: KeyValue<boolean> = { ...options.secureJsonFields };
+  for (let key in currentSecureJsonFields) {
+    if (!secureHttpHeaderKeys[key] && key.startsWith('secureHttpHeaders.')) {
+      // Remove key from secureJsonData when it is no longer present in header config
+      secureHttpHeaderKeys[key] = false;
+      secureHttpHeaderValues[key] = '';
+    }
+  }
+
+  onOptionsChange({
+    ...options,
+    jsonData: {
+      ...options.jsonData,
+      httpHeaders
+    },
+    secureJsonFields: {
+      ...options.secureJsonFields,
+      ...secureHttpHeaderKeys
+    },
+    secureJsonData: {
+      ...options.secureJsonData,
+      ...secureHttpHeaderValues
+    },
+  });
 };


### PR DESCRIPTION
Allows adding custom HTTP headers. (Requested in #626)

- All header names are saved to `jsonData`.
- Plain text header values are saved to `jsonData`.
- Secure header values are saved to `secureJsonData`.

Includes frontend + backend changes. 

Also includes some label updates to the config page when selecting a port.

![New HTTP Headers section](https://github.com/grafana/clickhouse-datasource/assets/28887171/199ec705-24d1-4050-846e-400764e8e2cc)
