### PR TITLE
Update run-ci-cd to match Drone

### DIFF
--- a/.github/workflows/run-ci-cd.yml
+++ b/.github/workflows/run-ci-cd.yml
@@ -25,6 +25,7 @@ jobs:
           # When `install-mode` is `binary` (default) the value can be v1.2 or v1.2.3 or `latest` to use the latest version.
           # When `install-mode` is `goinstall` the value can be v1.2.3, `latest`, or the hash of a commit.
           version: latest
+          args: --timeout=5m
       
       - name: Check spelling
         run: npx --yes cspell@6.13.3 -c cspell.config.json "**/*.{ts,tsx,js,go,md,mdx,yml,yaml,json,scss,css}"


### PR DESCRIPTION
Drone uses a timeout of 5m for the linter