### PR TITLE
give the user more feedback when client creation fails

### DIFF
--- a/pkg/plugin/driver.go
+++ b/pkg/plugin/driver.go
@@ -253,7 +253,7 @@ func (h *Clickhouse) Connect(ctx context.Context, config backend.DataSourceInsta
 		}
 
 		backend.Logger.Error("failed to create ClickHouse client", "error", err)
-    return nil, errorsource.DownstreamError(fmt.Errorf("failed to create ClickHouse client: %w", err), false)
+		return nil, errorsource.DownstreamError(fmt.Errorf("failed to create ClickHouse client: %w", err), false)
 	}
 
 	return db, settings.isValid()


### PR DESCRIPTION
<!-- To surface this PR in the changelog add the label: changelog -->
<!-- If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way: -->
<!-- Bad: fix state bug in hooks -->
<!-- Good: Fix crash when switching from Query Builder -->

<img width="324" height="223" alt="Screenshot 2025-10-31 at 11 48 19" src="https://github.com/user-attachments/assets/6c3ab086-7d86-4b1d-afc1-e9cfaee022b8" />

Hopefully obvious but, that error message doesn't give me a whole lot to go on.

I think we should instead wrap the error so that the user is given some feedback as to what's gone wrong. Otherwise you basically just have to guess in the absence of any logs (such as when using Grafana Cloud, as we are).