### PR TITLE
Add support for the general `row_limit` config setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+# Unreleased
+
+### Features
+
+- Add support for the Grafana `row_limit` [configuration setting](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#row_limit).
+
 ## 4.8.2
 
 ### Fixes
@@ -169,7 +175,7 @@
 - Fixed empty builder options when switching from SQL Editor back to Query Editor
 - Fix SQL Generator including "undefined" in `FROM` when database isn't defined
 - Allow adding spaces in multi filters (such as `WHERE .. IN`)
-- Fixed missing `AND` keyword when adding a filter to a Trace ID query 
+- Fixed missing `AND` keyword when adding a filter to a Trace ID query
 
 ## 4.0.2
 
@@ -219,10 +225,12 @@ Version 4.0.0 contains major revisions to the query builder and datasource confi
 - Added column hints, which offers better linking across query components when working with columns and filters. For example, a filter can be added for the `Time` column, even without knowing what the time column name is yet. This enables better SQL generation that is "aware" of a column's intended use.
 
 ### Plugin Backend
+
 - Added migration logic for `v3` configs going to `v4+`. This is applied when the config is loaded when building a database connection.
 - `$__timeFilter`, `$__fromTime`, and `$__toTime` macros now convert to `DateTime64(3)` for better server-side type conversion. Also enables millisecond precision time range filtering.
 
 #### Datasource Configuration
+
 - Added migration script for `v3.x` configurations to `v4+`. This runs automatically when opening/saving the datasource configuration.
 - Renamed config value `server` to `host`.
 - Renamed config value `timeout` to the more specific `dial_timeout`.

--- a/pkg/plugin/driver.go
+++ b/pkg/plugin/driver.go
@@ -169,6 +169,8 @@ func (h *Clickhouse) Connect(ctx context.Context, config backend.DataSourceInsta
 		}
 	}
 
+	customSettings["limit"] = settings.RowLimit
+
 	httpHeaders, err := extractForwardedHeadersFromMessage(message)
 	if err != nil {
 		return nil, err

--- a/pkg/plugin/settings.go
+++ b/pkg/plugin/settings.go
@@ -44,6 +44,8 @@ type Settings struct {
 	ForwardGrafanaHeaders bool              `json:"forwardGrafanaHeaders,omitempty"`
 	CustomSettings        []CustomSetting   `json:"customSettings"`
 	ProxyOptions          *proxy.Options
+
+	RowLimit int64 `json:"rowLimit,omitempty"`
 }
 
 type CustomSetting struct {
@@ -234,6 +236,14 @@ func LoadSettings(ctx context.Context, config backend.DataSourceInstanceSettings
 
 		settings.ProxyOptions = proxyOpts
 	}
+
+	cfg := backend.GrafanaConfigFromContext(ctx)
+	sqlCfg, err := cfg.SQL()
+	if err != nil {
+		return settings, err
+	}
+
+	settings.RowLimit = sqlCfg.RowLimit
 
 	return settings, settings.isValid()
 }


### PR DESCRIPTION
This PR adds support for the general `row_limit` configuration setting.

If set, this will override the `limit` set in the query builder.

Fixes #1134