### PR TITLE
Query Builder: Extract Map value type for mapKey filter in getFilters

### DIFF
--- a/src/data/sqlGenerator.test.ts
+++ b/src/data/sqlGenerator.test.ts
@@ -793,6 +793,78 @@ describe('getFilters', () => {
     expect(sql).toEqual(expectedSql);
   });
 
+  it('extracts Map value type for mapKey filter with Map(String, String)', () => {
+    const options = {
+      filters: [
+        {
+          condition: 'AND',
+          filterType: 'custom',
+          key: 'ResourceAttributes',
+          mapKey: 'service.name',
+          operator: FilterOperator.Equals,
+          type: 'Map(String, String)',
+          value: 'my-service',
+        },
+      ],
+    } as QueryBuilderOptions;
+    const sql = _testExports.getFilters(options);
+    expect(sql).toEqual(`( ResourceAttributes['service.name'] = 'my-service' )`);
+  });
+
+  it('extracts Map value type for mapKey filter with Map(String, UInt64)', () => {
+    const options = {
+      filters: [
+        {
+          condition: 'AND',
+          filterType: 'custom',
+          key: 'NumericMap',
+          mapKey: 'count',
+          operator: FilterOperator.Equals,
+          type: 'Map(String, UInt64)',
+          value: 42,
+        },
+      ],
+    } as QueryBuilderOptions;
+    const sql = _testExports.getFilters(options);
+    expect(sql).toEqual(`( NumericMap['count'] = 42 )`);
+  });
+
+  it('extracts Map value type for mapKey filter with Map(LowCardinality(String), String)', () => {
+    const options = {
+      filters: [
+        {
+          condition: 'AND',
+          filterType: 'custom',
+          key: 'SpanAttributes',
+          mapKey: 'http.method',
+          operator: FilterOperator.Like,
+          type: 'Map(LowCardinality(String), String)',
+          value: 'GET',
+        },
+      ],
+    } as QueryBuilderOptions;
+    const sql = _testExports.getFilters(options);
+    expect(sql).toEqual(`( SpanAttributes['http.method'] LIKE '%GET%' )`);
+  });
+
+  it('extracts Map value type for mapKey filter with Map(LowCardinality(String), UInt64)', () => {
+    const options = {
+      filters: [
+        {
+          condition: 'AND',
+          filterType: 'custom',
+          key: 'NumericAttrs',
+          mapKey: 'retry_count',
+          operator: FilterOperator.Equals,
+          type: 'Map(LowCardinality(String), UInt64)',
+          value: 3,
+        },
+      ],
+    } as QueryBuilderOptions;
+    const sql = _testExports.getFilters(options);
+    expect(sql).toEqual(`( NumericAttrs['retry_count'] = 3 )`);
+  });
+
   it('returns complex filter array', () => {
     const options = {
       columns: [{ name: 'hinted', hint: ColumnHint.Time }],

--- a/src/data/sqlGenerator.ts
+++ b/src/data/sqlGenerator.ts
@@ -803,6 +803,9 @@ const getFilters = (options: QueryBuilderOptions): string => {
 
     if (filter.mapKey && type.startsWith('Map')) {
       column += `['${filter.mapKey}']`;
+      // Extract the value type from Map(KeyType, ValueType)
+      const valueType = type.match(/Map\(\s*.+\s*,\s*(.+)\s*\)/)?.[1]?.trim() || 'String';
+      type = valueType;
     } else if (filter.mapKey && type.startsWith('JSON')) {
       const escapedJSONPaths = filter.mapKey
         .split('.')


### PR DESCRIPTION
## What

Fixes the Query Builder's `getFilters()` function to extract the value type from Map columns when a `mapKey` filter is applied.

## Problem

When filtering on a Map-type column (e.g., `Map(String, UInt64)`) with a specific key, the column expression is correctly transformed to `column['key']`, but the `type` variable remains as the full Map type. This causes type-checking functions (`isStringType`, `isNumberType`, etc.) to receive the wrong type, leading to incorrect SQL generation.

**Example with `Map(String, UInt64)`:**
- Column: `NumericMap` with type `Map(String, UInt64)`
- Filter: mapKey `count`, operator `=`, value `42`
- **Expected**: `NumericMap['count'] = 42` (no quotes — value type is UInt64)
- **Actual**: `NumericMap['count'] = '42'` (incorrectly quoted — `Map(String, UInt64)` doesn't match any specific type check, falls through to string escaping)

### Root cause

In `src/data/sqlGenerator.ts`, the `getFilters()` function:

```typescript
if (filter.mapKey && type.startsWith('Map')) {
  column += `['${filter.mapKey}']`;
} else if (filter.mapKey && type.startsWith('JSON')) {
```

The column expression is updated, but `type` is not updated to the Map's value type.

## Fix

After constructing the Map key access expression, extract the value type from `Map(KeyType, ValueType)` using a regex and update the `type` variable:

```typescript
const valueType = type.match(/Map\(\s*.+\s*,\s*(.+)\s*\)/)?.[1]?.trim() || 'String';
type = valueType;
```

## Test plan

- [x] `Map(String, String)` — value type `String` extracted, string values properly quoted
- [x] `Map(String, UInt64)` — value type `UInt64` extracted, numeric values not quoted
- [x] `Map(LowCardinality(String), String)` — nested key type handled, value type `String` extracted
- [x] `Map(LowCardinality(String), UInt64)` — compound case, value type `UInt64` extracted
- [x] All existing tests pass without modification