### PR TITLE
Secure GHA Workflows

### DIFF
--- a/.github/workflows/dependabot-reviewer.yml
+++ b/.github/workflows/dependabot-reviewer.yml
@@ -1,6 +1,6 @@
 name: Dependabot reviewer
 
-on: pull_request_target
+on: pull_request
 
 permissions:
   pull-requests: write

--- a/.github/workflows/detect-breaking-changes.yml
+++ b/.github/workflows/detect-breaking-changes.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Build plugin
         run: yarn build
       - name: Compatibility check
-        uses: grafana/plugin-actions/is-compatible@v1
+        uses: grafana/plugin-actions/is-compatible@f567fc6454619e6c8dbc2f91692197457c10a02b
         with:
           module: './src/module.ts'
           comment-pr: 'yes'

--- a/.github/workflows/detect-breaking-changes.yml
+++ b/.github/workflows/detect-breaking-changes.yml
@@ -1,6 +1,6 @@
 name: Compatibility check
 on: [push, pull_request]
-
+ 
 jobs:
   compatibilitycheck:
     runs-on: ubuntu-latest

--- a/.github/workflows/detect-breaking-changes.yml
+++ b/.github/workflows/detect-breaking-changes.yml
@@ -1,6 +1,6 @@
 name: Compatibility check
 on: [push, pull_request]
- 
+
 jobs:
   compatibilitycheck:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixing remaining `high` issues reported by zizmor.

- Replace `pull_request_target` with `pull_request` in the dependabot-reviewer workflow
- Pin third-party GitHub actions to specific SHAs