### PR TITLE
CI/CD: add basic linting and spell check

### DIFF
--- a/.github/workflows/run-ci-cd.yml
+++ b/.github/workflows/run-ci-cd.yml
@@ -18,6 +18,13 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: 'stable'
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v4
+        with:
+          # When `install-mode` is `binary` (default) the value can be v1.2 or v1.2.3 or `latest` to use the latest version.
+          # When `install-mode` is `goinstall` the value can be v1.2.3, `latest`, or the hash of a commit.
+          version: latest
       
       - name: Check spelling
         run: npx --yes cspell@6.13.3 -c cspell.config.json "**/*.{ts,tsx,js,go,md,mdx,yml,yaml,json,scss,css}"

--- a/.github/workflows/run-ci-cd.yml
+++ b/.github/workflows/run-ci-cd.yml
@@ -1,0 +1,26 @@
+name: run-ci-cd
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 'stable'
+      
+      - name: Check spelling
+        run: npx --yes cspell@6.13.3 -c cspell.config.json "**/*.{ts,tsx,js,go,md,mdx,yml,yaml,json,scss,css}"
+
+      - name: Lint backend
+        run: golangci-lint run --timeout=5m

--- a/.github/workflows/run-ci-cd.yml
+++ b/.github/workflows/run-ci-cd.yml
@@ -28,6 +28,3 @@ jobs:
       
       - name: Check spelling
         run: npx --yes cspell@6.13.3 -c cspell.config.json "**/*.{ts,tsx,js,go,md,mdx,yml,yaml,json,scss,css}"
-
-      - name: Lint backend
-        run: golangci-lint run --timeout=5m


### PR DESCRIPTION
Our CI/CD doesn't run automatically for external contributions anymore. This leads to unnecessary back and forth for issues like linter errors or mispellings. This will hopefully surface these issues earlier.