### PR TITLE
Fix Ad-Hoc filters for variable datasources

### DIFF
--- a/src/data/CHDatasource.test.ts
+++ b/src/data/CHDatasource.test.ts
@@ -461,8 +461,8 @@ describe('ClickHouseDatasource', () => {
 
       expect(spy).toHaveBeenCalledWith({
         targets: [
-          { refId: '1', rawSql: '', meta: { timezone: 'UTC' } },
-          { refId: '2', hide: false, rawSql: '', meta: { timezone: 'UTC' } },
+          { refId: '1', meta: { timezone: 'UTC' } },
+          { refId: '2', hide: false, meta: { timezone: 'UTC' } },
         ],
         timezone: 'UTC',
       });

--- a/src/data/CHDatasource.test.ts
+++ b/src/data/CHDatasource.test.ts
@@ -137,8 +137,10 @@ describe('ClickHouseDatasource', () => {
       const ds = createInstance({});
       ds.adHocFilter = adHocFilter;
 
-      // Execute the method
-      const result = ds.applyTemplateVariables(query, {});
+      // Resolve variables
+      let result = ds.applyTemplateVariables(query, {});
+      // Apply ad-hoc filters
+      result = ds.applyAdHocFilters(result, adHocFilters);
 
       // Verify template variables were resolved before ad-hoc filters were applied
       expect(spyOnReplace).toHaveBeenCalled();
@@ -461,8 +463,8 @@ describe('ClickHouseDatasource', () => {
 
       expect(spy).toHaveBeenCalledWith({
         targets: [
-          { refId: '1', meta: { timezone: 'UTC' } },
-          { refId: '2', hide: false, meta: { timezone: 'UTC' } },
+          { refId: '1', rawSql: '', meta: { timezone: 'UTC' } },
+          { refId: '2', hide: false, rawSql: '', meta: { timezone: 'UTC' } },
         ],
         timezone: 'UTC',
       });

--- a/src/data/CHDatasource.test.ts
+++ b/src/data/CHDatasource.test.ts
@@ -138,9 +138,7 @@ describe('ClickHouseDatasource', () => {
       ds.adHocFilter = adHocFilter;
 
       // Resolve variables
-      let result = ds.applyTemplateVariables(query, {});
-      // Apply ad-hoc filters
-      result = ds.applyAdHocFilters(result, adHocFilters);
+      let result = ds.applyTemplateVariables(query, {}, adHocFilters);
 
       // Verify template variables were resolved before ad-hoc filters were applied
       expect(spyOnReplace).toHaveBeenCalled();

--- a/src/data/CHDatasource.test.ts
+++ b/src/data/CHDatasource.test.ts
@@ -138,7 +138,7 @@ describe('ClickHouseDatasource', () => {
       ds.adHocFilter = adHocFilter;
 
       // Resolve variables
-      let result = ds.applyTemplateVariables(query, {}, adHocFilters);
+      const result = ds.applyTemplateVariables(query, {}, adHocFilters);
 
       // Verify template variables were resolved before ad-hoc filters were applied
       expect(spyOnReplace).toHaveBeenCalled();

--- a/src/data/CHDatasource.ts
+++ b/src/data/CHDatasource.ts
@@ -238,7 +238,7 @@ export class Datasource
     rawQuery = this.replace(rawQuery, scoped) || '';
 
     if (!this.skipAdHocFilter) {
-      if (this.adHocFiltersStatus === AdHocFilterStatus.disabled && filters?.length > 0) {
+      if (this.adHocFiltersStatus === AdHocFilterStatus.disabled && filters.length > 0) {
         throw new Error(
           `Unable to apply ad hoc filters. Upgrade ClickHouse to >=${this.adHocCHVerReq.major}.${this.adHocCHVerReq.minor} or remove ad hoc filters for the dashboard.`
         );

--- a/src/data/CHDatasource.ts
+++ b/src/data/CHDatasource.ts
@@ -244,7 +244,6 @@ export class Datasource
         );
       }
       rawQuery = this.adHocFilter.apply(rawQuery, filters);
-      console.log('ADHOC APPLIED', rawQuery);
     }
     this.skipAdHocFilter = false;
 

--- a/src/data/adHocFilter.test.ts
+++ b/src/data/adHocFilter.test.ts
@@ -1,4 +1,5 @@
-import { AdHocFilter, AdHocVariableFilter } from './adHocFilter';
+import { AdHocVariableFilter } from '@grafana/data';
+import { AdHocFilter } from './adHocFilter';
 
 describe('AdHocManager', () => {
   it('apply ad hoc filter with no inner query and existing WHERE', () => {

--- a/src/data/adHocFilter.ts
+++ b/src/data/adHocFilter.ts
@@ -1,3 +1,4 @@
+import { AdHocVariableFilter } from '@grafana/data';
 import { getTable } from './ast';
 
 export class AdHocFilter {
@@ -71,7 +72,7 @@ function escapeKey(s: string): string {
   return s.includes('.') ? s.split('.')[1] : s;
 }
 
-function escapeValueBasedOnOperator(s: string, operator: AdHocVariableFilterOperator): string {
+function escapeValueBasedOnOperator(s: string, operator: string): string {
   if (operator === 'IN') {
     // Allow list of values without parentheses
     if (s.length > 2 && s[0] !== '(' && s[s.length - 1] !== ')') {
@@ -83,7 +84,7 @@ function escapeValueBasedOnOperator(s: string, operator: AdHocVariableFilterOper
   }
 }
 
-function convertOperatorToClickHouseOperator(operator: AdHocVariableFilterOperator): string {
+function convertOperatorToClickHouseOperator(operator: string): string {
   if (operator === '=~') {
     return 'ILIKE';
   }
@@ -93,11 +94,3 @@ function convertOperatorToClickHouseOperator(operator: AdHocVariableFilterOperat
   return operator;
 }
 
-type AdHocVariableFilterOperator = '>' | '<' | '=' | '!=' | '=~' | '!~' | 'IN';
-
-export type AdHocVariableFilter = {
-  key: string;
-  operator: AdHocVariableFilterOperator;
-  value: string;
-  condition?: string;
-};


### PR DESCRIPTION
The current function for fetching ad-hoc variables was deprecated over 2 years ago.
To fetch ad-hoc filters, it required the name of the datasource.

```js
const adHocFilters = (templateSrv as any)?.getAdhocFilters(this.name);
```

Some dashboards use variable datasources such as `${datasource}`, so the filters would show as empty and never be applied.

I updated this function to use the new ad-hoc variable source, and now filters are applied even when the datasource is a variable.

```js
// filters comes from the request.filters, which is the new recommended pattern
// for fetching ad-hoc filters from the dashboard
applyTemplateVariables(query: CHQuery, scoped: ScopedVars, filters: AdHocVariableFilter[] = [])
```

<img width="1560" height="356" alt="filter example" src="https://github.com/user-attachments/assets/024d778b-3463-466c-889e-0810c83859a0" />

There are still other bugs and limitations associated with filters, but this makes the behavior more consistent for some dashboards.
