### PR TITLE
temporarily disable slow JSON suggestions function

### DIFF
--- a/src/data/CHDatasource.test.ts
+++ b/src/data/CHDatasource.test.ts
@@ -297,7 +297,7 @@ describe('ClickHouseDatasource', () => {
     });
   });
 
-  describe('fetchPathsForJSONColumns', () => {
+  describe.skip('fetchPathsForJSONColumns', () => {
     it('sends a correct query when database and table names are provided', async () => {
       const ds = cloneDeep(mockDatasource);
       const frame = arrayToDataFrame([

--- a/src/data/CHDatasource.ts
+++ b/src/data/CHDatasource.ts
@@ -673,13 +673,15 @@ export class Datasource
       picklistValues: [],
     }));
 
-    const results = await Promise.all(
-      columns
-        .filter((c) => c.type.startsWith('JSON'))
-        .map((c) => this.fetchPathsForJSONColumns(database, table, c.name))
-    );
+    return columns;
 
-    return [...columns, ...results.flat()];
+    // TODO: wait for JSON function perf improvements
+    // const results = await Promise.all(
+    //   columns
+    //     .filter((c) => c.type.startsWith('JSON'))
+    //     .map((c) => this.fetchPathsForJSONColumns(database, table, c.name))
+    // );
+    // return [...columns, ...results.flat()];
   }
 
   /**


### PR DESCRIPTION
Even with `max_execution_time`, this function is timing out and blocking the other column suggestion functions.

This will be improved in a future version of ClickHouse, but for now we should disable it.
