### PR TITLE
No-change release to test Github Actions pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+# 4.9.2
+
+### Chore
+
+- No change release to test GHA release pipeline.
+
 # 4.9.1
 
 ### Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clickhouse-datasource",
-  "version": "4.9.1",
+  "version": "4.9.2",
   "description": "Clickhouse Datasource",
   "engines": {
     "node": ">=20"


### PR DESCRIPTION
Release 4.9.2, no changes other than version bump.

