### PR TITLE
fix: map key filtering from showing column name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Map filters in the query builder now correctly show the key instead of the column name
+
 ## 4.3.2
 
 ### Fixes

--- a/src/components/queryBuilder/FilterEditor.tsx
+++ b/src/components/queryBuilder/FilterEditor.tsx
@@ -206,7 +206,7 @@ export const FilterEditor = (props: {
   const mapKeys = useUniqueMapKeys(props.datasource, isMapType ? filter.key : '', props.database, props.table);
   const mapKeyOptions = mapKeys.map(k => ({ label: k, value: k }));
   if (filter.mapKey && !mapKeys.includes(filter.mapKey)) {
-    mapKeyOptions.push({ label: filter.label || filter.mapKey, value: filter.mapKey });
+    mapKeyOptions.push({ label: filter.mapKey, value: filter.mapKey });
   }
 
   const getFields = () => {


### PR DESCRIPTION
This fixes a regression from #862 that caused the column name to show up in the map key filter dropdown instead of showing the actual key being filtered. The filter still works but it's a confusing visual bug

changes:
- Map key now correctly shows in filter
- Updated changelog

broken:
![before fix](https://github.com/user-attachments/assets/6a608c1b-3e74-4e91-93b1-49c7111f342c)


fixed:
![after fix](https://github.com/user-attachments/assets/ca6f12bb-7be2-4a21-b7ff-1778be9ebdfd)
