### PR TITLE
Pin go version

### DIFF
--- a/.github/workflows/pull-request-image.yml
+++ b/.github/workflows/pull-request-image.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install Go environment
         uses: actions/setup-go@v5
         with:
-          go-version: 'stable'
+          go-version: 1.22
 
       - name: Install yarn dependencies
         run: yarn install

--- a/.github/workflows/run-backend-tests.yml
+++ b/.github/workflows/run-backend-tests.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: 'stable'
+          go-version: 1.22
 
       - name: Build
         run: go build -v ./...

--- a/.github/workflows/run-ci-cd.yml
+++ b/.github/workflows/run-ci-cd.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: 'stable'
+          go-version: 1.22
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
@@ -26,6 +26,6 @@ jobs:
           # When `install-mode` is `goinstall` the value can be v1.2.3, `latest`, or the hash of a commit.
           version: latest
           args: --timeout=5m
-      
+
       - name: Check spelling
         run: npx --yes cspell@6.13.3 -c cspell.config.json "**/*.{ts,tsx,js,go,md,mdx,yml,yaml,json,scss,css}"

--- a/.github/workflows/run-frontend-tests.yml
+++ b/.github/workflows/run-frontend-tests.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: 'stable'
+          go-version: 1.22
 
       - name: Install yarn dependencies
         run: yarn install

--- a/.github/workflows/run-k6e2e-tests.yml
+++ b/.github/workflows/run-k6e2e-tests.yml
@@ -22,10 +22,10 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: 'stable'
+          go-version: 1.22
 
       - name: Install Dagger CLI
         run: cd /usr/local && { curl -L https://dl.dagger.io/dagger/install.sh | sh; cd -; }
-      
+
       - name: Run Dagger pipeline
         run: dagger run go test e2e/e2e_test.go


### PR DESCRIPTION
Due to an issue between Go 1.23.0 and the Pyroscope package we're pinning the Go version until it's appropriately resolved.