### PR TITLE
fix: re-add query type selector to SQL Editor queries in dashboard view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added `$__fromTime_ms` macro that represents the dashboard "from" time in milliseconds using a `DateTime64(3)`
 - Added `$__toTime_ms` macro that represents the dashboard "to" time in milliseconds using a `DateTime64(3)`
 - Added `$__timeFilter_ms` macro that uses `DateTime64(3)` for millisecond precision time filtering
+- Re-added query type selector in dashboard view. This was only visible in explore view, but somehow it affects dashboard view, and so it has been re-added. (#730)
 
 ### Fixes
 

--- a/src/components/SqlEditor.tsx
+++ b/src/components/SqlEditor.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { CoreApp, QueryEditorProps } from '@grafana/data';
+import { QueryEditorProps } from '@grafana/data';
 import { CodeEditor, monacoTypes } from '@grafana/ui';
 import { Datasource } from 'data/CHDatasource';
 import { registerSQL, Range, Fetcher } from './sqlProvider';
@@ -31,7 +31,7 @@ function setupAutoSize(editor: monacoTypes.editor.IStandaloneCodeEditor) {
 }
 
 export const SqlEditor = (props: SqlEditorProps) => {
-  const { app, query, onChange, datasource } = props;
+  const { query, onChange, datasource } = props;
   const sqlQuery = query as CHSqlQuery;
   const queryType = sqlQuery.queryType || QueryType.Table;
 
@@ -90,12 +90,9 @@ export const SqlEditor = (props: SqlEditorProps) => {
 
   return (
     <>
-      {/* Only show in explore view where panel can't be manually selected. Dashboard view lets you change the panel. */}
-      {app === CoreApp.Explore && (
-        <div className={'gf-form ' + styles.QueryEditor.queryType}>
-          <QueryTypeSwitcher queryType={queryType} onChange={(queryType) => saveChanges({ queryType })} sqlEditor />
-        </div>
-      )}
+      <div className={'gf-form ' + styles.QueryEditor.queryType}>
+        <QueryTypeSwitcher queryType={queryType} onChange={(queryType) => saveChanges({ queryType })} sqlEditor />
+      </div>
       <div className={styles.Common.wrapper}>
         <CodeEditor
           aria-label="SQL Editor"


### PR DESCRIPTION
Fixes #730

Migration script works fine, but for some reason the dashboard still requires a `format` to be provided even though the data is the same.

This re-enables the `queryType`/`format` selector on dashboard view. Previously it was only enabled on explore view, but now it is visible on dashboard view again.

![query type selector](https://github.com/grafana/clickhouse-datasource/assets/28887171/4245504b-c0a0-40aa-9a7d-199140cf4268)
