### PR TITLE
Fix: Update Duration value in example traces dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Added warning for when `uid` is missing in provisioned datasources.
 - Map filters in the query builder now correctly show the key instead of the column name
 - Updated and fixed missing `system.dashboards` dashboard in list of dashboards
+- Updated the duration value in example traces dashboard to provide useful information
 
 ## 4.3.2
 

--- a/src/dashboards/opentelemetry-clickhouse.json
+++ b/src/dashboards/opentelemetry-clickhouse.json
@@ -670,8 +670,7 @@
           },
           "pluginVersion": "4.0.6",
           "queryType": "table",
-          "rawSql": "SELECT\r\n  min(Timestamp) as timestamp,\r\n  TraceId as `Trace ID`,\r\n  argMin(ServiceName, Timestamp) as `Service Name`,\r\n  sum(Duration)/1000000 as Duration\r\nFROM otel_traces\r\nWHERE\r\n  $__conditionalAll(TraceId IN (${trace_id:singlequote}),  $trace_id)\r\n  AND ServiceName IN (${serviceName:singlequote})\r\n  AND ServiceName != 'loadgenerator'\r\n  AND $__timeFilter(Timestamp)\r\nGROUP BY TraceId\r\nORDER BY Duration DESC\r\nLIMIT 100\r\n",
-          "refId": "A"
+          "rawSql": "SELECT\r\n  min(Timestamp) as timestamp,\r\n  TraceId as `Trace ID`,\r\n  argMin(ServiceName, Timestamp) as `Service Name`,\r\n  divide(max(Duration), 1000000) as Duration\r\nFROM otel_traces\r\nWHERE\r\n  $__conditionalAll(TraceId IN (${trace_id:singlequote}),  $trace_id)\r\n  AND ServiceName IN (${serviceName:singlequote})\r\n  AND ServiceName != 'loadgenerator'\r\n  AND $__timeFilter(Timestamp)\r\nGROUP BY TraceId\r\nORDER BY Duration DESC\r\nLIMIT 100\r\n",          "refId": "A"
         }
       ],
       "title": "Traces",


### PR DESCRIPTION
Similar to #966 the duration displayed will now be the maximum value. I'm also explicitly using the `divide` function for readability.