### PR TITLE
feat: Display column info for log type query

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clickhouse-datasource",
-  "version": "4.11.4",
+  "version": "4.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clickhouse-datasource",
-      "version": "4.11.4",
+      "version": "4.12.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/css": "11.13.5",

--- a/src/components/configEditor/LogsConfig.tsx
+++ b/src/components/configEditor/LogsConfig.tsx
@@ -21,6 +21,7 @@ interface LogsConfigProps {
   onMessageColumnChange: (v: string) => void;
   onSelectContextColumnsChange: (v: boolean) => void;
   onContextColumnsChange: (v: string[]) => void;
+  onShowTableSchemaChange?: (v: boolean) => void;
 }
 
 export const LogsConfig = (props: LogsConfigProps) => {
@@ -34,6 +35,7 @@ export const LogsConfig = (props: LogsConfigProps) => {
     onMessageColumnChange,
     onSelectContextColumnsChange,
     onContextColumnsChange,
+    onShowTableSchemaChange,
   } = props;
   let {
     defaultDatabase,
@@ -45,6 +47,7 @@ export const LogsConfig = (props: LogsConfigProps) => {
     messageColumn,
     selectContextColumns,
     contextColumns,
+    showTableSchema,
   } = props.logsConfig || {};
   const labels = allLabels.components.Config.LogsConfig;
 
@@ -137,6 +140,22 @@ export const LogsConfig = (props: LogsConfigProps) => {
           />
         </div>
       </ConfigSubSection>
+      {onShowTableSchemaChange && (
+        <div style={{ marginTop: 16 }}>
+          <ConfigSubSection
+            title="Log Details Schema"
+            description="Display table schema information in log details panel"
+          >
+            <Switch
+              label="Show table schema in log details"
+              tooltip="When enabled, displays all available table columns in log details, even if they are not selected in the query. Useful for discovering available fields without using SELECT *."
+              value={showTableSchema ?? true}
+              onChange={onShowTableSchemaChange}
+              wide
+            />
+          </ConfigSubSection>
+        </div>
+      )}
     </ConfigSection>
   );
 };

--- a/src/components/queryBuilder/views/logsQueryBuilderHooks.test.ts
+++ b/src/components/queryBuilder/views/logsQueryBuilderHooks.test.ts
@@ -90,7 +90,9 @@ describe('useOtelColumns', () => {
   it('should not call builderOptionsDispatch if OTEL is already enabled', async () => {
     jest.spyOn(mockDatasource, 'shouldSelectLogContextColumns').mockReturnValue(false);
     const builderOptionsDispatch = jest.fn();
-    const allColumns: readonly TableColumn[] = [{ name: 'LogAttributes', type: 'Map(String, String)', picklistValues: [] }];
+    const allColumns: readonly TableColumn[] = [
+      { name: 'LogAttributes', type: 'Map(String, String)', picklistValues: [] },
+    ];
 
     renderHook(() => useOtelColumns(mockDatasource, allColumns, true, testOtelVersion.version, builderOptionsDispatch));
 
@@ -102,7 +104,9 @@ describe('useOtelColumns', () => {
     // Should not be included, since shouldSelectLogContextColumns returns false
     jest.spyOn(mockDatasource, 'getLogContextColumnNames').mockReturnValue(['SampleColumn']);
     const builderOptionsDispatch = jest.fn();
-    const allColumns: readonly TableColumn[] = [{ name: 'LogAttributes', type: 'Map(String, String)', picklistValues: [] }];
+    const allColumns: readonly TableColumn[] = [
+      { name: 'LogAttributes', type: 'Map(String, String)', picklistValues: [] },
+    ];
 
     renderHook(() => useOtelColumns(mockDatasource, allColumns, true, testOtelVersion.version, builderOptionsDispatch));
 
@@ -127,7 +131,9 @@ describe('useOtelColumns', () => {
   it('should call builderOptionsDispatch with columns when OTEL is toggled on', async () => {
     jest.spyOn(mockDatasource, 'shouldSelectLogContextColumns').mockReturnValue(false);
     const builderOptionsDispatch = jest.fn();
-    const allColumns: readonly TableColumn[] = [{ name: 'LogAttributes', type: 'Map(String, String)', picklistValues: [] }];
+    const allColumns: readonly TableColumn[] = [
+      { name: 'LogAttributes', type: 'Map(String, String)', picklistValues: [] },
+    ];
 
     let otelEnabled = false;
     const hook = renderHook(
@@ -166,7 +172,9 @@ describe('useOtelColumns', () => {
     hook.rerender(otelEnabled);
 
     const columns: SelectedColumn[] = [];
-    testOtelVersion.logColumnMap.forEach((v, k) => {columns.push({ name: v, hint: k, type: allColumns.find((c) => c.name === v)?.type })});
+    testOtelVersion.logColumnMap.forEach((v, k) => {
+      columns.push({ name: v, hint: k, type: allColumns.find((c) => c.name === v)?.type });
+    });
     columns.push({ name: 'SampleColumn', type: allColumns.find((c) => c.name === 'SampleColumn')?.type });
     const expectedOptions = { columns };
 
@@ -177,7 +185,9 @@ describe('useOtelColumns', () => {
   it('should not call builderOptionsDispatch after OTEL columns are set', async () => {
     jest.spyOn(mockDatasource, 'shouldSelectLogContextColumns').mockReturnValue(false);
     const builderOptionsDispatch = jest.fn();
-    const allColumns: readonly TableColumn[] = [{ name: 'LogAttributes', type: 'Map(String, String)', picklistValues: [] }];
+    const allColumns: readonly TableColumn[] = [
+      { name: 'LogAttributes', type: 'Map(String, String)', picklistValues: [] },
+    ];
 
     let otelEnabled = false; // OTEL is off
     const hook = renderHook(

--- a/src/data/ast.test.ts
+++ b/src/data/ast.test.ts
@@ -1,4 +1,14 @@
-import { getFields, sqlToStatement } from './ast';
+import {
+  getFields,
+  sqlToStatement,
+  getTableInfo,
+  getSelectColumnNames,
+  getWhereColumnNames,
+  getAllQueriedColumns,
+  hasAggregateFunction,
+  hasGroupBy,
+  canAutoAddWhereColumns,
+} from './ast';
 import { toSql } from 'pgsql-ast-parser';
 
 describe('ast', () => {
@@ -41,6 +51,163 @@ describe('ast', () => {
       expect(errLog).toHaveBeenCalledTimes(0);
       expect(stm).not.toEqual({});
       expect(astSql).not.toBeFalsy();
+    });
+  });
+
+  describe('getTableInfo', () => {
+    it('extracts table without database', () => {
+      expect(getTableInfo('SELECT * FROM logs')).toEqual({ table: 'logs' });
+    });
+
+    it('extracts database and table', () => {
+      expect(getTableInfo('SELECT * FROM default.logs')).toEqual({
+        database: 'default',
+        table: 'logs',
+      });
+    });
+
+    it('preserves original casing', () => {
+      expect(getTableInfo('SELECT * FROM MyDatabase.MyTable')).toEqual({
+        database: 'MyDatabase',
+        table: 'MyTable',
+      });
+    });
+
+    it('handles quoted identifiers', () => {
+      expect(getTableInfo('SELECT * FROM "default"."logs"')).toEqual({
+        database: 'default',
+        table: 'logs',
+      });
+    });
+
+    it('returns null for invalid queries', () => {
+      expect(getTableInfo('INSERT INTO logs VALUES (1)')).toBeNull();
+      expect(getTableInfo('SELECT 1')).toBeNull();
+    });
+  });
+
+  describe('getSelectColumnNames', () => {
+    it('extracts simple column names', () => {
+      expect(getSelectColumnNames('SELECT a, b, c FROM t')).toEqual(new Set(['a', 'b', 'c']));
+    });
+
+    it('extracts column names from aliases', () => {
+      expect(getSelectColumnNames('SELECT a AS alias, b FROM t')).toEqual(new Set(['a', 'b']));
+    });
+
+    it('returns empty set for SELECT *', () => {
+      expect(getSelectColumnNames('SELECT * FROM t')).toEqual(new Set());
+    });
+
+    it('extracts columns from functions', () => {
+      expect(getSelectColumnNames('SELECT count(id), timestamp FROM t')).toEqual(new Set(['id', 'timestamp']));
+    });
+
+    it('handles complex expressions', () => {
+      expect(getSelectColumnNames('SELECT a + b AS sum, c FROM t')).toEqual(new Set(['a', 'b', 'c']));
+    });
+  });
+
+  describe('getWhereColumnNames', () => {
+    it('extracts column from simple condition', () => {
+      expect(getWhereColumnNames("SELECT * FROM t WHERE service = 'auth'")).toEqual(new Set(['service']));
+    });
+
+    it('extracts columns from AND/OR conditions', () => {
+      expect(getWhereColumnNames('SELECT * FROM t WHERE a = 1 AND b = 2 OR c = 3')).toEqual(new Set(['a', 'b', 'c']));
+    });
+
+    it('extracts columns from IN clause', () => {
+      expect(getWhereColumnNames("SELECT * FROM t WHERE level IN ('info', 'warn')")).toEqual(new Set(['level']));
+    });
+
+    it('extracts columns from functions', () => {
+      expect(getWhereColumnNames("SELECT * FROM t WHERE lower(name) = 'test'")).toEqual(new Set(['name']));
+    });
+
+    it('excludes macro variables', () => {
+      expect(getWhereColumnNames('SELECT * FROM t WHERE $__timeFilter(ts)')).toEqual(new Set(['ts']));
+    });
+
+    it('handles complex nested conditions', () => {
+      expect(getWhereColumnNames('SELECT * FROM t WHERE (a > 1 AND b < 2) OR c != 3')).toEqual(
+        new Set(['a', 'b', 'c'])
+      );
+    });
+
+    it('returns empty set when no WHERE clause', () => {
+      expect(getWhereColumnNames('SELECT * FROM t')).toEqual(new Set());
+    });
+  });
+
+  describe('getAllQueriedColumns', () => {
+    it('combines SELECT and WHERE columns', () => {
+      const sql = "SELECT timestamp, message FROM logs WHERE service = 'auth'";
+      expect(getAllQueriedColumns(sql)).toEqual(new Set(['timestamp', 'message', 'service']));
+    });
+
+    it('handles overlapping columns', () => {
+      const sql = 'SELECT a, b FROM t WHERE a = 1 AND c = 2';
+      expect(getAllQueriedColumns(sql)).toEqual(new Set(['a', 'b', 'c']));
+    });
+
+    it('handles SELECT * with WHERE', () => {
+      const sql = "SELECT * FROM t WHERE status = 'active'";
+      expect(getAllQueriedColumns(sql)).toEqual(new Set(['status']));
+    });
+  });
+
+  describe('hasAggregateFunction', () => {
+    it('detects count()', () => {
+      expect(hasAggregateFunction('SELECT count() FROM t')).toBe(true);
+      expect(hasAggregateFunction('SELECT COUNT(*) FROM t')).toBe(true);
+    });
+
+    it('detects sum, avg, min, max', () => {
+      expect(hasAggregateFunction('SELECT sum(value) FROM t')).toBe(true);
+      expect(hasAggregateFunction('SELECT AVG(value) FROM t')).toBe(true);
+      expect(hasAggregateFunction('SELECT min(value), max(value) FROM t')).toBe(true);
+    });
+
+    it('detects ClickHouse specific aggregates', () => {
+      expect(hasAggregateFunction('SELECT uniq(user_id) FROM t')).toBe(true);
+      expect(hasAggregateFunction('SELECT groupArray(name) FROM t')).toBe(true);
+      // Note: quantile(0.95)(latency) syntax is not supported by pgsql-ast-parser
+      expect(hasAggregateFunction('SELECT median(latency) FROM t')).toBe(true);
+    });
+
+    it('returns false for non-aggregate queries', () => {
+      expect(hasAggregateFunction('SELECT a, b, c FROM t')).toBe(false);
+      expect(hasAggregateFunction('SELECT lower(name) FROM t')).toBe(false);
+      expect(hasAggregateFunction('SELECT * FROM t')).toBe(false);
+    });
+  });
+
+  describe('hasGroupBy', () => {
+    it('detects GROUP BY clause', () => {
+      expect(hasGroupBy('SELECT a, count() FROM t GROUP BY a')).toBe(true);
+      expect(hasGroupBy('SELECT region, sum(sales) FROM t GROUP BY region')).toBe(true);
+    });
+
+    it('returns false without GROUP BY', () => {
+      expect(hasGroupBy('SELECT a, b FROM t')).toBe(false);
+      expect(hasGroupBy('SELECT * FROM t WHERE x = 1')).toBe(false);
+    });
+  });
+
+  describe('canAutoAddWhereColumns', () => {
+    it('returns true for simple SELECT queries', () => {
+      expect(canAutoAddWhereColumns('SELECT a, b FROM t WHERE c = 1')).toBe(true);
+      expect(canAutoAddWhereColumns('SELECT * FROM t')).toBe(true);
+    });
+
+    it('returns false for aggregate queries', () => {
+      expect(canAutoAddWhereColumns('SELECT count() FROM t WHERE status = 1')).toBe(false);
+      expect(canAutoAddWhereColumns('SELECT sum(value) FROM t WHERE region = "us"')).toBe(false);
+    });
+
+    it('returns false for GROUP BY queries', () => {
+      expect(canAutoAddWhereColumns('SELECT region, count() FROM t GROUP BY region')).toBe(false);
     });
   });
 });

--- a/src/data/ast.ts
+++ b/src/data/ast.ts
@@ -1,4 +1,14 @@
-import { parseFirst, Statement, SelectFromStatement, astMapper, toSql, ExprRef } from 'pgsql-ast-parser';
+import {
+  parseFirst,
+  Statement,
+  SelectFromStatement,
+  astMapper,
+  astVisitor,
+  toSql,
+  Expr,
+  ExprRef,
+  ExprCall,
+} from 'pgsql-ast-parser';
 
 interface ReplacePart {
   startIndex: number;
@@ -74,8 +84,8 @@ export function sqlToStatement(rawSql: string): Statement {
   let ast: Statement;
   try {
     ast = parseFirst(sql);
-  } catch (err) {
-    console.error(`Failed to parse SQL statement into an AST: ${err}`);
+  } catch {
+    // AST parsing failed - caller should handle with regex fallback
     return {} as Statement;
   }
 
@@ -160,4 +170,202 @@ export function getFields(sql: string): string[] {
       return `${exprName}`;
     }
   });
+}
+
+/**
+ * Extracts database and table name from SQL.
+ * Returns null if parsing fails or no table found.
+ */
+export function getTableInfo(sql: string): { database?: string; table?: string } | null {
+  const stm = sqlToStatement(sql);
+  if (stm.type !== 'select' || !stm.from?.length || stm.from.length <= 0) {
+    return null;
+  }
+
+  const from = stm.from[0];
+  if (from.type === 'table') {
+    const schema = from.name.schema;
+    const name = from.name.name;
+
+    // Restore original casing from raw SQL
+    const fullName = schema ? `${schema}.${name}` : name;
+    const match = new RegExp(`\\b${fullName}\\b`, 'gi').exec(sql);
+    const originalName = match ? match[0] : fullName;
+
+    if (schema) {
+      const parts = originalName.split('.');
+      return { database: parts[0], table: parts[1] || name };
+    }
+    return { table: originalName };
+  }
+
+  if (from.type === 'statement') {
+    // Handle subquery recursively
+    return getTableInfo(toSql.statement(from.statement));
+  }
+
+  return null;
+}
+
+/**
+ * Extracts column names from SELECT clause.
+ * Returns column names only (without aliases).
+ */
+export function getSelectColumnNames(sql: string): Set<string> {
+  const columns = new Set<string>();
+  const stm = sqlToStatement(sql) as SelectFromStatement;
+
+  if (stm.type !== 'select' || !stm.columns?.length) {
+    return columns;
+  }
+
+  for (const col of stm.columns) {
+    extractColumnNamesFromExpr(col.expr, columns);
+  }
+
+  return columns;
+}
+
+/**
+ * Extracts column names from WHERE clause.
+ */
+export function getWhereColumnNames(sql: string): Set<string> {
+  const columns = new Set<string>();
+  const stm = sqlToStatement(sql) as SelectFromStatement;
+
+  if (stm.type !== 'select' || !stm.where) {
+    return columns;
+  }
+
+  extractColumnNamesFromExpr(stm.where, columns);
+  return columns;
+}
+
+/**
+ * Extracts all queried column names (SELECT + WHERE).
+ */
+export function getAllQueriedColumns(sql: string): Set<string> {
+  const selectCols = getSelectColumnNames(sql);
+  const whereCols = getWhereColumnNames(sql);
+
+  return new Set([...selectCols, ...whereCols]);
+}
+
+/**
+ * Recursively extracts column names from an expression.
+ * Handles refs, binary ops, function calls, etc.
+ */
+function extractColumnNamesFromExpr(expr: Expr | undefined | null, columns: Set<string>): void {
+  if (!expr) {
+    return;
+  }
+
+  const visitor = astVisitor((map) => ({
+    ref: (r: ExprRef) => {
+      // Skip macro variables like $__fromTime
+      if (r.name && !r.name.startsWith('$') && r.name !== '*') {
+        columns.add(r.name);
+      }
+      return r;
+    },
+    call: (c: ExprCall) => {
+      // Extract column names from function arguments
+      if (c.args) {
+        for (const arg of c.args) {
+          map.expr(arg);
+        }
+      }
+      return c;
+    },
+  }));
+
+  visitor.expr(expr);
+}
+
+/**
+ * Common aggregate function names (case-insensitive).
+ * Covers standard SQL and ClickHouse-specific aggregates.
+ */
+const AGGREGATE_FUNCTIONS = new Set([
+  // Standard SQL
+  'count',
+  'sum',
+  'avg',
+  'min',
+  'max',
+  // ClickHouse specific
+  'any',
+  'anylast',
+  'argmin',
+  'argmax',
+  'grouparray',
+  'groupuniqarray',
+  'grouparrayinsertat',
+  'uniq',
+  'uniqexact',
+  'uniqcombined',
+  'uniqhll12',
+  'quantile',
+  'quantiles',
+  'median',
+  'stddevpop',
+  'stddevsamp',
+  'varpop',
+  'varsamp',
+  'covarPop',
+  'covarsamp',
+  'corr',
+  'topk',
+  'topkweighted',
+  'sumwithoverflow',
+  'summap',
+  'minmap',
+  'maxmap',
+]);
+
+/**
+ * Checks if the SQL contains aggregate functions.
+ */
+export function hasAggregateFunction(sql: string): boolean {
+  const stm = sqlToStatement(sql);
+  if (stm.type !== 'select' || !stm.columns?.length) {
+    return false;
+  }
+
+  let found = false;
+
+  const visitor = astVisitor(() => ({
+    call: (c: ExprCall) => {
+      const funcName = c.function?.name;
+      if (funcName && AGGREGATE_FUNCTIONS.has(funcName.toLowerCase())) {
+        found = true;
+      }
+      return c;
+    },
+  }));
+
+  for (const col of stm.columns) {
+    visitor.expr(col.expr);
+    if (found) {
+      break;
+    }
+  }
+
+  return found;
+}
+
+/**
+ * Checks if the SQL has a GROUP BY clause.
+ */
+export function hasGroupBy(sql: string): boolean {
+  const stm = sqlToStatement(sql) as SelectFromStatement;
+  return stm.type === 'select' && Array.isArray(stm.groupBy) && stm.groupBy.length > 0;
+}
+
+/**
+ * Determines if WHERE columns can be safely added to SELECT.
+ * Returns false if query has aggregates or GROUP BY (would cause SQL errors).
+ */
+export function canAutoAddWhereColumns(sql: string): boolean {
+  return !hasAggregateFunction(sql) && !hasGroupBy(sql);
 }

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -78,6 +78,12 @@ export interface CHLogsConfig {
 
   selectContextColumns?: boolean;
   contextColumns?: string[];
+
+  /**
+   * When enabled, shows all available table columns in log details,
+   * even if they are not selected in the query.
+   */
+  showTableSchema?: boolean;
 }
 
 export interface CHTracesConfig {

--- a/src/views/CHConfigEditor.tsx
+++ b/src/views/CHConfigEditor.tsx
@@ -181,15 +181,15 @@ export const ConfigEditor: React.FC<ConfigEditorProps> = (props) => {
 
   const hasAdditionalSettings = Boolean(
     window.location.hash || // if trying to link to section on page, open all settings (React breaks this?)
-      options.jsonData.defaultDatabase ||
-      options.jsonData.defaultTable ||
-      options.jsonData.dialTimeout ||
-      options.jsonData.queryTimeout ||
-      options.jsonData.validateSql ||
-      options.jsonData.enableSecureSocksProxy ||
-      options.jsonData.customSettings ||
-      options.jsonData.logs ||
-      options.jsonData.traces
+    options.jsonData.defaultDatabase ||
+    options.jsonData.defaultTable ||
+    options.jsonData.dialTimeout ||
+    options.jsonData.queryTimeout ||
+    options.jsonData.validateSql ||
+    options.jsonData.enableSecureSocksProxy ||
+    options.jsonData.customSettings ||
+    options.jsonData.logs ||
+    options.jsonData.traces
   );
 
   const defaultPort = jsonData.secure
@@ -508,6 +508,9 @@ export const ConfigEditor: React.FC<ConfigEditorProps> = (props) => {
           onContextColumnsChange={(c) => {
             trackingV1.trackClickhouseConfigV1LogsConfig({ contextColumns: c });
             onLogsConfigChange('contextColumns', c);
+          }}
+          onShowTableSchemaChange={(v) => {
+            onLogsConfigChange('showTableSchema', v);
           }}
         />
 

--- a/src/views/config-v2/HttpProtocolSettingsSection.tsx
+++ b/src/views/config-v2/HttpProtocolSettingsSection.tsx
@@ -7,8 +7,10 @@ import { css } from '@emotion/css';
 import { onHttpHeadersChange } from 'views/CHConfigEditorHooks';
 import { HttpHeadersConfigV2 } from './HttpHeadersConfigV2';
 
-export interface HttpProtocolSettingsSectionProps
-  extends DataSourcePluginOptionsEditorProps<CHConfig, CHSecureConfig> {}
+export interface HttpProtocolSettingsSectionProps extends DataSourcePluginOptionsEditorProps<
+  CHConfig,
+  CHSecureConfig
+> {}
 
 export const HttpProtocolSettingsSection = (props: HttpProtocolSettingsSectionProps) => {
   const { options, onOptionsChange } = props;


### PR DESCRIPTION
  ## Summary

  Add table schema metadata display in log details panel, allowing users to discover available columns without using `SELECT *`.

  ## Motivation

  ClickHouse is a columnar database where selecting only necessary columns significantly improves query performance. However, users often don't know what columns are available in a table without running `SELECT *` or checking the schema separately.

  This feature bridges the gap by:
  - Showing all available table columns in the log details panel
  - Marking non-queried columns as `not queried (Type)` to indicate they exist but weren't selected
  - Automatically adding WHERE clause columns to SELECT (since ClickHouse already scans them for filtering)

  ## Changes

  ### Core Logic (`src/data/CHDatasource.ts`)
  - Add `schemaCache` for caching table schemas (avoids repeated `DESC TABLE` queries)
  - Add `fetchColumnsFromTableCached()` for cached schema fetching
  - Add `addSchemaMetadataToLogFrames()` to enrich log frames with schema metadata
  - Auto-append WHERE clause columns to SELECT for non-aggregate queries

  ### SQL Parsing (`src/data/ast.ts`)
  - `getTableInfo()`: Extract database/table from SQL using AST
  - `getSelectColumnNames()` / `getWhereColumnNames()`: Extract column names from clauses
  - `hasAggregateFunction()` / `hasGroupBy()`: Detect aggregate queries
  - `canAutoAddWhereColumns()`: Determine if WHERE columns can be safely added

  ### Utilities (`src/data/utils.ts`)
  - `extractTableFromSql()`: AST-first with regex fallback
  - `extractColumnsFromSql()`: Extract all queried columns (SELECT + WHERE)
  - `appendWhereColumnsToSelect()`: Safely add WHERE columns to SELECT clause

  ### Configuration
  - Add `showTableSchema` option to `CHLogsConfig` (default: `true`)
  - Add toggle in Logs Config UI: "Show table schema in log details"

  ## Behavior

  | Query Type | Behavior |
  |------------|----------|
  | `QueryType.Logs` (Builder) | Schema metadata added |
  | `QueryType.Logs` (SQL) | Schema metadata + WHERE columns auto-added |
  | `QueryType.Table` | No change (feature disabled) |
  | `SELECT *` | No change (all columns already visible) |
  | Aggregate/GROUP BY | WHERE columns NOT auto-added (would cause SQL error) |

  ## Test Plan

  - [x] `npm run lint` passes
  - [x] `npm run typecheck` passes
  - [x] `npm run test:ci` passes (615 tests)
  - [x] Manual test: Verify WHERE columns appear in results for non-aggregate queries
  - [x] Manual test: Verify aggregate queries are not modified

  ## Screenshots
<img width="538" height="419" alt="image" src="https://github.com/user-attachments/assets/f163370e-a949-419a-91f7-c99315f3f9aa" />
