### PR TITLE
Correctly display events and links for table view queries

### DIFF
--- a/src/data/utils.test.ts
+++ b/src/data/utils.test.ts
@@ -187,6 +187,8 @@ describe('transformQueryResponseWithTraceAndLogLinks', () => {
     const getDefaultLogsDatabase = jest.spyOn(mockDatasource, 'getDefaultLogsDatabase');
     const getDefaultLogsTable = jest.spyOn(mockDatasource, 'getDefaultLogsTable');
     const getDefaultLogsColumns = jest.spyOn(mockDatasource, 'getDefaultLogsColumns');
+    const getDefaultTraceEventsColumnPrefix = jest.spyOn(mockDatasource, 'getDefaultTraceEventsColumnPrefix');
+    const getDefaultTraceLinksColumnPrefix = jest.spyOn(mockDatasource, 'getDefaultTraceLinksColumnPrefix');
 
     const builderOptions: Partial<QueryBuilderOptions> = {
       queryType: QueryType.Logs
@@ -204,6 +206,8 @@ describe('transformQueryResponseWithTraceAndLogLinks', () => {
     expect(getDefaultLogsDatabase).not.toHaveBeenCalled();
     expect(getDefaultLogsTable).not.toHaveBeenCalled();
     expect(getDefaultLogsColumns).not.toHaveBeenCalled();
+    expect(getDefaultTraceEventsColumnPrefix).toHaveBeenCalled();
+    expect(getDefaultTraceEventsColumnPrefix).toHaveBeenCalled();
   });
 });
 

--- a/src/data/utils.test.ts
+++ b/src/data/utils.test.ts
@@ -207,7 +207,7 @@ describe('transformQueryResponseWithTraceAndLogLinks', () => {
     expect(getDefaultLogsTable).not.toHaveBeenCalled();
     expect(getDefaultLogsColumns).not.toHaveBeenCalled();
     expect(getDefaultTraceEventsColumnPrefix).toHaveBeenCalled();
-    expect(getDefaultTraceEventsColumnPrefix).toHaveBeenCalled();
+    expect(getDefaultTraceLinksColumnPrefix).toHaveBeenCalled();
   });
 });
 

--- a/src/data/utils.ts
+++ b/src/data/utils.ts
@@ -188,11 +188,7 @@ export const transformQueryResponseWithTraceAndLogLinks = (datasource: Datasourc
       };
 
       if (otelConfig?.traceColumnMap) {
-        const columns: SelectedColumn[] = [];
-        otelConfig.traceColumnMap.forEach((name, hint) => {
-          columns.push({ name, hint });
-        });
-        options.columns = columns;
+        options.columns = Array.from(otelConfig.traceColumnMap, ([hint, name]) => ({ name, hint }));
       } else {
         const defaultColumns = datasource.getDefaultTraceColumns();
         for (let [hint, colName] of defaultColumns) {


### PR DESCRIPTION
Fix https://github.com/grafana/clickhouse-datasource/issues/1262

Pass the events and links configuration to the query and use otel columns if opentelemetry is enabled.

This allows displaying events in the trace panel.

I tested it locally: the events are correctly displayed when coming from a table trace ID.