### PR TITLE
fix: v3 config page migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 4.0.2
+
+### Fixes
+
+- Fixed migration script not running when opening an existing v3 config
+
 ## 4.0.1
 
 ### Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clickhouse-datasource",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "Clickhouse Datasource",
   "engines": {
     "node": ">=16"

--- a/src/views/CHConfigEditor.tsx
+++ b/src/views/CHConfigEditor.tsx
@@ -18,7 +18,7 @@ import { LogsConfig } from 'components/configEditor/LogsConfig';
 import { TracesConfig } from 'components/configEditor/TracesConfig';
 import { HttpHeadersConfig } from 'components/configEditor/HttpHeadersConfig';
 import allLabels from 'labels';
-import { onHttpHeadersChange, useConfigDefaults, useMigrateV3Config } from './CHConfigEditorHooks';
+import { onHttpHeadersChange, useConfigDefaults } from './CHConfigEditorHooks';
 
 export interface ConfigEditorProps extends DataSourcePluginOptionsEditorProps<CHConfig, CHSecureConfig> {}
 
@@ -35,7 +35,6 @@ export const ConfigEditor: React.FC<ConfigEditorProps> = (props) => {
     { label: 'HTTP', value: Protocol.Http },
   ];
 
-  useMigrateV3Config(options, onOptionsChange);
   useConfigDefaults(options, onOptionsChange);
 
   const onPortChange = (port: string) => {

--- a/src/views/CHConfigEditorHooks.test.ts
+++ b/src/views/CHConfigEditorHooks.test.ts
@@ -228,6 +228,21 @@ describe('useConfigDefaults', () => {
     expect(onOptionsChange).toHaveBeenCalledWith(expect.objectContaining(expectedOptions));
   });
 
+  it('should apply defaults for unset config fields', async () => {
+    const onOptionsChange = jest.fn();
+    const options = {
+      jsonData: {}
+    } as any as DataSourceSettings<CHConfig>;
+
+    renderHook(opts => useConfigDefaults(opts, onOptionsChange), { initialProps: options });
+
+    const expectedOptions = {
+      jsonData: { ...expectedDefaults }
+    };
+    expect(onOptionsChange).toHaveBeenCalledTimes(1);
+    expect(onOptionsChange).toHaveBeenCalledWith(expect.objectContaining(expectedOptions));
+  });
+
   it('should not call onOptionsChange after defaults are already set', async () => {
     const onOptionsChange = jest.fn();
     const options = {


### PR DESCRIPTION
Fixes the config migration from not running by combining the migration logic and default setting logic into one single hook.

Includes changelog+version increment

### The Problem

The v3 `server` field is not migrating to the v4 `host` field. This causes the UI to show the field as empty, even though the data is still present in the config.

### Why

There are two `useEffect` hooks that call `onOptionsChange`: `useMigrateV3Config` and `useConfigDefaults`.

`useConfigDefaults` overwrites the first call by `useMigrateV3Config`

### Will it still work?

Yes, the plugin backend is still loading the connection from the `server` field, it's backwards compatible even though the UI isn't loading it correctly. The data is also still present in the config state, it just isn't copied into the new field.

If the user decides to re-enter the `host` manually, then it will be updated to the value they enter and the old value will be ignored