### PR TITLE
Update log and trace column names to match ClickHouse otel defaults

### DIFF
--- a/src/otel.ts
+++ b/src/otel.ts
@@ -26,7 +26,7 @@ const otel129: OtelVersion = {
   specUrl: 'https://opentelemetry.io/docs/specs/otel',
   logsTable: defaultLogsTable,
   logColumnMap: new Map<ColumnHint, string>([
-    [ColumnHint.Time, 'Timestamp'],
+    [ColumnHint.Time, 'TimestampTime'],
     [ColumnHint.LogMessage, 'Body'],
     [ColumnHint.LogLevel, 'SeverityText'],
     [ColumnHint.LogLabels, 'LogAttributes'],
@@ -42,7 +42,7 @@ const otel129: OtelVersion = {
   ],
   traceTable: defaultTraceTable,
   traceColumnMap: new Map<ColumnHint, string>([
-    [ColumnHint.Time, 'Timestamp'],
+    [ColumnHint.Time, 'TimestampTime'],
     [ColumnHint.TraceId, 'TraceId'],
     [ColumnHint.TraceSpanId, 'SpanId'],
     [ColumnHint.TraceParentSpanId, 'ParentSpanId'],


### PR DESCRIPTION
In ClickHouse the logs and trace tables use the order:
`ServiceName, TimestampTime, Timestamp`
This is set by the clickhouse exporter for opentelemetry-collector-contrib.

Currently in this plugin the defaults when use_otel is enabled sets the timestamp column to `Timestamp`. As a result ClickHouse has to search much more data, making queries against very large tables quite slow.
On my 1.5TB logs table, `Timestamp` queries take 94.5s, whereas the same `TimestampTime` queries take 10.1s.

The correct timestamp column to use would be `TimestampTime`.

Ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/clickhouseexporter/internal/sqltemplates/logs_table.sql

I'm unsure if there are more changes I need to make here, any advice would be appreciated!