### PR TITLE
fix(converters): add support for Nullable(Enum8/16) column types

### DIFF
--- a/pkg/converters/converters.go
+++ b/pkg/converters/converters.go
@@ -50,6 +50,8 @@ var matchRegexes = map[string]*regexp.Regexp{
 	"Dynamic":                   regexp.MustCompile(`^Dynamic`),
 	"JSON":                      regexp.MustCompile(`^JSON`),
 	"Nullable(JSON)":            regexp.MustCompile(`^Nullable\(JSON`),
+	"Enum":                      regexp.MustCompile(`^Enum(8|16)\(.*\)`),
+	"Nullable(Enum)":            regexp.MustCompile(`^Nullable\(Enum(8|16)\(.*\)\)`),
 }
 
 // Converters defines a list of type converters.
@@ -60,6 +62,18 @@ var Converters = []Converter{
 		name:      "String",
 		fieldType: data.FieldTypeString,
 		scanType:  reflect.PointerTo(reflect.TypeOf("")),
+	},
+	{
+		name:       "Enum",
+		fieldType:  data.FieldTypeString,
+		matchRegex: matchRegexes["Enum"],
+		scanType:   reflect.PointerTo(reflect.TypeOf("")),
+	},
+	{
+		name:       "Nullable(Enum)",
+		fieldType:  data.FieldTypeNullableString,
+		matchRegex: matchRegexes["Nullable(Enum)"],
+		scanType:   reflect.PointerTo(reflect.PointerTo(reflect.TypeOf(""))),
 	},
 	{
 		name:      "Bool",

--- a/pkg/converters/converters_test.go
+++ b/pkg/converters/converters_test.go
@@ -86,6 +86,68 @@ func TestNullableString(t *testing.T) {
 	assert.Equal(t, value, actual)
 }
 
+func TestEnum8(t *testing.T) {
+	value := "CONST"
+	sut := GetConverter("Enum8('WRITABLE' = 0, 'CONST' = 1, 'CHANGEABLE_IN_READONLY' = 2)")
+	require.NotNil(t, sut.InputScanType, "Enum8 converter should be found")
+	v, err := sut.FrameConverter.ConverterFunc(&value)
+	assert.Nil(t, err)
+	actual := v.(string)
+	assert.Equal(t, value, actual)
+}
+
+func TestEnum16(t *testing.T) {
+	value := "option1"
+	sut := GetConverter("Enum16('option1' = 1000, 'option2' = 2000)")
+	require.NotNil(t, sut.InputScanType, "Enum16 converter should be found")
+	v, err := sut.FrameConverter.ConverterFunc(&value)
+	assert.Nil(t, err)
+	actual := v.(string)
+	assert.Equal(t, value, actual)
+}
+
+func TestNullableEnum8(t *testing.T) {
+	value := "CONST"
+	valuePtr := &value
+	sut := GetConverter("Nullable(Enum8('WRITABLE' = 0, 'CONST' = 1, 'CHANGEABLE_IN_READONLY' = 2))")
+	require.NotNil(t, sut.InputScanType, "Nullable(Enum8) converter should be found")
+	v, err := sut.FrameConverter.ConverterFunc(&valuePtr)
+	assert.Nil(t, err)
+	actual := v.(*string)
+	assert.Equal(t, valuePtr, actual)
+}
+
+func TestNullableEnum8ShouldBeNil(t *testing.T) {
+	var value *string
+	sut := GetConverter("Nullable(Enum8('WRITABLE' = 0, 'CONST' = 1, 'CHANGEABLE_IN_READONLY' = 2))")
+	require.NotNil(t, sut.InputScanType, "Nullable(Enum8) converter should be found")
+	v, err := sut.FrameConverter.ConverterFunc(&value)
+	assert.Nil(t, err)
+	actual := v.(*string)
+	assert.Equal(t, (*string)(nil), actual)
+}
+
+func TestNullableEnum16(t *testing.T) {
+	value := "option1"
+	valuePtr := &value
+	sut := GetConverter("Nullable(Enum16('option1' = 1000, 'option2' = 2000))")
+	require.NotNil(t, sut.InputScanType, "Nullable(Enum16) converter should be found")
+	v, err := sut.FrameConverter.ConverterFunc(&valuePtr)
+	assert.Nil(t, err)
+	actual := v.(*string)
+	assert.Equal(t, valuePtr, actual)
+}
+
+func TestNullableEnum16ShouldBeNil(t *testing.T) {
+	var value *string
+	sut := GetConverter("Nullable(Enum16('option1' = 1000, 'option2' = 2000))")
+	require.NotNil(t, sut.InputScanType, "Nullable(Enum16) converter should be found")
+	v, err := sut.FrameConverter.ConverterFunc(&value)
+	assert.Nil(t, err)
+	actual := v.(*string)
+	assert.Equal(t, (*string)(nil), actual)
+}
+
 func TestBool(t *testing.T) {
 	value := true
 	sut := GetConverter("Bool")

--- a/pkg/plugin/driver_integration_test.go
+++ b/pkg/plugin/driver_integration_test.go
@@ -1020,6 +1020,62 @@ func TestConvertEnum(t *testing.T) {
 	}
 }
 
+func TestConvertEnum8(t *testing.T) {
+	for name, protocol := range Protocols {
+		t.Run(fmt.Sprintf("using %s", name), func(t *testing.T) {
+			conn, close := setupTest(t, "col1 Enum8('WRITABLE' = 0, 'CONST' = 1, 'CHANGEABLE_IN_READONLY' = 2)", protocol, nil)
+			defer close(t)
+			insertData(t, conn, "CONST")
+			checkRows(t, conn, 1, "CONST")
+		})
+	}
+}
+
+func TestConvertNullableEnum8(t *testing.T) {
+	for name, protocol := range Protocols {
+		t.Run(fmt.Sprintf("using %s", name), func(t *testing.T) {
+			conn, close := setupTest(t, "col1 Nullable(Enum8('WRITABLE' = 0, 'CONST' = 1, 'CHANGEABLE_IN_READONLY' = 2))", protocol, nil)
+			defer close(t)
+			insertData(t, conn, "CONST")
+			val := "CONST"
+			checkRows(t, conn, 1, &val)
+		})
+	}
+}
+
+func TestConvertNullableEnum8WithNull(t *testing.T) {
+	for name, protocol := range Protocols {
+		t.Run(fmt.Sprintf("using %s", name), func(t *testing.T) {
+			conn, close := setupTest(t, "col1 Nullable(Enum8('WRITABLE' = 0, 'CONST' = 1, 'CHANGEABLE_IN_READONLY' = 2))", protocol, nil)
+			defer close(t)
+			insertData(t, conn, nil)
+			checkRows(t, conn, 1, (*string)(nil))
+		})
+	}
+}
+
+func TestConvertEnum16(t *testing.T) {
+	for name, protocol := range Protocols {
+		t.Run(fmt.Sprintf("using %s", name), func(t *testing.T) {
+			conn, close := setupTest(t, "col1 Enum16('option1' = 1000, 'option2' = 2000)", protocol, nil)
+			defer close(t)
+			insertData(t, conn, "option1")
+			checkRows(t, conn, 1, "option1")
+		})
+	}
+}
+
+func TestConvertNullableEnum16WithNull(t *testing.T) {
+	for name, protocol := range Protocols {
+		t.Run(fmt.Sprintf("using %s", name), func(t *testing.T) {
+			conn, close := setupTest(t, "col1 Nullable(Enum16('option1' = 1000, 'option2' = 2000))", protocol, nil)
+			defer close(t)
+			insertData(t, conn, nil)
+			checkRows(t, conn, 1, (*string)(nil))
+		})
+	}
+}
+
 func TestConvertUUID(t *testing.T) {
 	for name, protocol := range Protocols {
 		t.Run(fmt.Sprintf("using %s", name), func(t *testing.T) {


### PR DESCRIPTION
== Motivation ==

Fix scan errors when querying columns with Nullable(Enum8) or Nullable(Enum16) types containing NULL values

== Details ==

Fixes: https://github.com/grafana/clickhouse-datasource/issues/807

The plugin was missing converter definitions for Enum types, causing queries on Nullable(Enum8/16) columns to fail with "converting NULL to string is unsupported" when NULL values were present. This happened because without a matching converter, the framework fell back to default handling which couldn't properly scan NULL into a non-pointer string destination.

The fix adds regex-based converters for both Enum8 and Enum16 (and their Nullable variants) following the same pattern as other types like Nullable(String). Non-nullable enums use *string scan type, nullable enums use **string to allow the outer pointer to be nil for NULL values.