### PR TITLE
Update e2e tests

### DIFF
--- a/tests/e2e/configEditor.spec.ts
+++ b/tests/e2e/configEditor.spec.ts
@@ -6,34 +6,20 @@ const CLICKHOUSE_DB_URL = Boolean(process.env.CI) ? 'clickhouse-server' : 'local
 test.describe('Config Editor', () => {
   test('invalid credentials should return an error', async ({ createDataSourceConfigPage, page }) => {
     const configPage = await createDataSourceConfigPage({ type: PLUGIN_UID });
-    await page.getByPlaceholder('Server address').fill(CLICKHOUSE_DB_URL);
+    await page.getByPlaceholder('Enter server address').fill(CLICKHOUSE_DB_URL);
     await expect(configPage.saveAndTest()).not.toBeOK();
   });
 
   test('valid credentials should display a success alert on the page', async ({ createDataSourceConfigPage, page }) => {
     const configPage = await createDataSourceConfigPage({ type: PLUGIN_UID });
 
-    await page.getByPlaceholder('Server address').fill(CLICKHOUSE_DB_URL);
-    await page.getByPlaceholder('9000').fill('9000');
-    await page.getByPlaceholder('default').fill('default');
+    await page.getByPlaceholder('Enter server address').fill(CLICKHOUSE_DB_URL);
+    await page.getByPlaceholder('Enter server port').fill('9000');
+    await page.getByPlaceholder('Enter username').fill('default');
 
     await configPage.saveAndTest();
     await expect(configPage).toHaveAlert('success', { hasNotText: 'Datasource updated' });
 
     await page.pause();
-  });
-
-  test('mandatory fields should show error if left empty', async ({ createDataSourceConfigPage, page }) => {
-    const configPage = await createDataSourceConfigPage({ type: PLUGIN_UID });
-
-    await page.getByPlaceholder('Server address').fill('');
-    await page.keyboard.press('Tab');
-    await expect(page.getByText('Server address required')).toBeVisible();
-
-    await page.getByPlaceholder('9000').fill('');
-    await page.keyboard.press('Tab');
-    await expect(page.getByText('Port is required')).toBeVisible();
-
-    await expect(configPage.saveAndTest()).not.toBeOK();
   });
 });


### PR DESCRIPTION
Fix broken e2e tests by updating the placeholder text to match the new design. Also, remove an irrelevant test that checked for required fields to show an error if left blank (the new configuration design does not do this). 