### PR TITLE
Add warning for missing `uid` in provisioned datasources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Added warning for when `uid` is missing in provisioned datasources.
+
 ## 4.3.2
 
 ### Fixes

--- a/src/views/CHConfigEditor.tsx
+++ b/src/views/CHConfigEditor.tsx
@@ -200,7 +200,7 @@ export const ConfigEditor: React.FC<ConfigEditorProps> = (props) => {
             style={{ textDecoration: 'underline' }}
             href='https://grafana.com/docs/grafana/latest/administration/provisioning/#data-sources'
             target='_blank'
-            referrerPolicy='no-referrer'
+            rel='noreferrer'
           >provisioned via YAML</a>
           {', please verify the UID is set. This is required to enable data linking between logs and traces.'}
         </div>

--- a/src/views/CHConfigEditor.tsx
+++ b/src/views/CHConfigEditor.tsx
@@ -4,7 +4,7 @@ import {
   onUpdateDatasourceJsonDataOption,
   onUpdateDatasourceSecureJsonDataOption,
 } from '@grafana/data';
-import { RadioButtonGroup, Switch, Input, SecretInput, Button, Field, HorizontalGroup } from '@grafana/ui';
+import { RadioButtonGroup, Switch, Input, SecretInput, Button, Field, HorizontalGroup, Alert, VerticalGroup } from '@grafana/ui';
 import { CertificationKey } from '../components/ui/CertificationKey';
 import {
   CHConfig,
@@ -189,8 +189,28 @@ export const ConfigEditor: React.FC<ConfigEditorProps> = (props) => {
   (jsonData.protocol === Protocol.Native ? labels.serverPort.insecureNativePort : labels.serverPort.insecureHttpPort);
   const portDescription = `${labels.serverPort.tooltip} (default for ${jsonData.secure ? 'secure' : ''} ${jsonData.protocol}: ${defaultPort})`
 
+  const uidWarning = (!options.uid) && (
+    <Alert title="" severity="warning" buttonContent="Close">
+      <VerticalGroup>
+        <div>
+          {'This datasource is missing the'}
+          <code>uid</code>
+          {'field in its configuration. If your datasource is '}
+          <a
+            style={{ textDecoration: 'underline' }}
+            href='https://grafana.com/docs/grafana/latest/administration/provisioning/#data-sources'
+            target='_blank'
+            referrerPolicy='no-referrer'
+          >provisioned via YAML</a>
+          {', please verify the UID is set. This is required to enable data linking between logs and traces.'}
+        </div>
+      </VerticalGroup>
+    </Alert>
+  );
+
   return (
     <>
+      {uidWarning}
       <DataSourceDescription
         dataSourceName="Clickhouse"
         docsLink="https://grafana.com/grafana/plugins/grafana-clickhouse-datasource/"


### PR DESCRIPTION
Some users reported confusion with data linking not working between logs/traces.
This is because a `uid` must be set for the datasource. All UI-configured datasources generate one automatically, but not all provisioned datasources have one. I have added a warning to the config page to remind users to add one.

Changes:
- added warning banner when `uid` is not set
- updated changelog

Example of what this warning looks like:
![example warning](https://github.com/user-attachments/assets/ccb40aae-4ac1-47ab-9dfd-eb92dd1df42c)
