### PR TITLE
improvements to query overview panel in query analysis dashboard

### DIFF
--- a/src/dashboards/query-analysis.json
+++ b/src/dashboards/query-analysis.json
@@ -1081,12 +1081,16 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "memory usage"
+              "options": "memory_usage"
             },
             "properties": [
               {
                 "id": "custom.width",
                 "value": 119
+              },
+              {
+                "id": "unit",
+                "value": "bytes"
               }
             ]
           },
@@ -1246,7 +1250,7 @@
               },
               {
                 "id": "unit",
-                "value": "dtdurationms"
+                "value": "ms"
               }
             ]
           },
@@ -1378,7 +1382,7 @@
             }
           },
           "queryType": "sql",
-          "rawSql": "SELECT query_start_time, type, query_duration_ms, initial_user, substring(query_id,1, 8) as query_id, query_kind, normalizeQuery(query) AS normalized_query, concat( toString(read_rows), ' rows / ', formatReadableSize(read_bytes) ) AS read, concat( toString(written_rows), ' rows / ', formatReadableSize(written_bytes) ) AS written, concat( toString(result_rows), ' rows / ', formatReadableSize(result_bytes) ) AS result, formatReadableSize(memory_usage) AS \"memory usage\" FROM system.query_log WHERE type in ($type) AND initial_user IN ($user) AND query_kind IN ($query_kind) AND $__timeFilter(event_time) ORDER BY query_duration_ms DESC LIMIT  1000",
+          "rawSql": "SELECT query_start_time, type, query_duration_ms, initial_user, substring(query_id,1, 8) as query_id, query_kind, normalizeQuery(query) AS normalized_query, concat( toString(read_rows), ' rows / ', formatReadableSize(read_bytes) ) AS read, concat( toString(written_rows), ' rows / ', formatReadableSize(written_bytes) ) AS written, concat( toString(result_rows), ' rows / ', formatReadableSize(result_bytes) ) AS result, memory_usage FROM system.query_log WHERE type in ($type) AND initial_user IN ($user) AND query_kind IN ($query_kind) AND $__timeFilter(event_time) ORDER BY query_duration_ms DESC LIMIT  1000",
           "refId": "A"
         }
       ],
@@ -1390,7 +1394,7 @@
             "excludeByName": {},
             "indexByName": {
               "initial_user": 5,
-              "memory usage": 2,
+              "memory_usage": 2,
               "normalized_query": 7,
               "query_duration_ms": 4,
               "query_id": 0,
@@ -1408,7 +1412,7 @@
               "databases": "Databases",
               "exception": "Exception",
               "initial_user": "User",
-              "memory usage": "Memory usage",
+              "memory_usage": "Memory usage",
               "normalized_query": "Normalized query",
               "query_duration_ms": "Duration",
               "query_id": "Query id",


### PR DESCRIPTION
## Type of Change

- [x] 🐛 Bug Fix

---

## Bug Fix

### What is the bug?

- Clicking the header of the "Memory usage" column sorts the rows lexically (rather than by actual bytes quantity)
- The "Duration" column's unit is not using abbreviations, causing the actual valuable information (the amount) to overflow out of the cell width

<img width="686" height="430" alt="image" src="https://github.com/user-attachments/assets/221f9849-23e7-421d-8ee9-92080004206f" />


### Changes

- update query to return `memory_usage` value directly; delegate formatting to Grafana via `unit` field property override
- update `unit` property override for `"Duration"` to be `ms`

## Screenshots / Videos

(After)

<img width="686" height="430" alt="image" src="https://github.com/user-attachments/assets/fbb9a729-2a9b-45e9-841d-cd4815e02d51" />

