### PR TITLE
change `host` to `server` in yaml config example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ datasources:
     jsonData:
       defaultDatabase: database
       port: 9000
-      host: localhost
+      server: localhost
       username: username
       tlsSkipVerify: false
       # tlsAuth: <bool>


### PR DESCRIPTION
The `host` YAML property was not being recognized by grafana, however `server` is recognized.

<!-- To surface this PR in the changelog add the label: changelog -->
<!-- If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way: -->
<!-- Bad: fix state bug in hooks -->
<!-- Good: Fix crash when switching from Query Builder -->
