### PR TITLE
Revert ClickHouse driver update

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/grafana/clickhouse-datasource
 go 1.24.1
 
 require (
-	github.com/ClickHouse/clickhouse-go/v2 v2.40.1
+	github.com/ClickHouse/clickhouse-go/v2 v2.32.2
 	github.com/docker/docker v28.3.3+incompatible
 	github.com/docker/go-units v0.5.0
 	github.com/grafana/grafana-plugin-sdk-go v0.278.0

--- a/go.sum
+++ b/go.sum
@@ -11,8 +11,8 @@ github.com/BurntSushi/toml v1.4.0 h1:kuoIxZQy2WRRk1pttg9asf+WVv6tWQuBNVmK8+nqPr0
 github.com/BurntSushi/toml v1.4.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/ClickHouse/ch-go v0.67.0 h1:18MQF6vZHj+4/hTRaK7JbS/TIzn4I55wC+QzO24uiqc=
 github.com/ClickHouse/ch-go v0.67.0/go.mod h1:2MSAeyVmgt+9a2k2SQPPG1b4qbTPzdGDpf1+bcHh+18=
-github.com/ClickHouse/clickhouse-go/v2 v2.40.1 h1:PbwsHBgqXRydU7jKULD1C8CHmifczffvQqmFvltM2W4=
-github.com/ClickHouse/clickhouse-go/v2 v2.40.1/go.mod h1:GDzSBLVhladVm8V01aEB36IoBOVLLICfyeuiIp/8Ezc=
+github.com/ClickHouse/clickhouse-go/v2 v2.32.2 h1:Y8fAXt0CpLhqNXMLlSddg+cMfAr7zHBWqXLpih6ozCY=
+github.com/ClickHouse/clickhouse-go/v2 v2.32.2/go.mod h1:/vE8N/+9pozLkIiTMWbNUGviccDv/czEGS1KACvpXIk=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/andybalholm/brotli v1.2.0 h1:ukwgCxwYrmACq68yiUqwIWnGY0cTPox/M94sVwToPjQ=

--- a/pkg/plugin/driver_test.go
+++ b/pkg/plugin/driver_test.go
@@ -700,7 +700,14 @@ var datetime, _ = time.Parse("2006-01-02 15:04:05", "2022-01-12 00:00:00")
 func TestConvertDateTime(t *testing.T) {
 	for name, protocol := range Protocols {
 		t.Run(fmt.Sprintf("using %s", name), func(t *testing.T) {
-			loc, _ := time.LoadLocation("Europe/London")
+			var loc *time.Location
+			switch name {
+			case "native":
+				loc, _ = time.LoadLocation("Europe/London")
+			case "http":
+				// http sends back ClickHouse configured timezone which is UTC
+				loc = time.UTC
+			}
 			localTime := datetime.In(loc)
 			conn, close := setupTest(t, "col1 DateTime('Europe/London')", protocol, nil)
 			defer close(t)


### PR DESCRIPTION
The ClickHouse driver has caused an issue with JSON decoding. Additionally, some refactoring has led to unexpected behaviours when the `X-ClickHouse-User` header is specified (and the expected behaviour is unclear).

Rolling back the SDK will fix this (but reintroduce the issue relating to HTTP and timezones mentioned in #1326)
Fixes #1347