### PR TITLE
release 4.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 4.11.1
+
+### Fixes
+
+- All Clickhouse errors are marked as downstream errors for Grafana
+
 ## 4.11.0
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clickhouse-datasource",
-  "version": "4.11.0",
+  "version": "4.11.1",
   "description": "Clickhouse Datasource",
   "engines": {
     "node": ">=20"


### PR DESCRIPTION
- All Clickhouse errors are marked as downstream errors for Grafana