### PR TITLE
Update pull_request_template.md with CI/CD instructions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,3 +2,9 @@
 <!-- If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way: -->
 <!-- Bad: fix state bug in hooks -->
 <!-- Good: Fix crash when switching from Query Builder -->
+
+- [ ] I've run the test suite and linters and have no errors:
+  ```sh
+  npx --yes cspell@6.13.3 -c cspell.config.json "**/*.{ts,tsx,js,go,md,mdx,yml,yaml,json,scss,css}"
+  golangci-lint run --timeout=5m
+  ```


### PR DESCRIPTION
Our CI/CD doesn't run automatically for external contributions anymore. This leads to unnecessary back and forth for issues like linter errors or mispellings. This will hopefully surface these issues earlier in the PR process and result in PRs getting merged sooner.
