### PR TITLE
fix: set FrameTypeLogLines when body field exists in logs

### DIFF
--- a/src/components/queryBuilder/views/logsQueryBuilderHooks.test.ts
+++ b/src/components/queryBuilder/views/logsQueryBuilderHooks.test.ts
@@ -90,7 +90,9 @@ describe('useOtelColumns', () => {
   it('should not call builderOptionsDispatch if OTEL is already enabled', async () => {
     jest.spyOn(mockDatasource, 'shouldSelectLogContextColumns').mockReturnValue(false);
     const builderOptionsDispatch = jest.fn();
-    const allColumns: readonly TableColumn[] = [{ name: 'LogAttributes', type: 'Map(String, String)', picklistValues: [] }];
+    const allColumns: readonly TableColumn[] = [
+      { name: 'LogAttributes', type: 'Map(String, String)', picklistValues: [] },
+    ];
 
     renderHook(() => useOtelColumns(mockDatasource, allColumns, true, testOtelVersion.version, builderOptionsDispatch));
 
@@ -102,7 +104,9 @@ describe('useOtelColumns', () => {
     // Should not be included, since shouldSelectLogContextColumns returns false
     jest.spyOn(mockDatasource, 'getLogContextColumnNames').mockReturnValue(['SampleColumn']);
     const builderOptionsDispatch = jest.fn();
-    const allColumns: readonly TableColumn[] = [{ name: 'LogAttributes', type: 'Map(String, String)', picklistValues: [] }];
+    const allColumns: readonly TableColumn[] = [
+      { name: 'LogAttributes', type: 'Map(String, String)', picklistValues: [] },
+    ];
 
     renderHook(() => useOtelColumns(mockDatasource, allColumns, true, testOtelVersion.version, builderOptionsDispatch));
 
@@ -127,7 +131,9 @@ describe('useOtelColumns', () => {
   it('should call builderOptionsDispatch with columns when OTEL is toggled on', async () => {
     jest.spyOn(mockDatasource, 'shouldSelectLogContextColumns').mockReturnValue(false);
     const builderOptionsDispatch = jest.fn();
-    const allColumns: readonly TableColumn[] = [{ name: 'LogAttributes', type: 'Map(String, String)', picklistValues: [] }];
+    const allColumns: readonly TableColumn[] = [
+      { name: 'LogAttributes', type: 'Map(String, String)', picklistValues: [] },
+    ];
 
     let otelEnabled = false;
     const hook = renderHook(
@@ -166,7 +172,9 @@ describe('useOtelColumns', () => {
     hook.rerender(otelEnabled);
 
     const columns: SelectedColumn[] = [];
-    testOtelVersion.logColumnMap.forEach((v, k) => {columns.push({ name: v, hint: k, type: allColumns.find((c) => c.name === v)?.type })});
+    testOtelVersion.logColumnMap.forEach((v, k) => {
+      columns.push({ name: v, hint: k, type: allColumns.find((c) => c.name === v)?.type });
+    });
     columns.push({ name: 'SampleColumn', type: allColumns.find((c) => c.name === 'SampleColumn')?.type });
     const expectedOptions = { columns };
 
@@ -177,7 +185,9 @@ describe('useOtelColumns', () => {
   it('should not call builderOptionsDispatch after OTEL columns are set', async () => {
     jest.spyOn(mockDatasource, 'shouldSelectLogContextColumns').mockReturnValue(false);
     const builderOptionsDispatch = jest.fn();
-    const allColumns: readonly TableColumn[] = [{ name: 'LogAttributes', type: 'Map(String, String)', picklistValues: [] }];
+    const allColumns: readonly TableColumn[] = [
+      { name: 'LogAttributes', type: 'Map(String, String)', picklistValues: [] },
+    ];
 
     let otelEnabled = false; // OTEL is off
     const hook = renderHook(

--- a/src/data/utils.test.ts
+++ b/src/data/utils.test.ts
@@ -220,9 +220,7 @@ describe('transformQueryResponseWithTraceAndLogLinks', () => {
   it('includes TraceId filter in View logs link query using configured column', async () => {
     const mockDatasource = newMockDatasource();
     // Mock that TraceId is configured
-    jest.spyOn(mockDatasource, 'getDefaultLogsColumns').mockReturnValue(
-      new Map([[ColumnHint.TraceId, 'TraceId']])
-    );
+    jest.spyOn(mockDatasource, 'getDefaultLogsColumns').mockReturnValue(new Map([[ColumnHint.TraceId, 'TraceId']]));
 
     const builderOptions: Partial<QueryBuilderOptions> = {
       queryType: QueryType.Traces,
@@ -239,16 +237,12 @@ describe('transformQueryResponseWithTraceAndLogLinks', () => {
     expect(logsQuery.builderOptions.columns).toBeDefined();
 
     // TraceId column should be in the columns array
-    const traceIdColumn = logsQuery.builderOptions.columns?.find(
-      (c) => c.hint === ColumnHint.TraceId
-    );
+    const traceIdColumn = logsQuery.builderOptions.columns?.find((c) => c.hint === ColumnHint.TraceId);
     expect(traceIdColumn).toBeDefined();
     expect(traceIdColumn?.name).toBe('TraceId');
 
     // Filter should have the TraceId hint and column name as key
-    const traceIdFilter = logsQuery.builderOptions.filters?.find(
-      (f) => (f as any).hint === ColumnHint.TraceId
-    ) as any;
+    const traceIdFilter = logsQuery.builderOptions.filters?.find((f) => (f as any).hint === ColumnHint.TraceId) as any;
     expect(traceIdFilter).toBeDefined();
     expect(traceIdFilter.key).toBe('TraceId');
   });

--- a/src/data/utils.ts
+++ b/src/data/utils.ts
@@ -149,7 +149,8 @@ export const transformQueryResponseWithTraceAndLogLinks = (
     // Get the configured TraceId column name for use in both trace and logs queries
     const defaultLogsColumns = datasource.getDefaultLogsColumns();
     // Use traces config traceIdColumn if available, otherwise fallback to logs default
-    const traceIdColumnName = datasource.getTracesTraceIdColumn() || defaultLogsColumns.get(ColumnHint.TraceId) || 'TraceId';
+    const traceIdColumnName =
+      datasource.getTracesTraceIdColumn() || defaultLogsColumns.get(ColumnHint.TraceId) || 'TraceId';
 
     const traceIdQuery: CHBuilderQuery = {
       datasource: datasource,

--- a/src/views/CHConfigEditor.tsx
+++ b/src/views/CHConfigEditor.tsx
@@ -181,15 +181,15 @@ export const ConfigEditor: React.FC<ConfigEditorProps> = (props) => {
 
   const hasAdditionalSettings = Boolean(
     window.location.hash || // if trying to link to section on page, open all settings (React breaks this?)
-      options.jsonData.defaultDatabase ||
-      options.jsonData.defaultTable ||
-      options.jsonData.dialTimeout ||
-      options.jsonData.queryTimeout ||
-      options.jsonData.validateSql ||
-      options.jsonData.enableSecureSocksProxy ||
-      options.jsonData.customSettings ||
-      options.jsonData.logs ||
-      options.jsonData.traces
+    options.jsonData.defaultDatabase ||
+    options.jsonData.defaultTable ||
+    options.jsonData.dialTimeout ||
+    options.jsonData.queryTimeout ||
+    options.jsonData.validateSql ||
+    options.jsonData.enableSecureSocksProxy ||
+    options.jsonData.customSettings ||
+    options.jsonData.logs ||
+    options.jsonData.traces
   );
 
   const defaultPort = jsonData.secure

--- a/src/views/config-v2/HttpProtocolSettingsSection.tsx
+++ b/src/views/config-v2/HttpProtocolSettingsSection.tsx
@@ -7,8 +7,10 @@ import { css } from '@emotion/css';
 import { onHttpHeadersChange } from 'views/CHConfigEditorHooks';
 import { HttpHeadersConfigV2 } from './HttpHeadersConfigV2';
 
-export interface HttpProtocolSettingsSectionProps
-  extends DataSourcePluginOptionsEditorProps<CHConfig, CHSecureConfig> {}
+export interface HttpProtocolSettingsSectionProps extends DataSourcePluginOptionsEditorProps<
+  CHConfig,
+  CHSecureConfig
+> {}
 
 export const HttpProtocolSettingsSection = (props: HttpProtocolSettingsSectionProps) => {
   const { options, onOptionsChange } = props;


### PR DESCRIPTION
## Summary

Set `FrameTypeLogLines` metadata when a `body` field exists in log query results, ensuring Grafana correctly identifies the log message column.

## Motivation

Grafana's logs panel relies on frame metadata to determine which field contains the log message. Without `FrameTypeLogLines`, Grafana falls back to using the second string field as the log line, which can lead to incorrect column selection when the `body` field is present but not explicitly marked.

This issue particularly affects sql editor users, where:
- The **Log Message column** setting (from datasource config) is aliased as `body` in SQL
- Without proper metadata, Grafana may ignore the `body` field and use another string column
- Users see incorrect log messages in the logs panel

## Changes

### Backend (`pkg/plugin/driver.go`)
- Modified `MutateResponse()` to detect `body` field in logs frames
- Set `frame.Meta.Type = data.FrameTypeLogLines` when `body` field exists
- Added `frameHasField()` helper function to check field existence

### Tests (`pkg/plugin/driver_test.go`)
- Added `TestFrameHasField()` for field detection logic
- Added `TestMutateResponseLogsFrameType()` covering:
  - ✅ Sets `FrameTypeLogLines` when body field exists
  - ✅ Does not set when body field is missing
  - ✅ Does not affect non-logs visualizations

### Code Quality
- Applied prettier formatting to frontend files

## Behavior

| Scenario | Result |
|----------|--------|
| Query Builder + Log Message column configured | `body` field → `FrameTypeLogLines` set ✅ |
| SQL Editor with `SELECT body` | `body` field → `FrameTypeLogLines` set ✅ |
| SQL Editor with `SELECT col AS body` | `body` field → `FrameTypeLogLines` set ✅ |
| SQL Editor with `SELECT message` (no alias) | No `body` field → Falls back to Grafana default behavior |
| Table/Traces visualization | No change (only affects logs) |

**Note**: SQL Editor users should either select a column named `body` or use `AS body` alias for the log message column to benefit from this feature. Query Builder handles this automatically.

## Test Plan

- [x] `go test ./pkg/plugin/...` passes (all tests including new ones)
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes


## Related

This complements the existing `ColumnHint.LogMessage` system:
- **Frontend**: Maps configured column to `body` alias in SQL
- **Backend**: Detects `body` field and marks frame appropriately
- **Grafana**: Uses frame metadata to display log lines correctly
