### PR TITLE
RFC: Use ResourceAttributes and ScopeAttributes for log labels as well

### DIFF
--- a/src/components/queryBuilder/ColumnsEditor.tsx
+++ b/src/components/queryBuilder/ColumnsEditor.tsx
@@ -12,6 +12,8 @@ interface ColumnsEditorProps {
   onSelectedColumnsChange: (selectedColumns: SelectedColumn[]) => void;
   disabled?: boolean;
   showAllOption?: boolean;
+  label?: string;
+  tooltip?: string;
 }
 
 function getCustomColumns(columnNames: string[], allColumns: readonly TableColumn[]): Array<SelectableValue<string>> {
@@ -24,7 +26,10 @@ function getCustomColumns(columnNames: string[], allColumns: readonly TableColum
 const allColumnName = '*';
 
 export const ColumnsEditor = (props: ColumnsEditorProps) => {
-  const { allColumns, selectedColumns, onSelectedColumnsChange, disabled, showAllOption } = props;
+  const {
+    allColumns, selectedColumns, onSelectedColumnsChange, disabled, showAllOption,
+    label = labels.components.ColumnsEditor.label, tooltip = labels.components.ColumnsEditor.tooltip
+  } = props;
   const [customColumns, setCustomColumns] = useState<Array<SelectableValue<string>>>([]);
   const [isOpen, setIsOpen] = useState(false);
   const allColumnNames = allColumns.map(c => ({ label: c.label || c.name, value: c.name }));
@@ -32,7 +37,6 @@ export const ColumnsEditor = (props: ColumnsEditorProps) => {
     allColumnNames.push({ label: allColumnName, value: allColumnName });
   }
   const selectedColumnNames = (selectedColumns || []).map(c => ({ label: c.alias || c.name, value: c.name }));
-  const { label, tooltip } = labels.components.ColumnsEditor;
 
   const options = [...allColumnNames, ...customColumns];
 

--- a/src/components/queryBuilder/views/LogsQueryBuilder.tsx
+++ b/src/components/queryBuilder/views/LogsQueryBuilder.tsx
@@ -32,7 +32,7 @@ interface LogsQueryBuilderState {
   timeColumn?: SelectedColumn;
   logLevelColumn?: SelectedColumn;
   messageColumn?: SelectedColumn;
-  labelsColumn?: SelectedColumn;
+  labelsColumns: SelectedColumn[];
   // liveView: boolean;
   orderBy: OrderBy[];
   limit: number;
@@ -78,8 +78,9 @@ export const LogsQueryBuilder = (props: LogsQueryBuilderProps) => {
     if (next.messageColumn) {
       nextColumns.push(next.messageColumn);
     }
-    if (next.labelsColumn) {
-      nextColumns.push(next.labelsColumn);
+
+    for (const c of next.labelsColumns) {
+      nextColumns.push({ ...c, mapForLabels: true })
     }
 
     builderOptionsDispatch(setOptions({
@@ -161,16 +162,13 @@ export const LogsQueryBuilder = (props: LogsQueryBuilderProps) => {
           label={labels.logMessageColumn.label}
           tooltip={labels.logMessageColumn.tooltip}
         />
-        <ColumnSelect
+        <ColumnsEditor
           disabled={builderState.otelEnabled}
           allColumns={allColumns}
-          selectedColumn={builderState.labelsColumn}
-          invalid={!builderState.labelsColumn}
-          onColumnChange={onOptionChange('labelsColumn')}
-          columnHint={ColumnHint.LogLabels}
+          selectedColumns={builderState.labelsColumns}
+          onSelectedColumnsChange={onOptionChange('labelsColumns')}
           label={labels.logLabelsColumn.label}
           tooltip={labels.logLabelsColumn.tooltip}
-          inline
         />
         {/* <Switch
           value={builderState.liveView}

--- a/src/components/queryBuilder/views/logsQueryBuilderHooks.ts
+++ b/src/components/queryBuilder/views/logsQueryBuilderHooks.ts
@@ -23,7 +23,8 @@ export const useLogDefaultsOnMount = (datasource: Datasource, isNewQuery: boolea
     const nextColumns: SelectedColumn[] = [];
     const includedColumns = new Set<string>();
     for (let [hint, colName] of defaultColumns) {
-      nextColumns.push({ name: colName, hint });
+      const mapForLabels = (hint === ColumnHint.LogAttributes || hint === ColumnHint.LogResourceAttributes || hint === ColumnHint.LogScopeAttributes)
+      nextColumns.push({ name: colName, hint, mapForLabels });
       includedColumns.add(colName);
     }
 
@@ -77,7 +78,8 @@ export const useOtelColumns = (datasource: Datasource, otelEnabled: boolean, ote
     const columns: SelectedColumn[] = [];
     const includedColumns = new Set<string>();
     logColumnMap.forEach((name, hint) => {
-      columns.push({ name, hint });
+      const mapForLabels = (hint === ColumnHint.LogAttributes || hint === ColumnHint.LogResourceAttributes || hint === ColumnHint.LogScopeAttributes)
+      columns.push({ name, hint, mapForLabels });
       includedColumns.add(name);
     });
 

--- a/src/data/CHDatasource.ts
+++ b/src/data/CHDatasource.ts
@@ -159,6 +159,7 @@ export class Datasource
       for (level in LOG_LEVEL_TO_IN_CLAUSE) {
         aggregates.push({ aggregateType: AggregateType.Sum, column: `multiSearchAny(${llf}, [${LOG_LEVEL_TO_IN_CLAUSE[level]}])`, alias: level });
       }
+      columns.push({name: `count(*) - (${Object.keys(LOG_LEVEL_TO_IN_CLAUSE).join('+')})`, alias: 'unknown'})
     } else {
       // Count all logs if level column isn't selected
       aggregates.push({

--- a/src/data/utils.test.ts
+++ b/src/data/utils.test.ts
@@ -3,7 +3,7 @@ import { columnLabelToPlaceholder, dataFrameHasLogLabelWithName, isBuilderOption
 import { newMockDatasource } from "__mocks__/datasource";
 import { CoreApp, DataFrame, DataQueryRequest, DataQueryResponse, Field, FieldType } from "@grafana/data";
 import { CHBuilderQuery, CHQuery, EditorType } from "types/sql";
-import { logColumnHintsToAlias } from "./sqlGenerator";
+import { LABELS_ALIAS } from "./sqlGenerator";
 
 describe('isBuilderOptionsRunnable', () => {
   it('should return false for empty builder options', () => {
@@ -209,7 +209,7 @@ describe('transformQueryResponseWithTraceAndLogLinks', () => {
 
 
 describe('dataFrameHasLogLabelWithName', () => {
-  const logLabelsFieldName = logColumnHintsToAlias.get(ColumnHint.LogLabels);
+  const logLabelsFieldName = LABELS_ALIAS;
 
   it('should return false for undefined dataframe', () => {
     expect(dataFrameHasLogLabelWithName(undefined, 'testLabel')).toBe(false);

--- a/src/labels.ts
+++ b/src/labels.ts
@@ -452,7 +452,10 @@ export default {
 
       [ColumnHint.LogLevel]: 'Level',
       [ColumnHint.LogMessage]: 'Message',
-      [ColumnHint.LogLabels]: 'Labels',
+
+      [ColumnHint.LogAttributes]: 'Log Attributes',
+      [ColumnHint.LogResourceAttributes]: 'Resource Attributes',
+      [ColumnHint.LogScopeAttributes]: 'Scope Attributes',
 
       [ColumnHint.TraceId]: 'Trace ID',
       [ColumnHint.TraceSpanId]: 'Span ID',

--- a/src/otel.ts
+++ b/src/otel.ts
@@ -26,7 +26,9 @@ const otel129: OtelVersion = {
     [ColumnHint.Time, 'Timestamp'],
     [ColumnHint.LogMessage, 'Body'],
     [ColumnHint.LogLevel, 'SeverityText'],
-    [ColumnHint.LogLabels, 'LogAttributes'],
+    [ColumnHint.LogAttributes, 'LogAttributes'],
+    [ColumnHint.LogResourceAttributes, 'ResourceAttributes'],
+    [ColumnHint.LogScopeAttributes, 'ScopeAttributes'],
     [ColumnHint.TraceId, 'TraceId'],
   ]),
   logLevels: [

--- a/src/types/queryBuilder.ts
+++ b/src/types/queryBuilder.ts
@@ -122,7 +122,10 @@ export enum ColumnHint {
 
   LogLevel = 'log_level',
   LogMessage = 'log_message',
-  LogLabels = 'log_labels',
+
+  LogAttributes = 'log_attributes',
+  LogResourceAttributes = 'log_resource_attributes',
+  LogScopeAttributes = 'log_scope_attributes',
 
   TraceId = 'trace_id',
   TraceSpanId = 'trace_span_id',
@@ -155,6 +158,7 @@ export interface SelectedColumn {
   alias?: string;
   custom?: boolean;
   hint?: ColumnHint;
+  mapForLabels?: boolean
 }
 
 export enum OrderByDirection {


### PR DESCRIPTION
Heya, have just been trying to get something working on #1103 - currently when Exploring logs, you can see labels from LogAttributes, but not from ResourceAttributes or ScopeAttributes. This is pretty important functionality - "I have a random log line from somewhere in my k8s cluster, which pod did it come from?"

To query, I'm merging all the Attributes maps together and prefixing their keys so I can track where they came from.

I wasn't 100% sure on the best way to model this - I flipped and flopped between having a special `.labelColumns` field added on `QueryBuilderOptions` , or in a special `.magicMapForLabels` bool on `SelectedColumn` - I went with the latter.

This seems to work OK!
![image](https://github.com/user-attachments/assets/e4a0709b-5b7a-402b-9497-d31096878671)

SQL Preview
```sql
SELECT Timestamp as "timestamp", Body as "body", SeverityText as "level", mapConcat(mapApply((k, v) -> ('attr.' || k,  v), "LogAttributes"),mapApply((k, v) -> ('res.' || k,  v), "ResourceAttributes"),mapApply((k, v) -> ('span.' || k,  v), "ScopeAttributes")) as "labels", TraceId as "traceID" FROM "otel"."otel_logs" WHERE ( timestamp >= $__fromTime AND timestamp <= $__toTime ) AND ( ResourceAttributes['k8s.namespace.name'] = 'sys-nginx-gateway' ) AND ( ResourceAttributes['k8s.node.name'] = 'i-04fb08d3a1fcd7eed.ap-southeast-2.compute.internal' ) ORDER BY timestamp DESC LIMIT 1000
````

Could I ask for a pointer if this is an ok approach to take to achieve this? I can't promise I'd be able to finish it off but I can probably get pretty far at least.