### PR TITLE
Prepare v4.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@
 - Add support for the Grafana `row_limit` [configuration setting](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#row_limit).
 - Add support for kind, status, instrumentation library, links, events and state data for traces (#1043, #1208)
 - Cancel JSON paths query after 10s (#1206)
-- SQL Editor Suggestions (#1204)
-- Add SQL Formatter button + shortcut (#1205)
+- SQL Editor now suggests database, table, column, and function names while typing (#1204)
+- Add SQL Formatter button + shortcut for making long queries more readable in the editor (#1205)
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Features
 
 - Add support for the Grafana `row_limit` [configuration setting](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#row_limit).
-- Add support for kind, status, instrumentation library, links, events and state data for traces (#1043)
+- Add support for kind, status, instrumentation library, links, events and state data for traces (#1043, #1208)
 - Cancel JSON paths query after 10s (#1206)
 - SQL Editor Suggestions (#1204)
 - Add SQL Formatter button + shortcut (#1205)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,19 @@
 # Changelog
 
-# Unreleased
+# 4.9.0
 
 ### Features
 
 - Add support for the Grafana `row_limit` [configuration setting](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#row_limit).
+- Add support for kind, status, instrumentation library, links, events and state data for traces (#1043)
+- Cancel JSON paths query after 10s (#1206)
+- SQL Editor Suggestions (#1204)
+- Add SQL Formatter button + shortcut (#1205)
+
+### Fixes
+
+- Fixed "run query" shortcut from running stale query (#1205)
+- Dependency updates
 
 ## 4.8.2
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clickhouse-datasource",
-  "version": "4.8.2",
+  "version": "4.9.0",
   "description": "Clickhouse Datasource",
   "engines": {
     "node": ">=20"


### PR DESCRIPTION
Added missing changelog entries for recent PRs

# 4.9.0

### Features

- Add support for the Grafana `row_limit` [configuration setting](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#row_limit).
- Add support for kind, status, instrumentation library, links, events and state data for traces (#1043, #1208)
- Cancel JSON paths query after 10s (#1206)
- SQL Editor now suggests database, table, column, and function names while typing (#1204)
- Add SQL Formatter button + shortcut for making long queries more readable in the editor (#1205)

### Fixes

- Fixed "run query" shortcut from running stale query (#1205)
- Dependency updates