### PR TITLE
Performance improvements: use `multiSearchAny` instead of `IN` to support Clickhouse projections for logs volumes

### DIFF
--- a/src/data/CHDatasource.test.ts
+++ b/src/data/CHDatasource.test.ts
@@ -477,13 +477,13 @@ describe('ClickHouseDatasource', () => {
         const result = datasource.getSupplementaryLogsVolumeQuery(request, query);
         expect(result?.rawSql).toEqual(
           `SELECT toStartOfInterval("created_at", INTERVAL 1 DAY) as "time", ` +
-            `sum(toString("level") IN ('critical','fatal','crit','alert','emerg','CRITICAL','FATAL','CRIT','ALERT','EMERG','Critical','Fatal','Crit','Alert','Emerg')) as critical, ` +
-            `sum(toString("level") IN ('error','err','eror','ERROR','ERR','EROR','Error','Err','Eror')) as error, ` +
-            `sum(toString("level") IN ('warn','warning','WARN','WARNING','Warn','Warning')) as warn, ` +
-            `sum(toString("level") IN ('info','information','informational','INFO','INFORMATION','INFORMATIONAL','Info','Information','Informational')) as info, ` +
-            `sum(toString("level") IN ('debug','dbug','DEBUG','DBUG','Debug','Dbug')) as debug, ` +
-            `sum(toString("level") IN ('trace','TRACE','Trace')) as trace, ` +
-            `sum(toString("level") IN ('unknown','UNKNOWN','Unknown')) as unknown ` +
+            `sum(multiSearchAny(toString("level"), ['critical','fatal','crit','alert','emerg','CRITICAL','FATAL','CRIT','ALERT','EMERG','Critical','Fatal','Crit','Alert','Emerg'])) as critical, ` +
+            `sum(multiSearchAny(toString("level"), ['error','err','eror','ERROR','ERR','EROR','Error','Err','Eror'])) as error, ` +
+            `sum(multiSearchAny(toString("level"), ['warn','warning','WARN','WARNING','Warn','Warning'])) as warn, ` +
+            `sum(multiSearchAny(toString("level"), ['info','information','informational','INFO','INFORMATION','INFORMATIONAL','Info','Information','Informational'])) as info, ` +
+            `sum(multiSearchAny(toString("level"), ['debug','dbug','DEBUG','DBUG','Debug','Dbug'])) as debug, ` +
+            `sum(multiSearchAny(toString("level"), ['trace','TRACE','Trace'])) as trace, ` +
+            `sum(multiSearchAny(toString("level"), ['unknown','UNKNOWN','Unknown'])) as unknown ` +
             `FROM "default"."logs" ` +
             `GROUP BY time ` +
             `ORDER BY time ASC`

--- a/src/data/CHDatasource.ts
+++ b/src/data/CHDatasource.ts
@@ -157,7 +157,7 @@ export class Datasource
       const llf = `toString("${logLevelColumn.name}")`;
       let level: keyof typeof LOG_LEVEL_TO_IN_CLAUSE;
       for (level in LOG_LEVEL_TO_IN_CLAUSE) {
-        aggregates.push({ aggregateType: AggregateType.Sum, column: `${llf} ${LOG_LEVEL_TO_IN_CLAUSE[level]}`, alias: level });
+        aggregates.push({ aggregateType: AggregateType.Sum, column: `multiSearchAny(${llf}, [${LOG_LEVEL_TO_IN_CLAUSE[level]}])`, alias: level });
       }
     } else {
       // Count all logs if level column isn't selected

--- a/src/data/logs.test.ts
+++ b/src/data/logs.test.ts
@@ -226,13 +226,13 @@ describe('logs', () => {
     it('should generate correct IN clauses', async () => {
       expect(LOG_LEVEL_TO_IN_CLAUSE).toEqual({
         critical:
-          "IN ('critical','fatal','crit','alert','emerg','CRITICAL','FATAL','CRIT','ALERT','EMERG','Critical','Fatal','Crit','Alert','Emerg')",
-        debug: "IN ('debug','dbug','DEBUG','DBUG','Debug','Dbug')",
-        error: "IN ('error','err','eror','ERROR','ERR','EROR','Error','Err','Eror')",
-        info: "IN ('info','information','informational','INFO','INFORMATION','INFORMATIONAL','Info','Information','Informational')",
-        trace: "IN ('trace','TRACE','Trace')",
-        unknown: "IN ('unknown','UNKNOWN','Unknown')",
-        warn: "IN ('warn','warning','WARN','WARNING','Warn','Warning')",
+          "'critical','fatal','crit','alert','emerg','CRITICAL','FATAL','CRIT','ALERT','EMERG','Critical','Fatal','Crit','Alert','Emerg'",
+        debug: "'debug','dbug','DEBUG','DBUG','Debug','Dbug'",
+        error: "'error','err','eror','ERROR','ERR','EROR','Error','Err','Eror'",
+        info: "'info','information','informational','INFO','INFORMATION','INFORMATIONAL','Info','Information','Informational'",
+        trace: "'trace','TRACE','Trace'",
+        unknown: "'unknown','UNKNOWN','Unknown'",
+        warn: "'warn','warning','WARN','WARNING','Warn','Warning'",
       });
     });
   });

--- a/src/data/logs.ts
+++ b/src/data/logs.ts
@@ -245,11 +245,11 @@ export const LOG_LEVEL_TO_IN_CLAUSE: LogLevelToInClause = (() => {
     unknown: ['unknown'],
   };
   return (Object.keys(levels) as Array<keyof typeof levels>).reduce((allLevels, level) => {
-    allLevels[level] = `IN (${[
+    allLevels[level] = `${[
       ...levels[level].map((l) => `'${l}'`),
       ...levels[level].map((l) => `'${l.toUpperCase()}'`),
       ...levels[level].map((l) => `'${l.charAt(0).toUpperCase() + l.slice(1)}'`),
-    ].join(',')})`;
+    ].join(',')}`;
     return allLevels;
   }, {} as LogLevelToInClause);
 })();


### PR DESCRIPTION
Problem: Fetching log volumes by severity is slow because it performs a full table scan in ClickHouse.

OTeL default schema for logs does not contain an index or any performance optimizations that could help avoid a full scan: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/clickhouseexporter/exporter_logs.go#L141

Grafana (`docker.io/grafana/grafana:11.2.2-security-01`) uses the following queries for log volumes (intervals change based on current view time settings):
```sql
SELECT
    toStartOfInterval(Timestamp, toIntervalMinute(1)) AS time,
    sum(toString(SeverityText) IN ('critical', 'fatal', 'crit', 'alert', 'emerg', 'CRITICAL', 'FATAL', 'CRIT', 'ALERT', 'EMERG', 'Critical', 'Fatal', 'Crit', 'Alert', 'Emerg')) AS critical,
    sum(toString(SeverityText) IN ('error', 'err', 'eror', 'ERROR', 'ERR', 'EROR', 'Error', 'Err', 'Eror')) AS error,
    sum(toString(SeverityText) IN ('warn', 'warning', 'WARN', 'WARNING', 'Warn', 'Warning')) AS warn,
    sum(toString(SeverityText) IN ('info', 'information', 'informational', 'INFO', 'INFORMATION', 'INFORMATIONAL', 'Info', 'Information', 'Informational')) AS info,
    sum(toString(SeverityText) IN ('debug', 'dbug', 'DEBUG', 'DBUG', 'Debug', 'Dbug')) AS debug,
    sum(toString(SeverityText) IN ('trace', 'TRACE', 'Trace')) AS trace,
    sum(toString(SeverityText) IN ('unknown', 'UNKNOWN', 'Unknown')) AS unknown
FROM otel.otel_logs
WHERE (time >= toDateTime(1731221399)) AND (time <= toDateTime(1731224999))
GROUP BY time
ORDER BY time ASC

Query id: e9381009-1175-4751-8bac-56dd9dba5d53

    ┌────────────────time─┬─critical─┬─error─┬─warn─┬─info─┬─debug─┬─trace─┬─unknown─┐
 1. │ 2024-11-10 07:35:00 │        0 │    36 │    2 │   26 │     0 │     0 │     254 │
 2. │ 2024-11-10 07:36:00 │        0 │   121 │    4 │   46 │     0 │     0 │     845 │
 3. │ 2024-11-10 07:37:00 │        0 │   114 │    6 │   68 │     0 │     0 │     850 │
 4. │ 2024-11-10 07:38:00 │        0 │   112 │   19 │   54 │     0 │     0 │     771 │
 5. │ 2024-11-10 07:39:00 │        0 │    97 │   25 │   65 │     0 │     0 │     691 │
 6. │ 2024-11-10 07:40:00 │        0 │    93 │    4 │   44 │     0 │     0 │     644 │
 7. │ 2024-11-10 07:41:00 │        0 │   101 │    5 │   58 │     0 │     0 │     707 │
 8. │ 2024-11-10 07:42:00 │        0 │    89 │   10 │   61 │     0 │     0 │     622 │
 9. │ 2024-11-10 07:43:00 │        0 │    97 │    4 │   56 │     0 │     0 │     686 │
10. │ 2024-11-10 07:44:00 │        0 │   102 │    4 │   49 │     0 │     0 │     709 │
11. │ 2024-11-10 07:45:00 │        0 │   101 │    4 │   56 │     0 │     0 │     704 │
12. │ 2024-11-10 07:46:00 │        0 │   110 │    4 │   47 │     0 │     0 │     758 │
13. │ 2024-11-10 07:47:00 │        0 │   106 │    6 │   64 │     0 │     0 │     794 │
14. │ 2024-11-10 07:48:00 │        0 │   105 │    4 │   47 │     0 │     0 │     743 │
15. │ 2024-11-10 07:49:00 │        0 │   114 │    6 │   94 │     0 │     0 │     806 │
    └─────────────────────┴──────────┴───────┴──────┴──────┴───────┴───────┴─────────┘
15 rows in set. Elapsed: 0.111 sec. Processed 14.70 thousand rows, 132.19 KB (132.53 thousand rows/s., 1.19 MB/s.)
```

One of the solutions that can drastically improve performance is ClickHouse projections: https://clickhouse.com/docs/en/sql-reference/statements/alter/projection

Using ClickHouse projections, it's possible to pre-calculate log volumes by severity, e.g.:
```sql
ALTER TABLE otel.otel_logs ADD PROJECTION timestamp_severity
(
    SELECT
        toStartOfInterval("Timestamp", INTERVAL 1 MINUTE) as "time", 
        sum(toString("SeverityText") IN ('critical','fatal','crit','alert','emerg','CRITICAL','FATAL','CRIT','ALERT','EMERG','Critical','Fatal','Crit','Alert','Emerg')) as critical, 
        sum(toString("SeverityText") IN ('error','err','eror','ERROR','ERR','EROR','Error','Err','Eror')) as error, 
        sum(toString("SeverityText") IN ('warn','warning','WARN','WARNING','Warn','Warning')) as warn, 
        sum(toString("SeverityText") IN ('info','information','informational','INFO','INFORMATION','INFORMATIONAL','Info','Information','Informational')) as info, 
        sum(toString("SeverityText") IN ('debug','dbug','DEBUG','DBUG','Debug','Dbug')) as debug, 
        sum(toString("SeverityText") IN ('trace','TRACE','Trace')) as trace, 
        sum(toString("SeverityText") IN ('unknown','UNKNOWN','Unknown')) as unknown 
    GROUP BY
        time
);
ALTER TABLE otel.otel_logs MATERIALIZE PROJECTION timestamp_severity;
```

However, this projection does **not** work as expected. The values from this projection are the **same** for every severity level and equal to the first one listed (`critical` in this case). I don't have enough expertise in ClickHouse to understand this behavior, and it's most likely a bug in ClickHouse itself (unless I'm missing information that could explain this). ClickHouse version used: `24.10.1.2812`

```sql
SELECT
    toStartOfInterval(Timestamp, toIntervalMinute(1)) AS time,
    sum(toString(SeverityText) IN ('critical', 'fatal', 'crit', 'alert', 'emerg', 'CRITICAL', 'FATAL', 'CRIT', 'ALERT', 'EMERG', 'Critical', 'Fatal', 'Crit', 'Alert', 'Emerg')) AS critical,
    sum(toString(SeverityText) IN ('error', 'err', 'eror', 'ERROR', 'ERR', 'EROR', 'Error', 'Err', 'Eror')) AS error,
    sum(toString(SeverityText) IN ('warn', 'warning', 'WARN', 'WARNING', 'Warn', 'Warning')) AS warn,
    sum(toString(SeverityText) IN ('info', 'information', 'informational', 'INFO', 'INFORMATION', 'INFORMATIONAL', 'Info', 'Information', 'Informational')) AS info,
    sum(toString(SeverityText) IN ('debug', 'dbug', 'DEBUG', 'DBUG', 'Debug', 'Dbug')) AS debug,
    sum(toString(SeverityText) IN ('trace', 'TRACE', 'Trace')) AS trace,
    sum(toString(SeverityText) IN ('unknown', 'UNKNOWN', 'Unknown')) AS unknown
FROM otel.otel_logs
WHERE (time >= toDateTime(1731221399)) AND (time <= toDateTime(1731224999))
GROUP BY time
ORDER BY time ASC

Query id: f53041c1-3ec6-4bf0-be6b-7eeb453e4d9b

    ┌────────────────time─┬─critical─┬─error─┬─warn─┬─info─┬─debug─┬─trace─┬─unknown─┐
 1. │ 2024-11-10 07:35:00 │        0 │     0 │    0 │    0 │     0 │     0 │       0 │
 2. │ 2024-11-10 07:36:00 │        0 │     0 │    0 │    0 │     0 │     0 │       0 │
 3. │ 2024-11-10 07:37:00 │        0 │     0 │    0 │    0 │     0 │     0 │       0 │
 4. │ 2024-11-10 07:38:00 │        0 │     0 │    0 │    0 │     0 │     0 │       0 │
 5. │ 2024-11-10 07:39:00 │        0 │     0 │    0 │    0 │     0 │     0 │       0 │
 6. │ 2024-11-10 07:40:00 │        0 │     0 │    0 │    0 │     0 │     0 │       0 │
 7. │ 2024-11-10 07:41:00 │        0 │     0 │    0 │    0 │     0 │     0 │       0 │
 8. │ 2024-11-10 07:42:00 │        0 │     0 │    0 │    0 │     0 │     0 │       0 │
 9. │ 2024-11-10 07:43:00 │        0 │     0 │    0 │    0 │     0 │     0 │       0 │
10. │ 2024-11-10 07:44:00 │        0 │     0 │    0 │    0 │     0 │     0 │       0 │
11. │ 2024-11-10 07:45:00 │        0 │     0 │    0 │    0 │     0 │     0 │       0 │
12. │ 2024-11-10 07:46:00 │        0 │     0 │    0 │    0 │     0 │     0 │       0 │
13. │ 2024-11-10 07:47:00 │        0 │     0 │    0 │    0 │     0 │     0 │       0 │
14. │ 2024-11-10 07:48:00 │        0 │     0 │    0 │    0 │     0 │     0 │       0 │
15. │ 2024-11-10 07:49:00 │        0 │     0 │    0 │    0 │     0 │     0 │       0 │
    └─────────────────────┴──────────┴───────┴──────┴──────┴───────┴───────┴─────────┘

15 rows in set. Elapsed: 0.108 sec.
```

Same with `EXPLAIN`
```sql
   ┌─explain──────────────────────────────────────────┐
1. │ Expression (Project names)                       │
2. │   Sorting (Sorting for ORDER BY)                 │
3. │     Expression ((Before ORDER BY + Projection))  │
4. │       Aggregating                                │
5. │         Filter                                   │
6. │           ReadFromMergeTree (timestamp_severity) │
   └──────────────────────────────────────────────────┘
```

I want to address this problem by using `multiSearchAny` function instead of `IN`:
```sql
sum(multiSearchAny(toString("level"), ['error','err','eror','ERROR','ERR','EROR','Error','Err','Eror'])) as error
```

Results of the query running with proposed projection:
```sql
chi-otel-otel-0-0-0.chi-otel-otel-0-0.opentelemetry-system.svc.cluster.local :) SELECT
    toStartOfInterval(Timestamp, toIntervalMinute(1)) AS time,
    sum(multiSearchAny(toString(SeverityText), ['critical', 'fatal', 'crit', 'alert', 'emerg', 'CRITICAL', 'FATAL', 'CRIT', 'ALERT', 'EMERG', 'Critical', 'Fatal', 'Crit', 'Alert', 'Emerg'])) AS critical,
    sum(multiSearchAny(toString(SeverityText), ['error', 'err', 'eror', 'ERROR', 'ERR', 'EROR', 'Error', 'Err', 'Eror'])) AS error,
    sum(multiSearchAny(toString(SeverityText), ['warn', 'warning', 'WARN', 'WARNING', 'Warn', 'Warning'])) AS warn,
    sum(multiSearchAny(toString(SeverityText), ['info', 'information', 'informational', 'INFO', 'INFORMATION', 'INFORMATIONAL', 'Info', 'Information', 'Informational'])) AS info,
    sum(multiSearchAny(toString(SeverityText), ['debug', 'dbug', 'DEBUG', 'DBUG', 'Debug', 'Dbug'])) AS debug,
    sum(multiSearchAny(toString(SeverityText), ['trace', 'TRACE', 'Trace'])) AS trace,
    sum(multiSearchAny(toString(SeverityText), ['unknown', 'UNKNOWN', 'Unknown'])) AS unknown
FROM otel.otel_logs
WHERE (time >= toDateTime(1731221399)) AND (time <= toDateTime(1731224999))
GROUP BY time
ORDER BY time ASC

Query id: c6ff8cae-a039-4235-bd31-e9f802d9f7e6

    ┌────────────────time─┬─critical─┬─error─┬─warn─┬─info─┬─debug─┬─trace─┬─unknown─┐
 1. │ 2024-11-10 07:35:00 │        0 │    36 │    2 │   26 │     0 │     0 │     254 │
 2. │ 2024-11-10 07:36:00 │        0 │   121 │    4 │   46 │     0 │     0 │     845 │
 3. │ 2024-11-10 07:37:00 │        0 │   114 │    6 │   68 │     0 │     0 │     850 │
 4. │ 2024-11-10 07:38:00 │        0 │   112 │   19 │   54 │     0 │     0 │     771 │
 5. │ 2024-11-10 07:39:00 │        0 │    97 │   25 │   65 │     0 │     0 │     691 │
 6. │ 2024-11-10 07:40:00 │        0 │    93 │    4 │   44 │     0 │     0 │     644 │
 7. │ 2024-11-10 07:41:00 │        0 │   101 │    5 │   58 │     0 │     0 │     707 │
 8. │ 2024-11-10 07:42:00 │        0 │    89 │   10 │   61 │     0 │     0 │     622 │
 9. │ 2024-11-10 07:43:00 │        0 │    97 │    4 │   56 │     0 │     0 │     686 │
10. │ 2024-11-10 07:44:00 │        0 │   102 │    4 │   49 │     0 │     0 │     709 │
11. │ 2024-11-10 07:45:00 │        0 │   101 │    4 │   56 │     0 │     0 │     704 │
12. │ 2024-11-10 07:46:00 │        0 │   110 │    4 │   47 │     0 │     0 │     758 │
13. │ 2024-11-10 07:47:00 │        0 │   106 │    6 │   64 │     0 │     0 │     794 │
14. │ 2024-11-10 07:48:00 │        0 │   105 │    4 │   47 │     0 │     0 │     743 │
15. │ 2024-11-10 07:49:00 │        0 │   114 │    6 │   94 │     0 │     0 │     806 │
    └─────────────────────┴──────────┴───────┴──────┴──────┴───────┴───────┴─────────┘

15 rows in set. Elapsed: 0.403 sec. Processed 21.54 thousand rows, 192.97 KB (53.48 thousand rows/s., 479.22 KB/s.)
Peak memory usage: 86.90 KiB.

chi-otel-otel-0-0-0.chi-otel-otel-0-0.opentelemetry-system.svc.cluster.local :) ALTER TABLE otel.otel_logs
    (DROP PROJECTION timestamp_severity)

Query id: c41c161f-aba7-410f-a832-d5789d05176c

Ok.

0 rows in set. Elapsed: 1.072 sec.

chi-otel-otel-0-0-0.chi-otel-otel-0-0.opentelemetry-system.svc.cluster.local :) ALTER TABLE otel.otel_logs
    (ADD PROJECTION timestamp_severity
    (
        SELECT
            toStartOfInterval(Timestamp, toIntervalMinute(1)) AS time,
            sum(multiSearchAny(toString(SeverityText), ['critical', 'fatal', 'crit', 'alert', 'emerg', 'CRITICAL', 'FATAL', 'CRIT', 'ALERT', 'EMERG', 'Critical', 'Fatal', 'Crit', 'Alert', 'Emerg'])) AS critical,
            sum(multiSearchAny(toString(SeverityText), ['error', 'err', 'eror', 'ERROR', 'ERR', 'EROR', 'Error', 'Err', 'Eror'])) AS error,
            sum(multiSearchAny(toString(SeverityText), ['warn', 'warning', 'WARN', 'WARNING', 'Warn', 'Warning'])) AS warn,
            sum(multiSearchAny(toString(SeverityText), ['info', 'information', 'informational', 'INFO', 'INFORMATION', 'INFORMATIONAL', 'Info', 'Information', 'Informational'])) AS info,
            sum(multiSearchAny(toString(SeverityText), ['debug', 'dbug', 'DEBUG', 'DBUG', 'Debug', 'Dbug'])) AS debug,
            sum(multiSearchAny(toString(SeverityText), ['trace', 'TRACE', 'Trace'])) AS trace,
            sum(multiSearchAny(toString(SeverityText), ['unknown', 'UNKNOWN', 'Unknown'])) AS unknown
        GROUP BY time
    ))

Query id: 798dba4e-8809-4e72-9be6-352dc350cb57

Ok.

0 rows in set. Elapsed: 1.941 sec.

chi-otel-otel-0-0-0.chi-otel-otel-0-0.opentelemetry-system.svc.cluster.local :) ALTER TABLE otel.otel_logs
    (MATERIALIZE PROJECTION timestamp_severity)

Query id: 5ecdb407-aba7-4630-b1f2-fd6cc5760fb4

Ok.

0 rows in set. Elapsed: 0.182 sec.

chi-otel-otel-0-0-0.chi-otel-otel-0-0.opentelemetry-system.svc.cluster.local :) SELECT
    toStartOfInterval(Timestamp, toIntervalMinute(1)) AS time,
    sum(multiSearchAny(toString(SeverityText), ['critical', 'fatal', 'crit', 'alert', 'emerg', 'CRITICAL', 'FATAL', 'CRIT', 'ALERT', 'EMERG', 'Critical', 'Fatal', 'Crit', 'Alert', 'Emerg'])) AS critical,
    sum(multiSearchAny(toString(SeverityText), ['error', 'err', 'eror', 'ERROR', 'ERR', 'EROR', 'Error', 'Err', 'Eror'])) AS error,
    sum(multiSearchAny(toString(SeverityText), ['warn', 'warning', 'WARN', 'WARNING', 'Warn', 'Warning'])) AS warn,
    sum(multiSearchAny(toString(SeverityText), ['info', 'information', 'informational', 'INFO', 'INFORMATION', 'INFORMATIONAL', 'Info', 'Information', 'Informational'])) AS info,
    sum(multiSearchAny(toString(SeverityText), ['debug', 'dbug', 'DEBUG', 'DBUG', 'Debug', 'Dbug'])) AS debug,
    sum(multiSearchAny(toString(SeverityText), ['trace', 'TRACE', 'Trace'])) AS trace,
    sum(multiSearchAny(toString(SeverityText), ['unknown', 'UNKNOWN', 'Unknown'])) AS unknown
FROM otel.otel_logs
WHERE (time >= toDateTime(1731221399)) AND (time <= toDateTime(1731224999))
GROUP BY time
ORDER BY time ASC

Query id: f2604949-384d-45d0-ba5c-461c0f3e8fed

    ┌────────────────time─┬─critical─┬─error─┬─warn─┬─info─┬─debug─┬─trace─┬─unknown─┐
 1. │ 2024-11-10 07:35:00 │        0 │    36 │    2 │   26 │     0 │     0 │     254 │
 2. │ 2024-11-10 07:36:00 │        0 │   121 │    4 │   46 │     0 │     0 │     845 │
 3. │ 2024-11-10 07:37:00 │        0 │   114 │    6 │   68 │     0 │     0 │     850 │
 4. │ 2024-11-10 07:38:00 │        0 │   112 │   19 │   54 │     0 │     0 │     771 │
 5. │ 2024-11-10 07:39:00 │        0 │    97 │   25 │   65 │     0 │     0 │     691 │
 6. │ 2024-11-10 07:40:00 │        0 │    93 │    4 │   44 │     0 │     0 │     644 │
 7. │ 2024-11-10 07:41:00 │        0 │   101 │    5 │   58 │     0 │     0 │     707 │
 8. │ 2024-11-10 07:42:00 │        0 │    89 │   10 │   61 │     0 │     0 │     622 │
 9. │ 2024-11-10 07:43:00 │        0 │    97 │    4 │   56 │     0 │     0 │     686 │
10. │ 2024-11-10 07:44:00 │        0 │   102 │    4 │   49 │     0 │     0 │     709 │
11. │ 2024-11-10 07:45:00 │        0 │   101 │    4 │   56 │     0 │     0 │     704 │
12. │ 2024-11-10 07:46:00 │        0 │   110 │    4 │   47 │     0 │     0 │     758 │
13. │ 2024-11-10 07:47:00 │        0 │   106 │    6 │   64 │     0 │     0 │     794 │
14. │ 2024-11-10 07:48:00 │        0 │   105 │    4 │   47 │     0 │     0 │     743 │
15. │ 2024-11-10 07:49:00 │        0 │   114 │    6 │   94 │     0 │     0 │     806 │
    └─────────────────────┴──────────┴───────┴──────┴──────┴───────┴───────┴─────────┘

15 rows in set. Elapsed: 0.293 sec.

chi-otel-otel-0-0-0.chi-otel-otel-0-0.opentelemetry-system.svc.cluster.local :) EXPLAIN
SELECT
    toStartOfInterval(Timestamp, toIntervalMinute(1)) AS time,
    sum(multiSearchAny(toString(SeverityText), ['critical', 'fatal', 'crit', 'alert', 'emerg', 'CRITICAL', 'FATAL', 'CRIT', 'ALERT', 'EMERG', 'Critical', 'Fatal', 'Crit', 'Alert', 'Emerg'])) AS critical,
    sum(multiSearchAny(toString(SeverityText), ['error', 'err', 'eror', 'ERROR', 'ERR', 'EROR', 'Error', 'Err', 'Eror'])) AS error,
    sum(multiSearchAny(toString(SeverityText), ['warn', 'warning', 'WARN', 'WARNING', 'Warn', 'Warning'])) AS warn,
    sum(multiSearchAny(toString(SeverityText), ['info', 'information', 'informational', 'INFO', 'INFORMATION', 'INFORMATIONAL', 'Info', 'Information', 'Informational'])) AS info,
    sum(multiSearchAny(toString(SeverityText), ['debug', 'dbug', 'DEBUG', 'DBUG', 'Debug', 'Dbug'])) AS debug,
    sum(multiSearchAny(toString(SeverityText), ['trace', 'TRACE', 'Trace'])) AS trace,
    sum(multiSearchAny(toString(SeverityText), ['unknown', 'UNKNOWN', 'Unknown'])) AS unknown
FROM otel.otel_logs
WHERE (time >= toDateTime(1731221399)) AND (time <= toDateTime(1731224999))
GROUP BY time
ORDER BY time ASC

Query id: 6377e317-24d2-46ef-87c4-242a09c50ea5

   ┌─explain──────────────────────────────────────────┐
1. │ Expression (Project names)                       │
2. │   Sorting (Sorting for ORDER BY)                 │
3. │     Expression ((Before ORDER BY + Projection))  │
4. │       Aggregating                                │
5. │         Filter                                   │
6. │           ReadFromMergeTree (timestamp_severity) │
   └──────────────────────────────────────────────────┘

6 rows in set. Elapsed: 0.013 sec.
```

Performance-wise `sum(toString(field) IN tuple)` and `sum(multiSearchAny(toString(field), array))` are almost identical.

```sql
chi-otel-otel-0-0-0.chi-otel-otel-0-0.opentelemetry-system.svc.cluster.local :) SELECT
    toStartOfInterval(Timestamp, toIntervalMinute(1)) AS time,
    sum(multiSearchAny(toString(SeverityText), ['critical', 'fatal', 'crit', 'alert', 'emerg', 'CRITICAL', 'FATAL', 'CRIT', 'ALERT', 'EMERG', 'Critical', 'Fatal', 'Crit', 'Alert', 'Emerg'])) AS critical,
    sum(multiSearchAny(toString(SeverityText), ['error', 'err', 'eror', 'ERROR', 'ERR', 'EROR', 'Error', 'Err', 'Eror'])) AS error,
    sum(multiSearchAny(toString(SeverityText), ['warn', 'warning', 'WARN', 'WARNING', 'Warn', 'Warning'])) AS warn,
    sum(multiSearchAny(toString(SeverityText), ['info', 'information', 'informational', 'INFO', 'INFORMATION', 'INFORMATIONAL', 'Info', 'Information', 'Informational'])) AS info,
    sum(multiSearchAny(toString(SeverityText), ['debug', 'dbug', 'DEBUG', 'DBUG', 'Debug', 'Dbug'])) AS debug,
    sum(multiSearchAny(toString(SeverityText), ['trace', 'TRACE', 'Trace'])) AS trace,
    sum(multiSearchAny(toString(SeverityText), ['unknown', 'UNKNOWN', 'Unknown'])) AS unknown
FROM otel.otel_logs_v3
WHERE (time >= toDateTime(1731110400)) AND (time <= toDateTime(1731111300))
GROUP BY time
ORDER BY time ASC

Query id: b7dccccc-49c1-4b0e-9c4b-d42ef7b95479

    ┌────────────────time─┬─critical─┬─error─┬─warn─┬───info─┬─debug─┬─trace─┬─unknown─┐
 1. │ 2024-11-09 00:00:00 │      995 │  2593 │ 3913 │ 243991 │    24 │     0 │   31279 │
 2. │ 2024-11-09 00:01:00 │     1570 │  3266 │ 3573 │ 225046 │    94 │     1 │   27434 │
 3. │ 2024-11-09 00:02:00 │     1373 │  2867 │ 3679 │ 186718 │    24 │     0 │   17803 │
 4. │ 2024-11-09 00:03:00 │     1204 │  2442 │ 3910 │ 218610 │    24 │     2 │   17762 │
 5. │ 2024-11-09 00:04:00 │     1198 │  2517 │ 3658 │ 223099 │    24 │     0 │   14996 │
 6. │ 2024-11-09 00:05:00 │     1133 │  2399 │ 3294 │ 202705 │    24 │     0 │   18125 │
 7. │ 2024-11-09 00:06:00 │      694 │  1814 │ 3424 │ 195853 │    24 │     1 │   16544 │
 8. │ 2024-11-09 00:07:00 │     1157 │  2895 │ 3874 │ 212035 │    24 │     1 │   23233 │
 9. │ 2024-11-09 00:08:00 │     1127 │  2638 │ 3930 │ 181388 │    24 │     0 │   22259 │
10. │ 2024-11-09 00:09:00 │      888 │  2156 │ 3403 │ 181759 │    24 │     1 │   17589 │
11. │ 2024-11-09 00:10:00 │      782 │  1895 │ 3424 │ 181360 │    26 │     0 │   18611 │
12. │ 2024-11-09 00:11:00 │      718 │  2430 │ 3240 │ 197387 │    24 │     0 │   15816 │
13. │ 2024-11-09 00:12:00 │      752 │  1723 │ 2944 │ 191507 │    24 │     3 │   16346 │
14. │ 2024-11-09 00:13:00 │      550 │  1934 │ 3674 │ 191722 │    24 │     0 │   15927 │
15. │ 2024-11-09 00:14:00 │      733 │  1743 │ 3036 │ 211204 │    24 │     0 │   19286 │
16. │ 2024-11-09 00:15:00 │      740 │  1686 │ 3072 │ 191288 │    24 │     0 │   21369 │
    └─────────────────────┴──────────┴───────┴──────┴────────┴───────┴───────┴─────────┘

16 rows in set. Elapsed: 108.719 sec. Processed 4.19 billion rows, 33.49 GB (38.51 million rows/s., 308.08 MB/s.)
Peak memory usage: 155.36 MiB.
```

```sql
chi-otel-otel-0-0-0.chi-otel-otel-0-0.opentelemetry-system.svc.cluster.local :) SELECT
    toStartOfInterval(Timestamp, toIntervalMinute(1)) AS time,
    sum(toString(SeverityText) IN ('critical', 'fatal', 'crit', 'alert', 'emerg', 'CRITICAL', 'FATAL', 'CRIT', 'ALERT', 'EMERG', 'Critical', 'Fatal', 'Crit', 'Alert', 'Emerg')) AS critical,
    sum(toString(SeverityText) IN ('error', 'err', 'eror', 'ERROR', 'ERR', 'EROR', 'Error', 'Err', 'Eror')) AS error,
    sum(toString(SeverityText) IN ('warn', 'warning', 'WARN', 'WARNING', 'Warn', 'Warning')) AS warn,
    sum(toString(SeverityText) IN ('info', 'information', 'informational', 'INFO', 'INFORMATION', 'INFORMATIONAL', 'Info', 'Information', 'Informational')) AS info,
    sum(toString(SeverityText) IN ('debug', 'dbug', 'DEBUG', 'DBUG', 'Debug', 'Dbug')) AS debug,
    sum(toString(SeverityText) IN ('trace', 'TRACE', 'Trace')) AS trace,
    sum(toString(SeverityText) IN ('unknown', 'UNKNOWN', 'Unknown')) AS unknown
FROM otel.otel_logs_v3
WHERE (time >= toDateTime(1731110400)) AND (time <= toDateTime(1731111300))
GROUP BY time
ORDER BY time ASC

Query id: 485cddda-978c-4db1-b1de-8f1a1c6475b6

    ┌────────────────time─┬─critical─┬─error─┬─warn─┬───info─┬─debug─┬─trace─┬─unknown─┐
 1. │ 2024-11-09 00:00:00 │      995 │  2593 │ 3913 │ 243991 │    24 │     0 │   31279 │
 2. │ 2024-11-09 00:01:00 │     1570 │  3266 │ 3573 │ 225046 │    94 │     1 │   27434 │
 3. │ 2024-11-09 00:02:00 │     1373 │  2867 │ 3679 │ 186718 │    24 │     0 │   17803 │
 4. │ 2024-11-09 00:03:00 │     1204 │  2442 │ 3910 │ 218610 │    24 │     2 │   17762 │
 5. │ 2024-11-09 00:04:00 │     1198 │  2517 │ 3658 │ 223099 │    24 │     0 │   14996 │
 6. │ 2024-11-09 00:05:00 │     1133 │  2399 │ 3294 │ 202705 │    24 │     0 │   18125 │
 7. │ 2024-11-09 00:06:00 │      694 │  1814 │ 3424 │ 195853 │    24 │     1 │   16544 │
 8. │ 2024-11-09 00:07:00 │     1157 │  2895 │ 3874 │ 212035 │    24 │     1 │   23233 │
 9. │ 2024-11-09 00:08:00 │     1127 │  2638 │ 3930 │ 181388 │    24 │     0 │   22259 │
10. │ 2024-11-09 00:09:00 │      888 │  2156 │ 3403 │ 181759 │    24 │     1 │   17589 │
11. │ 2024-11-09 00:10:00 │      782 │  1895 │ 3424 │ 181360 │    26 │     0 │   18611 │
12. │ 2024-11-09 00:11:00 │      718 │  2430 │ 3240 │ 197387 │    24 │     0 │   15816 │
13. │ 2024-11-09 00:12:00 │      752 │  1723 │ 2944 │ 191507 │    24 │     3 │   16346 │
14. │ 2024-11-09 00:13:00 │      550 │  1934 │ 3674 │ 191722 │    24 │     0 │   15927 │
15. │ 2024-11-09 00:14:00 │      733 │  1743 │ 3036 │ 211204 │    24 │     0 │   19286 │
16. │ 2024-11-09 00:15:00 │      740 │  1686 │ 3072 │ 191288 │    24 │     0 │   21369 │
    └─────────────────────┴──────────┴───────┴──────┴────────┴───────┴───────┴─────────┘

16 rows in set. Elapsed: 113.432 sec. Processed 4.19 billion rows, 33.50 GB (36.91 million rows/s., 295.35 MB/s.)
Peak memory usage: 128.90 MiB.
```

