### PR TITLE
Merge OTel labels

### DIFF
--- a/pkg/plugin/driver.go
+++ b/pkg/plugin/driver.go
@@ -311,6 +311,72 @@ func (h *Clickhouse) MutateQuery(ctx context.Context, req backend.DataQuery) (co
 // except for specific visualizations (traces, tables, and logs).
 func (h *Clickhouse) MutateResponse(ctx context.Context, res data.Frames) (data.Frames, error) {
 	for _, frame := range res {
+		if frame.Meta.PreferredVisualization == data.VisTypeLogs {
+			var attrFields []*data.Field
+			for _, field := range frame.Fields {
+				if field.Type() != data.FieldTypeJSON {
+					continue
+				}
+
+				if field.Name == "ResourceAttributes" || field.Name == "ScopeAttributes" || field.Name == "LogAttributes" {
+					attrFields = append(attrFields, field)
+				}
+			}
+
+			rowLen, err := frame.RowLen()
+			if err != nil {
+				return nil, err
+			}
+
+			allLabelsValues := make([]map[string]any, rowLen)
+
+			for _, field := range attrFields {
+				for j := 0; j < rowLen; j++ {
+					currentVal := allLabelsValues[j]
+					if currentVal == nil {
+						currentVal = make(map[string]any)
+					}
+
+					val := field.At(j).(json.RawMessage)
+					if val != nil {
+						var valMap map[string]any
+						err := json.Unmarshal(val, &valMap)
+						if err != nil {
+							return nil, err
+						}
+
+						for valMapKey, valMapValue := range valMap {
+							currentVal[fmt.Sprintf("%s.%s", field.Name, valMapKey)] = valMapValue
+						}
+
+						allLabelsValues[j] = currentVal
+					}
+				}
+			}
+
+			allLabelsValuesJSON := make([]json.RawMessage, rowLen)
+			for i, value := range allLabelsValues {
+				valueJSON, err := json.Marshal(value)
+				if err != nil {
+					return nil, err
+				}
+
+				allLabelsValuesJSON[i] = valueJSON
+			}
+			allLabels := data.NewField("labels", make(data.Labels), allLabelsValuesJSON)
+
+			filteredFields := make([]*data.Field, 0, len(frame.Fields)-len(attrFields))
+			for _, field := range frame.Fields {
+				if field.Name == "ResourceAttributes" || field.Name == "ScopeAttributes" || field.Name == "LogAttributes" {
+					continue
+				}
+
+				filteredFields = append(filteredFields, field)
+			}
+			filteredFields = append(filteredFields, allLabels)
+			frame.Fields = filteredFields
+		}
+
 		if shouldConvertFields(frame.Meta.PreferredVisualization) {
 			if err := convertNullableJSONFields(frame); err != nil {
 				return res, err

--- a/pkg/plugin/driver.go
+++ b/pkg/plugin/driver.go
@@ -311,7 +311,7 @@ func (h *Clickhouse) MutateQuery(ctx context.Context, req backend.DataQuery) (co
 // except for specific visualizations (traces, tables, and logs).
 func (h *Clickhouse) MutateResponse(ctx context.Context, res data.Frames) (data.Frames, error) {
 	for _, frame := range res {
-		if frame.Meta.PreferredVisualization == data.VisTypeLogs || frame.Meta.PreferredVisualization == data.VisTypeTrace {
+		if frame.Meta.PreferredVisualization == data.VisTypeLogs {
 			err := mergeOpenTelemetryLabels(frame)
 			if err != nil {
 				return nil, err
@@ -430,7 +430,7 @@ func mergeOpenTelemetryLabels(frame *data.Frame) error {
 			continue
 		}
 
-		if field.Name == "ResourceAttributes" || field.Name == "ScopeAttributes" || field.Name == "LogAttributes" || field.Name == "SpanAttributes" {
+		if field.Name == "ResourceAttributes" || field.Name == "ScopeAttributes" || field.Name == "LogAttributes" {
 			attrFields = append(attrFields, field)
 		}
 	}
@@ -479,7 +479,7 @@ func mergeOpenTelemetryLabels(frame *data.Frame) error {
 
 	filteredFields := make([]*data.Field, 0, len(frame.Fields)-len(attrFields))
 	for _, field := range frame.Fields {
-		if field.Name == "ResourceAttributes" || field.Name == "ScopeAttributes" || field.Name == "LogAttributes" || field.Name == "SpanAttributes" {
+		if field.Name == "ResourceAttributes" || field.Name == "ScopeAttributes" || field.Name == "LogAttributes" {
 			continue
 		}
 

--- a/src/components/queryBuilder/FilterEditor.tsx
+++ b/src/components/queryBuilder/FilterEditor.tsx
@@ -203,6 +203,7 @@ export const FilterEditor = (props: {
   const { index, filter, allColumns: fieldsList, onFilterChange, removeFilter } = props;
   const [isOpen, setIsOpen] = useState(false);
   const isMapType = filter.type.startsWith('Map');
+  const isJSONType = filter.type.startsWith('JSON');
   const mapKeys = useUniqueMapKeys(props.datasource, isMapType ? filter.key : '', props.database, props.table);
   const mapKeyOptions = mapKeys.map(k => ({ label: k, value: k }));
   if (filter.mapKey && !mapKeys.includes(filter.mapKey)) {
@@ -214,6 +215,8 @@ export const FilterEditor = (props: {
       let label = f.label || f.name;
       if (f.type.startsWith('Map')) {
         label += '[]';
+      } else if (f.type.startsWith('JSON')) {
+        label += '{}';
       }
 
       return { label, value: f.name };
@@ -375,7 +378,7 @@ export const FilterEditor = (props: {
         allowCustomValue
         menuPlacement={'bottom'}
       />
-      { isMapType &&
+      { (isMapType || isJSONType) &&
         <Select
           value={filter.mapKey}
           placeholder={labels.components.FilterEditor.mapKeyPlaceholder}

--- a/src/data/CHDatasource.ts
+++ b/src/data/CHDatasource.ts
@@ -288,9 +288,17 @@ export class Datasource
       return query;
     }
 
-    const columnName = action.options.key;
+    let columnName = action.options.key || '';
     const actionFrame: DataFrame | undefined = (action as any).frame;
     const actionValue = action.options.value;
+    let mapKey = '';
+
+    // Convert flattened/merged OTel attributes into column+path pair
+    if (['ResourceAttributes', 'ScopeAttributes', 'LogAttributes', 'SpanAttributes'].includes(columnName.split('.')[0])) {
+        const prefixIndex = columnName.indexOf('.');
+        mapKey = columnName.substring(prefixIndex + 1)
+        columnName = columnName.substring(0, prefixIndex);        
+    }
 
     // Find selected column by alias/name
     const lookupByAlias = query.builderOptions.columns?.find(c => c.alias === columnName); // Check all aliases first,
@@ -298,6 +306,8 @@ export class Datasource
     const lookupByLogsAlias = logAliasToColumnHints.has(columnName) ? getColumnByHint(query.builderOptions, logAliasToColumnHints.get(columnName)!) : undefined;
     const lookupByLogLabels = dataFrameHasLogLabelWithName(actionFrame, columnName) && getColumnByHint(query.builderOptions, ColumnHint.LogLabels);
     const column = lookupByAlias || lookupByName || lookupByLogsAlias || lookupByLogLabels;
+    const columnType = column ? (column.type || '') : '';
+    const hasMapKey = mapKey !== '' || Boolean(lookupByLogLabels);
 
     let nextFilters: Filter[] = (query.builderOptions.filters?.slice() || []);
     if (action.type === 'ADD_FILTER') {
@@ -310,8 +320,8 @@ export class Datasource
           (f.operator === FilterOperator.IsAnything || f.operator === FilterOperator.Equals || f.operator === FilterOperator.NotEquals)
         ) &&
         !(
-          f.type.toLowerCase().startsWith('map') &&
-          (column && lookupByLogLabels && f.mapKey === columnName) &&
+          (f.type.startsWith('Map') || f.type.startsWith('JSON')) &&
+          (column && hasMapKey && f.mapKey === mapKey) &&
           (f.operator === FilterOperator.IsAnything || f.operator === FilterOperator.Equals || f.operator === FilterOperator.NotEquals)
         )
       );
@@ -320,8 +330,8 @@ export class Datasource
         condition: 'AND',
         key: (column && column.hint) ? '' : columnName,
         hint: (column && column.hint) ? column.hint : undefined,
-        mapKey: lookupByLogLabels ? columnName : undefined,
-        type: lookupByLogLabels ? 'Map(String, String)' : 'string',
+        mapKey: hasMapKey ? mapKey : undefined,
+        type: hasMapKey ? (columnType.startsWith('Map') ? 'Map(String, String)' : 'JSON') : 'String',
         filterType: 'custom',
         operator: FilterOperator.Equals,
         value: actionValue,
@@ -343,8 +353,8 @@ export class Datasource
             (f.operator === FilterOperator.IsAnything || f.operator === FilterOperator.Equals)
           ) ||
           (
-            f.type.toLowerCase().startsWith('map') &&
-            (column && lookupByLogLabels && f.mapKey === columnName) &&
+            (f.type.startsWith('Map') || f.type.startsWith('JSON')) &&
+            (column && hasMapKey && f.mapKey === mapKey) &&
             (f.operator === FilterOperator.IsAnything || f.operator === FilterOperator.Equals)
           )
         )
@@ -354,8 +364,8 @@ export class Datasource
         condition: 'AND',
         key: (column && column.hint) ? '' : columnName,
         hint: (column && column.hint) ? column.hint : undefined,
-        mapKey: lookupByLogLabels ? columnName : undefined,
-        type: lookupByLogLabels ? 'Map(String, String)' : 'string',
+        mapKey: hasMapKey ? mapKey : undefined,
+        type: hasMapKey ? (columnType.startsWith('Map') ? 'Map(String, String)' : 'JSON') : 'String',
         filterType: 'custom',
         operator: FilterOperator.NotEquals,
         value: actionValue,
@@ -579,7 +589,11 @@ export class Datasource
         continue;
       }
 
-      const kv = JSON.parse(x[0]);
+      let kv = x[0];
+      if (typeof kv === 'string') {
+        kv = JSON.parse(x[0]);
+      }
+
       if (!kv.keys || !kv.values) {
         continue;
       }

--- a/src/data/CHDatasource.ts
+++ b/src/data/CHDatasource.ts
@@ -294,7 +294,7 @@ export class Datasource
     let mapKey = '';
 
     // Convert flattened/merged OTel attributes into column+path pair
-    if (['ResourceAttributes', 'ScopeAttributes', 'LogAttributes', 'SpanAttributes'].includes(columnName.split('.')[0])) {
+    if (['ResourceAttributes', 'ScopeAttributes', 'LogAttributes'].includes(columnName.split('.')[0])) {
         const prefixIndex = columnName.indexOf('.');
         mapKey = columnName.substring(prefixIndex + 1)
         columnName = columnName.substring(0, prefixIndex);        

--- a/src/data/sqlGenerator.ts
+++ b/src/data/sqlGenerator.ts
@@ -727,7 +727,7 @@ const getFilters = (options: QueryBuilderOptions): string => {
     const filterParts: string[] = [];
 
     let column = filter.key;
-    let type = filter.type;
+    let type = filter.type || '';
     const hintedColumn = filter.hint && getColumnByHint(options, filter.hint);
     if (hintedColumn) {
       column = hintedColumn.alias || hintedColumn.name;
@@ -738,8 +738,11 @@ const getFilters = (options: QueryBuilderOptions): string => {
       continue;
     }
 
-    if (filter.mapKey) {
+    if (filter.mapKey && type.startsWith('Map')) {
       column += `['${filter.mapKey}']`;
+    } else if (filter.mapKey && type.startsWith('JSON')) {
+      const escapedJSONPaths = filter.mapKey.split('.').map(p => `\`${p}\``).join('.')
+      column += `.${escapedJSONPaths}`;
     }
 
     filterParts.push(column);


### PR DESCRIPTION
The Logs UI currently has a "Labels" field for logs. By default it selects `LogAttributes` to show in the logs explore panel, but this excludes important information from `ResourceAttributes` and `ScopeAttributes`.

This PR adds logic to auto merge these columns (JSON or Map type) into a single `labels` field for easy viewing and filtering. To use this, simply use Logs visualization with at least one of `ResourceAttributes`, `LogAttributes`, or `ScopeAttributes` selected. The labels will not be merged if there's an existing `labels` field selected, so you may have to clear the "Labels" input on the query builder.

Example:
<img width="675" height="719" alt="example label merge" src="https://github.com/user-attachments/assets/d9a36875-225a-4580-9948-9a463dbb14e1" />

Note that the fields are prefixed with the associated column. Instead of showing only `a`, it is displayed as `ResourceAttributes.a`. This is done to prevent label conflicts, and to give context for filtering logic.

## Filtering

Filtering is also enhanced with this. Because the labels are prefixed, we can easily convert these filters into the correct syntax for `Map` and `JSON` types.


### JSON Filter Example

Top-level JSON columns have a `{}` appended at the end in the column selector to show the type.

<img width="1046" height="117" alt="JSON filter" src="https://github.com/user-attachments/assets/9e604b93-513c-4af4-88fc-24e7e197495b" />

Generated SQL:
```sql
ResourceAttributes.`env` = 'staging'
```

Note that the path is escaped with back ticks to prevent errors for complex path names:
```sql
ResourceAttributes.`path with spaces`.`a`.`b` = 'staging'
```

Another important detail is that JSON paths are not yet flattened. I expect this to be a server side setting at some point. You can manually type in the path as a workaround if the filter does not apply correctly. In a future PR we can add a setting to let the driver do the flattening, but this is risky due to potential path conflicts.

### Map Filter Example

Top-level Map columns have a `[]` appended at the end in the column selector to show the type.

<img width="977" height="98" alt="Map filter" src="https://github.com/user-attachments/assets/66204dcf-b7f3-447e-85fc-6815f035db92" />

Generated SQL:
```sql
ResourceAttributes['env'] = 'staging'
```
