### PR TITLE
Add JSON paths to column selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+### Features
+- Add JSON column sub-paths to column selection in query builder
 
 ## 4.6.0
 

--- a/src/data/CHDatasource.test.ts
+++ b/src/data/CHDatasource.test.ts
@@ -1,5 +1,5 @@
 import {
-  ArrayDataFrame,
+  arrayToDataFrame,
   CoreApp,
   DataQueryRequest,
   DataQueryResponse,
@@ -106,7 +106,7 @@ describe('ClickHouseDatasource', () => {
     it('should Fetch Default Tags When No Second AdHoc Variable', async () => {
       const spyOnReplace = jest.spyOn(templateSrvMock, 'replace').mockImplementation(() => '$clickhouse_adhoc_query');
       const ds = cloneDeep(mockDatasource);
-      const frame = new ArrayDataFrame([{ name: 'foo', type: 'string', table: 'table' }]);
+      const frame = arrayToDataFrame([{ name: 'foo', type: 'string', table: 'table' }]);
       jest.spyOn(ds, 'getDefaultDatabase').mockImplementation(() => undefined!); // Disable default DB
       const spyOnQuery = jest.spyOn(ds, 'query').mockImplementation((_request) => of({ data: [frame] }));
 
@@ -123,7 +123,7 @@ describe('ClickHouseDatasource', () => {
 
     it('should Fetch Tags With Default Database', async () => {
       const spyOnReplace = jest.spyOn(templateSrvMock, 'replace').mockImplementation(() => '$clickhouse_adhoc_query');
-      const frame = new ArrayDataFrame([{ name: 'foo', type: 'string', table: 'table' }]);
+      const frame = arrayToDataFrame([{ name: 'foo', type: 'string', table: 'table' }]);
       const ds = cloneDeep(mockDatasource);
       const spyOnQuery = jest.spyOn(ds, 'query').mockImplementation((_request) => of({ data: [frame] }));
 
@@ -140,7 +140,7 @@ describe('ClickHouseDatasource', () => {
 
     it('should Fetch Tags From Query', async () => {
       const spyOnReplace = jest.spyOn(templateSrvMock, 'replace').mockImplementation(() => 'select name from foo');
-      const frame = new ArrayDataFrame([{ name: 'foo' }]);
+      const frame = arrayToDataFrame([{ name: 'foo' }]);
       const ds = cloneDeep(mockDatasource);
       const spyOnQuery = jest.spyOn(ds, 'query').mockImplementation((_request) => of({ data: [frame] }));
 
@@ -156,7 +156,7 @@ describe('ClickHouseDatasource', () => {
     });
     it('returns no tags when CH version is less than 22.7 ', async () => {
       const spyOnReplace = jest.spyOn(templateSrvMock, 'replace').mockImplementation(() => 'select name from foo');
-      const frame = new ArrayDataFrame([{ version: '21.9.342' }]);
+      const frame = arrayToDataFrame([{ version: '21.9.342' }]);
       const ds = cloneDeep(mockDatasource);
       ds.adHocFiltersStatus = 2;
       const spyOnQuery = jest.spyOn(ds, 'query').mockImplementation((_request) => of({ data: [frame] }));
@@ -171,8 +171,8 @@ describe('ClickHouseDatasource', () => {
 
     it('returns tags when CH version is greater than 22.7 ', async () => {
       const spyOnReplace = jest.spyOn(templateSrvMock, 'replace').mockImplementation(() => 'select name from foo');
-      const frameVer = new ArrayDataFrame([{ version: '23.2.212' }]);
-      const frameData = new ArrayDataFrame([{ name: 'foo' }]);
+      const frameVer = arrayToDataFrame([{ version: '23.2.212' }]);
+      const frameData = arrayToDataFrame([{ name: 'foo' }]);
       const ds = cloneDeep(mockDatasource);
       ds.adHocFiltersStatus = 2;
       const spyOnQuery = jest.spyOn(ds, 'query').mockImplementation((request) => {
@@ -193,7 +193,7 @@ describe('ClickHouseDatasource', () => {
       const spyOnReplace = jest.spyOn(templateSrvMock, 'replace').mockImplementation(() => '$clickhouse_adhoc_query');
       const ds = cloneDeep(mockDatasource);
       ds.settings.jsonData.defaultDatabase = undefined;
-      const frame = new ArrayDataFrame([{ bar: 'foo' }]);
+      const frame = arrayToDataFrame([{ bar: 'foo' }]);
       const spyOnQuery = jest.spyOn(ds, 'query').mockImplementation((_request) => of({ data: [frame] }));
       const values = await ds.getTagValues({ key: 'foo.bar' });
       expect(spyOnReplace).toHaveBeenCalled();
@@ -209,7 +209,7 @@ describe('ClickHouseDatasource', () => {
     it('should Fetch Tag Values from Query', async () => {
       const spyOnReplace = jest.spyOn(templateSrvMock, 'replace').mockImplementation(() => 'select name from bar');
       const ds = cloneDeep(mockDatasource);
-      const frame = new ArrayDataFrame([{ name: 'foo' }]);
+      const frame = arrayToDataFrame([{ name: 'foo' }]);
       const spyOnQuery = jest.spyOn(ds, 'query').mockImplementation((_request) => of({ data: [frame] }));
       const values = await ds.getTagValues({ key: 'name' });
       expect(spyOnReplace).toHaveBeenCalled();
@@ -252,7 +252,7 @@ describe('ClickHouseDatasource', () => {
   describe('fetchPathsForJSONColumns', () => {
     it('sends a correct query when database and table names are provided', async () => {
       const ds = cloneDeep(mockDatasource);
-      const frame = new ArrayDataFrame([
+      const frame = arrayToDataFrame([
         JSON.stringify({ keys: 'a.b.c', values: ['Int64'] }),
         JSON.stringify({ keys: 'a.b.d', values: ['String'] }),
         JSON.stringify({ keys: 'a.b.e', values: ['Bool'] })
@@ -268,7 +268,7 @@ describe('ClickHouseDatasource', () => {
 
     it('sends a correct query when only table name is provided', async () => {
       const ds = cloneDeep(mockDatasource);
-      const frame = new ArrayDataFrame([
+      const frame = arrayToDataFrame([
         JSON.stringify({ keys: 'a.b.c', values: ['Int64'] }),
         JSON.stringify({ keys: 'a.b.d', values: ['String'] }),
         JSON.stringify({ keys: 'a.b.e', values: ['Bool'] })
@@ -284,7 +284,7 @@ describe('ClickHouseDatasource', () => {
 
     it('sends a correct query when table name contains a dot', async () => {
       const ds = cloneDeep(mockDatasource);
-      const frame = new ArrayDataFrame([
+      const frame = arrayToDataFrame([
         JSON.stringify({ keys: 'a.b.c', values: ['Int64'] }),
         JSON.stringify({ keys: 'a.b.d', values: ['String'] }),
         JSON.stringify({ keys: 'a.b.e', values: ['Bool'] })
@@ -300,7 +300,7 @@ describe('ClickHouseDatasource', () => {
 
     it('returns correct json columns', async () => {
       const ds = cloneDeep(mockDatasource);
-      const frame = new ArrayDataFrame([
+      const frame = arrayToDataFrame([
         JSON.stringify({ keys: 'a.b.c', values: ['Int64'] }),
         JSON.stringify({ keys: 'a.b.d', values: ['String'] }),
         JSON.stringify({ keys: 'a.b.e', values: ['Bool'] })
@@ -319,7 +319,7 @@ describe('ClickHouseDatasource', () => {
   describe('fetchColumnsFromTable', () => {
     it('sends a correct query when database and table names are provided', async () => {
       const ds = cloneDeep(mockDatasource);
-      const frame = new ArrayDataFrame([{ name: 'foo', type: 'string', table: 'table' }]);
+      const frame = arrayToDataFrame([{ name: 'foo', type: 'string', table: 'table' }]);
       const spyOnQuery = jest.spyOn(ds, 'query').mockImplementation((_request) => of({ data: [frame] }));
       await ds.fetchColumnsFromTable('db_name', 'table_name');
       const expected = { rawSql: 'DESC TABLE "db_name"."table_name"' };
@@ -331,7 +331,7 @@ describe('ClickHouseDatasource', () => {
 
     it('sends a correct query when only table name is provided', async () => {
       const ds = cloneDeep(mockDatasource);
-      const frame = new ArrayDataFrame([{ name: 'foo', type: 'string', table: 'table' }]);
+      const frame = arrayToDataFrame([{ name: 'foo', type: 'string', table: 'table' }]);
       const spyOnQuery = jest.spyOn(ds, 'query').mockImplementation((_request) => of({ data: [frame] }));
       await ds.fetchColumnsFromTable('', 'table_name');
       const expected = { rawSql: 'DESC TABLE "table_name"' };
@@ -343,7 +343,7 @@ describe('ClickHouseDatasource', () => {
 
     it('sends a correct query when table name contains a dot', async () => {
       const ds = cloneDeep(mockDatasource);
-      const frame = new ArrayDataFrame([{ name: 'foo', type: 'string', table: 'table' }]);
+      const frame = arrayToDataFrame([{ name: 'foo', type: 'string', table: 'table' }]);
       const spyOnQuery = jest.spyOn(ds, 'query').mockImplementation((_) => of({ data: [frame] }));
 
       await ds.fetchColumnsFromTable('', 'table.name');
@@ -358,7 +358,7 @@ describe('ClickHouseDatasource', () => {
   describe('fetchColumnsFromAliasTable', () => {
     it('sends a correct query when full table name is provided', async () => {
       const ds = cloneDeep(mockDatasource);
-      const frame = new ArrayDataFrame([{ name: 'foo', type: 'string', table: 'table' }]);
+      const frame = arrayToDataFrame([{ name: 'foo', type: 'string', table: 'table' }]);
       const spyOnQuery = jest.spyOn(ds, 'query').mockImplementation((_request) => of({ data: [frame] }));
       await ds.fetchColumnsFromAliasTable('"db_name"."table_name"');
       const expected = { rawSql: 'SELECT alias, select, "type" FROM "db_name"."table_name"' };

--- a/src/data/CHDatasource.ts
+++ b/src/data/CHDatasource.ts
@@ -602,13 +602,13 @@ export class Datasource
       picklistValues: [],
     }));
 
-    const jsonColumnNames = columns.filter(c => c.type.startsWith('JSON')).map(c => c.name);
-    for (let jsonColumnName of jsonColumnNames) {
-      const jsonColumns = await this.fetchPathsForJSONColumns(database, table, jsonColumnName);
-      columns.push(...jsonColumns);
-    }
+    const results = await Promise.all(
+      columns
+        .filter(c => c.type.startsWith("JSON"))
+        .map(c => this.fetchPathsForJSONColumns(database, table, c.name))
+    );
 
-    return columns;
+    return [...columns, ...results.flat()];
   }
 
   /**


### PR DESCRIPTION
When viewing a table with `JSON` columns, the paths are now included in the column suggestions. Since the path types are also included, the filters automatically adapt to the underlying type.

![json path suggestions in query builder](https://github.com/user-attachments/assets/fb0aeef9-c4fb-491c-928d-bcb853b8d45b)


Changes:
- updated tests
- updated changelog
