### PR TITLE
Handle legacy HTTP error format

### DIFF
--- a/pkg/plugin/driver.go
+++ b/pkg/plugin/driver.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -295,6 +296,15 @@ func containsClickHouseException(err error) bool {
 
 	// Look for common ClickHouse error patterns in response bodies
 	if strings.Contains(errStr, "DB::Exception") {
+		return true
+	}
+
+	// Catch legacy ClickHouse HTTP error format.
+	// This is more general than the above and we attempt the DB::Exception catch first
+	// as those errors also contain this pattern.
+	// We're only catching 4xx errors for now but we can expand to 5xx if needed.
+	matcher, _ := regexp.Compile(`(\[HTTP 4\d\d\])`)
+	if matcher.MatchString(errStr) {
 		return true
 	}
 

--- a/pkg/plugin/driver_test.go
+++ b/pkg/plugin/driver_test.go
@@ -293,6 +293,13 @@ func TestContainsClickHouseException(t *testing.T) {
 		assert.True(t, result)
 	})
 
+	t.Run("HTTP response body with legacy clickhouse error", func(t *testing.T) {
+		errMsg := `error querying the database: sendQuery: [HTTP 404] response body: \"[Error] Unknown table expression identifier 'hello' in scope SELECT * FROM hello. (UNKNOWN_TABLE) (version 25.1.3.23 (official build))\n\"`
+		err := errors.New(errMsg)
+		result := containsClickHouseException(err)
+		assert.True(t, result)
+	})
+
 	t.Run("regular error without clickhouse patterns", func(t *testing.T) {
 		err := errors.New("connection timeout")
 		result := containsClickHouseException(err)


### PR DESCRIPTION
Older versions of ClickHouse produce errors that do not contain `DB::Exception`. Our logic that marks errors as downstream fails to catch these errors.

This logic adds a check for `[HTTP 4xx]` in the error text. This should only be present in responses from the ClickHouse server and be unrelated to any plugin code so they _should_ be safe to mark as downstream.

It's also worth noting I've added this check after the `DB::Exception` check as the `DB::Exception` check is more reliable for ensuring something is a downstream error. If we need to expand this to 5xx errors to that's straightforward to do.

Fixes grafana/oss-plugin-partnerships#1408.