### PR TITLE
Fix failing g13 e2e tests

### DIFF
--- a/tests/e2e/configEditor.spec.ts
+++ b/tests/e2e/configEditor.spec.ts
@@ -15,15 +15,26 @@ async function configurePDC(page: Page, networkName: string) {
   await page.getByText(networkName).click();
 }
 
+/**
+ * Wait for the V1 config editor form to be rendered after navigating to the config page.
+ * Grafana 13.x redirects /datasources/edit/:uid → /connections/datasources/edit/:uid
+ * client-side, and async plugin loading means the form can take several seconds to appear.
+ */
+async function waitForConfigEditorReady(page: Page) {
+  await expect(page.getByPlaceholder('Server address')).toBeVisible({ timeout: 30000 });
+}
+
 test.describe('Config editor', () => {
   test.describe('rendering', () => {
     test('smoke: should render config editor', { tag: ['@plugins'] }, async ({ createDataSourceConfigPage, page }) => {
       await createDataSourceConfigPage({ type: PLUGIN_UID });
+      await waitForConfigEditorReady(page);
       await expect(page.getByRole('heading', { name: 'Server' })).toBeVisible();
     });
 
     test('should render Server section', async ({ createDataSourceConfigPage, page }) => {
       await createDataSourceConfigPage({ type: PLUGIN_UID });
+      await waitForConfigEditorReady(page);
       await expect(page.getByRole('heading', { name: 'Server' })).toBeVisible();
       await expect(page.getByPlaceholder('Server address')).toBeVisible();
       await expect(page.getByPlaceholder('9000')).toBeVisible();
@@ -33,6 +44,7 @@ test.describe('Config editor', () => {
 
     test('should render TLS / SSL Settings section', async ({ createDataSourceConfigPage, page }) => {
       await createDataSourceConfigPage({ type: PLUGIN_UID });
+      await waitForConfigEditorReady(page);
       await expect(page.getByRole('heading', { name: 'TLS / SSL Settings' })).toBeVisible();
       // The label and description for these fields share identical text — use .first() to
       // target the visible label div, not the description span that follows it.
@@ -42,6 +54,7 @@ test.describe('Config editor', () => {
 
     test('should render Credentials section', async ({ createDataSourceConfigPage, page }) => {
       await createDataSourceConfigPage({ type: PLUGIN_UID });
+      await waitForConfigEditorReady(page);
       await expect(page.getByRole('heading', { name: 'Credentials' })).toBeVisible();
       await expect(page.getByPlaceholder('default')).toBeVisible();
       await expect(page.getByPlaceholder('password')).toBeVisible();
@@ -66,6 +79,8 @@ test.describe('Config editor', () => {
     }) => {
       const ds = await readProvisionedDataSource<CHConfig>({ fileName: PROVISIONING_FILE });
       await gotoDataSourceConfigPage(ds.uid);
+      // Wait for provisioned settings to populate before checking form values
+      await expect(page.getByPlaceholder('Server address')).toHaveValue('clickhouse-server');
       await expect(page.getByPlaceholder('9000')).toHaveValue('9000');
       await expect(page.getByRole('radio', { name: 'Native' })).toBeChecked();
     });
@@ -81,12 +96,15 @@ test.describe('Config editor', () => {
       // since the UI cannot modify provisioned configuration.
       const ds = await readProvisionedDataSource<CHConfig>({ fileName: PROVISIONING_FILE });
       await gotoDataSourceConfigPage(ds.uid);
+      // Wait for provisioned settings to load before clicking Test
+      await expect(page.getByPlaceholder('Server address')).toHaveValue('clickhouse-server');
       await page.getByRole('button', { name: 'Test' }).click();
       await expect(page.getByText('Data source is working')).toBeVisible();
     });
 
     test('invalid credentials should return an error', async ({ createDataSourceConfigPage, page }) => {
       const configPage = await createDataSourceConfigPage({ type: PLUGIN_UID });
+      await waitForConfigEditorReady(page);
       await page.getByPlaceholder('Server address').fill(resolveClickhouseUrl());
       await expect(configPage.saveAndTest()).not.toBeOK();
     });
@@ -103,6 +121,7 @@ test.describe('Config editor', () => {
       );
 
       const configPage = await createDataSourceConfigPage({ type: PLUGIN_UID });
+      await waitForConfigEditorReady(page);
       await page.getByPlaceholder('Server address').fill(resolveClickhouseUrl());
       await page.getByPlaceholder('9000').fill(process.env.DS_INSTANCE_PORT ?? '9000');
       await page.getByPlaceholder('default').fill(process.env.DS_INSTANCE_USERNAME ?? 'default');
@@ -118,6 +137,7 @@ test.describe('Config editor', () => {
 
     test('mandatory fields should show error if left empty', async ({ createDataSourceConfigPage, page }) => {
       const configPage = await createDataSourceConfigPage({ type: PLUGIN_UID });
+      await waitForConfigEditorReady(page);
 
       await page.getByPlaceholder('Server address').fill('');
       await page.keyboard.press('Tab');

--- a/tests/e2e/queryEditor.spec.ts
+++ b/tests/e2e/queryEditor.spec.ts
@@ -36,7 +36,7 @@ function exploreUrl(opts: ExploreUrlOpts = {}): string {
   };
 
   const panes = JSON.stringify({
-    explore: {
+    che: {
       datasource: DATASOURCE_UID,
       queries: [query],
       range: { from, to },
@@ -44,6 +44,14 @@ function exploreUrl(opts: ExploreUrlOpts = {}): string {
   });
   
   return `/explore?orgId=1&schemaVersion=1&panes=${encodeURIComponent(panes)}`;
+}
+
+/**
+ * Wait for the query editor row to be visible after navigating to Explore.
+ * Grafana 13.x may take >5 s to render the query editor due to async plugin loading.
+ */
+async function waitForQueryEditorReady(page: Page) {
+  await expect(page.locator('.query-editor-row')).toBeVisible({ timeout: 30000 });
 }
 
 /**
@@ -107,6 +115,7 @@ test.describe('Query editor', () => {
   test.describe('rendering', () => {
     test('smoke: renders all query type options', { tag: ['@plugins'] }, async ({ page }) => {
       await page.goto(exploreUrl());
+      await waitForQueryEditorReady(page);
       // Query type radios are always visible regardless of editor mode
       await expect(page.getByRole('radio', { name: 'Table' })).toBeVisible();
       await expect(page.getByRole('radio', { name: 'Logs' })).toBeVisible();
@@ -116,6 +125,7 @@ test.describe('Query editor', () => {
 
     test('renders editor type switcher', async ({ page }) => {
       await page.goto(exploreUrl());
+      await waitForQueryEditorReady(page);
       // Grafana opens the editor in SQL Editor mode by default
       await expect(page.getByRole('radio', { name: 'SQL Editor' })).toBeChecked();
       await expect(page.getByRole('radio', { name: 'Query Builder' })).toBeVisible();
@@ -126,8 +136,8 @@ test.describe('Query editor', () => {
       // The toolbar also has a "Run query" button — scope to the query editor row to
       // avoid a strict-mode violation from matching both.
       await expect(
-        page.locator('[data-testid="query-editor-row"]').getByRole('button', { name: 'Run Query' })
-      ).toBeVisible();
+        page.locator('.query-editor-row').getByRole('button', { name: 'Run Query' })
+      ).toBeVisible({ timeout: 30000 });
     });
 
     test('renders SQL editor code area', async ({ page }) => {
@@ -143,7 +153,7 @@ test.describe('Query editor', () => {
       // Use a scoped locator — `label.query-keyword` is the Grafana inline form label
       // class used by the builder for all its field labels (Database, Table, etc.).
       await expect(
-        page.locator('[data-testid="query-editor-row"] label.query-keyword', { hasText: 'Database' })
+        page.locator('.query-editor-row label.query-keyword', { hasText: 'Database' })
       ).toBeVisible();
     });
 
@@ -191,7 +201,7 @@ test.describe('Query editor with fixture data', () => {
     await enterSql(page, 'SELECT timestamp, level, message FROM e2e_test.events ORDER BY timestamp LIMIT 10');
 
     const { responsePromise, getBody } = await waitForQueryDataResponseWithBody(explorePage);
-    await page.locator('[data-testid="query-editor-row"]').getByRole('button', { name: 'Run Query' }).click();
+    await page.locator('.query-editor-row').getByRole('button', { name: 'Run Query' }).click();
 
     await responsePromise;
     expect((getBody() as any)?.results?.A?.frames?.length).toBeGreaterThan(0);
@@ -202,7 +212,7 @@ test.describe('Query editor with fixture data', () => {
     await enterSql(page, 'SELECT count(*) AS total FROM e2e_test.events');
 
     const { responsePromise, getBody } = await waitForQueryDataResponseWithBody(explorePage);
-    await page.locator('[data-testid="query-editor-row"]').getByRole('button', { name: 'Run Query' }).click();
+    await page.locator('.query-editor-row').getByRole('button', { name: 'Run Query' }).click();
 
     await responsePromise;
     expect((getBody() as any)?.results?.A?.frames?.length).toBeGreaterThan(0);
@@ -213,7 +223,7 @@ test.describe('Query editor with fixture data', () => {
     await enterSql(page, "SELECT timestamp, message FROM e2e_test.events WHERE level = 'error' ORDER BY timestamp");
 
     const { responsePromise, getBody } = await waitForQueryDataResponseWithBody(explorePage);
-    await page.locator('[data-testid="query-editor-row"]').getByRole('button', { name: 'Run Query' }).click();
+    await page.locator('.query-editor-row').getByRole('button', { name: 'Run Query' }).click();
 
     await responsePromise;
     expect((getBody() as any)?.results?.A?.frames?.length).toBeGreaterThan(0);


### PR DESCRIPTION
ueryEditor.spec.ts:
  - exploreUrl(): changed pane key "explore" → "che" (Grafana 13.x requires a 3-char alphanumeric key)
  - Added waitForQueryEditorReady() helper — waits up to 30s for .query-editor-row to appear
  - "smoke" and "renders editor type switcher" tests: call waitForQueryEditorReady before assertions (fixes 5s timeout failures)
  - "renders Run Query button": changed [data-testid="query-editor-row"] → .query-editor-row + 30s timeout (the data-testid attribute doesn't exist in Grafana 13.x)
  - "renders database and table selectors": same selector fix
  - All fixture data tests: same selector fix for the Run Query click

  configEditor.spec.ts:
  - Added waitForConfigEditorReady() helper — waits up to 30s for placeholder="Server address" to appear (covers the client-side redirect from /datasources/edit/:uid → /connections/datasources/edit/:uid plus async plugin loading)
  - All createDataSourceConfigPage() tests: call waitForConfigEditorReady before any assertions or interactions
  - "should load provisioned port and protocol": added wait for server address value before checking the port/radio (ensures settings have populated from the API)
  - "should pass health check for provisioned datasource": same settings-loaded wait before clicking Test