### PR TITLE
Fix trace_start and trace_end changes from #890

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Fix trace start/duration/end times (#900)
+
 ## 4.3.0
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- Fix trace start/duration/end times (#900)
+- Fix trace start times in trace ID mode (#900)
 
 ## 4.3.0
 

--- a/src/data/sqlGenerator.test.ts
+++ b/src/data/sqlGenerator.test.ts
@@ -261,7 +261,7 @@ describe('SQL Generator', () => {
       `arrayMap(key -> map('key', key, 'value',"SpanAttributes"[key]),`,
       `mapKeys("SpanAttributes")) as tags,`,
       `arrayMap(key -> map('key', key, 'value',"ResourceAttributes"[key]), mapKeys("ResourceAttributes")) as serviceTags`,
-      `FROM "default"."otel_traces" WHERE traceID = trace_id AND startTime >= trace_start AND startTime <= trace_end`,
+      `FROM "default"."otel_traces" WHERE traceID = trace_id AND "Timestamp" >= trace_start AND "Timestamp" <= trace_end`,
       'LIMIT 1000'
     ];
 
@@ -335,7 +335,7 @@ describe('SQL Generator', () => {
     };
     const expectedSqlParts = [
       'SELECT "TraceId" as traceID, "ServiceName" as serviceName, "SpanName" as operationName,',
-      'multiply(toUnixTimestamp64Nano("Timestamp"), 0.000001) as startTime, multiply("Duration", 0.000001) as duration',
+      '"Timestamp" as startTime, multiply("Duration", 0.000001) as duration',
       'FROM "default"."otel_traces" WHERE ( Timestamp >= $__fromTime AND Timestamp <= $__toTime )',
       'AND ( ParentSpanId = \'\' ) AND ( Duration > 0 ) ORDER BY Timestamp DESC, Duration DESC LIMIT 1000'
     ];

--- a/src/data/sqlGenerator.ts
+++ b/src/data/sqlGenerator.ts
@@ -50,7 +50,7 @@ const generateTraceSearchQuery = (options: QueryBuilderOptions): string => {
   
   const traceStartTime = getColumnByHint(options, ColumnHint.Time);
   if (traceStartTime !== undefined) {
-    selectParts.push(`${convertTimeFieldToMilliseconds(escapeIdentifier(traceStartTime.name))} as startTime`);
+    selectParts.push(`${escapeIdentifier(traceStartTime.name)} as startTime`);
   }
   
   const traceDurationTime = getColumnByHint(options, ColumnHint.TraceDurationTime);

--- a/src/data/sqlGenerator.ts
+++ b/src/data/sqlGenerator.ts
@@ -149,7 +149,7 @@ const generateTraceIdQuery = (options: QueryBuilderOptions): string => {
   // Optimize trace ID filtering for OTel enabled trace lookups
   const hasTraceIdFilter = options.meta?.isTraceIdMode && options.meta?.traceId;
   const otelVersion = otel.getVersion(options.meta?.otelVersion);
-  const applyTraceIdOptimization = hasTraceIdFilter && options.meta?.otelEnabled && otelVersion;
+  const applyTraceIdOptimization = hasTraceIdFilter && traceStartTime !== undefined && options.meta?.otelEnabled && otelVersion;
   if (applyTraceIdOptimization) {
     const traceId = options.meta!.traceId;
     const timestampTable = getTableIdentifier(database, table + otel.traceTimestampTableSuffix);
@@ -173,9 +173,9 @@ const generateTraceIdQuery = (options: QueryBuilderOptions): string => {
   if (applyTraceIdOptimization) {
     queryParts.push('traceID = trace_id');
     queryParts.push('AND');
-    queryParts.push(`startTime >= trace_start`);
+    queryParts.push(`${escapeIdentifier(traceStartTime.name)} >= trace_start`);
     queryParts.push('AND');
-    queryParts.push(`startTime <= trace_end`);
+    queryParts.push(`${escapeIdentifier(traceStartTime.name)} <= trace_end`);
   } else if (hasTraceIdFilter) {
     const traceId = options.meta!.traceId;
     queryParts.push(`traceID = '${traceId}'`);


### PR DESCRIPTION
fixes (#900)

changes:
- Reverted Trace Search back to original timestamp, since that is intended to be human readable
- Fixed Trace ID mode to use the original DateTime type instead of the float type, which fixes the time range filtering
- Updated changelog
