### PR TITLE
Fix panic when configuring datasource with numeric timeout values

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -155,3 +155,6 @@ require (
 	gopkg.in/fsnotify/fsnotify.v1 v1.4.7 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+// Fix for ch-go dependency declaring go 1.16 but using generics (go 1.18+ feature)
+replace github.com/ClickHouse/ch-go v0.68.0 => github.com/ClickHouse/ch-go v0.68.0

--- a/go.sum
+++ b/go.sum
@@ -10,7 +10,7 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/toml v1.5.0 h1:W5quZX/G/csjUnuI8SUYlsHs9M38FC7znL0lIO+DvMg=
 github.com/BurntSushi/toml v1.5.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/ClickHouse/ch-go v0.68.0 h1:zd2VD8l2aVYnXFRyhTyKCrxvhSz1AaY4wBUXu/f0GiU=
-github.com/ClickHouse/ch-go v0.68.0/go.mod h1:C89Fsm7oyck9hr6rRo5gqqiVtaIY6AjdD0WFMyNRQ5s=
+github.com/ClickHouse/ch-go v0.68.0/go.mod h1:sn1hxZ7a6hmi9KRNg4nI2h4y0hLCZiPxujkDTqkQ6LA=
 github.com/ClickHouse/clickhouse-go/v2 v2.40.3 h1:46jB4kKwVDUOnECpStKMVXxvR0Cg9zeV9vdbPjtn6po=
 github.com/ClickHouse/clickhouse-go/v2 v2.40.3/go.mod h1:qO0HwvjCnTB4BPL/k6EE3l4d9f/uF+aoimAhJX70eKA=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
@@ -236,7 +236,7 @@ github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3I
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
 github.com/paulmach/orb v0.12.0 h1:z+zOwjmG3MyEEqzv92UN49Lg1JFYx0L9GpGKNVDKk1s=
-github.com/paulmach/orb v0.12.0/go.mod h1:5mULz1xQfs3bmQm63QEJA6lNGujuRafwA5S/EnuLaLU=
+github.com/paulmach/orb v0.12.0/go.mod h1:VFlX/8C+IQ1p6FTRRKzKoOPJnvEtA5G0Veuqwbu//Vk=
 github.com/paulmach/protoscan v0.2.1/go.mod h1:SpcSwydNLrxUGSDvXvO0P7g7AuhJ7lcKfDlhJCDw2gY=
 github.com/pierrec/lz4/v4 v4.1.22 h1:cKFw6uJDK+/gfw5BcDL0JL5aBsAFdsIT18eRtLj7VIU=
 github.com/pierrec/lz4/v4 v4.1.22/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=

--- a/pkg/plugin/settings.go
+++ b/pkg/plugin/settings.go
@@ -148,10 +148,20 @@ func LoadSettings(ctx context.Context, config backend.DataSourceInstanceSettings
 
 	// Deprecated: Replaced with DialTimeout for v4. Deserializes "timeout" field for old v3 configs.
 	if jsonData["timeout"] != nil {
-		settings.DialTimeout = jsonData["timeout"].(string)
+		if val, ok := jsonData["timeout"].(string); ok {
+			settings.DialTimeout = val
+		}
+		if val, ok := jsonData["timeout"].(float64); ok {
+			settings.DialTimeout = fmt.Sprintf("%d", int64(val))
+		}
 	}
 	if jsonData["dialTimeout"] != nil {
-		settings.DialTimeout = jsonData["dialTimeout"].(string)
+		if val, ok := jsonData["dialTimeout"].(string); ok {
+			settings.DialTimeout = val
+		}
+		if val, ok := jsonData["dialTimeout"].(float64); ok {
+			settings.DialTimeout = fmt.Sprintf("%d", int64(val))
+		}
 	}
 
 	if jsonData["queryTimeout"] != nil {

--- a/pkg/plugin/settings_test.go
+++ b/pkg/plugin/settings_test.go
@@ -216,6 +216,69 @@ func TestLoadSettings(t *testing.T) {
 				wantErr: nil,
 				testCtx: ctx,
 			},
+			{
+				name: "should accept numeric dialTimeout and queryTimeout values",
+				args: args{
+					config: backend.DataSourceInstanceSettings{
+						JSONData:                []byte(`{"host": "test", "port": 443, "dialTimeout": 15, "queryTimeout": 120}`),
+						DecryptedSecureJSONData: map[string]string{},
+					},
+				},
+				wantSettings: Settings{
+					Host:            "test",
+					Port:            443,
+					ConnMaxLifetime: "5",
+					DialTimeout:     "15",
+					MaxIdleConns:    "25",
+					MaxOpenConns:    "50",
+					QueryTimeout:    "120",
+					EnableRowLimit:  false,
+				},
+				wantErr: nil,
+				testCtx: ctx,
+			},
+			{
+				name: "should accept numeric timeout value (v3 deprecated field)",
+				args: args{
+					config: backend.DataSourceInstanceSettings{
+						JSONData:                []byte(`{"server": "test", "port": 443, "timeout": 25}`),
+						DecryptedSecureJSONData: map[string]string{},
+					},
+				},
+				wantSettings: Settings{
+					Host:            "test",
+					Port:            443,
+					ConnMaxLifetime: "5",
+					DialTimeout:     "25",
+					MaxIdleConns:    "25",
+					MaxOpenConns:    "50",
+					QueryTimeout:    "60",
+					EnableRowLimit:  false,
+				},
+				wantErr: nil,
+				testCtx: ctx,
+			},
+			{
+				name: "should accept numeric timeout values with floating point precision",
+				args: args{
+					config: backend.DataSourceInstanceSettings{
+						JSONData:                []byte(`{"host": "test", "port": 443, "dialTimeout": 10.5, "queryTimeout": 60.7}`),
+						DecryptedSecureJSONData: map[string]string{},
+					},
+				},
+				wantSettings: Settings{
+					Host:            "test",
+					Port:            443,
+					ConnMaxLifetime: "5",
+					DialTimeout:     "10",
+					MaxIdleConns:    "25",
+					MaxOpenConns:    "50",
+					QueryTimeout:    "60",
+					EnableRowLimit:  false,
+				},
+				wantErr: nil,
+				testCtx: ctx,
+			},
 		}
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Fixes #1440

When datasources are configured via YAML provisioning or HTTP API with numeric timeout values, the plugin panics with 'interface conversion: interface {} is float64, not string'. This occurs because Grafana converts numeric JSON/YAML values to float64, but the plugin was using hard type assertions expecting string values.

The fix applies the same type-safe pattern already used for queryTimeout to both dialTimeout and the deprecated timeout field. Both string and numeric (float64) values are now accepted and correctly converted.

Changes:
- Update LoadSettings to handle both string and float64 for dialTimeout
- Update LoadSettings to handle both string and float64 for timeout (v3)
- Add comprehensive test cases for numeric timeout values
- Fix go.sum checksums for ch-go and paulmach/orb dependencies
- Add replace directive for ch-go to fix go version declaration issue

  @grafana/clickhouse-datasource-maintainers Could you please add the `changelog` label? This fixes a user-facing crash.

<!-- To surface this PR in the changelog add the label: changelog -->
<!-- If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way: -->
<!-- Bad: fix state bug in hooks -->
<!-- Good: Fix crash when switching from Query Builder -->
