### PR TITLE
Refactor `clickhouse.Connect` to improve context cancellation handling

### DIFF
--- a/pkg/plugin/driver_test.go
+++ b/pkg/plugin/driver_test.go
@@ -83,7 +83,8 @@ func TestMain(m *testing.M) {
 	}
 	req := testcontainers.ContainerRequest{
 		Env: map[string]string{
-			"TZ": time.Local.String(),
+			"CLICKHOUSE_SKIP_USER_SETUP": "1", // added because of https://github.com/ClickHouse/ClickHouse/commit/65435a3db7214261b793acfb69388567b4c8c9b3
+			"TZ":                         time.Local.String(),
 		},
 		ExposedPorts: []string{"9000/tcp", "8123/tcp"},
 		Files: []testcontainers.ContainerFile{


### PR DESCRIPTION
This PR removes an unnecessary goroutine for `db.PingContext(ctx)`, preventing potential leaks when timeouts occur. It properly propagates `context.WithTimeout` throughout the function, ensuring `db.PingContext` and the PDC dialler respects the timeout. It also removes the `chErr` channel and simplifies the `select` statement for cleaner and safer connection handling.