### PR TITLE
Allow empty string values for `$__conditionAll` macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Added warning for when `uid` is missing in provisioned datasources.
 - Map filters in the query builder now correctly show the key instead of the column name
+- Allow empty string values for `$__conditionAll` macro (#947)
 
 ## 4.3.2
 

--- a/src/data/CHDatasource.ts
+++ b/src/data/CHDatasource.ts
@@ -265,7 +265,7 @@ export class Datasource
       if (templateVar) {
         const key = templateVars.find((x) => x.name === templateVar[0]) as any;
         let value = key?.current.value.toString();
-        if (value === '' || value === '$__all') {
+        if (value === '$__all') {
           phrase = '1=1';
         }
       }


### PR DESCRIPTION
Fixes #947 but may also break #262.

It makes sense to allow empty strings for this macro, anyone who wishes to exclude the macro can use `$__all` in their query to get the `1=1` functionality.

Changes:
- Empty string will no longer replace the macro with `1=1`
- Changelog
