### PR TITLE
Config Page Redesign Part 1

### DIFF
--- a/cspell.config.json
+++ b/cspell.config.json
@@ -76,6 +76,8 @@
     "timerange",
     "timeseries",
     "timespan",
+    "Toggletip",
+    "toggleTip",
     "TLSCA",
     "totime",
     "traceid",

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,16 +1,20 @@
-import { DataSourcePlugin, DashboardLoadedEvent } from '@grafana/data';
+import { DataSourcePlugin, DashboardLoadedEvent, FeatureToggles } from '@grafana/data';
 import { Datasource } from './data/CHDatasource';
-import { ConfigEditor } from './views/CHConfigEditor';
+import { ConfigEditor as ConfigEditorV1 } from './views/CHConfigEditor';
+import { ConfigEditor as ConfigEditorV2 } from './views/config-v2/CHConfigEditor';
 import { CHQueryEditor } from './views/CHQueryEditor';
 import { CHConfig } from 'types/config';
 import { CHQuery } from 'types/sql';
-import { getAppEvents } from '@grafana/runtime';
+import { config, getAppEvents } from '@grafana/runtime';
 import { analyzeQueries, trackClickhouseDashboardLoaded } from 'tracking';
 import pluginJson from './plugin.json';
 import clickhouseVersion from '../package.json';
 
+// ConfigEditorV2 is the new design for the Clickhouse configuration page
+const configEditor = config.featureToggles['newClickhouseConfigPageDesign' as keyof FeatureToggles] ? ConfigEditorV2 : ConfigEditorV1;
+
 export const plugin = new DataSourcePlugin<Datasource, CHQuery, CHConfig>(Datasource)
-  .setConfigEditor(ConfigEditor)
+  .setConfigEditor(configEditor)
   .setQueryEditor(CHQueryEditor);
 
 // Track dashboard loads to RudderStack

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -39,6 +39,8 @@ export interface CHConfig extends DataSourceJsonData {
   customSettings?: CHCustomSetting[];
   enableSecureSocksProxy?: boolean;
   enableRowLimit?: boolean;
+
+  pdcInjected?: boolean;
 }
 
 interface CHSecureConfigProperties {

--- a/src/views/CHConfigEditor.tsx
+++ b/src/views/CHConfigEditor.tsx
@@ -237,13 +237,11 @@ export const ConfigEditor: React.FC<ConfigEditorProps> = (props) => {
             name="host"
             width={80}
             value={jsonData.host || ''}
-            onChange={(e) => {
-              trackingV1.trackClickhouseConfigV1HostInput();
-              return onUpdateDatasourceJsonDataOption(props, 'host')(e);
-            }}
+            onChange={(e) => onUpdateDatasourceJsonDataOption(props, 'host')(e)}
             label={labels.serverAddress.label}
             aria-label={labels.serverAddress.label}
             placeholder={labels.serverAddress.placeholder}
+            onBlur={trackingV1.trackClickhouseConfigV1HostInput}
           />
         </Field>
         <Field
@@ -258,13 +256,11 @@ export const ConfigEditor: React.FC<ConfigEditorProps> = (props) => {
             width={40}
             type="number"
             value={jsonData.port || ''}
-            onChange={e => {
-              trackingV1.trackClickhouseConfigV1PortInput({ port: e.currentTarget.value});
-              onPortChange(e.currentTarget.value);
-            }}
+            onChange={e => onPortChange(e.currentTarget.value)}
             label={labels.serverPort.label}
             aria-label={labels.serverPort.label}
             placeholder={defaultPort}
+            onBlur={(e) => trackingV1.trackClickhouseConfigV1PortInput({ port: e.currentTarget.value})}
           />
         </Field>
 

--- a/src/views/config-v2/CHConfigEditor.test.tsx
+++ b/src/views/config-v2/CHConfigEditor.test.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import '@testing-library/jest-dom';
+
+import { render, screen } from '@testing-library/react';
+
+import { ConfigEditor } from './CHConfigEditor';
+import { createTestProps } from './helpers';
+
+jest.mock('./LeftSidebar', () => ({
+  LeftSidebar: () => <div data-testid="left-sidebar" />,
+}));
+
+jest.mock('./ServerAndEncryptionSection', () => ({
+  ServerAndEncryptionSection: () => <div data-testid="server-encryption-section" />,
+}));
+
+describe('ConfigEditor', () => {
+  const defaultProps = createTestProps({
+    options: {
+      jsonData: {},
+      secureJsonData: {},
+      secureJsonFields: {},
+    },
+    mocks: {
+      onOptionsChange: jest.fn(),
+    },
+  });
+
+  it('renders the LeftSideBar, ServerAndEncryptionSection, and HttpProtocolSettingsSection', () => {
+    render(<ConfigEditor {...defaultProps} />);
+
+    expect(screen.getByTestId('left-sidebar')).toBeInTheDocument();
+    expect(screen.getByTestId('server-encryption-section')).toBeInTheDocument();
+  });
+
+  it.skip('shows the informational alert', () => {
+    render(<ConfigEditor {...defaultProps} />);
+    expect(screen.getByText(/You are viewing a new design/i)).toBeInTheDocument();
+  });
+});

--- a/src/views/config-v2/CHConfigEditor.tsx
+++ b/src/views/config-v2/CHConfigEditor.tsx
@@ -7,6 +7,7 @@ import { css } from '@emotion/css';
 import { LeftSidebar } from './LeftSidebar';
 import { CONTAINER_MIN_WIDTH } from './constants';
 import { trackInfluxDBConfigV2FeedbackButtonClicked } from './tracking';
+import { RemainingConfigCode } from './RemainingConfigCode';
 
 export interface ConfigEditorProps extends DataSourcePluginOptionsEditorProps<CHConfig, CHSecureConfig> {}
 
@@ -44,6 +45,7 @@ export const ConfigEditor: React.FC<ConfigEditorProps> = (props) => {
             </Text>
         </div>
           <ServerAndEncryptionSection onOptionsChange={onOptionsChange} options={options} />
+          <RemainingConfigCode onOptionsChange={onOptionsChange} options={options} />
         </Box>
         <Box width="20%" flex="0 0 20%">
             {/* TODO: Right sidebar */}

--- a/src/views/config-v2/CHConfigEditor.tsx
+++ b/src/views/config-v2/CHConfigEditor.tsx
@@ -1,0 +1,194 @@
+import React from 'react';
+import {
+  Box,
+  CollapsableSection,
+  Field,
+  IconButton,
+  Input,
+  RadioButtonGroup,
+  Text,
+  TextLink,
+  Toggletip,
+  useTheme2,
+} from '@grafana/ui';
+import { CONFIG_SECTION_HEADERS, CONTAINER_MIN_WIDTH, PROTOCOL_OPTIONS } from './constants';
+import allLabels from './labels';
+import { DataSourcePluginOptionsEditorProps, onUpdateDatasourceJsonDataOption } from '@grafana/data';
+import { CHConfig, CHSecureConfig, Protocol } from 'types/config';
+import { css } from '@emotion/css';
+
+export interface ConfigEditorProps extends DataSourcePluginOptionsEditorProps<CHConfig, CHSecureConfig> {}
+
+export const ConfigEditor: React.FC<ConfigEditorProps> = (props) => {
+  const { options, onOptionsChange } = props;
+  const { jsonData, secureJsonFields } = options;
+  const secureJsonData = (options.secureJsonData || {}) as CHSecureConfig;
+  const labels = allLabels.components.Config.ConfigEditor;
+  const defaultPort = jsonData.secure
+    ? jsonData.protocol === Protocol.Native
+      ? labels.serverPort.secureNativePort
+      : labels.serverPort.secureHttpPort
+    : jsonData.protocol === Protocol.Native
+      ? labels.serverPort.insecureNativePort
+      : labels.serverPort.insecureHttpPort;
+  const portDescription = `${labels.serverPort.tooltip} (default for ${jsonData.secure ? 'secure' : ''} ${jsonData.protocol}: ${defaultPort})`;
+
+  const theme = useTheme2();
+  const styles = {
+    protocolPortRow: css({
+      display: 'flex',
+      alignItems: 'center',
+    }),
+    protocolLabel: css({
+      display: 'flex',
+      height: 15,
+    }),
+    protocolSection: css({
+      display: 'flex',
+      flexDirection: 'column',
+      justifyContent: 'center',
+      gap: theme.spacing(0),
+      marginRight: theme.spacing(10),
+      width: '250px',
+    }),
+    toggletipIcon: css({
+      marginLeft: theme.spacing(0.5),
+      padding: 0,
+    }),
+    portSection: css({
+      width: '100%',
+    }),
+    toggleTipText: css({
+      whiteSpace: 'pre-line',
+    }),
+  };
+
+  const onProtocolToggle = (protocol: Protocol) => {
+    onOptionsChange({
+      ...options,
+      jsonData: {
+        ...options.jsonData,
+        protocol: protocol,
+      },
+    });
+  };
+
+  const onPortChange = (port: string) => {
+    onOptionsChange({
+      ...options,
+      jsonData: {
+        ...options.jsonData,
+        port: +port,
+      },
+    });
+  };
+
+  return (
+    <>
+      <div style={{ marginBottom: '10px' }}>
+        <Text variant="bodySmall" color="secondary">
+          Fields marked with * are required
+        </Text>
+      </div>
+      <Box
+        borderStyle="solid"
+        borderColor="weak"
+        padding={2}
+        marginBottom={4}
+        id={`${CONFIG_SECTION_HEADERS[0].id}`}
+        minWidth={CONTAINER_MIN_WIDTH}
+      >
+        <CollapsableSection
+          label={<Text variant="h3">1. {CONFIG_SECTION_HEADERS[0].label}</Text>}
+          isOpen={CONFIG_SECTION_HEADERS[0].isOpen}
+        >
+          <Text variant="body" color="secondary">
+            Enter the server address of your Clickhouse instance. Then select your protocol, port and security options.
+            If you need further guidance, visit the{' '}
+            <TextLink
+              href="https://grafana.com/grafana/plugins/grafana-clickhouse-datasource/"
+              icon="external-link-alt"
+            >
+              Grafana docs
+            </TextLink>
+          </Text>
+          <Field required label={labels.serverAddress.label} style={{ marginTop: '20px' }}>
+            <Input
+              name="host"
+              value={jsonData.host || ''}
+              onChange={(e) => {
+                // trackingV1.trackClickhouseConfigV1HostInput();
+                return onUpdateDatasourceJsonDataOption(props, 'host')(e);
+              }}
+              label={labels.serverAddress.label}
+              aria-label={labels.serverAddress.label}
+              placeholder={labels.serverAddress.placeholder}
+            />
+          </Field>
+          <div className={styles.protocolPortRow}>
+            <div className={styles.protocolSection}>
+              <div className={styles.protocolLabel}>
+                <Text variant="bodySmall" weight="bold">
+                  {labels.protocol.label}
+                </Text>
+                <Toggletip
+                  theme="info"
+                  placement="top"
+                  content={
+                    <div className={styles.toggleTipText}>
+                      <Text>
+                        ClickHouse supports two server protocols: Native TCP and HTTP. Both protocols can be secured
+                        with TLS.
+                        <br />
+                        <br />
+                        <TextLink href="https://clickhouse.com/docs/interfaces/tcp" variant="bodySmall">
+                          Native TCP
+                        </TextLink>{' '}
+                        is the default and recommended option.
+                        <br />
+                        <TextLink href="https://clickhouse.com/docs/interfaces/http" variant="bodySmall">
+                          HTTP
+                        </TextLink>{' '}
+                        is for servers configured to accept HTTP connections.
+                      </Text>
+                    </div>
+                  }
+                >
+                  <IconButton
+                    name="question-circle"
+                    aria-label="More info about Protocol"
+                    size="xs"
+                    className={styles.toggletipIcon}
+                  />
+                </Toggletip>
+              </div>
+              <Field label=" " description={<div className={styles.toggleTipText}>{labels.protocol.description}</div>}>
+                <RadioButtonGroup<Protocol>
+                  options={PROTOCOL_OPTIONS}
+                  value={jsonData.protocol || Protocol.Native}
+                  onChange={(e) => onProtocolToggle(e!)}
+                />
+              </Field>
+            </div>
+            <div className={styles.portSection}>
+              <Field required label={labels.serverPort.label} description={portDescription}>
+                <Input
+                  name="port"
+                  type="number"
+                  value={jsonData.port || ''}
+                  onChange={(e) => {
+                    // trackingV1.trackClickhouseConfigV1PortInput({ port: e.currentTarget.value });
+                    onPortChange(e.currentTarget.value);
+                  }}
+                  label={labels.serverPort.label}
+                  aria-label={labels.serverPort.label}
+                  placeholder={defaultPort}
+                />
+              </Field>
+            </div>
+          </div>
+        </CollapsableSection>
+      </Box>
+    </>
+  );
+};

--- a/src/views/config-v2/CHConfigEditor.tsx
+++ b/src/views/config-v2/CHConfigEditor.tsx
@@ -1,194 +1,69 @@
 import React from 'react';
-import {
-  Box,
-  CollapsableSection,
-  Field,
-  IconButton,
-  Input,
-  RadioButtonGroup,
-  Text,
-  TextLink,
-  Toggletip,
-  useTheme2,
-} from '@grafana/ui';
-import { CONFIG_SECTION_HEADERS, CONTAINER_MIN_WIDTH, PROTOCOL_OPTIONS } from './constants';
-import allLabels from './labels';
-import { DataSourcePluginOptionsEditorProps, onUpdateDatasourceJsonDataOption } from '@grafana/data';
-import { CHConfig, CHSecureConfig, Protocol } from 'types/config';
+import { DataSourcePluginOptionsEditorProps, GrafanaTheme2 } from '@grafana/data';
+import { Alert, Box, Stack, Text, TextLink, useStyles2 } from "@grafana/ui";
+import { CHConfig, CHSecureConfig } from 'types/config';
+import { ServerAndEncryptionSection } from './ServerAndEncryptionSection';
 import { css } from '@emotion/css';
+import { LeftSidebar } from './LeftSidebar';
+import { CONTAINER_MIN_WIDTH } from './constants';
+import { trackInfluxDBConfigV2FeedbackButtonClicked } from './tracking';
 
 export interface ConfigEditorProps extends DataSourcePluginOptionsEditorProps<CHConfig, CHSecureConfig> {}
 
 export const ConfigEditor: React.FC<ConfigEditorProps> = (props) => {
   const { options, onOptionsChange } = props;
-  const { jsonData, secureJsonFields } = options;
-  const secureJsonData = (options.secureJsonData || {}) as CHSecureConfig;
-  const labels = allLabels.components.Config.ConfigEditor;
-  const defaultPort = jsonData.secure
-    ? jsonData.protocol === Protocol.Native
-      ? labels.serverPort.secureNativePort
-      : labels.serverPort.secureHttpPort
-    : jsonData.protocol === Protocol.Native
-      ? labels.serverPort.insecureNativePort
-      : labels.serverPort.insecureHttpPort;
-  const portDescription = `${labels.serverPort.tooltip} (default for ${jsonData.secure ? 'secure' : ''} ${jsonData.protocol}: ${defaultPort})`;
-
-  const theme = useTheme2();
-  const styles = {
-    protocolPortRow: css({
-      display: 'flex',
-      alignItems: 'center',
-    }),
-    protocolLabel: css({
-      display: 'flex',
-      height: 15,
-    }),
-    protocolSection: css({
-      display: 'flex',
-      flexDirection: 'column',
-      justifyContent: 'center',
-      gap: theme.spacing(0),
-      marginRight: theme.spacing(10),
-      width: '250px',
-    }),
-    toggletipIcon: css({
-      marginLeft: theme.spacing(0.5),
-      padding: 0,
-    }),
-    portSection: css({
-      width: '100%',
-    }),
-    toggleTipText: css({
-      whiteSpace: 'pre-line',
-    }),
-  };
-
-  const onProtocolToggle = (protocol: Protocol) => {
-    onOptionsChange({
-      ...options,
-      jsonData: {
-        ...options.jsonData,
-        protocol: protocol,
-      },
-    });
-  };
-
-  const onPortChange = (port: string) => {
-    onOptionsChange({
-      ...options,
-      jsonData: {
-        ...options.jsonData,
-        port: +port,
-      },
-    });
-  };
+  const styles = useStyles2(getStyles);
 
   return (
-    <>
-      <div style={{ marginBottom: '10px' }}>
-        <Text variant="bodySmall" color="secondary">
-          Fields marked with * are required
-        </Text>
-      </div>
-      <Box
-        borderStyle="solid"
-        borderColor="weak"
-        padding={2}
-        marginBottom={4}
-        id={`${CONFIG_SECTION_HEADERS[0].id}`}
-        minWidth={CONTAINER_MIN_WIDTH}
-      >
-        <CollapsableSection
-          label={<Text variant="h3">1. {CONFIG_SECTION_HEADERS[0].label}</Text>}
-          isOpen={CONFIG_SECTION_HEADERS[0].isOpen}
-        >
-          <Text variant="body" color="secondary">
-            Enter the server address of your Clickhouse instance. Then select your protocol, port and security options.
-            If you need further guidance, visit the{' '}
-            <TextLink
-              href="https://grafana.com/grafana/plugins/grafana-clickhouse-datasource/"
-              icon="external-link-alt"
+    <Stack justifyContent="space-between">
+        <div className={styles.hideOnSmallScreen}>
+            <Box width="100%" flex="1 1 auto">
+                <LeftSidebar pdcInjected={Boolean(options?.jsonData?.pdcInjected)} />
+            </Box>
+        </div>
+        <Box width="60%" flex="1 1 auto" minWidth={CONTAINER_MIN_WIDTH}>
+        <div className={styles.requiredFields}>
+            <Alert
+                severity="info"
+                title="You are viewing a new design for the Clickhouse configuration settings."
+                className={styles.alertHeight}
             >
-              Grafana docs
-            </TextLink>
-          </Text>
-          <Field required label={labels.serverAddress.label} style={{ marginTop: '20px' }}>
-            <Input
-              name="host"
-              value={jsonData.host || ''}
-              onChange={(e) => {
-                // trackingV1.trackClickhouseConfigV1HostInput();
-                return onUpdateDatasourceJsonDataOption(props, 'host')(e);
-              }}
-              label={labels.serverAddress.label}
-              aria-label={labels.serverAddress.label}
-              placeholder={labels.serverAddress.placeholder}
-            />
-          </Field>
-          <div className={styles.protocolPortRow}>
-            <div className={styles.protocolSection}>
-              <div className={styles.protocolLabel}>
-                <Text variant="bodySmall" weight="bold">
-                  {labels.protocol.label}
-                </Text>
-                <Toggletip
-                  theme="info"
-                  placement="top"
-                  content={
-                    <div className={styles.toggleTipText}>
-                      <Text>
-                        ClickHouse supports two server protocols: Native TCP and HTTP. Both protocols can be secured
-                        with TLS.
-                        <br />
-                        <br />
-                        <TextLink href="https://clickhouse.com/docs/interfaces/tcp" variant="bodySmall">
-                          Native TCP
-                        </TextLink>{' '}
-                        is the default and recommended option.
-                        <br />
-                        <TextLink href="https://clickhouse.com/docs/interfaces/http" variant="bodySmall">
-                          HTTP
-                        </TextLink>{' '}
-                        is for servers configured to accept HTTP connections.
-                      </Text>
-                    </div>
-                  }
-                >
-                  <IconButton
-                    name="question-circle"
-                    aria-label="More info about Protocol"
-                    size="xs"
-                    className={styles.toggletipIcon}
-                  />
-                </Toggletip>
-              </div>
-              <Field label=" " description={<div className={styles.toggleTipText}>{labels.protocol.description}</div>}>
-                <RadioButtonGroup<Protocol>
-                  options={PROTOCOL_OPTIONS}
-                  value={jsonData.protocol || Protocol.Native}
-                  onChange={(e) => onProtocolToggle(e!)}
-                />
-              </Field>
-            </div>
-            <div className={styles.portSection}>
-              <Field required label={labels.serverPort.label} description={portDescription}>
-                <Input
-                  name="port"
-                  type="number"
-                  value={jsonData.port || ''}
-                  onChange={(e) => {
-                    // trackingV1.trackClickhouseConfigV1PortInput({ port: e.currentTarget.value });
-                    onPortChange(e.currentTarget.value);
-                  }}
-                  label={labels.serverPort.label}
-                  aria-label={labels.serverPort.label}
-                  placeholder={defaultPort}
-                />
-              </Field>
-            </div>
-          </div>
-        </CollapsableSection>
-      </Box>
-    </>
+            <>
+              <TextLink
+                href="https://docs.google.com/forms/d/e/1FAIpQLSd5YOYxfW-CU0tQnfFA08fkymGlmZ8XcFRMniE5lScIsmdt5w/viewform"
+                external
+                onClick={trackInfluxDBConfigV2FeedbackButtonClicked}
+              >
+                Share your thoughts
+              </TextLink>{' '}
+              to help us make it even better.
+            </>
+          </Alert>
+            <Text variant="bodySmall" color="secondary">
+            Fields marked with * are required
+            </Text>
+        </div>
+          <ServerAndEncryptionSection onOptionsChange={onOptionsChange} options={options} />
+        </Box>
+        <Box width="20%" flex="0 0 20%">
+            {/* TODO: Right sidebar */}
+        </Box>
+    </Stack>
   );
 };
+
+  const getStyles = (theme: GrafanaTheme2) => ({
+    hideOnSmallScreen: css({
+      width: '250px',
+      flex: '0 0 250px',
+      [theme.breakpoints.down('sm')]: {
+        display: 'none',
+      },
+    }),
+    requiredFields: css({
+        marginBottom: theme.spacing(2),
+    }),
+    alertHeight: css({
+      height: '100px',
+    }),
+  });

--- a/src/views/config-v2/HttpProtocolSettingsSection.test.tsx
+++ b/src/views/config-v2/HttpProtocolSettingsSection.test.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+import { HttpProtocolSettingsSection } from './HttpProtocolSettingsSection';
+import { createTestProps } from './helpers';
+import { Protocol } from 'types/config';
+
+describe('HttpProtocolSettingsSection', () => {
+    const onOptionsChangeMock = jest.fn();
+    let consoleSpy: jest.SpyInstance;
+
+    const defaultProps = createTestProps({
+        options: {
+            jsonData: {
+            protocol: Protocol.Http,
+            path: '/',
+            httpHeaders: [],
+            forwardGrafanaHeaders: false,
+            },
+            secureJsonData: {},
+            secureJsonFields: {},
+        },
+        mocks: {
+            onOptionsChange: onOptionsChangeMock,
+        },
+    });
+
+    beforeEach(() => {
+        // Mock console.error to suppress React act() warnings
+        consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+        jest.clearAllMocks();
+    });
+
+    afterEach(() => {
+        consoleSpy.mockRestore();
+    });
+
+    it('renders nothing when protocol is not HTTP', () => {
+        render(
+            <HttpProtocolSettingsSection
+            {...defaultProps}
+            options={{
+                ...defaultProps.options,
+                jsonData: { ...defaultProps.options.jsonData, protocol: Protocol.Native },
+            }}
+            onSwitchToggle={jest.fn()}
+            />
+        );
+
+        expect(screen.queryByLabelText(/path/i)).toBeNull();
+        expect(screen.queryByRole('button', { name: /optional http settings/i })).toBeNull();
+    });
+
+    it('calls onOptionsChange when HTTP path is changed', () => {
+        render(<HttpProtocolSettingsSection {...defaultProps} onSwitchToggle={jest.fn()} />);
+
+        const pathInput = screen.getByLabelText(/path/i);
+        fireEvent.change(pathInput, { target: { value: '/api' } });
+
+        expect(onOptionsChangeMock).toHaveBeenCalled();
+    });
+
+    it('toggles Optional HTTP settings open/closed via the button (icon changes)', () => {
+        render(<HttpProtocolSettingsSection {...defaultProps} onSwitchToggle={jest.fn()} />);
+
+        // Closed by default - angle-right icon visible
+        expect(screen.getByTestId('angle-right')).toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole('button', { name: /optional http settings/i }));
+
+        // Now open - angle-down icon visible
+        expect(screen.getByTestId('angle-down')).toBeInTheDocument();
+    });
+
+    it('calls onSwitchToggle with forwardGrafanaHeaders=true when toggled', () => {
+        const onSwitchToggleMock = jest.fn();
+
+        render(<HttpProtocolSettingsSection {...defaultProps} onSwitchToggle={onSwitchToggleMock}/>);
+
+        fireEvent.click(screen.getByRole('button', { name: /optional http settings/i }));
+        const forwardHeadersSwitch = screen.getByRole('checkbox', { name: /toggle switch/i });
+        fireEvent.click(forwardHeadersSwitch);
+
+        expect(onSwitchToggleMock).toHaveBeenLastCalledWith('forwardGrafanaHeaders', true);
+    });
+});

--- a/src/views/config-v2/HttpProtocolSettingsSection.tsx
+++ b/src/views/config-v2/HttpProtocolSettingsSection.tsx
@@ -1,0 +1,71 @@
+import React, { useState } from 'react';
+import { DataSourcePluginOptionsEditorProps, onUpdateDatasourceJsonDataOption } from '@grafana/data';
+import { Field, Input, Button, useTheme2 } from '@grafana/ui';
+import { HttpHeadersConfig } from 'components/configEditor/HttpHeadersConfig';
+import allLabels from './labels';
+import { CHConfig, CHSecureConfig, Protocol } from 'types/config';
+import { css } from '@emotion/css';
+import { onHttpHeadersChange } from 'views/CHConfigEditorHooks';
+
+export interface HttpProtocolSettingsSectionProps
+  extends DataSourcePluginOptionsEditorProps<CHConfig, CHSecureConfig> {
+  onSwitchToggle: (
+    key: keyof Pick<
+      CHConfig,
+      'secure' | 'validateSql' | 'enableSecureSocksProxy' | 'forwardGrafanaHeaders' | 'enableRowLimit'
+    >,
+    value: boolean
+  ) => void;
+}
+
+export const HttpProtocolSettingsSection = (props: HttpProtocolSettingsSectionProps) => {
+  const { options, onOptionsChange, onSwitchToggle } = props;
+  const { jsonData, secureJsonFields } = options;
+  const labels = allLabels.components.Config.ConfigEditor;
+
+  const [optionalHttpIsOpen, setOptionalHttpIsOpen] = useState(
+    Boolean(jsonData.httpHeaders?.length || jsonData.forwardGrafanaHeaders)
+  );
+
+  const theme = useTheme2();
+  const styles = {
+    httpSettingsSection: css({ marginTop: theme.spacing(2) }),
+    httpSettingsButton: css({ marginBottom: theme.spacing(2) }),
+  };
+
+  return jsonData.protocol === Protocol.Http ? (
+    <div className={styles.httpSettingsSection}>
+      <Field label={labels.path.label} description={labels.path.tooltip}>
+        <Input
+          value={jsonData.path ?? '/'}
+          name="path"
+          onChange={onUpdateDatasourceJsonDataOption(props, 'path')}
+          aria-label={labels.path.label}
+          placeholder={labels.path.placeholder}
+        />
+      </Field>
+      <Button
+        icon={optionalHttpIsOpen ? 'angle-down' : 'angle-right'}
+        size="sm"
+        variant="secondary"
+        onClick={() => setOptionalHttpIsOpen(!optionalHttpIsOpen)}
+        className={styles.httpSettingsButton}
+      >
+        Optional HTTP settings
+      </Button>
+      {optionalHttpIsOpen && (
+        <HttpHeadersConfig
+          headers={jsonData.httpHeaders}
+          forwardGrafanaHeaders={jsonData.forwardGrafanaHeaders}
+          secureFields={secureJsonFields}
+          onHttpHeadersChange={(headers) =>
+            onHttpHeadersChange(headers, options, onOptionsChange)
+          }
+          onForwardGrafanaHeadersChange={(forward) =>
+            onSwitchToggle('forwardGrafanaHeaders', forward)
+          }
+        />
+      )}
+    </div>
+  ) : null;
+};

--- a/src/views/config-v2/LeftSidebar.test.tsx
+++ b/src/views/config-v2/LeftSidebar.test.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+import { LeftSidebar } from './LeftSidebar';
+import { CONFIG_SECTION_HEADERS, CONFIG_SECTION_HEADERS_WITH_PDC } from './constants';
+
+describe('LeftSidebar', () => {
+    let consoleSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+            // Mock console.error to suppress React act() warnings
+            consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+            jest.clearAllMocks();
+    });
+
+    afterEach(() => {
+        consoleSpy.mockRestore();
+    });
+
+    it('renders all default headers when pdcInjected is false', () => {
+        render(<LeftSidebar pdcInjected={false} />);
+
+        CONFIG_SECTION_HEADERS.forEach((header) => {
+            expect(screen.getByTestId(`${header.label}-sidebar`)).toBeInTheDocument();
+            expect(screen.getByText(header.label)).toBeInTheDocument();
+        });
+    });
+
+    it('renders all PDC headers when pdcInjected is true', () => {
+        render(<LeftSidebar pdcInjected={true} />);
+
+        CONFIG_SECTION_HEADERS_WITH_PDC.forEach((header) => {
+            expect(screen.getByTestId(`${header.label}-sidebar`)).toBeInTheDocument();
+            expect(screen.getByText(header.label)).toBeInTheDocument();
+        });
+    });
+
+    it('shows optional text for optional headers', () => {
+        render(<LeftSidebar pdcInjected={false} />);
+
+        CONFIG_SECTION_HEADERS.filter((h) => h.isOptional).forEach((header) => {
+            expect(
+            screen.getByTestId(`${header.label}-sidebar`).querySelector('div')
+            ).toHaveTextContent(/optional/i);
+        });
+    });
+
+    it('calls scrollIntoView when link is clicked', () => {
+        render(<LeftSidebar pdcInjected={false} />);
+        const firstHeader = CONFIG_SECTION_HEADERS[0];
+
+        // add a fake target element with scrollIntoView defined
+        const target = document.createElement('div');
+        target.id = firstHeader.id;
+        target.scrollIntoView = jest.fn();
+        document.body.appendChild(target);
+
+        fireEvent.click(screen.getByText(firstHeader.label));
+
+        expect(target.scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth', block: 'start' });
+
+        document.body.removeChild(target);
+    });
+});

--- a/src/views/config-v2/LeftSidebar.tsx
+++ b/src/views/config-v2/LeftSidebar.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { Box, InlineField, LinkButton, Space, Stack, Text, useStyles2 } from '@grafana/ui';
+import { CONFIG_SECTION_HEADERS, CONFIG_SECTION_HEADERS_WITH_PDC } from './constants';
+import { css } from '@emotion/css';
+import type { GrafanaTheme2 } from '@grafana/data';
+
+interface LeftSidebarProps {
+  pdcInjected: boolean;
+}
+
+export const LeftSidebar = ({ pdcInjected }: LeftSidebarProps) => {
+  const headers = pdcInjected ? CONFIG_SECTION_HEADERS_WITH_PDC : CONFIG_SECTION_HEADERS;
+  const styles = useStyles2(getStyles);
+
+  return (
+    <Stack>
+      <Box flex={1} marginY={10}>
+        <Box height="75px"></Box>
+        <Text element="h4">Connect data source</Text>
+        <Box paddingTop={2}>
+          {headers.map((header, index) => (
+            <div key={index} data-testid={`${header.label}-sidebar`}>
+              <InlineField label={`${index + 1}`} className={styles.inlineField} labelWidth={3} grow>
+                <LinkButton
+                  variant="secondary"
+                  fill="text"
+                  onClick={(e) => {
+                    e.preventDefault();
+                    const target = document.getElementById(header.id);
+                    if (target) {
+                      target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+                    }
+                  }}
+                >
+                <div className={styles.sidebarText}>
+                    <div className={styles.sidebarLabel}>
+                      {header.label}
+                    </div>
+                    {header.isOptional && (
+                      <div className={styles.sidebarOptional}>
+                        <Text color="secondary" variant="bodySmall">
+                          optional
+                        </Text>
+                      </div>
+                    )}
+                </div>                
+                </LinkButton>
+              </InlineField>
+              <Space v={1} />
+            </div>
+          ))}
+        </Box>
+      </Box>
+    </Stack>
+  );
+};
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  inlineField: css({
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+  }),
+  sidebarText: css({
+    display: 'flex',
+    flexDirection: 'column',
+  }),
+  sidebarLabel: css({
+    display: 'flex', 
+    alignItems: 'center', 
+    justifyContent: 'center',
+    marginBottom: 0, 
+    lineHeight: 1,
+  }),
+  sidebarOptional: css({
+    marginTop: 0, 
+    marginBottom: 0, 
+    lineHeight: 1,
+  }),
+});
+

--- a/src/views/config-v2/RemainingConfigCode.tsx
+++ b/src/views/config-v2/RemainingConfigCode.tsx
@@ -1,0 +1,391 @@
+import { Field, CertificationKey, Switch, Input, SecretInput, Button, Divider, Stack } from '@grafana/ui';
+import { ConfigSection, ConfigSubSection } from 'components/experimental/ConfigSection';
+import allLabels from './labels';
+import React, { ChangeEvent, useState } from 'react';
+import { DataSourcePluginOptionsEditorProps, onUpdateDatasourceJsonDataOption, onUpdateDatasourceSecureJsonDataOption } from '@grafana/data';
+import { AliasTableEntry, CHConfig, CHCustomSetting, CHLogsConfig, CHSecureConfig, CHTracesConfig } from 'types/config';
+import { AliasTableConfig } from 'components/configEditor/AliasTableConfig';
+import { DefaultDatabaseTableConfig } from 'components/configEditor/DefaultDatabaseTableConfig';
+import { LogsConfig } from 'components/configEditor/LogsConfig';
+import { QuerySettingsConfig } from 'components/configEditor/QuerySettingsConfig';
+import { TracesConfig } from 'components/configEditor/TracesConfig';
+import { config } from '@grafana/runtime';
+import { TimeUnit } from 'types/queryBuilder';
+import { useConfigDefaults } from 'views/CHConfigEditorHooks';
+import { gte as versionGte } from 'semver';
+
+export interface Props extends DataSourcePluginOptionsEditorProps<CHConfig, CHSecureConfig> {}
+
+// This code will be formatted into the new design in future iterations
+export const RemainingConfigCode = (props: Props) => {
+    const { options, onOptionsChange } = props;
+    const { jsonData, secureJsonFields } = options;
+    const labels = allLabels.components.Config.ConfigEditor;
+    const secureJsonData = (options.secureJsonData || {}) as CHSecureConfig;
+    const hasTLSCACert = secureJsonFields && secureJsonFields.tlsCACert;
+    const hasTLSClientCert = secureJsonFields && secureJsonFields.tlsClientCert;
+    const hasTLSClientKey = secureJsonFields && secureJsonFields.tlsClientKey;
+
+    useConfigDefaults(options, onOptionsChange);
+
+    const hasAdditionalSettings = Boolean(
+        window.location.hash || // if trying to link to section on page, open all settings (React breaks this?)
+        options.jsonData.defaultDatabase ||
+        options.jsonData.defaultTable ||
+        options.jsonData.dialTimeout ||
+        options.jsonData.queryTimeout ||
+        options.jsonData.validateSql ||
+        options.jsonData.enableSecureSocksProxy ||
+        options.jsonData.customSettings ||
+        options.jsonData.logs ||
+        options.jsonData.traces
+    );
+
+    const [customSettings, setCustomSettings] = useState(jsonData.customSettings || []);
+    
+    const onSwitchToggle = (
+        key: keyof Pick<
+          CHConfig,
+          'secure' | 'validateSql' | 'enableSecureSocksProxy' | 'forwardGrafanaHeaders' | 'enableRowLimit'
+        >,
+        value: boolean
+      ) => {
+        onOptionsChange({
+          ...options,
+          jsonData: {
+            ...options.jsonData,
+            [key]: value,
+          },
+        });
+      };
+
+    const onTLSSettingsChange = (
+        key: keyof Pick<CHConfig, 'tlsSkipVerify' | 'tlsAuth' | 'tlsAuthWithCACert'>,
+        value: boolean
+      ) => {
+        onOptionsChange({
+          ...options,
+          jsonData: {
+            ...options.jsonData,
+            [key]: value,
+          },
+        });
+      };
+
+    const onCertificateChangeFactory = (key: keyof Omit<CHSecureConfig, 'password'>, value: string) => {
+        onOptionsChange({
+        ...options,
+        secureJsonData: {
+            ...secureJsonData,
+            [key]: value,
+        },
+        });
+    };
+    const onResetClickFactory = (key: keyof Omit<CHSecureConfig, 'password'>) => {
+        onOptionsChange({
+        ...options,
+        secureJsonFields: {
+            ...secureJsonFields,
+            [key]: false,
+        },
+        secureJsonData: {
+            ...secureJsonData,
+            [key]: '',
+        },
+        });
+    };
+
+    const onResetPassword = () => {
+        onOptionsChange({
+        ...options,
+        secureJsonFields: {
+            ...options.secureJsonFields,
+            password: false,
+        },
+        secureJsonData: {
+            ...options.secureJsonData,
+            password: '',
+        },
+        });
+    };
+
+    const onLogsConfigChange = (key: keyof CHLogsConfig, value: string | boolean | string[]) => {
+        onOptionsChange({
+          ...options,
+          jsonData: {
+            ...options.jsonData,
+            logs: {
+              ...options.jsonData.logs,
+              [key]: value
+            }
+          }
+        });
+      };
+      
+      const onTracesConfigChange = (key: keyof CHTracesConfig, value: string | boolean) => {
+        onOptionsChange({
+          ...options,
+          jsonData: {
+            ...options.jsonData,
+            traces: {
+              ...options.jsonData.traces,
+              durationUnit: options.jsonData.traces?.durationUnit || TimeUnit.Nanoseconds,
+              [key]: value
+            }
+          }
+        });
+      };
+
+    const onAliasTableConfigChange = (aliasTables: AliasTableEntry[]) => {
+        onOptionsChange({
+        ...options,
+        jsonData: {
+            ...options.jsonData,
+            aliasTables
+        }
+        });
+    };
+
+    const onCustomSettingsChange = (customSettings: CHCustomSetting[]) => {
+        onOptionsChange({
+            ...options,
+            jsonData: {
+            ...options.jsonData,
+            customSettings: customSettings.filter((s) => !!s.setting && !!s.value),
+            },
+        });
+    };
+
+    return (
+        <div>
+            <ConfigSection title="TLS / SSL Settings">
+        <Field
+          label={labels.tlsSkipVerify.label}
+          description={labels.tlsSkipVerify.tooltip}
+        >
+          <Switch
+            className="gf-form"
+            value={jsonData.tlsSkipVerify || false}
+            onChange={(e) => onTLSSettingsChange('tlsSkipVerify', e.currentTarget.checked)}
+          />
+        </Field>
+        <Field
+          label={labels.tlsClientAuth.label}
+          description={labels.tlsClientAuth.tooltip}
+        >
+          <Switch
+            className="gf-form"
+            value={jsonData.tlsAuth || false}
+            onChange={(e) => onTLSSettingsChange('tlsAuth', e.currentTarget.checked)}
+          />
+        </Field>
+        <Field
+          label={labels.tlsAuthWithCACert.label}
+          description={labels.tlsAuthWithCACert.tooltip}
+        >
+          <Switch
+            className="gf-form"
+            value={jsonData.tlsAuthWithCACert || false}
+            onChange={(e) => onTLSSettingsChange('tlsAuthWithCACert', e.currentTarget.checked)}
+          />
+        </Field>
+        {jsonData.tlsAuthWithCACert && (
+          <CertificationKey
+            hasCert={!!hasTLSCACert}
+            onChange={(e) => onCertificateChangeFactory('tlsCACert', e.currentTarget.value)}
+            placeholder={labels.tlsCACert.placeholder}
+            label={labels.tlsCACert.label}
+            onClick={() => onResetClickFactory('tlsCACert')}
+          />
+        )}
+        {jsonData.tlsAuth && (
+          <>
+            <CertificationKey
+              hasCert={!!hasTLSClientCert}
+              onChange={(e) => onCertificateChangeFactory('tlsClientCert', e.currentTarget.value)}
+              placeholder={labels.tlsClientCert.placeholder}
+              label={labels.tlsClientCert.label}
+              onClick={() => onResetClickFactory('tlsClientCert')}
+            />
+            <CertificationKey
+              hasCert={!!hasTLSClientKey}
+              placeholder={labels.tlsClientKey.placeholder}
+              label={labels.tlsClientKey.label}
+              onChange={(e) => onCertificateChangeFactory('tlsClientKey', e.currentTarget.value)}
+              onClick={() => onResetClickFactory('tlsClientKey')}
+            />
+          </>
+        )}
+      </ConfigSection>
+      <ConfigSection title="Credentials">
+        <Field
+          label={labels.username.label}
+          description={labels.username.tooltip}
+        >
+          <Input
+            name="user"
+            width={40}
+            value={jsonData.username || ''}
+            onChange={onUpdateDatasourceJsonDataOption(props, 'username')}
+            label={labels.username.label}
+            aria-label={labels.username.label}
+            placeholder={labels.username.placeholder}
+          />
+        </Field>
+        <Field label={labels.password.label} description={labels.password.tooltip}>
+          <SecretInput
+            name="pwd"
+            width={40}
+            label={labels.password.label}
+            aria-label={labels.password.label}
+            placeholder={labels.password.placeholder}
+            value={secureJsonData.password || ''}
+            isConfigured={(secureJsonFields && secureJsonFields.password) as boolean}
+            onReset={onResetPassword}
+            onChange={onUpdateDatasourceSecureJsonDataOption(props, 'password')}
+          />
+        </Field>
+      </ConfigSection>
+       <ConfigSection
+        title="Additional settings"
+        description="Additional settings are optional settings that can be configured for more control over your data source. This includes the default database, dial and query timeouts, SQL validation, and custom ClickHouse settings."
+        isCollapsible
+        isInitiallyOpen={hasAdditionalSettings}
+      >
+        <Divider />
+        <DefaultDatabaseTableConfig
+          defaultDatabase={jsonData.defaultDatabase}
+          defaultTable={jsonData.defaultTable}
+          onDefaultDatabaseChange={(e) => onUpdateDatasourceJsonDataOption(props, 'defaultDatabase')(e)}
+          onDefaultTableChange={(e) => onUpdateDatasourceJsonDataOption(props, 'defaultTable')(e)}
+        />
+        
+        <Divider />
+        <QuerySettingsConfig
+          connMaxLifetime={jsonData.connMaxLifetime}
+          dialTimeout={jsonData.dialTimeout}
+          maxIdleConns={jsonData.maxIdleConns}
+          maxOpenConns={jsonData.maxOpenConns}
+          queryTimeout={jsonData.queryTimeout}
+          validateSql={jsonData.validateSql}
+          onDialTimeoutChange={(e) => onUpdateDatasourceJsonDataOption(props, 'dialTimeout')(e)}
+          onQueryTimeoutChange={(e) => onUpdateDatasourceJsonDataOption(props, 'queryTimeout')(e)}
+          onConnMaxLifetimeChange={(e) => onUpdateDatasourceJsonDataOption(props, 'connMaxLifetime')(e)}
+          onConnMaxIdleConnsChange={(e) => onUpdateDatasourceJsonDataOption(props, 'maxIdleConns')(e)}
+          onConnMaxOpenConnsChange={(e) => onUpdateDatasourceJsonDataOption(props, 'maxOpenConns')(e)}
+          onValidateSqlChange={(e) => onUpdateDatasourceJsonDataOption(props, 'validateSql')(e)}
+        />
+
+        <Divider />
+        <LogsConfig
+          logsConfig={jsonData.logs}
+          onDefaultDatabaseChange={db => onLogsConfigChange('defaultDatabase', db)}
+          onDefaultTableChange={table => onLogsConfigChange('defaultTable', table)}
+          onOtelEnabledChange={v => onLogsConfigChange('otelEnabled', v)}
+          onOtelVersionChange={v => onLogsConfigChange('otelVersion', v)}
+          onTimeColumnChange={c => onLogsConfigChange('timeColumn', c)}
+          onLevelColumnChange={c => onLogsConfigChange('levelColumn', c)}
+          onMessageColumnChange={c => onLogsConfigChange('messageColumn', c)}
+          onSelectContextColumnsChange={c => onLogsConfigChange('selectContextColumns', c)}
+          onContextColumnsChange={c => onLogsConfigChange('contextColumns', c)}
+        />
+
+        <Divider />
+        <TracesConfig
+          tracesConfig={jsonData.traces}
+          onDefaultDatabaseChange={db => onTracesConfigChange('defaultDatabase', db)}
+          onDefaultTableChange={table => onTracesConfigChange('defaultTable', table)}
+          onOtelEnabledChange={v => onTracesConfigChange('otelEnabled', v)}
+          onOtelVersionChange={v => onTracesConfigChange('otelVersion', v)}
+          onTraceIdColumnChange={c => onTracesConfigChange('traceIdColumn', c)}
+          onSpanIdColumnChange={c => onTracesConfigChange('spanIdColumn', c)}
+          onOperationNameColumnChange={c => onTracesConfigChange('operationNameColumn', c)}
+          onParentSpanIdColumnChange={c => onTracesConfigChange('parentSpanIdColumn', c)}
+          onServiceNameColumnChange={c => onTracesConfigChange('serviceNameColumn', c)}
+          onDurationColumnChange={c => onTracesConfigChange('durationColumn', c)}
+          onDurationUnitChange={c => onTracesConfigChange('durationUnit', c)}
+          onStartTimeColumnChange={c => onTracesConfigChange('startTimeColumn', c)}
+          onTagsColumnChange={c => onTracesConfigChange('tagsColumn', c)}
+          onServiceTagsColumnChange={c => onTracesConfigChange('serviceTagsColumn', c)}
+          onKindColumnChange={c => onTracesConfigChange('kindColumn', c)}
+          onStatusCodeColumnChange={c => onTracesConfigChange('statusCodeColumn', c)}
+          onStatusMessageColumnChange={c => onTracesConfigChange('statusMessageColumn', c)}
+          onStateColumnChange={c => onTracesConfigChange('stateColumn', c)}
+          onInstrumentationLibraryNameColumnChange={c => onTracesConfigChange('instrumentationLibraryNameColumn', c)}
+          onInstrumentationLibraryVersionColumnChange={c => onTracesConfigChange('instrumentationLibraryVersionColumn', c)}
+          onFlattenNestedChange={c => onTracesConfigChange('flattenNested', c)}
+          onEventsColumnPrefixChange={c => onTracesConfigChange('traceEventsColumnPrefix', c)}
+          onLinksColumnPrefixChange={c => onTracesConfigChange('traceLinksColumnPrefix', c)}
+        />
+
+        <Divider />
+        <AliasTableConfig aliasTables={jsonData.aliasTables} onAliasTablesChange={onAliasTableConfigChange} />
+        <Divider />
+        <Field label={labels.enableRowLimit.label} description={labels.enableRowLimit.tooltip}>
+          <Switch
+            className="gf-form"
+            value={jsonData.enableRowLimit || false}
+            data-testid={labels.enableRowLimit.testid}
+            onChange={(e) => onSwitchToggle('enableRowLimit', e.currentTarget.checked)}
+          />
+        </Field>
+        {config.secureSocksDSProxyEnabled && versionGte(config.buildInfo.version, '10.0.0') && (
+          <Field
+            label={labels.secureSocksProxy.label}
+            description={labels.secureSocksProxy.tooltip}
+          >
+            <Switch
+              className="gf-form"
+              value={jsonData.enableSecureSocksProxy || false}
+              onChange={(e) => onSwitchToggle('enableSecureSocksProxy', e.currentTarget.checked)}
+            />
+          </Field>
+        )}
+        <ConfigSubSection title="Custom Settings">
+          {customSettings.map(({ setting, value }, i) => {
+            return (
+              <Stack key={i} direction='row'>
+                <Field label={`Setting`} aria-label={`Setting`}>
+                  <Input
+                    value={setting}
+                    placeholder={'Setting'}
+                    onChange={(changeEvent: ChangeEvent<HTMLInputElement>) => {
+                      let newSettings = customSettings.concat();
+                      newSettings[i] = { setting: changeEvent.target.value, value };
+                      setCustomSettings(newSettings);
+                    }}
+                    onBlur={() => onCustomSettingsChange(customSettings)}
+                  ></Input>
+                </Field>
+                <Field label={'Value'} aria-label={`Value`}>
+                  <Input
+                    value={value}
+                    placeholder={'Value'}
+                    onChange={(changeEvent: ChangeEvent<HTMLInputElement>) => {
+                      let newSettings = customSettings.concat();
+                      newSettings[i] = { setting, value: changeEvent.target.value };
+                      setCustomSettings(newSettings);
+                    }}
+                    onBlur={() => {
+                      onCustomSettingsChange(customSettings);
+                    }}
+                  ></Input>
+                </Field>
+              </Stack>
+            );
+          })}
+          <Button
+            variant="secondary"
+            icon="plus"
+            type="button"
+            onClick={() => {
+              setCustomSettings([...customSettings, { setting: '', value: '' }]);
+            }}
+          >
+            Add custom setting
+          </Button>
+        </ConfigSubSection>
+      </ConfigSection>
+        </div>
+    )
+};

--- a/src/views/config-v2/ServerAndEncryptionSection.test.tsx
+++ b/src/views/config-v2/ServerAndEncryptionSection.test.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+import { ServerAndEncryptionSection } from './ServerAndEncryptionSection';
+import { createTestProps } from './helpers';
+import { Protocol } from 'types/config';
+
+describe('ServerAndEncryptionSection', () => {
+  const onOptionsChangeMock = jest.fn();
+  let consoleSpy: jest.SpyInstance;
+
+  const defaultProps = createTestProps({
+    options: {
+        jsonData: {
+        host: '',
+        secure: false,
+        protocol: Protocol.Native,
+        port: undefined,
+        pdcInjected: false,
+        },
+        secureJsonData: {},
+        secureJsonFields: {},
+    },
+    mocks: {
+      onOptionsChange: onOptionsChangeMock,
+    },
+  });
+
+  beforeEach(() => {
+    // Mock console.error to suppress React act() warnings
+    consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+  });
+
+  it('calls onOptionsChange when server host address is changed', () => {
+    render(<ServerAndEncryptionSection {...defaultProps} />);
+
+    const input = screen.getByTestId('clickhouse-v2-config-host-input');
+    fireEvent.change(input, { target: { value: 'clickhouse-example.com' } });
+
+    expect(onOptionsChangeMock).toHaveBeenCalled();
+  }); 
+
+  it('updates protocol on radio toggle', () => {
+    render(<ServerAndEncryptionSection {...defaultProps} />);
+
+    const httpOption = screen.getByRole('radio', { name: /http/i });
+    fireEvent.click(httpOption);
+
+    expect(onOptionsChangeMock).toHaveBeenCalled();
+    expect(onOptionsChangeMock.mock.lastCall[0].jsonData.protocol).toBe(Protocol.Http);
+  });
+
+  it('calls onOptionsChange when server port is changed', () => {
+    render(<ServerAndEncryptionSection {...defaultProps} />);
+
+    const input = screen.getByTestId('clickhouse-v2-config-port-input');
+    fireEvent.change(input, { target: { value: 9000 } });
+
+    expect(onOptionsChangeMock).toHaveBeenCalled();
+  });
+
+    it('updates secure state on switch toggle', async () => {
+        render(<ServerAndEncryptionSection {...defaultProps} />);
+
+        const secureSwitch = screen.getByRole('checkbox', { name: /toggle switch/i });
+        await fireEvent.click(secureSwitch);
+
+        expect(onOptionsChangeMock).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+                jsonData: expect.objectContaining({ secure: true }),
+            })
+        );
+    });
+});
+
+

--- a/src/views/config-v2/ServerAndEncryptionSection.test.tsx
+++ b/src/views/config-v2/ServerAndEncryptionSection.test.tsx
@@ -67,7 +67,7 @@ describe('ServerAndEncryptionSection', () => {
     it('updates secure state on switch toggle', async () => {
         render(<ServerAndEncryptionSection {...defaultProps} />);
 
-        const secureSwitch = screen.getByRole('checkbox', { name: /toggle switch/i });
+        const secureSwitch = screen.getByRole('checkbox', { name: /secure connection/i });
         await fireEvent.click(secureSwitch);
 
         expect(onOptionsChangeMock).toHaveBeenLastCalledWith(

--- a/src/views/config-v2/ServerAndEncryptionSection.tsx
+++ b/src/views/config-v2/ServerAndEncryptionSection.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { DataSourcePluginOptionsEditorProps, GrafanaTheme2, onUpdateDatasourceJsonDataOption } from "@grafana/data";
-import { Box, CollapsableSection, TextLink, Field, Input, Toggletip, IconButton, RadioButtonGroup, InlineField, InlineSwitch, Text, useStyles2 } from "@grafana/ui";
+import { Box, CollapsableSection, TextLink, Field, Input, Toggletip, IconButton, RadioButtonGroup, Text, useStyles2, Checkbox } from "@grafana/ui";
 import allLabels from './labels';
 import { CHConfig, CHSecureConfig, Protocol } from "types/config";
 import { CONFIG_SECTION_HEADERS, CONTAINER_MIN_WIDTH, PROTOCOL_OPTIONS } from "./constants";
@@ -158,7 +158,11 @@ export const ServerAndEncryptionSection = (props: Props) => {
             </div>
           </div>
             <div className={styles.secureToggle}>
-             <InlineField label={labels.secure.label} tooltip={labels.secure.tooltip}>
+              <Checkbox label={labels.secure.label} description={labels.secure.description} checked={jsonData.secure || false} onChange={(e) => {
+                trackClickhouseConfigV2SecureConnectionToggleClicked({ secureConnection: e.currentTarget.checked  });
+                onSwitchToggle('secure', e.currentTarget.checked);
+              }} />
+             {/* <InlineField label={labels.secure.label} tooltip={labels.secure.tooltip}>
                 <InlineSwitch
                 value={jsonData.secure || false}
                 onChange={(e) => {
@@ -166,7 +170,7 @@ export const ServerAndEncryptionSection = (props: Props) => {
                   onSwitchToggle('secure', e.currentTarget.checked);
                 }}                
                 />
-            </InlineField>
+            </InlineField> */}
           </div>
           <HttpProtocolSettingsSection onSwitchToggle={onSwitchToggle} {...props} />
         </CollapsableSection>

--- a/src/views/config-v2/ServerAndEncryptionSection.tsx
+++ b/src/views/config-v2/ServerAndEncryptionSection.tsx
@@ -1,0 +1,208 @@
+import React from "react";
+import { DataSourcePluginOptionsEditorProps, GrafanaTheme2, onUpdateDatasourceJsonDataOption } from "@grafana/data";
+import { Box, CollapsableSection, TextLink, Field, Input, Toggletip, IconButton, RadioButtonGroup, InlineField, InlineSwitch, Text, useStyles2 } from "@grafana/ui";
+import allLabels from './labels';
+import { CHConfig, CHSecureConfig, Protocol } from "types/config";
+import { CONFIG_SECTION_HEADERS, CONTAINER_MIN_WIDTH, PROTOCOL_OPTIONS } from "./constants";
+import { css } from "@emotion/css";
+import { trackClickhouseConfigV2HostInput, trackClickhouseConfigV2PortInput, trackClickhouseConfigV2SecureConnectionToggleClicked } from './tracking';
+import { HttpProtocolSettingsSection } from "./HttpProtocolSettingsSection";
+
+export interface Props extends DataSourcePluginOptionsEditorProps<CHConfig, CHSecureConfig> {}
+
+export const ServerAndEncryptionSection = (props: Props) => {
+    const { options, onOptionsChange } = props;
+    const { jsonData } = options;
+    const labels = allLabels.components.Config.ConfigEditor;
+    const defaultPort = jsonData.secure
+    ? jsonData.protocol === Protocol.Native
+        ? labels.serverPort.secureNativePort
+        : labels.serverPort.secureHttpPort
+    : jsonData.protocol === Protocol.Native
+        ? labels.serverPort.insecureNativePort
+        : labels.serverPort.insecureHttpPort;
+    const portDescription = `${labels.serverPort.tooltip} (default for ${jsonData.secure ? 'secure' : ''} ${jsonData.protocol}: ${defaultPort})`;
+    const styles = useStyles2(getStyles); 
+    
+    const onProtocolToggle = (protocol: Protocol) => {
+        onOptionsChange({
+            ...options,
+            jsonData: {
+            ...options.jsonData,
+            protocol: protocol,
+            },
+        });
+    };
+
+    const onPortChange = (port: string) => {
+        onOptionsChange({
+            ...options,
+            jsonData: {
+            ...options.jsonData,
+            port: +port,
+            },
+        });
+    };
+
+    const onSwitchToggle = (
+        key: keyof Pick<
+        CHConfig,
+        'secure' | 'validateSql' | 'enableSecureSocksProxy' | 'forwardGrafanaHeaders' | 'enableRowLimit'
+        >,
+        value: boolean
+    ) => {
+        onOptionsChange({
+        ...options,
+        jsonData: {
+            ...options.jsonData,
+            [key]: value,
+        },
+        });
+    };
+    
+    return (
+        <Box
+            borderStyle="solid"
+            borderColor="weak"
+            padding={2}
+            marginBottom={4}
+            id={`${CONFIG_SECTION_HEADERS[0].id}`}
+            minWidth={CONTAINER_MIN_WIDTH}
+        >
+        <CollapsableSection
+          label={<Text variant="h3">1. {CONFIG_SECTION_HEADERS[0].label}</Text>}
+          isOpen={CONFIG_SECTION_HEADERS[0].isOpen}
+        >
+          <Text variant="body" color="secondary">
+            Enter the server address of your Clickhouse instance. Then select your protocol, port and security options.
+            If you need further guidance, visit the{' '}
+            <TextLink
+              href="https://grafana.com/grafana/plugins/grafana-clickhouse-datasource/"
+              icon="external-link-alt"
+              external
+            >
+              Grafana docs
+            </TextLink>
+          </Text>
+          <Field required label={labels.serverAddress.label} style={{ marginTop: '20px' }}>
+            <Input
+              name="host"
+              value={jsonData.host || ''}
+              onChange={(e) => onUpdateDatasourceJsonDataOption(props, 'host')(e)}
+              label={labels.serverAddress.label}
+              aria-label={labels.serverAddress.label}
+              data-testid='clickhouse-v2-config-host-input'
+              placeholder={labels.serverAddress.placeholder}
+              onBlur={trackClickhouseConfigV2HostInput}
+            />
+          </Field>
+          <div className={styles.protocolPortRow}>
+            <div className={styles.protocolSection}>
+              <div className={styles.protocolLabel}>
+                <Text variant="bodySmall" weight="bold">
+                  {labels.protocol.label}
+                </Text>
+                <Toggletip
+                  theme="info"
+                  placement="top"
+                  content={
+                    <div className={styles.toggleTipText}>
+                      <Text>
+                        ClickHouse supports two server protocols: Native TCP and HTTP. Both protocols can be secured
+                        with TLS.
+                        <br />
+                        <br />
+                        <TextLink href="https://clickhouse.com/docs/interfaces/tcp" variant="bodySmall" external>
+                          Native TCP
+                        </TextLink>{' '}
+                        is the default and recommended option.
+                        <br />
+                        <TextLink href="https://clickhouse.com/docs/interfaces/http" variant="bodySmall" external>
+                          HTTP
+                        </TextLink>{' '}
+                        is for servers configured to accept HTTP connections.
+                      </Text>
+                    </div>
+                  }
+                >
+                  <IconButton
+                    name="question-circle"
+                    aria-label="More info about Protocol"
+                    size="xs"
+                    className={styles.toggletipIcon}
+                  />
+                </Toggletip>
+              </div>
+              <Field label=" " description={<div className={styles.toggleTipText}>{labels.protocol.description}</div>}>
+                <RadioButtonGroup<Protocol>
+                  options={PROTOCOL_OPTIONS}
+                  value={jsonData.protocol || Protocol.Native}
+                  onChange={(e) => onProtocolToggle(e!)}
+                />
+              </Field>
+            </div>
+            <div className={styles.portSection}>
+              <Field required label={labels.serverPort.label} description={portDescription}>
+                <Input
+                  name="port"
+                  type="number"
+                  value={jsonData.port || ''}
+                  onChange={(e) => onPortChange(e.currentTarget.value)}
+                  label={labels.serverPort.label}
+                  aria-label={labels.serverPort.label}
+                  placeholder={defaultPort}
+                  onBlur={(e) => trackClickhouseConfigV2PortInput({ port: e.currentTarget.value })}
+                />
+              </Field>
+            </div>
+          </div>
+            <div className={styles.secureToggle}>
+             <InlineField label={labels.secure.label} tooltip={labels.secure.tooltip}>
+                <InlineSwitch
+                value={jsonData.secure || false}
+                onChange={(e) => {
+                  trackClickhouseConfigV2SecureConnectionToggleClicked({ secureConnection: e.currentTarget.checked  });
+                  onSwitchToggle('secure', e.currentTarget.checked);
+                }}                
+                />
+            </InlineField>
+          </div>
+          <HttpProtocolSettingsSection onSwitchToggle={onSwitchToggle} {...props} />
+        </CollapsableSection>
+      </Box>
+    )
+};
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  protocolPortRow: css({
+    display: 'flex',
+    alignItems: 'center',
+  }),
+  protocolLabel: css({
+    display: 'flex',
+    height: 15,
+    width: '205px'
+  }),
+  protocolSection: css({
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'center',
+    gap: theme.spacing(0),
+    marginRight: theme.spacing(5),
+  }),
+  toggletipIcon: css({
+    marginLeft: theme.spacing(0.5),
+    padding: 0,
+  }),
+  portSection: css({
+    width: '100%',
+  }),
+  toggleTipText: css({
+    whiteSpace: 'pre-line',
+  }),
+  secureToggle: css({
+    display: 'flex',
+    alignItems: 'center',
+    marginTop: theme.spacing(1),
+  }),
+});

--- a/src/views/config-v2/ServerAndEncryptionSection.tsx
+++ b/src/views/config-v2/ServerAndEncryptionSection.tsx
@@ -162,15 +162,6 @@ export const ServerAndEncryptionSection = (props: Props) => {
                 trackClickhouseConfigV2SecureConnectionToggleClicked({ secureConnection: e.currentTarget.checked  });
                 onSwitchToggle('secure', e.currentTarget.checked);
               }} />
-             {/* <InlineField label={labels.secure.label} tooltip={labels.secure.tooltip}>
-                <InlineSwitch
-                value={jsonData.secure || false}
-                onChange={(e) => {
-                  trackClickhouseConfigV2SecureConnectionToggleClicked({ secureConnection: e.currentTarget.checked  });
-                  onSwitchToggle('secure', e.currentTarget.checked);
-                }}                
-                />
-            </InlineField> */}
           </div>
           <HttpProtocolSettingsSection onSwitchToggle={onSwitchToggle} {...props} />
         </CollapsableSection>

--- a/src/views/config-v2/ServerAndEncryptionSection.tsx
+++ b/src/views/config-v2/ServerAndEncryptionSection.tsx
@@ -150,6 +150,7 @@ export const ServerAndEncryptionSection = (props: Props) => {
                   onChange={(e) => onPortChange(e.currentTarget.value)}
                   label={labels.serverPort.label}
                   aria-label={labels.serverPort.label}
+                  data-testid='clickhouse-v2-config-port-input'
                   placeholder={defaultPort}
                   onBlur={(e) => trackClickhouseConfigV2PortInput({ port: e.currentTarget.value })}
                 />

--- a/src/views/config-v2/ServerAndEncryptionSection.tsx
+++ b/src/views/config-v2/ServerAndEncryptionSection.tsx
@@ -129,7 +129,7 @@ export const ServerAndEncryptionSection = (props: Props) => {
                     name="question-circle"
                     aria-label="More info about Protocol"
                     size="xs"
-                    className={styles.toggletipIcon}
+                    className={styles.toggleTipIcon}
                   />
                 </Toggletip>
               </div>
@@ -191,7 +191,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
     gap: theme.spacing(0),
     marginRight: theme.spacing(5),
   }),
-  toggletipIcon: css({
+  toggleTipIcon: css({
     marginLeft: theme.spacing(0.5),
     padding: 0,
   }),

--- a/src/views/config-v2/constants.ts
+++ b/src/views/config-v2/constants.ts
@@ -1,0 +1,50 @@
+import { css } from '@emotion/css';
+
+import { GrafanaTheme2 } from '@grafana/data';
+import { selectors } from '@grafana/e2e-selectors';
+import { Protocol } from 'types/config';
+
+export const DB_SETTINGS_LABEL_WIDTH = 18;
+export const CONTAINER_MIN_WIDTH = '450px';
+
+export const CONFIG_SECTION_HEADERS = [
+  { label: 'Server and encryption', id: 'server', isOpen: true },
+  { label: 'Credentials', id: 'credentials', isOpen: true },
+  { label: 'TLS/SSL settings', id: 'tls', isOpen: true },
+  { label: 'Additional settings', id: 'additional', isOpen: true },
+  { label: 'Save & test', id: `${selectors.pages.DataSource.saveAndTest}`, isOpen: true },
+];
+
+export const CONFIG_SECTION_HEADERS_WITH_PDC = [
+  { label: 'Server and encryption', id: 'server', isOpen: true },
+  { label: 'Credentials', id: 'credentials', isOpen: true },
+  { label: 'TLS/SSL settings', id: 'tls', isOpen: true },
+  { label: 'Additional settings', id: 'additional', isOpen: true },
+  { label: 'Private data source connect', id: 'pdc', isOpen: true },
+  { label: 'Save & test', id: `${selectors.pages.DataSource.saveAndTest}`, isOpen: true },
+];
+
+export const PROTOCOL_OPTIONS = [
+  { label: 'Native', value: Protocol.Native },
+  { label: 'HTTP', value: Protocol.Http },
+];
+
+export const getInlineLabelStyles = (theme: GrafanaTheme2, transparent = false, width?: number | 'auto') => {
+  return {
+    label: css({
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      flexShrink: 0,
+      padding: theme.spacing(0, 1),
+      backgroundColor: transparent ? 'transparent' : theme.colors.background.secondary,
+      height: theme.spacing(theme.components.height.md),
+      lineHeight: theme.spacing(theme.components.height.md),
+      marginRight: theme.spacing(0.5),
+      borderRadius: theme.shape.radius.default,
+      border: 'none',
+      width: '220px',
+      color: theme.colors.text.primary,
+    }),
+  };
+};

--- a/src/views/config-v2/constants.ts
+++ b/src/views/config-v2/constants.ts
@@ -8,20 +8,20 @@ export const DB_SETTINGS_LABEL_WIDTH = 18;
 export const CONTAINER_MIN_WIDTH = '450px';
 
 export const CONFIG_SECTION_HEADERS = [
-  { label: 'Server and encryption', id: 'server', isOpen: true },
-  { label: 'Credentials', id: 'credentials', isOpen: true },
-  { label: 'TLS/SSL settings', id: 'tls', isOpen: true },
-  { label: 'Additional settings', id: 'additional', isOpen: true },
-  { label: 'Save & test', id: `${selectors.pages.DataSource.saveAndTest}`, isOpen: true },
+  { label: 'Server and encryption', id: 'server', isOpen: true, isOptional: false },
+  { label: 'Credentials', id: 'credentials', isOpen: true, isOptional: false },
+  { label: 'TLS/SSL settings', id: 'tls', isOpen: true, isOptional: true },
+  { label: 'Additional settings', id: 'additional', isOpen: true, isOptional: true },
+  { label: 'Save & test', id: `${selectors.pages.DataSource.saveAndTest}`, isOpen: true, isOptional: null },
 ];
 
 export const CONFIG_SECTION_HEADERS_WITH_PDC = [
-  { label: 'Server and encryption', id: 'server', isOpen: true },
-  { label: 'Credentials', id: 'credentials', isOpen: true },
-  { label: 'TLS/SSL settings', id: 'tls', isOpen: true },
-  { label: 'Additional settings', id: 'additional', isOpen: true },
-  { label: 'Private data source connect', id: 'pdc', isOpen: true },
-  { label: 'Save & test', id: `${selectors.pages.DataSource.saveAndTest}`, isOpen: true },
+  { label: 'Server and encryption', id: 'server', isOpen: true, isOptional: false },
+  { label: 'Credentials', id: 'credentials', isOpen: true, isOptional: false },
+  { label: 'TLS/SSL settings', id: 'tls', isOpen: true, isOptional: true },
+  { label: 'Additional settings', id: 'additional', isOpen: true, isOptional: true },
+  { label: 'Private data source connect', id: 'pdc', isOpen: true, isOptional: true },
+  { label: 'Save & test', id: `${selectors.pages.DataSource.saveAndTest}`, isOpen: true, isOptional: null },
 ];
 
 export const PROTOCOL_OPTIONS = [

--- a/src/views/config-v2/helpers.ts
+++ b/src/views/config-v2/helpers.ts
@@ -1,0 +1,37 @@
+import { Protocol } from "types/config";
+
+/**
+ * Creates a set of test props for the InfluxDB V2 config page for use in tests.
+ * This function allows you to override default properties for specific test cases.
+ */
+export const createTestProps = (overrides: { options?: object; mocks?: object }) => ({
+  options: {
+    access: 'proxy',
+    basicAuth: false,
+    basicAuthUser: '',
+    database: '', 
+    id: 1,
+    isDefault: false, 
+    jsonData: {
+        version: '', 
+        host: '', 
+        port: 9000, 
+        protocol: Protocol.Native, 
+        username: ''
+    }, 
+    name: 'Clickhouse',
+    orgId: 1, 
+    readOnly: false,
+    secureJsonFields: {}, 
+    type: 'clickhouse',
+    typeLogoUrl: '',
+    typeName: 'Clickhouse',
+    uid: 'z',
+    url: '',
+    user: '',
+    withCredentials: false,
+    ...overrides.options,
+  },
+  onOptionsChange: jest.fn(),
+  ...overrides.mocks,
+});

--- a/src/views/config-v2/labels.ts
+++ b/src/views/config-v2/labels.ts
@@ -1,0 +1,302 @@
+export default {
+  components: {
+    Config: {
+      ConfigEditor: {
+        serverAddress: {
+          label: 'Server host address',
+          placeholder: 'Enter URL',
+        },
+        protocol: {
+          label: 'Protocol',
+          description: 'Native or HTTP for server protocol',
+          toggletip:
+            'ClickHouse supports two server protocols: Native TCP and HTTP. Both protocols can be secured with TLS.\n\nNative TCP is the default and recommended option.\nHTTP is for servers configured to accept HTTP connections.',
+        },
+        serverPort: {
+          label: 'Server port',
+          insecureNativePort: '9000',
+          insecureHttpPort: '8123',
+          secureNativePort: '9440',
+          secureHttpPort: '8443',
+          tooltip: 'ClickHouse server port',
+          error: 'Port is required',
+        },
+        path: {
+          label: 'HTTP URL Path',
+          tooltip: 'Additional URL path for HTTP requests',
+          placeholder: 'additional-path',
+        },
+        username: {
+          label: 'Username',
+          placeholder: 'default',
+          tooltip: 'ClickHouse username',
+        },
+        password: {
+          label: 'Password',
+          placeholder: 'password',
+          tooltip: 'ClickHouse password',
+        },
+        tlsSkipVerify: {
+          label: 'Skip TLS Verify',
+          tooltip: 'Skip TLS Verify',
+        },
+        tlsClientAuth: {
+          label: 'TLS Client Auth',
+          tooltip: 'TLS Client Auth',
+        },
+        tlsAuthWithCACert: {
+          label: 'With CA Cert',
+          tooltip: 'Needed for verifying self-signed TLS Certs',
+        },
+        tlsCACert: {
+          label: 'CA Cert',
+          placeholder: 'CA Cert. Begins with -----BEGIN CERTIFICATE-----',
+        },
+        tlsClientCert: {
+          label: 'Client Cert',
+          placeholder: 'Client Cert. Begins with -----BEGIN CERTIFICATE-----',
+        },
+        tlsClientKey: {
+          label: 'Client Key',
+          placeholder: 'Client Key. Begins with -----BEGIN RSA PRIVATE KEY-----',
+        },
+        secure: {
+          label: 'Secure Connection',
+          tooltip: 'Toggle on if the connection is secure',
+        },
+        secureSocksProxy: {
+          label: 'Enable Secure Socks Proxy',
+          tooltip: 'Enable proxying the datasource connection through the secure socks proxy to a different network.',
+        },
+        enableRowLimit: {
+          label: 'Enable row limit',
+          testid: 'data-testid enable-row-limit-switch',
+          tooltip:
+            'Enable using the Grafana row limit setting to limit the number of rows returned from Clickhouse. Ensure the appropriate permissions are set for your user. Only supported for Grafana >= 11.0.0. Defaults to false.',
+        },
+      },
+      HttpHeadersConfig: {
+        title: 'HTTP Headers',
+        label: 'Custom HTTP Headers',
+        description: 'Add Custom HTTP headers when querying the database',
+        headerNameLabel: 'Header Name',
+        headerNamePlaceholder: 'X-Custom-Header',
+        insecureHeaderValueLabel: 'Header Value',
+        secureHeaderValueLabel: 'Secure Header Value',
+        secureLabel: 'Secure',
+        addHeaderLabel: 'Add Header',
+        forwardGrafanaHeaders: {
+          label: 'Forward Grafana HTTP Headers',
+          tooltip: 'Forward Grafana HTTP Headers to datasource.',
+        },
+      },
+      AliasTableConfig: {
+        title: 'Column Alias Tables',
+        descriptionParts: [
+          'Provide alias tables with a',
+          '(`alias` String, `select` String, `type` String)',
+          'schema to use as a source for column selection.',
+        ],
+        addTableLabel: 'Add Table',
+        targetDatabaseLabel: 'Target Database',
+        targetDatabasePlaceholder: '(optional)',
+        targetTableLabel: 'Target Table',
+        aliasDatabaseLabel: 'Alias Database',
+        aliasDatabasePlaceholder: '(optional)',
+        aliasTableLabel: 'Alias Table',
+      },
+
+      DefaultDatabaseTableConfig: {
+        title: 'Default DB and table',
+        database: {
+          label: 'Default database',
+          description: 'the default database used by the query builder',
+          name: 'defaultDatabase',
+          placeholder: 'default',
+        },
+        table: {
+          label: 'Default table',
+          description: 'the default table used by the query builder',
+          name: 'defaultTable',
+          placeholder: 'table',
+        },
+      },
+      QuerySettingsConfig: {
+        title: 'Query settings',
+        connMaxLifetime: {
+          label: 'Connection Max Lifetime (minutes)',
+          name: 'connMaxLifetime',
+          placeholder: '5',
+          tooltip: 'Maximum lifetime of a connection in minutes',
+        },
+        dialTimeout: {
+          label: 'Dial Timeout (seconds)',
+          name: 'dialTimeout',
+          placeholder: '10',
+          tooltip: 'Timeout in seconds for connection',
+        },
+        maxIdleConns: {
+          label: 'Max Idle Connections',
+          name: 'maxIdleConns',
+          placeholder: '25',
+          tooltip: 'Maximum number of idle connections',
+        },
+        maxOpenConns: {
+          label: 'Max Open Connections',
+          name: 'maxOpenConns',
+          placeholder: '50',
+          tooltip: 'Maximum number of open connections',
+        },
+        queryTimeout: {
+          label: 'Query Timeout (seconds)',
+          name: 'queryTimeout',
+          placeholder: '60',
+          tooltip: 'Timeout in seconds for read queries',
+        },
+        validateSql: {
+          label: 'Validate SQL',
+          tooltip: 'Validate SQL in the editor.',
+        },
+      },
+      TracesConfig: {
+        title: 'Traces configuration',
+        description: '(Optional) Default settings for trace queries',
+        defaultDatabase: {
+          label: 'Default trace database',
+          description: 'the default database used by the trace query builder',
+          name: 'defaultDatabase',
+          placeholder: 'default',
+        },
+        defaultTable: {
+          label: 'Default trace table',
+          description: 'the default table used by the trace query builder',
+          name: 'defaultTable',
+        },
+        columns: {
+          title: 'Default columns',
+          description: 'Default columns for trace queries. Leave empty to disable.',
+
+          traceId: {
+            label: 'Trace ID column',
+            tooltip: 'Column for the trace ID',
+          },
+          spanId: {
+            label: 'Span ID column',
+            tooltip: 'Column for the span ID',
+          },
+          parentSpanId: {
+            label: 'Parent Span ID column',
+            tooltip: 'Column for the parent span ID',
+          },
+          serviceName: {
+            label: 'Service Name column',
+            tooltip: 'Column for the service name',
+          },
+          operationName: {
+            label: 'Operation Name column',
+            tooltip: 'Column for the operation name',
+          },
+          startTime: {
+            label: 'Start Time column',
+            tooltip: 'Column for the start time',
+          },
+          durationTime: {
+            label: 'Duration Time column',
+            tooltip: 'Column for the duration time',
+          },
+          tags: {
+            label: 'Tags column',
+            tooltip: 'Column for the trace tags',
+          },
+          serviceTags: {
+            label: 'Service Tags column',
+            tooltip: 'Column for the service tags',
+          },
+          flattenNested: {
+            label: 'Use Flatten Nested',
+            tooltip: 'Enable if your traces table was created with flatten_nested=1',
+          },
+          eventsPrefix: {
+            label: 'Events prefix',
+            tooltip: 'Prefix for the events column (Events.Timestamp, Events.Name, etc.)',
+          },
+          linksPrefix: {
+            label: 'Links prefix',
+            tooltip: 'Prefix for the trace references column (Links.TraceId, Links.TraceState, etc.)',
+          },
+          kind: {
+            label: 'Kind column',
+            tooltip: 'Column for the trace kind',
+          },
+          statusCode: {
+            label: 'Status Code column',
+            tooltip: 'Column for the trace status code',
+          },
+          statusMessage: {
+            label: 'Status Message column',
+            tooltip: 'Column for the trace status message',
+          },
+          instrumentationLibraryName: {
+            label: 'Library Name column',
+            tooltip: 'Column for the instrumentation library name',
+          },
+          instrumentationLibraryVersion: {
+            label: 'Library Version column',
+            tooltip: 'Column for the instrumentation library version',
+          },
+          state: {
+            label: 'State column',
+            tooltip: 'Column for the trace state',
+          },
+        },
+      },
+      LogsConfig: {
+        title: 'Logs configuration',
+        description: '(Optional) default settings for log queries',
+        defaultDatabase: {
+          label: 'Default log database',
+          description: 'the default database used by the logs query builder',
+          name: 'defaultDatabase',
+          placeholder: 'default',
+        },
+        defaultTable: {
+          label: 'Default log table',
+          description: 'the default table used by the logs query builder',
+          name: 'defaultTable',
+        },
+        columns: {
+          title: 'Default columns',
+          description: 'Default columns for log queries. Leave empty to disable.',
+
+          time: {
+            label: 'Time column',
+            tooltip: 'Column for the log timestamp',
+          },
+          level: {
+            label: 'Log Level column',
+            tooltip: 'Column for the log level',
+          },
+          message: {
+            label: 'Log Message column',
+            tooltip: 'Column for log message',
+          },
+        },
+        contextColumns: {
+          title: 'Context columns',
+          description:
+            'These columns are used to narrow down a single log row to its original service/container/pod source. At least one is required for the log context feature to work.',
+
+          selectContextColumns: {
+            label: 'Auto-Select Columns',
+            tooltip: 'When enabled, will always include context columns in log queries',
+          },
+          columns: {
+            label: 'Context Columns',
+            tooltip: "Comma separated list of column names to use for identifying a log's source",
+            placeholder: 'Column name (enter key to add)',
+          },
+        },
+      },
+    },
+  },
+};

--- a/src/views/config-v2/labels.ts
+++ b/src/views/config-v2/labels.ts
@@ -21,49 +21,49 @@ export default {
           tooltip: 'ClickHouse server port',
           error: 'Port is required',
         },
+        secure: {
+          label: 'Secure Connection',
+          tooltip: 'Toggle on if the connection is secure',
+        },
         path: {
           label: 'HTTP URL Path',
           tooltip: 'Additional URL path for HTTP requests',
           placeholder: 'additional-path',
         },
-        username: {
-          label: 'Username',
-          placeholder: 'default',
-          tooltip: 'ClickHouse username',
-        },
-        password: {
-          label: 'Password',
-          placeholder: 'password',
-          tooltip: 'ClickHouse password',
-        },
-        tlsSkipVerify: {
-          label: 'Skip TLS Verify',
-          tooltip: 'Skip TLS Verify',
-        },
-        tlsClientAuth: {
-          label: 'TLS Client Auth',
-          tooltip: 'TLS Client Auth',
-        },
-        tlsAuthWithCACert: {
-          label: 'With CA Cert',
-          tooltip: 'Needed for verifying self-signed TLS Certs',
-        },
-        tlsCACert: {
-          label: 'CA Cert',
-          placeholder: 'CA Cert. Begins with -----BEGIN CERTIFICATE-----',
-        },
-        tlsClientCert: {
-          label: 'Client Cert',
-          placeholder: 'Client Cert. Begins with -----BEGIN CERTIFICATE-----',
-        },
-        tlsClientKey: {
-          label: 'Client Key',
-          placeholder: 'Client Key. Begins with -----BEGIN RSA PRIVATE KEY-----',
-        },
-        secure: {
-          label: 'Secure Connection',
-          tooltip: 'Toggle on if the connection is secure',
-        },
+        // username: {
+        //   label: 'Username',
+        //   placeholder: 'default',
+        //   tooltip: 'ClickHouse username',
+        // },
+        // password: {
+        //   label: 'Password',
+        //   placeholder: 'password',
+        //   tooltip: 'ClickHouse password',
+        // },
+        // tlsSkipVerify: {
+        //   label: 'Skip TLS Verify',
+        //   tooltip: 'Skip TLS Verify',
+        // },
+        // tlsClientAuth: {
+        //   label: 'TLS Client Auth',
+        //   tooltip: 'TLS Client Auth',
+        // },
+        // tlsAuthWithCACert: {
+        //   label: 'With CA Cert',
+        //   tooltip: 'Needed for verifying self-signed TLS Certs',
+        // },
+        // tlsCACert: {
+        //   label: 'CA Cert',
+        //   placeholder: 'CA Cert. Begins with -----BEGIN CERTIFICATE-----',
+        // },
+        // tlsClientCert: {
+        //   label: 'Client Cert',
+        //   placeholder: 'Client Cert. Begins with -----BEGIN CERTIFICATE-----',
+        // },
+        // tlsClientKey: {
+        //   label: 'Client Key',
+        //   placeholder: 'Client Key. Begins with -----BEGIN RSA PRIVATE KEY-----',
+        // },
         secureSocksProxy: {
           label: 'Enable Secure Socks Proxy',
           tooltip: 'Enable proxying the datasource connection through the secure socks proxy to a different network.',
@@ -73,21 +73,6 @@ export default {
           testid: 'data-testid enable-row-limit-switch',
           tooltip:
             'Enable using the Grafana row limit setting to limit the number of rows returned from Clickhouse. Ensure the appropriate permissions are set for your user. Only supported for Grafana >= 11.0.0. Defaults to false.',
-        },
-      },
-      HttpHeadersConfig: {
-        title: 'HTTP Headers',
-        label: 'Custom HTTP Headers',
-        description: 'Add Custom HTTP headers when querying the database',
-        headerNameLabel: 'Header Name',
-        headerNamePlaceholder: 'X-Custom-Header',
-        insecureHeaderValueLabel: 'Header Value',
-        secureHeaderValueLabel: 'Secure Header Value',
-        secureLabel: 'Secure',
-        addHeaderLabel: 'Add Header',
-        forwardGrafanaHeaders: {
-          label: 'Forward Grafana HTTP Headers',
-          tooltip: 'Forward Grafana HTTP Headers to datasource.',
         },
       },
       AliasTableConfig: {

--- a/src/views/config-v2/labels.ts
+++ b/src/views/config-v2/labels.ts
@@ -23,47 +23,47 @@ export default {
         },
         secure: {
           label: 'Secure Connection',
-          tooltip: 'Toggle on if the connection is secure',
+          description: 'Check this box to connect securely',
         },
         path: {
           label: 'HTTP URL Path',
           tooltip: 'Additional URL path for HTTP requests',
           placeholder: 'additional-path',
         },
-        // username: {
-        //   label: 'Username',
-        //   placeholder: 'default',
-        //   tooltip: 'ClickHouse username',
-        // },
-        // password: {
-        //   label: 'Password',
-        //   placeholder: 'password',
-        //   tooltip: 'ClickHouse password',
-        // },
-        // tlsSkipVerify: {
-        //   label: 'Skip TLS Verify',
-        //   tooltip: 'Skip TLS Verify',
-        // },
-        // tlsClientAuth: {
-        //   label: 'TLS Client Auth',
-        //   tooltip: 'TLS Client Auth',
-        // },
-        // tlsAuthWithCACert: {
-        //   label: 'With CA Cert',
-        //   tooltip: 'Needed for verifying self-signed TLS Certs',
-        // },
-        // tlsCACert: {
-        //   label: 'CA Cert',
-        //   placeholder: 'CA Cert. Begins with -----BEGIN CERTIFICATE-----',
-        // },
-        // tlsClientCert: {
-        //   label: 'Client Cert',
-        //   placeholder: 'Client Cert. Begins with -----BEGIN CERTIFICATE-----',
-        // },
-        // tlsClientKey: {
-        //   label: 'Client Key',
-        //   placeholder: 'Client Key. Begins with -----BEGIN RSA PRIVATE KEY-----',
-        // },
+        username: {
+          label: 'Username',
+          placeholder: 'default',
+          tooltip: 'ClickHouse username',
+        },
+        password: {
+          label: 'Password',
+          placeholder: 'password',
+          tooltip: 'ClickHouse password',
+        },
+        tlsSkipVerify: {
+          label: 'Skip TLS Verify',
+          tooltip: 'Skip TLS Verify',
+        },
+        tlsClientAuth: {
+          label: 'TLS Client Auth',
+          tooltip: 'TLS Client Auth',
+        },
+        tlsAuthWithCACert: {
+          label: 'With CA Cert',
+          tooltip: 'Needed for verifying self-signed TLS Certs',
+        },
+        tlsCACert: {
+          label: 'CA Cert',
+          placeholder: 'CA Cert. Begins with -----BEGIN CERTIFICATE-----',
+        },
+        tlsClientCert: {
+          label: 'Client Cert',
+          placeholder: 'Client Cert. Begins with -----BEGIN CERTIFICATE-----',
+        },
+        tlsClientKey: {
+          label: 'Client Key',
+          placeholder: 'Client Key. Begins with -----BEGIN RSA PRIVATE KEY-----',
+        },
         secureSocksProxy: {
           label: 'Enable Secure Socks Proxy',
           tooltip: 'Enable proxying the datasource connection through the secure socks proxy to a different network.',

--- a/src/views/config-v2/tracking.ts
+++ b/src/views/config-v2/tracking.ts
@@ -1,0 +1,78 @@
+import { reportInteraction } from "@grafana/runtime";
+import { TimeUnit } from "types/queryBuilder";
+
+// Feedback form
+export const trackInfluxDBConfigV2FeedbackButtonClicked = () => {
+    reportInteraction('clickhouse_config_v2_feedback_button_clicked');
+};
+
+// Server section
+export const trackClickhouseConfigV2HostInput = () => {
+    reportInteraction('clickhouse_config_v2_host_input');
+};
+
+export const trackClickhouseConfigV2PortInput = (props: { port: string }) => {
+    reportInteraction('clickhouse_config_v2_port_input', props);
+};
+
+export const trackClickhouseConfigV2NativeHttpToggleClicked = (props: { nativeHttpToggle: string}) => {
+    reportInteraction('clickhouse_config_v2_native_http_toggle_clicked', props);
+};
+
+export const trackClickhouseConfigV2SecureConnectionToggleClicked = (props: { secureConnection: boolean}) => {
+    reportInteraction('clickhouse_config_v2_secure_connection_toggle_clicked', props);
+};
+
+// TLS/SSL Settings section
+export const trackClickhouseConfigV2SkipTLSVerifyToggleClicked = (props: { skipTlsVerifyToggle: boolean}) => {
+    reportInteraction('clickhouse_config_v2_skip_tls_verify_toggle_clicked', props);
+};
+
+export const trackClickhouseConfigV2TLSClientAuthToggleClicked = (props: { clientAuthToggle: boolean}) => {
+    reportInteraction('clickhouse_config_v2_tls_client_auth_toggle_clicked', props);
+};
+
+export const trackClickhouseConfigV2WithCACertToggleClicked = (props: { caCertToggle: boolean }) => {
+    reportInteraction('clickhouse_config_v2_with_ca_cert_toggle_clicked', props);
+};
+
+// Default DB and Table section
+export const trackClickhouseConfigV2DefaultDbInput = () => {
+    reportInteraction('clickhouse_config_v2_default_db_input');
+};
+
+export const trackClickhouseConfigV2DefaultTableInput = () => {
+    reportInteraction('clickhouse_config_v2_default_table_input');
+};
+
+// Query settings section
+export const trackClickhouseConfigV2QuerySettings = (props: { queryTimeout?: number, dialTimeout?: number, maxIdleConns?: number, maxOpenConns?: number, connMaxLifetime?: number, validateSql?: boolean }) => {
+    reportInteraction('clickhouse_config_v2_query_settings', props);
+};
+
+// Logs config section
+export const trackClickhouseConfigV2LogsConfig = (props: {defaultDatabase?: string, defaultTable?: string, otelEnabled?: boolean, version?: string, timeColumn?: string, levelColumn?: string, messageColumn?: string, selectContextColumns?: boolean, contextColumns?: string[] }) => {
+    reportInteraction('clickhouse_config_v2_logs_config', props);
+}
+
+// Traces config section
+export const trackClickhouseConfigV2TracesConfig = (props: { defaultDatabase?: string, defaultTable?: string, otelEnabled?: boolean, version?: string, traceIdColumn?: string, spanIdColumn?: string, operationNameColumn?: string, parentSpanIdColumn?: string, serviceNameColumn?: string, durationColumn?: string, durationUnit?: TimeUnit, startTimeColumn?: string, tagsColumn?: string, serviceTagsColumn?: string, kindColumn?: string, statusCodeColumn?: string, statusMessageColumn?: string, stateColumn?: string, instrumentationLibraryNameColumn?: string, instrumentationLibraryVersionColumn?: string, flattenNested?: boolean, traceEventsColumnPrefix?: string, traceLinksColumnPrefix?: string }) => {
+    reportInteraction('clickhouse_config_v2_traces_config', props);
+}
+
+// Column Alias Tables section
+export const trackClickhouseConfigV2ColumnAliasTableAdded = () => {
+    reportInteraction('clickhouse_config_v2_column_alias_table_added');
+};
+
+// Row limit section
+export const trackClickhouseConfigV2EnableRowLimitToggle = (props: {rowLimitEnabled: boolean}) => {
+    reportInteraction('clickhouse_config_v2_enable_row_limit_toggle', props);
+};
+
+// Custom Settings section
+export const trackClickhouseConfigV2CustomSettingAdded = () => {
+    reportInteraction('clickhouse_config_v2_custom_setting_added');
+};
+
+

--- a/src/views/trackingV1.ts
+++ b/src/views/trackingV1.ts
@@ -3,71 +3,71 @@ import { TimeUnit } from "types/queryBuilder";
 
 // Server section
 export const trackClickhouseConfigV1HostInput = () => {
-    reportInteraction('clickhouse-config-v1-host-input');
+    reportInteraction('clickhouse_config_v1_host_input');
 };
 
 export const trackClickhouseConfigV1PortInput = (props: { port: string }) => {
-    reportInteraction('clickhouse-config-v1-port-input', props);
+    reportInteraction('clickhouse_config_v1_port_input', props);
 };
 
 export const trackClickhouseConfigV1NativeHttpToggleClicked = (props: { nativeHttpToggle: string}) => {
-    reportInteraction('clickhouse-config-v1-native-http-toggle-clicked', props);
+    reportInteraction('clickhouse_config_v1_native_http_toggle_clicked', props);
 };
 
 export const trackClickhouseConfigV1SecureConnectionToggleClicked = (props: { secureConnection: boolean}) => {
-    reportInteraction('clickhouse-config-v1-secure-connection-toggle-clicked', props);
+    reportInteraction('clickhouse_config_v1_secure_connection_toggle_clicked', props);
 };
 
 // TLS/SSL Settings section
 export const trackClickhouseConfigV1SkipTLSVerifyToggleClicked = (props: { skipTlsVerifyToggle: boolean}) => {
-    reportInteraction('clickhouse-config-v1-skip-tls-verify-toggle-clicked', props);
+    reportInteraction('clickhouse_config_v1_skip_tls_verify_toggle_clicked', props);
 };
 
 export const trackClickhouseConfigV1TLSClientAuthToggleClicked = (props: { clientAuthToggle: boolean}) => {
-    reportInteraction('clickhouse-config-v1-tls-client-auth-toggle-clicked', props);
+    reportInteraction('clickhouse_config_v1_tls_client_auth_toggle_clicked', props);
 };
 
 export const trackClickhouseConfigV1WithCACertToggleClicked = (props: { caCertToggle: boolean }) => {
-    reportInteraction('clickhouse-config-v1-with-ca-cert-toggle-clicked', props);
+    reportInteraction('clickhouse_config_v1_with_ca_cert_toggle_clicked', props);
 };
 
 // Default DB and Table section
 export const trackClickhouseConfigV1DefaultDbInput = () => {
-    reportInteraction('clickhouse-config-v1-default-db-input');
+    reportInteraction('clickhouse_config_v1_default_db_input');
 };
 
 export const trackClickhouseConfigV1DefaultTableInput = () => {
-    reportInteraction('clickhouse-config-v1-default-table-input');
+    reportInteraction('clickhouse_config_v1_default_table_input');
 };
 
 // Query settings section
 export const trackClickhouseConfigV1QuerySettings = (props: { queryTimeout?: number, dialTimeout?: number, maxIdleConns?: number, maxOpenConns?: number, connMaxLifetime?: number, validateSql?: boolean }) => {
-    reportInteraction('clickhouse-config-v1-query-settings', props);
+    reportInteraction('clickhouse_config_v1_query_settings', props);
 };
 
 // Logs config section
 export const trackClickhouseConfigV1LogsConfig = (props: {defaultDatabase?: string, defaultTable?: string, otelEnabled?: boolean, version?: string, timeColumn?: string, levelColumn?: string, messageColumn?: string, selectContextColumns?: boolean, contextColumns?: string[] }) => {
-    reportInteraction('clickhouse-config-v1-logs-config', props);
+    reportInteraction('clickhouse_config_v1_logs_config', props);
 }
 
 // Traces config section
 export const trackClickhouseConfigV1TracesConfig = (props: { defaultDatabase?: string, defaultTable?: string, otelEnabled?: boolean, version?: string, traceIdColumn?: string, spanIdColumn?: string, operationNameColumn?: string, parentSpanIdColumn?: string, serviceNameColumn?: string, durationColumn?: string, durationUnit?: TimeUnit, startTimeColumn?: string, tagsColumn?: string, serviceTagsColumn?: string, kindColumn?: string, statusCodeColumn?: string, statusMessageColumn?: string, stateColumn?: string, instrumentationLibraryNameColumn?: string, instrumentationLibraryVersionColumn?: string, flattenNested?: boolean, traceEventsColumnPrefix?: string, traceLinksColumnPrefix?: string }) => {
-    reportInteraction('clickhouse-config-v1-traces-config', props);
+    reportInteraction('clickhouse_config_v1_traces_config', props);
 }
 
 // Column Alias Tables section
 export const trackClickhouseConfigV1ColumnAliasTableAdded = () => {
-    reportInteraction('clickhouse-config-v1-column-alias-table-added');
+    reportInteraction('clickhouse_config_v1_column_alias_table_added');
 };
 
 // Row limit section
 export const trackClickhouseConfigV1EnableRowLimitToggle = (props: {rowLimitEnabled: boolean}) => {
-    reportInteraction('clickhouse-config-v1-enable-row-limit-toggle', props);
+    reportInteraction('clickhouse_config_v1_enable_row_limit_toggle', props);
 };
 
 // Custom Settings section
 export const trackClickhouseConfigV1CustomSettingAdded = () => {
-    reportInteraction('clickhouse-config-v1-custom-setting-added');
+    reportInteraction('clickhouse_config_v1_custom_setting_added');
 };
 
 


### PR DESCRIPTION
This PR is the first step in a larger project to redesign and improve the ClickHouse data source configuration experience. It introduces a new layout with a left sidebar, clearer required fields, better handling of HTTP settings, and user feedback collection. Future parts will build on this foundation with additional sections and refinements.

### Summary
- Added **LeftSidebar** with clickable steps that scroll to sections and mark optional steps.  
- Added **Server and encryption** as the first section of the config page in a collapsable container.  
- Added **“Fields marked with * are required”** above the first section.  
- Moved **Optional HTTP settings** into its own collapsible section.  
- Added a **Feedback link** to a Google Form so users can share input.
- Renders the new configuration page if `newClickhouseConfigPageDesign` feature toggle is enabled.
- Moves tracking the host and port tracking events from the original configuration page to `onBlur`.

### Protocol = HTTP
<img width="1495" height="780" alt="Screenshot 2025-09-17 at 3 57 10 PM" src="https://github.com/user-attachments/assets/f92dc1cd-7dd5-4201-ba5d-b3980049af86" />

### Protocol = Native
<img width="1512" height="485" alt="Screenshot 2025-09-17 at 3 52 37 PM" src="https://github.com/user-attachments/assets/4a39390c-58b2-4a43-8f16-d84dfbf9117e" />

### RudderStack events
- `clickhouse-config-v2-host-input` (blur on host input)  
- `clickhouse-config-v2-port-input` (blur on port input)  
- `clickhouse-config-v2-secure-toggle-clicked` (secure switch toggle)  
- `clickhouse-config-v2-protocol-selected` (protocol radio change)  
- `clickhouse-config-v2-forward-grafana-headers-toggled` (forward Grafana headers switch)  
- `clickhouse-config-v2-feedback-button-clicked` (feedback form link click)  
