### PR TITLE
Optimize OTel Trace ID queries with skip index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,13 @@
 - Added `$__fromTime_ms` macro that represents the dashboard "from" time in milliseconds using a `DateTime64(3)`
 - Added `$__toTime_ms` macro that represents the dashboard "to" time in milliseconds using a `DateTime64(3)`
 - Added `$__timeFilter_ms` macro that uses `DateTime64(3)` for millisecond precision time filtering
+- When OTel is enabled, Trace ID queries now use a skip index to optimize exact ID lookups on large trace datasets (#724)
 
 ### Fixes
 
 - Fixed performance issues caused by `$__timeFilter` using a `DateTime64(3)` instead of `DateTime` (#699)
 - Fixed trace queries from rounding span durations under 1ms to `0` (#720)
+- Fixed missing `AND` keyword when adding a filter to a Trace ID query 
 
 ## 4.0.2
 

--- a/src/components/configEditor/LogsConfig.tsx
+++ b/src/components/configEditor/LogsConfig.tsx
@@ -3,7 +3,7 @@ import { ConfigSection, ConfigSubSection } from '@grafana/experimental';
 import { Input, Field } from '@grafana/ui';
 import { OtelVersionSelect } from 'components/queryBuilder/OtelVersionSelect';
 import { ColumnHint } from 'types/queryBuilder';
-import { versions as otelVersions } from 'otel';
+import otel from 'otel';
 import { LabeledInput } from './LabeledInput';
 import { CHLogsConfig } from 'types/config';
 import allLabels from 'labels';
@@ -33,7 +33,7 @@ export const LogsConfig = (props: LogsConfigProps) => {
   } = (props.logsConfig || {});
   const labels = allLabels.components.Config.LogsConfig;
 
-  const otelConfig = otelVersions.find(v => v.version === otelVersion);
+  const otelConfig = otel.getVersion(otelVersion);
   if (otelEnabled && otelConfig) {
     timeColumn = otelConfig.logColumnMap.get(ColumnHint.Time);
     levelColumn = otelConfig.logColumnMap.get(ColumnHint.LogLevel);

--- a/src/components/configEditor/TracesConfig.tsx
+++ b/src/components/configEditor/TracesConfig.tsx
@@ -4,7 +4,7 @@ import { ConfigSection, ConfigSubSection } from '@grafana/experimental';
 import { Input, Field } from '@grafana/ui';
 import { OtelVersionSelect } from 'components/queryBuilder/OtelVersionSelect';
 import { ColumnHint, TimeUnit } from 'types/queryBuilder';
-import { versions as otelVersions } from 'otel';
+import otel from 'otel';
 import { LabeledInput } from './LabeledInput';
 import { DurationUnitSelect } from 'components/queryBuilder/DurationUnitSelect';
 import { CHTracesConfig } from 'types/config';
@@ -45,7 +45,7 @@ export const TracesConfig = (props: TraceConfigProps) => {
   } = (props.tracesConfig || {}) as CHTracesConfig;
   const labels = allLabels.components.Config.TracesConfig;
 
-  const otelConfig = otelVersions.find(v => v.version === otelVersion);
+  const otelConfig = otel.getVersion(otelVersion);
   if (otelEnabled && otelConfig) {
     startTimeColumn = otelConfig.traceColumnMap.get(ColumnHint.Time);
     traceIdColumn = otelConfig.traceColumnMap.get(ColumnHint.TraceId);

--- a/src/components/queryBuilder/OtelVersionSelect.test.tsx
+++ b/src/components/queryBuilder/OtelVersionSelect.test.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import { OtelVersionSelect } from './OtelVersionSelect';
-import { versions as allVersions } from 'otel';
+import otel from 'otel';
 
 describe('OtelVersionSelect', () => {
-  const testVersion = allVersions[0];
+  const testVersion = otel.getLatestVersion();
   const testVersionName = testVersion.name;
 
   it('should render with empty properties', () => {

--- a/src/components/queryBuilder/OtelVersionSelect.tsx
+++ b/src/components/queryBuilder/OtelVersionSelect.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import { SelectableValue } from '@grafana/data';
 import { InlineFormLabel, Select, Switch as GrafanaSwitch, useTheme } from '@grafana/ui';
-import { versions as allVersions } from 'otel';
+import otel from 'otel';
 import selectors from 'labels';
 
 interface OtelVersionSelectProps {
@@ -15,15 +15,15 @@ interface OtelVersionSelectProps {
 export const OtelVersionSelect = (props: OtelVersionSelectProps) => {
   const { enabled, onEnabledChange, selectedVersion, onVersionChange, wide } = props;
   const { label, tooltip } = selectors.components.OtelVersionSelect;
-  const options: SelectableValue[] = allVersions.map(v => ({
+  const options: SelectableValue[] = otel.versions.map(v => ({
     label: v.name,
     value: v.version
   }));
 
   useEffect(() => {
     // Use latest version if not set or doesn't exist (which may happen if config is broken)
-    if (selectedVersion === '' || !allVersions.find(v => selectedVersion === v.version)) {
-      onVersionChange(allVersions[0].version);
+    if (selectedVersion === '' || !otel.getVersion(selectedVersion)) {
+      onVersionChange(otel.getLatestVersion().version);
     }
   }, [selectedVersion, onVersionChange]);
 

--- a/src/components/queryBuilder/views/logsQueryBuilderHooks.test.ts
+++ b/src/components/queryBuilder/views/logsQueryBuilderHooks.test.ts
@@ -3,7 +3,7 @@ import { useDefaultFilters, useDefaultTimeColumn, useLogDefaultsOnMount, useOtel
 import { mockDatasource } from '__mocks__/datasource';
 import { ColumnHint, QueryBuilderOptions, SelectedColumn, TableColumn } from 'types/queryBuilder';
 import { setColumnByHint, setOptions } from 'hooks/useBuilderOptionsState';
-import { versions as otelVersions } from 'otel';
+import otel from 'otel';
 
 describe('useLogDefaultsOnMount', () => {
   it('should call builderOptionsDispatch with default log columns', async () => {
@@ -47,7 +47,7 @@ describe('useLogDefaultsOnMount', () => {
 });
 
 describe('useOtelColumns', () => {
-  const testOtelVersion = otelVersions[0]; // use latest version
+  const testOtelVersion = otel.getLatestVersion();
 
   it('should not call builderOptionsDispatch if OTEL is already enabled', async () => {
     const builderOptionsDispatch = jest.fn();

--- a/src/components/queryBuilder/views/logsQueryBuilderHooks.ts
+++ b/src/components/queryBuilder/views/logsQueryBuilderHooks.ts
@@ -3,7 +3,7 @@ import { columnFilterDateTime } from "data/columnFilters";
 import { BuilderOptionsReducerAction, setColumnByHint, setOptions } from "hooks/useBuilderOptionsState";
 import { useEffect, useMemo, useRef } from "react";
 import { ColumnHint, DateFilterWithoutValue, Filter, FilterOperator, OrderBy, OrderByDirection, QueryBuilderOptions, SelectedColumn, StringFilter, TableColumn } from "types/queryBuilder";
-import { versions as otelVersions } from 'otel';
+import otel from 'otel';
 
 /**
  * Loads the default configuration for new queries. (Only runs on new queries)
@@ -53,7 +53,7 @@ export const useOtelColumns = (otelEnabled: boolean, otelVersion: string, builde
       return;
     }
 
-    const otelConfig = otelVersions.find(v => v.version === otelVersion);
+    const otelConfig = otel.getVersion(otelVersion);
     const logColumnMap = otelConfig?.logColumnMap;
     if (!logColumnMap) {
       return;

--- a/src/components/queryBuilder/views/traceQueryBuilderHooks.test.ts
+++ b/src/components/queryBuilder/views/traceQueryBuilderHooks.test.ts
@@ -3,7 +3,7 @@ import { useTraceDefaultsOnMount, useOtelColumns, useDefaultFilters } from './tr
 import { mockDatasource } from '__mocks__/datasource';
 import { ColumnHint, QueryBuilderOptions, SelectedColumn } from 'types/queryBuilder';
 import { setOptions } from 'hooks/useBuilderOptionsState';
-import { versions as otelVersions } from 'otel';
+import otel from 'otel';
 
 describe('useTraceDefaultsOnMount', () => {
   it('should call builderOptionsDispatch with default trace columns', async () => {
@@ -48,7 +48,7 @@ describe('useTraceDefaultsOnMount', () => {
 });
 
 describe('useOtelColumns', () => {
-  const testOtelVersion = otelVersions[0]; // use latest version
+  const testOtelVersion = otel.getLatestVersion();
 
   it('should not call builderOptionsDispatch if OTEL is already enabled', async () => {
     const builderOptionsDispatch = jest.fn();

--- a/src/components/queryBuilder/views/traceQueryBuilderHooks.ts
+++ b/src/components/queryBuilder/views/traceQueryBuilderHooks.ts
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef } from 'react';
 import { Datasource } from 'data/CHDatasource';
-import { versions as otelVersions } from 'otel';
+import otel from 'otel';
 import { ColumnHint, DateFilterWithoutValue, Filter, FilterOperator, NumberFilter, OrderBy, OrderByDirection, QueryBuilderOptions, SelectedColumn, StringFilter } from 'types/queryBuilder';
 import { BuilderOptionsReducerAction, setOptions } from 'hooks/useBuilderOptionsState';
 
@@ -54,7 +54,7 @@ export const useOtelColumns = (otelEnabled: boolean, otelVersion: string, builde
       return;
     }
 
-    const otelConfig = otelVersions.find(v => v.version === otelVersion);
+    const otelConfig = otel.getVersion(otelVersion);
     const traceColumnMap = otelConfig?.traceColumnMap;
     if (!traceColumnMap) {
       return;

--- a/src/data/CHDatasource.ts
+++ b/src/data/CHDatasource.ts
@@ -45,7 +45,7 @@ import {
   TIME_FIELD_ALIAS,
 } from './logs';
 import { generateSql, getColumnByHint, logAliasToColumnHints } from './sqlGenerator';
-import { versions as otelVersions } from 'otel';
+import otel from 'otel';
 import { ReactNode } from 'react';
 import { transformQueryResponseWithTraceAndLogLinks } from './utils';
 import { pluginVersion } from 'utils/version';
@@ -414,7 +414,7 @@ export class Datasource
     const otelEnabled = logsConfig.otelEnabled;
     const otelVersion = logsConfig.otelVersion;
 
-    const otelConfig = otelVersions.find(v => v.version === otelVersion);
+    const otelConfig = otel.getVersion(otelVersion);
     if (otelEnabled && otelConfig) {
       return otelConfig.logColumnMap;
     }
@@ -452,7 +452,7 @@ export class Datasource
     const otelEnabled = traceConfig.otelEnabled;
     const otelVersion = traceConfig.otelVersion;
 
-    const otelConfig = otelVersions.find(v => v.version === otelVersion);
+    const otelConfig = otel.getVersion(otelVersion);
     if (otelEnabled && otelConfig) {
       return otelConfig.traceColumnMap;
     }

--- a/src/data/sqlGenerator.ts
+++ b/src/data/sqlGenerator.ts
@@ -1,5 +1,5 @@
 import { BooleanFilter, BuilderMode, ColumnHint, DateFilterWithValue, FilterOperator, MultiFilter, NumberFilter, QueryBuilderOptions, QueryType, SelectedColumn, StringFilter, TimeUnit } from 'types/queryBuilder';
-import { getVersion as getOtelVersion } from 'otel';
+import otel from 'otel';
 
 /**
  * Generates a SQL string for the given QueryBuilderOptions
@@ -148,7 +148,7 @@ const generateTraceIdQuery = (options: QueryBuilderOptions): string => {
 
   // Optimize trace ID filtering for OTel enabled trace lookups
   const hasTraceIdFilter = options.meta?.isTraceIdMode && options.meta?.traceId;
-  const otelVersion = getOtelVersion(options.meta?.otelVersion);
+  const otelVersion = otel.getVersion(options.meta?.otelVersion);
   const applyTraceIdOptimization = hasTraceIdFilter && options.meta?.otelEnabled && otelVersion;
   if (applyTraceIdOptimization) {
     const traceId = options.meta!.traceId;

--- a/src/data/sqlGenerator.ts
+++ b/src/data/sqlGenerator.ts
@@ -149,7 +149,7 @@ const generateTraceIdQuery = (options: QueryBuilderOptions): string => {
   // Optimize trace ID filtering for OTel enabled trace lookups
   const hasTraceIdFilter = options.meta?.isTraceIdMode && options.meta?.traceId;
   const otelVersion = getOtelVersion(options.meta?.otelVersion);
-  const applyTraceIdOptimization = options.meta?.otelEnabled && hasTraceIdFilter && otelVersion;
+  const applyTraceIdOptimization = hasTraceIdFilter && options.meta?.otelEnabled && otelVersion;
   if (applyTraceIdOptimization) {
     const traceId = options.meta!.traceId;
     const timestampTable = getTableIdentifier(database, otelVersion.traceTimestampTable);
@@ -170,17 +170,15 @@ const generateTraceIdQuery = (options: QueryBuilderOptions): string => {
     queryParts.push('WHERE');
   }
 
-  if (hasTraceIdFilter) {
-    if (applyTraceIdOptimization) {
-      queryParts.push('traceID = trace_id');
-      queryParts.push('AND');
-      queryParts.push(`startTime >= trace_start`);
-      queryParts.push('AND');
-      queryParts.push(`startTime <= trace_end`);
-    } else {
-      const traceId = options.meta!.traceId;
-      queryParts.push(`traceID = '${traceId}'`);
-    }
+  if (applyTraceIdOptimization) {
+    queryParts.push('traceID = trace_id');
+    queryParts.push('AND');
+    queryParts.push(`startTime >= trace_start`);
+    queryParts.push('AND');
+    queryParts.push(`startTime <= trace_end`);
+  } else if (hasTraceIdFilter) {
+    const traceId = options.meta!.traceId;
+    queryParts.push(`traceID = '${traceId}'`);
   }
 
   if (filterParts) {

--- a/src/otel.ts
+++ b/src/otel.ts
@@ -1,7 +1,8 @@
 import { ColumnHint, TimeUnit } from "types/queryBuilder";
 
 const defaultLogsTable = 'otel_logs';
-const defaultTraceTable = 'otel_traces'
+const defaultTraceTable = 'otel_traces';
+const defaultTraceTimestampTable = 'otel_traces_trace_id_ts';
 
 export interface OtelVersion {
   name: string;
@@ -11,6 +12,7 @@ export interface OtelVersion {
   logColumnMap: Map<ColumnHint, string>;
   logLevels: string[];
   traceTable: string;
+  traceTimestampTable: string;
   traceColumnMap: Map<ColumnHint, string>;
   traceDurationUnit: TimeUnit.Nanoseconds;
 }
@@ -35,6 +37,7 @@ const otel129: OtelVersion = {
     'FATAL'
   ],
   traceTable: defaultTraceTable,
+  traceTimestampTable: defaultTraceTimestampTable,
   traceColumnMap: new Map<ColumnHint, string>([
     [ColumnHint.Time, 'Timestamp'],
     [ColumnHint.TraceId, 'TraceId'],
@@ -56,3 +59,10 @@ export const versions: readonly OtelVersion[] = [
 ];
 
 export const getLatestVersion = (): OtelVersion => versions[0];
+export const getVersion = (version: string | undefined): OtelVersion | undefined => {
+  if (!version) {
+    return;
+  }
+
+  return versions.find(v => v.version === version);
+};

--- a/src/otel.ts
+++ b/src/otel.ts
@@ -66,3 +66,9 @@ export const getVersion = (version: string | undefined): OtelVersion | undefined
 
   return versions.find(v => v.version === version);
 };
+
+export default {
+  versions,
+  getLatestVersion,
+  getVersion
+};


### PR DESCRIPTION
Adds the optimization requested in #724 

This optimization is only included in the SQL when OTel is enabled since the table is specific to OTel.

Here's the new SQL that is generated for Trace ID queries:

```diff
+ WITH
+ '207c6fb96eda8541559a283678587c86' as trace_id,
+ (SELECT min(Start) FROM "default"."otel_traces_trace_id_ts" WHERE TraceId = trace_id) as trace_start,
+ (SELECT max(End) + 1 FROM "default"."otel_traces_trace_id_ts" WHERE TraceId = trace_id) as trace_end
SELECT
"TraceId" as traceID, "SpanId" as spanID, "ParentSpanId" as parentSpanID, "ServiceName" as serviceName,
"SpanName" as operationName, "Timestamp" as startTime, multiply("Duration", 0.000001) as duration,
arrayMap(key -> map('key', key, 'value',"SpanAttributes"[key]), mapKeys("SpanAttributes")) as tags,
arrayMap(key -> map('key', key, 'value',"ResourceAttributes"[key]), mapKeys("ResourceAttributes")) as serviceTags
FROM "default"."otel_traces"
WHERE
- traceID = '207c6fb96eda8541559a283678587c86'
+ traceID = trace_id
+ AND startTime >= trace_start
+ AND startTime <= trace_end 
LIMIT 1000
```

Here's a rough graph of query duration before and after:
![image](https://github.com/grafana/clickhouse-datasource/assets/28887171/74cf1529-d27f-4352-968e-4a629116ea81)

