### PR TITLE
Format bytes in Grafana to fix column sorting

### DIFF
--- a/src/dashboards/data-analysis.json
+++ b/src/dashboards/data-analysis.json
@@ -1,6 +1,15 @@
 {
-  "__inputs": [],
-  "__elements": [],
+  "__inputs": [
+    {
+      "name": "DS_GRAFANA-CLICKHOUSE-DATASOURCE",
+      "label": "grafana-clickhouse-datasource",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "grafana-clickhouse-datasource",
+      "pluginName": "ClickHouse"
+    }
+  ],
+  "__elements": {},
   "__requires": [
     {
       "type": "panel",
@@ -18,13 +27,13 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "9.0.1"
+      "version": "12.1.1"
     },
     {
       "type": "datasource",
       "id": "grafana-clickhouse-datasource",
       "name": "ClickHouse",
-      "version": "2.0.0"
+      "version": "4.10.2"
     },
     {
       "type": "panel",
@@ -71,9 +80,7 @@
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
   "id": null,
-  "iteration": 1661857991116,
   "links": [],
-  "liveNow": false,
   "panels": [
     {
       "datasource": {
@@ -91,7 +98,7 @@
             "steps": [
               {
                 "color": "semi-dark-blue",
-                "value": null
+                "value": 0
               }
             ]
           }
@@ -123,19 +130,24 @@
         "graphMode": "area",
         "justifyMode": "center",
         "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "/.*/",
           "values": false
         },
-        "textMode": "auto"
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "9.0.1",
+      "pluginVersion": "12.1.1",
       "targets": [
         {
           "datasource": {
             "type": "grafana-clickhouse-datasource",
-            "uid": "${datasource}"
+            "uid": "${DS_GRAFANA-CLICKHOUSE-DATASOURCE}"
           },
           "format": 1,
           "meta": {
@@ -193,7 +205,7 @@
             "steps": [
               {
                 "color": "semi-dark-blue",
-                "value": null
+                "value": 0
               }
             ]
           }
@@ -225,19 +237,24 @@
         "graphMode": "area",
         "justifyMode": "center",
         "orientation": "auto",
+        "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "9.0.1",
+      "pluginVersion": "12.1.1",
       "targets": [
         {
           "datasource": {
             "type": "grafana-clickhouse-datasource",
-            "uid": "${datasource}"
+            "uid": "${DS_GRAFANA-CLICKHOUSE-DATASOURCE}"
           },
           "format": 1,
           "meta": {
@@ -283,7 +300,7 @@
             "steps": [
               {
                 "color": "light-blue",
-                "value": null
+                "value": 0
               }
             ]
           }
@@ -302,19 +319,24 @@
         "graphMode": "area",
         "justifyMode": "center",
         "orientation": "auto",
+        "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
-        "textMode": "value_and_name"
+        "showPercentChange": false,
+        "textMode": "value_and_name",
+        "wideLayout": true
       },
-      "pluginVersion": "9.0.1",
+      "pluginVersion": "12.1.1",
       "targets": [
         {
           "datasource": {
             "type": "grafana-clickhouse-datasource",
-            "uid": "${datasource}"
+            "uid": "${DS_GRAFANA-CLICKHOUSE-DATASOURCE}"
           },
           "format": 1,
           "meta": {
@@ -329,7 +351,6 @@
           "refId": "A"
         }
       ],
-      "transformations": [],
       "type": "stat"
     },
     {
@@ -349,7 +370,7 @@
             "steps": [
               {
                 "color": "light-blue",
-                "value": null
+                "value": 0
               }
             ]
           }
@@ -368,19 +389,24 @@
         "graphMode": "area",
         "justifyMode": "center",
         "orientation": "auto",
+        "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
-        "textMode": "value_and_name"
+        "showPercentChange": false,
+        "textMode": "value_and_name",
+        "wideLayout": true
       },
-      "pluginVersion": "9.0.1",
+      "pluginVersion": "12.1.1",
       "targets": [
         {
           "datasource": {
             "type": "grafana-clickhouse-datasource",
-            "uid": "${datasource}"
+            "uid": "${DS_GRAFANA-CLICKHOUSE-DATASOURCE}"
           },
           "format": 1,
           "meta": {
@@ -395,7 +421,6 @@
           "refId": "A"
         }
       ],
-      "transformations": [],
       "type": "stat"
     },
     {
@@ -410,7 +435,9 @@
           },
           "custom": {
             "align": "auto",
-            "displayMode": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
             "inspect": false
           },
           "mappings": [],
@@ -419,7 +446,7 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               }
             ]
           }
@@ -436,8 +463,11 @@
                 "value": "percentunit"
               },
               {
-                "id": "custom.displayMode",
-                "value": "lcd-gauge"
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "lcd",
+                  "type": "gauge"
+                }
               },
               {
                 "id": "max",
@@ -454,7 +484,7 @@
                   "steps": [
                     {
                       "color": "green",
-                      "value": null
+                      "value": 0
                     },
                     {
                       "color": "semi-dark-green",
@@ -539,15 +569,19 @@
       },
       "id": 9,
       "options": {
+        "cellHeight": "sm",
         "footer": {
+          "countRows": false,
           "fields": "",
-          "reducer": ["sum"],
+          "reducer": [
+            "sum"
+          ],
           "show": false
         },
         "showHeader": true,
         "sortBy": []
       },
-      "pluginVersion": "9.0.1",
+      "pluginVersion": "12.1.1",
       "targets": [
         {
           "builderOptions": {
@@ -557,7 +591,7 @@
           },
           "datasource": {
             "type": "grafana-clickhouse-datasource",
-            "uid": "${datasource}"
+            "uid": "${DS_GRAFANA-CLICKHOUSE-DATASOURCE}"
           },
           "format": 1,
           "meta": {
@@ -607,7 +641,7 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               },
               {
                 "color": "red",
@@ -627,17 +661,27 @@
       "id": 25,
       "options": {
         "displayMode": "lcd",
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "maxVizHeight": 300,
         "minVizHeight": 10,
         "minVizWidth": 0,
+        "namePlacement": "auto",
         "orientation": "horizontal",
         "reduceOptions": {
           "calcs": [],
           "fields": "",
           "values": true
         },
-        "showUnfilled": true
+        "showUnfilled": true,
+        "sizing": "auto",
+        "valueMode": "color"
       },
-      "pluginVersion": "9.0.1",
+      "pluginVersion": "12.1.1",
       "targets": [
         {
           "builderOptions": {
@@ -647,7 +691,7 @@
           },
           "datasource": {
             "type": "grafana-clickhouse-datasource",
-            "uid": "${datasource}"
+            "uid": "${DS_GRAFANA-CLICKHOUSE-DATASOURCE}"
           },
           "format": 1,
           "meta": {
@@ -681,7 +725,7 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               },
               {
                 "color": "red",
@@ -701,17 +745,27 @@
       "id": 26,
       "options": {
         "displayMode": "lcd",
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "maxVizHeight": 300,
         "minVizHeight": 10,
         "minVizWidth": 0,
+        "namePlacement": "auto",
         "orientation": "horizontal",
         "reduceOptions": {
           "calcs": [],
           "fields": "",
           "values": true
         },
-        "showUnfilled": true
+        "showUnfilled": true,
+        "sizing": "auto",
+        "valueMode": "color"
       },
-      "pluginVersion": "9.0.1",
+      "pluginVersion": "12.1.1",
       "targets": [
         {
           "builderOptions": {
@@ -721,7 +775,7 @@
           },
           "datasource": {
             "type": "grafana-clickhouse-datasource",
-            "uid": "${datasource}"
+            "uid": "${DS_GRAFANA-CLICKHOUSE-DATASOURCE}"
           },
           "format": 1,
           "meta": {
@@ -750,6 +804,9 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisGridShow": false,
             "axisLabel": "",
             "axisPlacement": "auto",
@@ -764,6 +821,9 @@
             "lineWidth": 1,
             "scaleDistribution": {
               "type": "linear"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
             }
           },
           "mappings": [],
@@ -772,7 +832,7 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               }
             ]
           }
@@ -789,23 +849,27 @@
       "options": {
         "barRadius": 0,
         "barWidth": 1,
+        "fullHighlight": false,
         "groupWidth": 0.7,
         "legend": {
           "calcs": [],
           "displayMode": "list",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "orientation": "auto",
         "showValue": "auto",
         "stacking": "none",
         "text": {},
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         },
         "xTickLabelRotation": 0,
         "xTickLabelSpacing": 0
       },
+      "pluginVersion": "12.1.1",
       "targets": [
         {
           "builderOptions": {
@@ -815,7 +879,7 @@
           },
           "datasource": {
             "type": "grafana-clickhouse-datasource",
-            "uid": "${datasource}"
+            "uid": "${DS_GRAFANA-CLICKHOUSE-DATASOURCE}"
           },
           "format": 1,
           "meta": {
@@ -844,6 +908,9 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisGridShow": false,
             "axisLabel": "",
             "axisPlacement": "auto",
@@ -858,6 +925,9 @@
             "lineWidth": 1,
             "scaleDistribution": {
               "type": "linear"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
             }
           },
           "mappings": [],
@@ -866,7 +936,7 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               }
             ]
           }
@@ -883,22 +953,26 @@
       "options": {
         "barRadius": 0,
         "barWidth": 0.97,
+        "fullHighlight": false,
         "groupWidth": 0.7,
         "legend": {
           "calcs": [],
           "displayMode": "list",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "orientation": "auto",
         "showValue": "auto",
         "stacking": "none",
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         },
         "xTickLabelRotation": 0,
         "xTickLabelSpacing": 0
       },
+      "pluginVersion": "12.1.1",
       "targets": [
         {
           "builderOptions": {
@@ -908,7 +982,7 @@
           },
           "datasource": {
             "type": "grafana-clickhouse-datasource",
-            "uid": "${datasource}"
+            "uid": "${DS_GRAFANA-CLICKHOUSE-DATASOURCE}"
           },
           "format": 1,
           "meta": {
@@ -935,7 +1009,9 @@
         "defaults": {
           "custom": {
             "align": "auto",
-            "displayMode": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
             "inspect": false
           },
           "mappings": [],
@@ -944,7 +1020,7 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               }
             ]
           }
@@ -1064,15 +1140,19 @@
       },
       "id": 6,
       "options": {
+        "cellHeight": "sm",
         "footer": {
+          "countRows": false,
           "fields": "",
-          "reducer": ["sum"],
+          "reducer": [
+            "sum"
+          ],
           "show": false
         },
         "showHeader": true,
         "sortBy": []
       },
-      "pluginVersion": "9.0.1",
+      "pluginVersion": "12.1.1",
       "targets": [
         {
           "builderOptions": {
@@ -1082,7 +1162,7 @@
           },
           "datasource": {
             "type": "grafana-clickhouse-datasource",
-            "uid": "${datasource}"
+            "uid": "${DS_GRAFANA-CLICKHOUSE-DATASOURCE}"
           },
           "format": 1,
           "meta": {
@@ -1142,7 +1222,9 @@
           },
           "custom": {
             "align": "auto",
-            "displayMode": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
             "inspect": false
           },
           "mappings": [],
@@ -1151,7 +1233,7 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               },
               {
                 "color": "red",
@@ -1207,15 +1289,19 @@
       },
       "id": 14,
       "options": {
+        "cellHeight": "sm",
         "footer": {
+          "countRows": false,
           "fields": "",
-          "reducer": ["sum"],
+          "reducer": [
+            "sum"
+          ],
           "show": false
         },
         "showHeader": true,
         "sortBy": []
       },
-      "pluginVersion": "9.0.1",
+      "pluginVersion": "12.1.1",
       "targets": [
         {
           "builderOptions": {
@@ -1225,7 +1311,7 @@
           },
           "datasource": {
             "type": "grafana-clickhouse-datasource",
-            "uid": "${datasource}"
+            "uid": "${DS_GRAFANA-CLICKHOUSE-DATASOURCE}"
           },
           "format": 1,
           "meta": {
@@ -1267,7 +1353,9 @@
         "defaults": {
           "custom": {
             "align": "auto",
-            "displayMode": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
             "filterable": false,
             "inspect": false
           },
@@ -1277,7 +1365,7 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               }
             ]
           }
@@ -1425,9 +1513,13 @@
       },
       "id": 7,
       "options": {
+        "cellHeight": "sm",
         "footer": {
+          "countRows": false,
           "fields": "",
-          "reducer": ["sum"],
+          "reducer": [
+            "sum"
+          ],
           "show": false
         },
         "showHeader": true,
@@ -1438,7 +1530,7 @@
           }
         ]
       },
-      "pluginVersion": "9.0.1",
+      "pluginVersion": "12.1.1",
       "targets": [
         {
           "builderOptions": {
@@ -1448,7 +1540,7 @@
           },
           "datasource": {
             "type": "grafana-clickhouse-datasource",
-            "uid": "${datasource}"
+            "uid": "${DS_GRAFANA-CLICKHOUSE-DATASOURCE}"
           },
           "format": 1,
           "meta": {
@@ -1513,7 +1605,9 @@
           },
           "custom": {
             "align": "auto",
-            "displayMode": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
             "inspect": false
           },
           "mappings": [],
@@ -1522,7 +1616,7 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               },
               {
                 "color": "red",
@@ -1650,15 +1744,19 @@
       },
       "id": 28,
       "options": {
+        "cellHeight": "sm",
         "footer": {
+          "countRows": false,
           "fields": "",
-          "reducer": ["sum"],
+          "reducer": [
+            "sum"
+          ],
           "show": false
         },
         "showHeader": true,
         "sortBy": []
       },
-      "pluginVersion": "9.0.1",
+      "pluginVersion": "12.1.1",
       "targets": [
         {
           "builderOptions": {
@@ -1668,7 +1766,7 @@
           },
           "datasource": {
             "type": "grafana-clickhouse-datasource",
-            "uid": "${datasource}"
+            "uid": "${DS_GRAFANA-CLICKHOUSE-DATASOURCE}"
           },
           "format": 1,
           "meta": {
@@ -1718,10 +1816,14 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "Rows in part",
             "axisPlacement": "auto",
             "axisWidth": 3,
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 10,
             "gradientMode": "none",
@@ -1730,6 +1832,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineStyle": {
               "fill": "solid"
@@ -1754,7 +1857,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
               }
             ]
           }
@@ -1772,13 +1876,16 @@
         "legend": {
           "calcs": [],
           "displayMode": "list",
-          "placement": "right"
+          "placement": "right",
+          "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "multi",
           "sort": "none"
         }
       },
+      "pluginVersion": "12.1.1",
       "targets": [
         {
           "builderOptions": {
@@ -1788,7 +1895,7 @@
           },
           "datasource": {
             "type": "grafana-clickhouse-datasource",
-            "uid": "${datasource}"
+            "uid": "${DS_GRAFANA-CLICKHOUSE-DATASOURCE}"
           },
           "format": 1,
           "meta": {
@@ -1848,7 +1955,8 @@
             "mode": "percentage",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
               }
             ]
           }
@@ -1864,17 +1972,29 @@
       "id": 16,
       "options": {
         "displayMode": "gradient",
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "maxVizHeight": 300,
         "minVizHeight": 10,
         "minVizWidth": 0,
+        "namePlacement": "auto",
         "orientation": "horizontal",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": true
         },
-        "showUnfilled": true
+        "showUnfilled": true,
+        "sizing": "auto",
+        "valueMode": "color"
       },
-      "pluginVersion": "9.0.1",
+      "pluginVersion": "12.1.1",
       "targets": [
         {
           "builderOptions": {
@@ -1884,7 +2004,7 @@
           },
           "datasource": {
             "type": "grafana-clickhouse-datasource",
-            "uid": "${datasource}"
+            "uid": "${DS_GRAFANA-CLICKHOUSE-DATASOURCE}"
           },
           "format": 1,
           "meta": {
@@ -1927,7 +2047,9 @@
           },
           "custom": {
             "align": "auto",
-            "displayMode": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
             "inspect": false
           },
           "mappings": [],
@@ -1935,7 +2057,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
               },
               {
                 "color": "red",
@@ -1952,8 +2075,11 @@
             },
             "properties": [
               {
-                "id": "custom.displayMode",
-                "value": "color-background-solid"
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "basic",
+                  "type": "color-background"
+                }
               },
               {
                 "id": "mappings",
@@ -2097,15 +2223,19 @@
       },
       "id": 20,
       "options": {
+        "cellHeight": "sm",
         "footer": {
+          "countRows": false,
           "fields": "",
-          "reducer": ["sum"],
+          "reducer": [
+            "sum"
+          ],
           "show": false
         },
         "showHeader": true,
         "sortBy": []
       },
-      "pluginVersion": "9.0.1",
+      "pluginVersion": "12.1.1",
       "targets": [
         {
           "builderOptions": {
@@ -2115,7 +2245,7 @@
           },
           "datasource": {
             "type": "grafana-clickhouse-datasource",
-            "uid": "${datasource}"
+            "uid": "${DS_GRAFANA-CLICKHOUSE-DATASOURCE}"
           },
           "format": 1,
           "meta": {
@@ -2171,24 +2301,19 @@
       "type": "table"
     }
   ],
-  "schemaVersion": 36,
-  "style": "dark",
+  "schemaVersion": 41,
   "tags": [],
   "templating": {
     "list": [
       {
         "current": {},
-        "hide": 0,
         "includeAll": false,
         "label": "ClickHouse instance",
-        "multi": false,
         "name": "datasource",
         "options": [],
         "query": "grafana-clickhouse-datasource",
-        "queryValue": "",
         "refresh": 1,
         "regex": "",
-        "skipUrlSync": false,
         "type": "datasource"
       },
       {
@@ -2198,7 +2323,6 @@
           "uid": "${datasource}"
         },
         "definition": "SELECT name FROM system.databases;\n",
-        "hide": 0,
         "includeAll": true,
         "label": "Database",
         "multi": true,
@@ -2207,18 +2331,15 @@
         "query": "SELECT name FROM system.databases;\n",
         "refresh": 1,
         "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
         "type": "query"
       },
       {
         "current": {},
         "datasource": {
           "type": "grafana-clickhouse-datasource",
-          "uid": "${datasource}"
+          "uid": "${DS_GRAFANA-CLICKHOUSE-DATASOURCE}"
         },
         "definition": "SELECT name FROM system.tables WHERE database IN (${database})",
-        "hide": 0,
         "includeAll": true,
         "label": "Table",
         "multi": true,
@@ -2227,8 +2348,6 @@
         "query": "SELECT name FROM system.tables WHERE database IN (${database})",
         "refresh": 1,
         "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
         "type": "query"
       }
     ]

--- a/src/dashboards/data-analysis.json
+++ b/src/dashboards/data-analysis.json
@@ -532,6 +532,10 @@
               {
                 "id": "custom.width",
                 "value": 96
+              },
+              {
+                "id": "unit",
+                "value": "bytes"
               }
             ]
           },
@@ -556,6 +560,10 @@
               {
                 "id": "custom.width",
                 "value": 103
+              },
+              {
+                "id": "unit",
+                "value": "bytes"
               }
             ]
           }
@@ -584,25 +592,25 @@
       "pluginVersion": "12.1.1",
       "targets": [
         {
-          "builderOptions": {
-            "fields": [],
-            "limit": 100,
-            "mode": "list"
-          },
           "datasource": {
             "type": "grafana-clickhouse-datasource",
             "uid": "${DS_GRAFANA-CLICKHOUSE-DATASOURCE}"
           },
+          "editorType": "sql",
           "format": 1,
           "meta": {
             "builderOptions": {
-              "fields": [],
+              "columns": [],
+              "database": "",
               "limit": 100,
-              "mode": "list"
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
             }
           },
-          "queryType": "sql",
-          "rawSql": "SELECT\n    name as Name,\n    path as Path,\n    formatReadableSize(free_space) as Free,\n    formatReadableSize(total_space) as Total,\n    1 - free_space/total_space as Used\nFROM system.disks",
+          "pluginVersion": "4.10.2",
+          "queryType": "table",
+          "rawSql": "SELECT\n    name as Name,\n    path as Path,\n    free_space as Free,\n    total_space as Total,\n    1 - free_space/total_space as Used\nFROM system.disks",
           "refId": "A"
         }
       ],
@@ -1127,6 +1135,22 @@
               {
                 "id": "custom.width",
                 "value": 203
+              },
+              {
+                "id": "unit",
+                "value": "bytes"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Uncompressed size"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "bytes"
               }
             ]
           }
@@ -1150,30 +1174,35 @@
           "show": false
         },
         "showHeader": true,
-        "sortBy": []
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Uncompressed size"
+          }
+        ]
       },
       "pluginVersion": "12.1.1",
       "targets": [
         {
-          "builderOptions": {
-            "fields": [],
-            "limit": 100,
-            "mode": "list"
-          },
           "datasource": {
             "type": "grafana-clickhouse-datasource",
             "uid": "${DS_GRAFANA-CLICKHOUSE-DATASOURCE}"
           },
+          "editorType": "sql",
           "format": 1,
           "meta": {
             "builderOptions": {
-              "fields": [],
+              "columns": [],
+              "database": "",
               "limit": 100,
-              "mode": "list"
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
             }
           },
-          "queryType": "sql",
-          "rawSql": "SELECT name,\n       engine,\n       tables,\n       partitions,\n       parts,\n       formatReadableSize(bytes_on_disk)            \"disk_size\",\n       col_count,\n       total_rows,\n       formatReadableSize(data_uncompressed_bytes) as \"uncompressed_size\"\nFROM system.databases db\n         LEFT JOIN ( SELECT database,\n                            uniq(table)                   \"tables\",\n                            uniq(table, partition)        \"partitions\",\n                            count()                    AS parts,\n                            sum(bytes_on_disk)            \"bytes_on_disk\",\n                            sum(data_uncompressed_bytes) as \"data_uncompressed_bytes\",\n                            sum(rows) as total_rows,\n                            max(col_count) as \"col_count\"\n                     FROM system.parts AS parts\n                               JOIN (SELECT database, count() as col_count\n                                         FROM system.columns\n                                         WHERE database IN (${database}) AND table IN (${table})\n                                         GROUP BY database) as col_stats\n                                        ON parts.database = col_stats.database\n                     WHERE database IN (${database}) AND active AND table IN (${table})\n                     GROUP BY database) AS db_stats ON db.name = db_stats.database\nWHERE database IN (${database}) AND lower(name) != 'information_schema'\nORDER BY bytes_on_disk DESC\nLIMIT 10;",
+          "pluginVersion": "4.10.2",
+          "queryType": "table",
+          "rawSql": "SELECT name,\n       engine,\n       tables,\n       partitions,\n       parts,\n       bytes_on_disk            \"disk_size\",\n       col_count,\n       total_rows,\n       data_uncompressed_bytes as \"uncompressed_size\"\nFROM system.databases db\n         LEFT JOIN ( SELECT database,\n                            uniq(table)                   \"tables\",\n                            uniq(table, partition)        \"partitions\",\n                            count()                    AS parts,\n                            sum(bytes_on_disk)            \"bytes_on_disk\",\n                            sum(data_uncompressed_bytes) as \"data_uncompressed_bytes\",\n                            sum(rows) as total_rows,\n                            max(col_count) as \"col_count\"\n                     FROM system.parts AS parts\n                               JOIN (SELECT database, count() as col_count\n                                         FROM system.columns\n                                         WHERE database IN (${database}) AND table IN (${table})\n                                         GROUP BY database) as col_stats\n                                        ON parts.database = col_stats.database\n                     WHERE database IN (${database}) AND active AND table IN (${table})\n                     GROUP BY database) AS db_stats ON db.name = db_stats.database\nWHERE database IN (${database}) AND lower(name) != 'information_schema'\nORDER BY bytes_on_disk DESC\nLIMIT 10;",
           "refId": "A"
         }
       ],
@@ -1444,6 +1473,10 @@
               {
                 "id": "custom.width",
                 "value": 145
+              },
+              {
+                "id": "unit",
+                "value": "bytes"
               }
             ]
           },
@@ -1500,6 +1533,10 @@
               {
                 "id": "custom.width",
                 "value": 171
+              },
+              {
+                "id": "unit",
+                "value": "bytes"
               }
             ]
           }
@@ -1526,32 +1563,32 @@
         "sortBy": [
           {
             "desc": true,
-            "displayName": "Column count"
+            "displayName": "Size on disk"
           }
         ]
       },
       "pluginVersion": "12.1.1",
       "targets": [
         {
-          "builderOptions": {
-            "fields": [],
-            "limit": 100,
-            "mode": "list"
-          },
           "datasource": {
             "type": "grafana-clickhouse-datasource",
             "uid": "${DS_GRAFANA-CLICKHOUSE-DATASOURCE}"
           },
+          "editorType": "sql",
           "format": 1,
           "meta": {
             "builderOptions": {
-              "fields": [],
+              "columns": [],
+              "database": "",
               "limit": 100,
-              "mode": "list"
+              "mode": "list",
+              "queryType": "table",
+              "table": ""
             }
           },
-          "queryType": "sql",
-          "rawSql": "SELECT name,\n       table.database,\n       engine,\n       partitions,\n       parts,\n       formatReadableSize(bytes_on_disk)            \"disk_size\",\n       col_count,\n       table_stats.total_rows,\n       formatReadableSize(data_uncompressed_bytes) as \"uncompressed_size\"\nFROM system.tables table\n         LEFT JOIN ( SELECT table,\n       database,\n       uniq(table, partition)        \"partitions\",\n       count()                    AS parts,\n       sum(bytes_on_disk)            \"bytes_on_disk\",\n       sum(data_uncompressed_bytes) as \"data_uncompressed_bytes\",\n       sum(rows)                  as total_rows,\n                            max(col_count) as col_count\nFROM system.parts as parts\n         LEFT JOIN (SELECT database, table, count() as col_count FROM system.columns GROUP BY table, database) as col_stats\n                   ON parts.table = col_stats.table AND col_stats.database = parts.database\nWHERE active\nGROUP BY table, database\n ) AS table_stats ON table.name = table_stats.table AND table.database = table_stats.database\nWHERE database IN (${database}) AND lower(name) != 'information_schema' AND table IN (${table})\nORDER BY bytes_on_disk DESC\nLIMIT 1000",
+          "pluginVersion": "4.10.2",
+          "queryType": "table",
+          "rawSql": "SELECT name,\n       table.database,\n       engine,\n       partitions,\n       parts,\n       bytes_on_disk            \"disk_size\",\n       col_count,\n       table_stats.total_rows,\n       data_uncompressed_bytes as \"uncompressed_size\"\nFROM system.tables table\n         LEFT JOIN ( SELECT table,\n       database,\n       uniq(table, partition)        \"partitions\",\n       count()                    AS parts,\n       sum(bytes_on_disk)            \"bytes_on_disk\",\n       sum(data_uncompressed_bytes) as \"data_uncompressed_bytes\",\n       sum(rows)                  as total_rows,\n                            max(col_count) as col_count\nFROM system.parts as parts\n         LEFT JOIN (SELECT database, table, count() as col_count FROM system.columns GROUP BY table, database) as col_stats\n                   ON parts.table = col_stats.table AND col_stats.database = parts.database\nWHERE active\nGROUP BY table, database\n ) AS table_stats ON table.name = table_stats.table AND table.database = table_stats.database\nWHERE database IN (${database}) AND lower(name) != 'information_schema' AND table IN (${table})\nORDER BY bytes_on_disk DESC\nLIMIT 1000",
           "refId": "A"
         }
       ],
@@ -2360,6 +2397,6 @@
   "timezone": "",
   "title": "ClickHouse - Data Analysis",
   "uid": "-B3tt7a7z",
-  "version": 2,
+  "version": 5,
   "weekStart": ""
 }


### PR DESCRIPTION
## Before
<img width="2620" height="614" alt="image" src="https://github.com/user-attachments/assets/43521dea-c4ec-434e-895b-3d3e114c53c6" />
Note that 57 KiB incorrectly comes before 1MiB

## After
<img width="2634" height="646" alt="image" src="https://github.com/user-attachments/assets/07c5283e-c600-468d-8b73-af1c2dacddde" />


Simply importing the dashboard and saving it will change the format. I have done this in a separate commmit.
