### PR TITLE
Add additional tracking events for v1 config

### DIFF
--- a/src/views/CHConfigEditor.tsx
+++ b/src/views/CHConfigEditor.tsx
@@ -28,7 +28,7 @@ import { HttpHeadersConfig } from 'components/configEditor/HttpHeadersConfig';
 import allLabels from 'labels';
 import { onHttpHeadersChange, useConfigDefaults } from './CHConfigEditorHooks';
 import {AliasTableConfig} from "../components/configEditor/AliasTableConfig";
-import { trackClickhouseConfigV1ColumnAliasTableAdded, trackClickhouseConfigV1ConnMaxLifetimeInput, trackClickhouseConfigV1CustomSettingAdded, trackClickhouseConfigV1DefaultDbInput, trackClickhouseConfigV1DefaultLogDbInput, trackClickhouseConfigV1DefaultLogTableInput, trackClickhouseConfigV1DefaultTableInput, trackClickhouseConfigV1DefaultTraceDbInput, trackClickhouseConfigV1DefaultTraceTableInput, trackClickhouseConfigV1DialTimeoutInput, trackClickhouseConfigV1DurationTimeColumnInput, trackClickhouseConfigV1DurationUnitInput, trackClickhouseConfigV1EnableRowLimitToggleClicked, trackClickhouseConfigV1EventsPrefixColumnInput, trackClickhouseConfigV1KindColumnInput, trackClickhouseConfigV1LibraryNameColumnInput, trackClickhouseConfigV1LibraryVersionColumnInput, trackClickhouseConfigV1LinksPrefixColumnInput, trackClickhouseConfigV1LogAutoSelectColumnsInput, trackClickhouseConfigV1LogContextColumnInput, trackClickhouseConfigV1LogLevelColumnInput, trackClickhouseConfigV1LogMessageColumnInput, trackClickhouseConfigV1LogsOtelVersion, trackClickhouseConfigV1LogTimeColumnInput, trackClickhouseConfigV1MaxIdleConnsInput, trackClickhouseConfigV1MaxOpenConnsInput, trackClickhouseConfigV1NativeHttpToggleClicked, trackClickhouseConfigV1OperationNameColumnInput, trackClickhouseConfigV1ParentSpanIdColumnInput, trackClickhouseConfigV1QueryTimeoutInput, trackClickhouseConfigV1SecureConnectionToggleClicked, trackClickhouseConfigV1ServiceNameColumnInput, trackClickhouseConfigV1ServiceTagsColumnInput, trackClickhouseConfigV1SkipTLSVerifyToggleClicked, trackClickhouseConfigV1SpanIdColumnInput, trackClickhouseConfigV1StartTimeColumnInput, trackClickhouseConfigV1StateColumnInput, trackClickhouseConfigV1StatusCodeColumnInput, trackClickhouseConfigV1StatusMessageColumnInput, trackClickhouseConfigV1TagsColumnInput, trackClickhouseConfigV1TraceIdColumnInput, trackClickhouseConfigV1TracesOtelVersion, trackClickhouseConfigV1UseFlattenNeededToggleClicked, trackClickhouseConfigV1UseOtelLogsToggleClicked, trackClickhouseConfigV1UseOtelTracesToggleClicked, trackClickhouseConfigV1ValidateSQLToggleClicked } from './trackingV1';
+import { trackClickhouseConfigV1ColumnAliasTableAdded, trackClickhouseConfigV1ConnMaxLifetimeInput, trackClickhouseConfigV1CustomSettingAdded, trackClickhouseConfigV1DefaultDbInput, trackClickhouseConfigV1DefaultLogDbInput, trackClickhouseConfigV1DefaultLogTableInput, trackClickhouseConfigV1DefaultTableInput, trackClickhouseConfigV1DefaultTraceDbInput, trackClickhouseConfigV1DefaultTraceTableInput, trackClickhouseConfigV1DialTimeoutInput, trackClickhouseConfigV1DurationTimeColumnInput, trackClickhouseConfigV1DurationUnitInput, trackClickhouseConfigV1EnableRowLimitToggleClicked, trackClickhouseConfigV1EventsPrefixColumnInput, trackClickhouseConfigV1HostInput, trackClickhouseConfigV1KindColumnInput, trackClickhouseConfigV1LibraryNameColumnInput, trackClickhouseConfigV1LibraryVersionColumnInput, trackClickhouseConfigV1LinksPrefixColumnInput, trackClickhouseConfigV1LogAutoSelectColumnsInput, trackClickhouseConfigV1LogContextColumnInput, trackClickhouseConfigV1LogLevelColumnInput, trackClickhouseConfigV1LogMessageColumnInput, trackClickhouseConfigV1LogsOtelVersion, trackClickhouseConfigV1LogTimeColumnInput, trackClickhouseConfigV1MaxIdleConnsInput, trackClickhouseConfigV1MaxOpenConnsInput, trackClickhouseConfigV1NativeHttpToggleClicked, trackClickhouseConfigV1OperationNameColumnInput, trackClickhouseConfigV1ParentSpanIdColumnInput, trackClickhouseConfigV1PortInput, trackClickhouseConfigV1QueryTimeoutInput, trackClickhouseConfigV1SecureConnectionToggleClicked, trackClickhouseConfigV1ServiceNameColumnInput, trackClickhouseConfigV1ServiceTagsColumnInput, trackClickhouseConfigV1SkipTLSVerifyToggleClicked, trackClickhouseConfigV1SpanIdColumnInput, trackClickhouseConfigV1StartTimeColumnInput, trackClickhouseConfigV1StateColumnInput, trackClickhouseConfigV1StatusCodeColumnInput, trackClickhouseConfigV1StatusMessageColumnInput, trackClickhouseConfigV1TagsColumnInput, trackClickhouseConfigV1TLSClientAuthToggleClicked, trackClickhouseConfigV1TraceIdColumnInput, trackClickhouseConfigV1TracesOtelVersion, trackClickhouseConfigV1UseFlattenNeededToggleClicked, trackClickhouseConfigV1UseOtelLogsToggleClicked, trackClickhouseConfigV1UseOtelTracesToggleClicked, trackClickhouseConfigV1ValidateSQLToggleClicked, trackClickhouseConfigV1WithCACertToggleClicked } from './trackingV1';
 
 export interface ConfigEditorProps extends DataSourcePluginOptionsEditorProps<CHConfig, CHSecureConfig> {}
 
@@ -237,7 +237,10 @@ export const ConfigEditor: React.FC<ConfigEditorProps> = (props) => {
             name="host"
             width={80}
             value={jsonData.host || ''}
-            onChange={onUpdateDatasourceJsonDataOption(props, 'host')}
+            onChange={() => {
+              trackClickhouseConfigV1HostInput();
+              onUpdateDatasourceJsonDataOption(props, 'host');
+            }}
             label={labels.serverAddress.label}
             aria-label={labels.serverAddress.label}
             placeholder={labels.serverAddress.placeholder}
@@ -255,7 +258,10 @@ export const ConfigEditor: React.FC<ConfigEditorProps> = (props) => {
             width={40}
             type="number"
             value={jsonData.port || ''}
-            onChange={e => onPortChange(e.currentTarget.value)}
+            onChange={e => {
+              trackClickhouseConfigV1PortInput();
+              onPortChange(e.currentTarget.value);
+            }}
             label={labels.serverPort.label}
             aria-label={labels.serverPort.label}
             placeholder={defaultPort}
@@ -332,7 +338,10 @@ export const ConfigEditor: React.FC<ConfigEditorProps> = (props) => {
           <Switch
             className="gf-form"
             value={jsonData.tlsAuth || false}
-            onChange={(e) => onTLSSettingsChange('tlsAuth', e.currentTarget.checked)}
+            onChange={(e) => {
+              trackClickhouseConfigV1TLSClientAuthToggleClicked();
+              onTLSSettingsChange('tlsAuth', e.currentTarget.checked);
+            }}
           />
         </Field>
         <Field
@@ -342,7 +351,10 @@ export const ConfigEditor: React.FC<ConfigEditorProps> = (props) => {
           <Switch
             className="gf-form"
             value={jsonData.tlsAuthWithCACert || false}
-            onChange={(e) => onTLSSettingsChange('tlsAuthWithCACert', e.currentTarget.checked)}
+            onChange={(e) => {
+              trackClickhouseConfigV1WithCACertToggleClicked();
+              onTLSSettingsChange('tlsAuthWithCACert', e.currentTarget.checked);
+            }}
           />
         </Field>
         {jsonData.tlsAuthWithCACert && (

--- a/src/views/trackingV1.ts
+++ b/src/views/trackingV1.ts
@@ -1,6 +1,14 @@
 import { reportInteraction } from "@grafana/runtime";
 
 // Server section
+export const trackClickhouseConfigV1HostInput = () => {
+    reportInteraction('clickhouse-config-v1-host-input');
+};
+
+export const trackClickhouseConfigV1PortInput = () => {
+    reportInteraction('clickhouse-config-v1-port-input');
+};
+
 export const trackClickhouseConfigV1NativeHttpToggleClicked = () => {
     reportInteraction('clickhouse-config-v1-native-http-toggle-clicked');
 };
@@ -12,6 +20,14 @@ export const trackClickhouseConfigV1SecureConnectionToggleClicked = () => {
 // TLS/SSL Settings section
 export const trackClickhouseConfigV1SkipTLSVerifyToggleClicked = () => {
     reportInteraction('clickhouse-config-v1-skip-tls-verify-toggle-clicked');
+};
+
+export const trackClickhouseConfigV1TLSClientAuthToggleClicked = () => {
+    reportInteraction('clickhouse-config-v1-tls-client-auth-toggle-clicked');
+};
+
+export const trackClickhouseConfigV1WithCACertToggleClicked = () => {
+    reportInteraction('clickhouse-config-v1-with-ca-cert-toggle-clicked');
 };
 
 // Default DB and Table section


### PR DESCRIPTION
This PR adds additional tracking events we want to capture for the v1 configuration page. Specifically, tracking the server and port input fields allow for better insights into the full user flow. 