### PR TITLE
Allow manual triggering of cron.yml

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -3,6 +3,7 @@ name: cron Jobs
 on:
   schedule:
     - cron: '0 9 * * *' # Daily at 09:00 UTC
+  workflow_dispatch: # Allow manual triggering
 
 defaults:
   run:
@@ -59,7 +60,7 @@ jobs:
         with:
           # Use /login so “reachable” also implies the app is up
           url: "https://datasourcese2e.grafana-dev.net/login"
-          timeout: 300 # 5 minutes
+          timeout: 600 # 10 minutes
           interval: 10 # 10 seconds
 
       - name: Run Grafana Bench tests


### PR DESCRIPTION
For debugging etc.

Also raising the timeout for `grafana/plugin-actions/wait-for-grafana` to 10 mins, as it can sometimes take up to 10 mins for DSE2EDEV to spin up. 😭 