### PR TITLE
Cancel JSON paths query after 10s

### DIFF
--- a/src/data/CHDatasource.test.ts
+++ b/src/data/CHDatasource.test.ts
@@ -259,7 +259,7 @@ describe('ClickHouseDatasource', () => {
       ]);
       const spyOnQuery = jest.spyOn(ds, 'query').mockImplementation((_request) => of({ data: [frame] }));
       await ds.fetchPathsForJSONColumns('db_name', 'table_name', 'jsonCol');
-      const expected = { rawSql: 'SELECT arrayJoin(distinctJSONPathsAndTypes(jsonCol)) FROM "db_name"."table_name"' };
+      const expected = { rawSql: 'SELECT arrayJoin(distinctJSONPathsAndTypes(jsonCol)) FROM "db_name"."table_name" SETTINGS max_execution_time=10' };
 
       expect(spyOnQuery).toHaveBeenCalledWith(
         expect.objectContaining({ targets: expect.arrayContaining([expect.objectContaining(expected)]) })
@@ -275,7 +275,7 @@ describe('ClickHouseDatasource', () => {
       ]);
       const spyOnQuery = jest.spyOn(ds, 'query').mockImplementation((_request) => of({ data: [frame] }));
       await ds.fetchPathsForJSONColumns('', 'table_name', 'jsonCol');
-      const expected = { rawSql: 'SELECT arrayJoin(distinctJSONPathsAndTypes(jsonCol)) FROM "table_name"' };
+      const expected = { rawSql: 'SELECT arrayJoin(distinctJSONPathsAndTypes(jsonCol)) FROM "table_name" SETTINGS max_execution_time=10' };
 
       expect(spyOnQuery).toHaveBeenCalledWith(
         expect.objectContaining({ targets: expect.arrayContaining([expect.objectContaining(expected)]) })
@@ -291,7 +291,7 @@ describe('ClickHouseDatasource', () => {
       ]);
       const spyOnQuery = jest.spyOn(ds, 'query').mockImplementation((_request) => of({ data: [frame] }));
       await ds.fetchPathsForJSONColumns('', 'table.name', 'jsonCol');
-      const expected = { rawSql: 'SELECT arrayJoin(distinctJSONPathsAndTypes(jsonCol)) FROM "table.name"' };
+      const expected = { rawSql: 'SELECT arrayJoin(distinctJSONPathsAndTypes(jsonCol)) FROM "table.name" SETTINGS max_execution_time=10' };
 
       expect(spyOnQuery).toHaveBeenCalledWith(
         expect.objectContaining({ targets: expect.arrayContaining([expect.objectContaining(expected)]) })

--- a/src/data/CHDatasource.ts
+++ b/src/data/CHDatasource.ts
@@ -545,7 +545,7 @@ export class Datasource
    */
   async fetchPathsForJSONColumns(database: string | undefined, table: string, jsonColumnName: string): Promise<TableColumn[]> {
     const prefix = Boolean(database) ? `"${database}".` : '';
-    const rawSql = `SELECT arrayJoin(distinctJSONPathsAndTypes(${jsonColumnName})) FROM ${prefix}"${table}"`;
+    const rawSql = `SELECT arrayJoin(distinctJSONPathsAndTypes(${jsonColumnName})) FROM ${prefix}"${table}" SETTINGS max_execution_time=10`;
     const frame = await this.runQuery({ rawSql });
     if (frame.fields?.length === 0) {
       return [];


### PR DESCRIPTION
Some JSON datasets take a long time to determine their Dynamic + SharedData paths, this change sets a 10 second timeout on that query. If the query times out then the JSON suggestions array is simply empty and things continue as usual.
