### PR TITLE
fix: Ad-Hoc filters not applied because variables are not recognized by the AST parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 - Fixed performance issues caused by `$__timeFilter` using a `DateTime64(3)` instead of `DateTime` (#699)
 - Fixed trace queries from rounding span durations under 1ms to `0` (#720)
+- Fixed AST error when including Grafana macros/variables in SQL (#714)
+- Fixed empty builder options when switching from SQL Editor back to Query Editor
+- Fix SQL Generator including "undefined" in `FROM` when database isn't defined
+- Allow adding spaces in multi filters (such as `WHERE .. IN`)
 
 ## 4.0.2
 

--- a/cspell.config.json
+++ b/cspell.config.json
@@ -10,6 +10,7 @@
     "mage_output_file.go"
   ],
   "words": [
+    "singlequote",
     "concats",
     "Milli",
     "traceid",

--- a/src/components/queryBuilder/utils.test.ts
+++ b/src/components/queryBuilder/utils.test.ts
@@ -1,4 +1,6 @@
-import { isDateTimeType, isDateType, isNumberType } from './utils';
+import { generateSql } from 'data/sqlGenerator';
+import { getQueryOptionsFromSql, isDateTimeType, isDateType, isNumberType } from './utils';
+import { AggregateType, BuilderMode, ColumnHint, DateFilterWithoutValue, FilterOperator, MultiFilter, OrderByDirection, QueryBuilderOptions, QueryType } from 'types/queryBuilder';
 
 describe('isDateType', () => {
   it('returns true for Date type', () => {
@@ -114,3 +116,366 @@ describe('isNumberType', () => {
     expect(isNumberType('Nullable')).toBe(false);
   });
 });
+
+describe('getQueryOptionsFromSql', () => {
+  testCondition('handles a table without a database', 'SELECT name FROM "foo"', {
+    queryType: QueryType.Table,
+    mode: BuilderMode.List,
+    database: '',
+    table: 'foo',
+    columns: [{ name: 'name', alias: undefined }],
+    aggregates: [],
+  });
+
+  testCondition('handles a database with a special character', 'SELECT name FROM "foo-bar"."buzz"', {
+    queryType: QueryType.Table,
+    mode: BuilderMode.List,
+    database: 'foo-bar',
+    table: 'buzz',
+    columns: [{ name: 'name', alias: undefined }],
+    aggregates: [],
+  });
+
+  testCondition('handles a database and a table', 'SELECT name FROM "db"."foo"', {
+    queryType: QueryType.Table,
+    mode: BuilderMode.List,
+    database: 'db',
+    table: 'foo',
+    columns: [{ name: 'name', alias: undefined }],
+    aggregates: [],
+  });
+
+  testCondition('handles a database and a table with a dot', 'SELECT name FROM "db"."foo.bar"', {
+    queryType: QueryType.Table,
+    mode: BuilderMode.List,
+    database: 'db',
+    table: 'foo.bar',
+    columns: [{ name: 'name', alias: undefined }],
+    aggregates: [],
+  });
+
+  testCondition('handles 2 columns', 'SELECT field1, field2 FROM "db"."foo"', {
+    queryType: QueryType.Table,
+    mode: BuilderMode.List,
+    database: 'db',
+    table: 'foo',
+    columns: [{ name: 'field1', alias: undefined }, { name: 'field2', alias: undefined }],
+    aggregates: [],
+  });
+
+  testCondition('handles a limit', 'SELECT field1, field2 FROM "db"."foo" LIMIT 20', {
+    queryType: QueryType.Table,
+    mode: BuilderMode.List,
+    database: 'db',
+    table: 'foo',
+    columns: [{ name: 'field1', alias: undefined }, { name: 'field2', alias: undefined }],
+    aggregates: [],
+    limit: 20,
+  });
+
+  testCondition(
+    'handles empty orderBy array',
+    'SELECT field1, field2 FROM "db"."foo" LIMIT 20',
+    {
+      queryType: QueryType.Table,
+      mode: BuilderMode.List,
+      database: 'db',
+      table: 'foo',
+      columns: [{ name: 'field1', alias: undefined }, { name: 'field2', alias: undefined }],
+      aggregates: [],
+      orderBy: [],
+      limit: 20,
+    },
+    false
+  );
+
+  testCondition('handles order by', 'SELECT field1, field2 FROM "db"."foo" ORDER BY field1 ASC LIMIT 20', {
+    queryType: QueryType.Table,
+    mode: BuilderMode.List,
+    database: 'db',
+    table: 'foo',
+    columns: [{ name: 'field1', alias: undefined }, { name: 'field2', alias: undefined }],
+    aggregates: [],
+    orderBy: [{ name: 'field1', dir: OrderByDirection.ASC }],
+    limit: 20,
+  });
+
+  testCondition(
+    'handles no select',
+    'SELECT FROM "db"',
+    {
+      queryType: QueryType.Table,
+      mode: BuilderMode.Aggregate,
+      database: 'db',
+      table: '',
+      columns: [],
+      aggregates: [],
+    },
+    false
+  );
+
+  testCondition(
+    'does not escape * field',
+    'SELECT * FROM "db"',
+    {
+      queryType: QueryType.Table,
+      mode: BuilderMode.Aggregate,
+      database: 'db',
+      table: '',
+      columns: [{ name: '*' }],
+      aggregates: [],
+      limit: undefined
+    },
+    false
+  );
+
+  testCondition('handles aggregation function', 'SELECT sum(field1) FROM "db"."foo"', {
+    queryType: QueryType.Table,
+    mode: BuilderMode.Aggregate,
+    database: 'db',
+    table: 'foo',
+    columns: [],
+    aggregates: [{ column: 'field1', aggregateType: AggregateType.Sum, alias: undefined }],
+    limit: undefined
+  });
+
+  testCondition('handles aggregation with alias', 'SELECT sum(field1) as total_records FROM "db"."foo"', {
+    queryType: QueryType.Table,
+    mode: BuilderMode.Aggregate,
+    database: 'db',
+    table: 'foo',
+    columns: [],
+    aggregates: [{ column: 'field1', aggregateType: AggregateType.Sum, alias: 'total_records' }],
+    limit: undefined
+  });
+
+  testCondition(
+    'handles 2 aggregations',
+    'SELECT sum(field1) as total_records, count(field2) as total_records2 FROM "db"."foo"',
+    {
+      queryType: QueryType.Table,
+      mode: BuilderMode.Aggregate,
+      table: 'foo',
+      database: 'db',
+      columns: [],
+      aggregates: [
+        { column: 'field1', aggregateType: AggregateType.Sum, alias: 'total_records' },
+        { column: 'field2', aggregateType: AggregateType.Count, alias: 'total_records2' },
+      ],
+      limit: undefined
+    }
+  );
+
+  testCondition(
+    'handles aggregation with groupBy',
+    'SELECT sum(field1) as total_records, count(field2) as total_records2 FROM "db"."foo" GROUP BY field3',
+    {
+      database: 'db',
+      table: 'foo',
+      queryType: QueryType.Table,
+      mode: BuilderMode.Aggregate,
+      columns: [],
+      aggregates: [
+        { column: 'field1', aggregateType: AggregateType.Sum, alias: 'total_records' },
+        { column: 'field2', aggregateType: AggregateType.Count, alias: 'total_records2' },
+      ],
+      groupBy: ['field3'],
+    },
+    false
+  );
+
+  testCondition(
+    'handles aggregation with groupBy with columns having group by value',
+    'SELECT field3, sum(field1) as total_records, count(field2) as total_records2 FROM "db"."foo" GROUP BY field3',
+    {
+      queryType: QueryType.Table,
+      mode: BuilderMode.Aggregate,
+      table: 'foo',
+      database: 'db',
+      columns: [{ name: 'field3' }],
+      aggregates: [
+        { column: 'field1', aggregateType: AggregateType.Sum, alias: 'total_records' },
+        { column: 'field2', aggregateType: AggregateType.Count, alias: 'total_records2' },
+      ],
+      groupBy: ['field3'],
+      limit: undefined
+    }
+  );
+
+  testCondition(
+    'handles aggregation with group by and order by',
+    'SELECT StageName, Type, count(Id) as count_of, sum(Amount) FROM "db"."foo" GROUP BY StageName, Type ORDER BY count_of DESC, StageName ASC',
+    {
+      mode: BuilderMode.Aggregate,
+      database: 'db',
+      table: 'foo',
+      queryType: QueryType.Table,
+      columns: [
+        { name: 'StageName' },
+        { name: 'Type' },
+      ],
+      aggregates: [
+        { column: 'Id', aggregateType: AggregateType.Count, alias: 'count_of' },
+        { column: 'Amount', aggregateType: AggregateType.Sum, alias: undefined },
+      ],
+      groupBy: ['StageName', 'Type'],
+      orderBy: [
+        { name: 'count_of', dir: OrderByDirection.DESC },
+        { name: 'StageName', dir: OrderByDirection.ASC },
+      ],
+    },
+    false
+  );
+
+  testCondition(
+    'handles aggregation with a IN filter',
+    `SELECT count(id) FROM "db"."foo" WHERE ( stagename IN ('Deal Won', 'Deal Lost') )`,
+    {
+      queryType: QueryType.Table,
+      mode: BuilderMode.Aggregate,
+      database: 'db',
+      table: 'foo',
+      columns: [],
+      aggregates: [{ column: 'id', aggregateType: AggregateType.Count, alias: undefined }],
+      filters: [
+        {
+          key: 'stagename',
+          operator: FilterOperator.In,
+          value: ['Deal Won', 'Deal Lost'],
+          type: 'string'
+        } as MultiFilter,
+      ]
+    }
+  );
+
+  testCondition(
+    'handles aggregation with a NOT IN filter',
+    `SELECT count(id) FROM "db"."foo" WHERE ( stagename NOT IN ('Deal Won', 'Deal Lost') )`,
+    {
+      queryType: QueryType.Table,
+      mode: BuilderMode.Aggregate,
+      database: 'db',
+      table: 'foo',
+      columns: [],
+      aggregates: [{ column: 'id', aggregateType: AggregateType.Count, alias: undefined }],
+      filters: [
+        {
+          key: 'stagename',
+          operator: FilterOperator.NotIn,
+          value: ['Deal Won', 'Deal Lost'],
+          type: 'string',
+        } as MultiFilter,
+      ],
+      limit: undefined
+    }
+  );
+
+  testCondition(
+    'handles aggregation with datetime filter',
+    `SELECT count(id) FROM "db"."foo" WHERE ( createddate >= $__fromTime AND createddate <= $__toTime )`,
+    {
+      queryType: QueryType.Table,
+      mode: BuilderMode.Aggregate,
+      database: 'db',
+      table: 'foo',
+      columns: [],
+      aggregates: [{ column: 'id', aggregateType: AggregateType.Count, alias: undefined }],
+      filters: [
+        {
+          key: 'createddate',
+          operator: FilterOperator.WithInGrafanaTimeRange,
+          type: 'datetime',
+        } as DateFilterWithoutValue,
+      ],
+      limit: undefined
+    }
+  );
+
+  testCondition(
+    'handles aggregation with date filter',
+    `SELECT count(id) FROM "db"."foo" WHERE ( NOT ( closedate >= $__fromTime AND closedate <= $__toTime ) )`,
+    {
+      queryType: QueryType.Table,
+      mode: BuilderMode.Aggregate,
+      database: 'db',
+      table: 'foo',
+      columns: [],
+      aggregates: [{ column: 'id', aggregateType: AggregateType.Count, alias: undefined }],
+      filters: [
+        {
+          key: 'closedate',
+          operator: FilterOperator.OutsideGrafanaTimeRange,
+          type: 'datetime',
+        } as DateFilterWithoutValue,
+      ],
+      limit: undefined
+    }
+  );
+
+  testCondition(
+    'handles timeseries function with "timeFieldType: DateType"',
+    'SELECT $__timeInterval(time) as time FROM "db"."foo" GROUP BY time',
+    {
+      queryType: QueryType.TimeSeries,
+      mode: BuilderMode.Trend,
+      database: 'db',
+      table: 'foo',
+      columns: [{ name: 'time', type: 'datetime', hint: ColumnHint.Time }],
+      aggregates: [],
+      filters: [],
+    },
+    false
+  );
+
+  testCondition(
+    'handles timeseries function with "timeFieldType: DateType" with a filter',
+    'SELECT $__timeInterval(time) as time FROM "db"."foo" WHERE ( base IS NOT NULL ) GROUP BY time',
+    {
+      queryType: QueryType.TimeSeries,
+      mode: BuilderMode.Trend,
+      database: 'db',
+      table: 'foo',
+      columns: [{ name: 'time', type: 'datetime', hint: ColumnHint.Time }],
+      aggregates: [],
+      filters: [
+        {
+          condition: 'AND',
+          filterType: 'custom',
+          key: 'base',
+          operator: FilterOperator.IsNotNull,
+          type: 'LowCardinality(String)'
+        },
+      ],
+    },
+    false
+  );
+
+  it('Handles brackets and Grafana macros/variables', () => {
+    const sql = `
+      SELECT
+        *,
+        \$__timeInterval(timestamp),
+        '{"a": 1, "b": { "c": 2, "d": [1, 2, 3] }}'::json as bracketTest
+      FROM default.table
+      WHERE $__timeFilter(timestamp)
+      AND col != \${variable}
+      AND col != \${variable.key}
+      AND col != \${variable.key:singlequote}
+      AND col != '\${variable}'
+      AND col != '\${__variable}'
+      AND col != ('\${__variable.key}')
+    `;
+
+    const builderOptions = getQueryOptionsFromSql(sql);
+    expect(builderOptions).not.toBeUndefined();
+  });
+});
+
+function testCondition(name: string, sql: string, builder: QueryBuilderOptions, testQueryOptionsFromSql = true) {
+  it(name, () => {
+    expect(generateSql(builder)).toBe(sql);
+    if (testQueryOptionsFromSql) {
+      expect(getQueryOptionsFromSql(sql)).toEqual(builder);
+    }
+  });
+}

--- a/src/components/queryBuilder/utils.test.ts
+++ b/src/components/queryBuilder/utils.test.ts
@@ -452,6 +452,7 @@ describe('getQueryOptionsFromSql', () => {
 
   it('Handles brackets and Grafana macros/variables', () => {
     const sql = `
+      /* \${__variable} \${__variable.key} */
       SELECT
         *,
         \$__timeInterval(timestamp),
@@ -464,10 +465,12 @@ describe('getQueryOptionsFromSql', () => {
       AND col != '\${variable}'
       AND col != '\${__variable}'
       AND col != ('\${__variable.key}')
+      AND col != \${variable:singlequote}
     `;
 
     const builderOptions = getQueryOptionsFromSql(sql);
     expect(builderOptions).not.toBeUndefined();
+    expect(typeof builderOptions).not.toBe('string');
   });
 });
 

--- a/src/data/ast.test.ts
+++ b/src/data/ast.test.ts
@@ -20,6 +20,7 @@ describe('ast', () => {
     it('does not error when brackets/macros/variables are present', () => {
       const errLog = jest.spyOn(console, 'error');
       const sql = `
+        /* \${__variable} \${__variable.key} */
         SELECT
           *,
           \$__timeInterval(timestamp),
@@ -32,6 +33,7 @@ describe('ast', () => {
         AND col != '\${variable}'
         AND col != '\${__variable}'
         AND col != ('\${__variable.key}')
+        AND col != \${variable:singlequote}
       `;
 
       const stm = sqlToStatement(sql);

--- a/src/data/ast.ts
+++ b/src/data/ast.ts
@@ -1,30 +1,68 @@
 import { parseFirst, Statement, SelectFromStatement, astMapper, toSql, ExprRef } from 'pgsql-ast-parser';
 
-export function sqlToStatement(sql: string): Statement {
-  const replaceFuncs: Array<{
-    startIndex: number;
-    name: string;
-    replacementName: string;
-  }> = [];
-  //default is a key word in this grammar, but it can be used in CH
-  const re = /(\$__|\$|default|settings)/gi;
+interface ReplacePart {
+  startIndex: number;
+  name: string;
+  replacementName: string;
+};
+type ReplaceParts = ReplacePart[];
+
+/**
+ * Replaces macro functions and keywords such as $__timeFilter() and "default"
+ */
+function replaceMacroFunctions(sql: string): [ReplaceParts, string] {
+  const replaceFuncs: ReplaceParts = [];
+  // default is a keyword in this grammar, but it can be used in CH
+  const keywordRegex = /(\$__|\$|default|settings)/gi;
   let regExpArray: RegExpExecArray | null;
-  while ((regExpArray = re.exec(sql)) !== null) {
+  while ((regExpArray = keywordRegex.exec(sql)) !== null) {
     replaceFuncs.push({ startIndex: regExpArray.index, name: regExpArray[0], replacementName: '' });
   }
 
-  //need to process in reverse so starting positions aren't effected by replacing other things
+  // need to process in reverse so starting positions aren't affected by replacing other things
   for (let i = replaceFuncs.length - 1; i >= 0; i--) {
     const si = replaceFuncs[i].startIndex;
     const replacementName = 'f' + (Math.random() + 1).toString(36).substring(7);
     replaceFuncs[i].replacementName = replacementName;
     // settings do not parse and we do not need information from them so we will remove them
-    if (replaceFuncs[i].name.toLowerCase() === "settings") {
-      sql = sql.substring(0, si)
+    if (replaceFuncs[i].name.toLowerCase() === 'settings') {
+      sql = sql.substring(0, si);
       continue;
     }
     sql = sql.substring(0, si) + replacementName + sql.substring(si + replaceFuncs[i].name.length);
   }
+
+  return [replaceFuncs, sql];
+}
+
+/**
+ * Replaces Grafana variables such as ${var} ${var.key} ${var.key:singlequote}
+ */
+function replaceMacroVariables(sql: string): [ReplaceParts, string] {
+  const replaceVariables: ReplaceParts = [];
+  const variableRegex = /\${[a-zA-Z0-9_:.\w]+}/g;
+
+  let regExpArray: RegExpExecArray | null;
+  while ((regExpArray = variableRegex.exec(sql)) !== null) {
+    replaceVariables.push({ startIndex: regExpArray.index, name: regExpArray[0], replacementName: '' });
+  }
+
+  // need to process in reverse so starting positions aren't affected by replacing other things
+  for (let i = replaceVariables.length - 1; i >= 0; i--) {
+    const si = replaceVariables[i].startIndex;
+    const replacementName = 'v' + (Math.random() + 1).toString(36).substring(7);
+    replaceVariables[i].replacementName = replacementName;
+    sql = sql.substring(0, si) + replacementName + sql.substring(si + replaceVariables[i].name.length);
+  }
+
+  return [replaceVariables, sql];
+}
+
+export function sqlToStatement(sql: string): Statement {
+  const [replaceVars, variableSql] = replaceMacroVariables(sql);
+  const [replaceFuncs, macroSql] = replaceMacroFunctions(variableSql);
+  const replaceParts = replaceVars.concat(replaceFuncs);
+  sql = macroSql;
 
   let ast: Statement;
   try {
@@ -36,26 +74,39 @@ export function sqlToStatement(sql: string): Statement {
 
   const mapper = astMapper((map) => ({
     tableRef: (t) => {
-      const rfs = replaceFuncs.find((x) => x.replacementName === t.schema);
+      const rfs = replaceParts.find((x) => x.replacementName === t.schema);
       if (rfs) {
         return { ...t, schema: t.schema?.replace(rfs.replacementName, rfs.name) };
       }
-      const rft = replaceFuncs.find((x) => x.replacementName === t.name);
+      const rft = replaceParts.find((x) => x.replacementName === t.name);
       if (rft) {
         return { ...t, name: t.name.replace(rft.replacementName, rft.name) };
       }
       return map.super().tableRef(t);
     },
     ref: (r) => {
-      const rf = replaceFuncs.find((x) => r.name.startsWith(x.replacementName));
+      const rf = replaceParts.find((x) => r.name.startsWith(x.replacementName));
       if (rf) {
         const d = r.name.replace(rf.replacementName, rf.name);
         return { ...r, name: d };
       }
       return map.super().ref(r);
     },
+    expr: (e) => {
+      if (!e || e.type !== 'string') {
+        return map.super().expr(e);
+      }
+
+      const rf = replaceParts.find(x => e.value.startsWith(x.replacementName));
+      if (rf) {
+        const d = e.value.replace(rf.replacementName, rf.name);
+        return { ...e, value: d };
+      }
+
+      return map.super().expr(e);
+    },
     call: (c) => {
-      const rf = replaceFuncs.find((x) => c.function.name.startsWith(x.replacementName));
+      const rf = replaceParts.find((x) => c.function.name.startsWith(x.replacementName));
       if (rf) {
         return { ...c, function: { ...c.function, name: c.function.name.replace(rf.replacementName, rf.name) } };
       }

--- a/src/data/sqlGenerator.test.ts
+++ b/src/data/sqlGenerator.test.ts
@@ -387,6 +387,7 @@ describe('escapeIdentifier', () => {
     { input: ' ', expected: `" "` },
     { input: 'x', expected: `"x"` },
     { input: 'x x x', expected: `"x x x"` },
+    { input: undefined as any as string, expected: `` },
   ];
 
   it.each(cases)('returns escaped identifier (case %#)', (c) => {
@@ -399,6 +400,10 @@ describe('escapeValue', () => {
     { input: ``, expected: `''` },
     { input: ` `, expected: `' '` },
     { input: `$variable`, expected: `$variable` },
+    { input: `\${variable}`, expected: `\${variable}` },
+    { input: `\${variable:singlequote}`, expected: `\${variable:singlequote}` },
+    { input: `\${variable.key}`, expected: `\${variable.key}` },
+    { input: `\${variable.key:singlequote}`, expected: `\${variable.key:singlequote}` },
     { input: `count(column)`, expected: `count(column)` },
     { input: `'custom expression'`, expected: `'custom expression'` },
     { input: `plain text`, expected: `'plain text'` },

--- a/src/data/sqlGenerator.ts
+++ b/src/data/sqlGenerator.ts
@@ -515,12 +515,12 @@ const getColumnIdentifier = (col: SelectedColumn): string => {
 }
 
 const getTableIdentifier = (database: string, table: string): string => {
-  const sep = (database === '' || table === '') ? '' : '.';
+  const sep = (!database || !table) ? '' : '.';
   return `${escapeIdentifier(database)}${sep}${escapeIdentifier(table)}`;
 }
 
 const escapeIdentifier = (id: string): string => {
-  return id === '' ? '' : `"${id}"`;
+  return id ? `"${id}"` : '';
 }
 
 const escapeValue = (value: string): string => {
@@ -696,7 +696,7 @@ const getFilters = (options: QueryBuilderOptions): string => {
         filterParts.push(escapeValue((filter as StringFilter).value || ''));
       }
     } else if (isMultiFilter(type, filter.operator)) {
-      filterParts.push(`(${(filter as MultiFilter).value?.map(v => escapeValue(v)).join(', ')})`);
+      filterParts.push(`(${(filter as MultiFilter).value?.map(v => escapeValue(v.trim())).join(', ')})`);
     } else {
       filterParts.push(escapeValue((filter as StringFilter).value || ''));
     }
@@ -724,7 +724,7 @@ const numberTypes = ['int', 'float', 'decimal'];
 const isNumberType = (type: string): boolean => numberTypes.some(t => type?.toLowerCase().includes(t));
 const isDateType = (type: string): boolean => type?.toLowerCase().startsWith('date') || type?.toLowerCase().startsWith('nullable(date');
 // const isDateTimeType = (type: string): boolean => type?.toLowerCase().startsWith('datetime') || type?.toLowerCase().startsWith('nullable(datetime');
-const isStringType = (type: string): boolean => type === 'String' && !(isBooleanType(type) || isNumberType(type) || isDateType(type));
+const isStringType = (type: string): boolean => type.toLowerCase() === 'string' && !(isBooleanType(type) || isNumberType(type) || isDateType(type));
 const isNullFilter = (operator: FilterOperator): boolean => operator === FilterOperator.IsNull || operator === FilterOperator.IsNotNull;
 const isBooleanFilter = (type: string): boolean => isBooleanType(type);
 const isNumberFilter = (type: string): boolean => isNumberType(type);

--- a/src/views/CHQueryEditor.tsx
+++ b/src/views/CHQueryEditor.tsx
@@ -50,6 +50,15 @@ const CHEditorByType = (props: CHQueryEditorProps) => {
     lastKey.current = queryKey;
   }
 
+  /**
+   * Sync builder options when switching from SQL Editor to Query Builder
+   */
+  const lastEditorType = useRef<EditorType>();
+  if (query.editorType !== lastEditorType.current && query.editorType === EditorType.Builder) {
+    builderOptionsDispatch(setAllOptions((query as CHBuilderQuery).builderOptions || {}));
+    lastEditorType.current = query.editorType;
+  }
+
   // Prevent trying to run empty query on load
   const shouldSkipChanges = useRef<boolean>(true);
   if (isBuilderOptionsRunnable(builderOptions)) {
@@ -61,12 +70,11 @@ const CHEditorByType = (props: CHQueryEditorProps) => {
       return;
     }
 
-    const sql = generateSql(builderOptions);
     onChange({
       ...query,
       pluginVersion,
       editorType: EditorType.Builder,
-      rawSql: sql,
+      rawSql: generateSql(builderOptions),
       builderOptions,
       format: mapQueryBuilderOptionsToGrafanaFormat(builderOptions)
     });


### PR DESCRIPTION
Fixes #714 

Changes:
- Fixed the AST from not recognizing variables such as `${var}` `${var.key}` and `${var:singlequote}`. This was causing Ad-Hoc filters to not be applied, and prevented switching back to the Query Builder.
- Switching from SQL Editor back to Query Builder works again. This worked before, but was also broken when using variables. Also it would open an empty query, but now the AST is able to recognize the v4 builder options a little better.
- Fixed an issue where an empty database name would put `FROM "undefined"."table"`
- Multi filters (such as ones using `WHERE .. IN`) now allows for spaces. v3 allowed for `a,b,c` or `a, b, c`, v4 had just the first one but now it supports both. You can also include expressions and it works nicely, for example: `a, b, toString('c')`
- Added new unit tests that specifically focus the AST when using macros and variables.
- Re-added some tests for the AST + SQL generator. These were removed before because the SQL generator was separated from the utils module, but I've added it back. The original intent of these tests seems to be testing consistency when converting sql->builderOptions->sql.
- updated changelog