### PR TITLE
Fix OTel dashboard

### DIFF
--- a/src/dashboards/opentelemetry-clickhouse.json
+++ b/src/dashboards/opentelemetry-clickhouse.json
@@ -24,7 +24,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 39,
+  "id": null,
   "links": [],
   "liveNow": false,
   "panels": [


### PR DESCRIPTION
The `id` property in the dashboard was set which leads to issues when attempting to import.

Fixes #908 