### PR TITLE
fix: isStringType for Nullable(String) and FixedString(N) (#830)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Fixed `IN` operator escaping the entire string (specifically with `Nullable(String)`), also added `FixedString(N)` (#830)
+
 ## 4.0.7
 
 - Upgrade dependencies

--- a/cspell.config.json
+++ b/cspell.config.json
@@ -10,6 +10,7 @@
     "mage_output_file.go"
   ],
   "words": [
+    "fixedstring",
     "singlequote",
     "concats",
     "Milli",

--- a/src/data/sqlGenerator.test.ts
+++ b/src/data/sqlGenerator.test.ts
@@ -530,11 +530,40 @@ describe('getLimit', () => {
   });
 });
 
+describe('is*Type', () => {
+  it.each<{ input: string, expected: boolean }>([
+    { input: 'Nullable(String)', expected: true },
+    { input: 'FixedString(1)', expected: true },
+    { input: 'String', expected: true },
+    { input: 'Array(String)', expected: false },
+  ])('$input isStringType $expected', (c) => {
+    expect(_testExports.isStringType(c.input)).toEqual(c.expected);
+  });
+});
+
 describe('getFilters', () => {
   it('returns empty filter array', () => {
     const options = {} as QueryBuilderOptions;
     const sql = _testExports.getFilters(options);
     const expectedSql = '';
+    expect(sql).toEqual(expectedSql);
+  });
+
+  it('returns correct IN clause for escaped and unescaped values', () => {
+    const options = {
+      filters: [
+        {
+          condition: 'AND',
+          filterType: 'custom',
+          key: 'col',
+          operator: FilterOperator.In,
+          type: 'string',
+          value: '1, (2), 3, some string, \'another string\', someFunction(123), "column reference"'.split(',')
+        }
+      ]
+    } as QueryBuilderOptions;
+    const sql = _testExports.getFilters(options);
+    const expectedSql = `( col IN ('1', (2), '3', 'some string', 'another string', someFunction(123), "column reference") )`;
     expect(sql).toEqual(expectedSql);
   });
 

--- a/src/data/sqlGenerator.ts
+++ b/src/data/sqlGenerator.ts
@@ -747,7 +747,7 @@ const numberTypes = ['int', 'float', 'decimal'];
 const isNumberType = (type: string): boolean => numberTypes.some(t => type?.toLowerCase().includes(t));
 const isDateType = (type: string): boolean => type?.toLowerCase().startsWith('date') || type?.toLowerCase().startsWith('nullable(date');
 // const isDateTimeType = (type: string): boolean => type?.toLowerCase().startsWith('datetime') || type?.toLowerCase().startsWith('nullable(datetime');
-const isStringType = (type: string): boolean => type.toLowerCase() === 'string' && !(isBooleanType(type) || isNumberType(type) || isDateType(type));
+const isStringType = (type: string): boolean => (type.toLowerCase() === 'string' || type.toLowerCase().startsWith('nullable(string') || type.toLowerCase().startsWith('fixedstring')) && !(isBooleanType(type) || isNumberType(type) || isDateType(type));
 const isNullFilter = (operator: FilterOperator): boolean => operator === FilterOperator.IsNull || operator === FilterOperator.IsNotNull;
 const isBooleanFilter = (type: string): boolean => isBooleanType(type);
 const isNumberFilter = (type: string): boolean => isNumberType(type);
@@ -778,4 +778,5 @@ export const _testExports = {
   getOrderBy,
   getLimit,
   getFilters,
+  isStringType,
 };


### PR DESCRIPTION
<!-- To surface this PR in the changelog add the label: changelog -->
<!-- If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way: -->
<!-- Bad: fix state bug in hooks -->
<!-- Good: Fix crash when switching from Query Builder -->
Fixes #830 

The `IN` operator was broken because the column type was `Nullabe(String)` instead of `String`.
- Fixed issue
- added tests for `String`, `Nullable(String)`, and `FixedString`
- Updated changelog
