### PR TITLE
Add datasource to traces\logs view button

### DIFF
--- a/src/data/utils.ts
+++ b/src/data/utils.ts
@@ -132,6 +132,7 @@ export const transformQueryResponseWithTraceAndLogLinks = (datasource: Datasourc
     }
 
     const traceIdQuery: CHBuilderQuery = {
+      datasource: datasource,
       editorType: EditorType.Builder,
       /**
        * Evil bug:
@@ -189,6 +190,7 @@ export const transformQueryResponseWithTraceAndLogLinks = (datasource: Datasourc
     }
 
     const traceLogsQuery: CHBuilderQuery = {
+      datasource: datasource,
       editorType: EditorType.Builder,
       rawSql: '',
       builderOptions: {} as QueryBuilderOptions,


### PR DESCRIPTION
We use **clickhouse-datasource** in dashboards. 
I noticed that if you press the button **View traces** on the dashboard, and ClickHouse is not the default data source, the default source will be selected. 
There is already a billet to replace the data source, but it has not been fully implemented.
[View trace](https://github.com/grafana/clickhouse-datasource/blob/v4.5.1/src/data/utils.ts#L264)
[View logs](https://github.com/grafana/clickhouse-datasource/blob/v4.5.1/src/data/utils.ts#L279)
PR offers a solution to this problem