### PR TITLE
Release 4.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 4.15.0
+
+### Features
+
+- Allow disabling logs and trace links (#1754)
+- Improve query modification (#1738)
+- Add initial support for SQL abstractions (dsAbstraction) (#1756)
+- Add OpenTelemetry instrumentation (#1734)
+- Add field config to trace search results for better default display (#1733)
+- Add filterQuery method to datasource (#1732)
+- Support grouping orderBy columns by their column hint values (#1695)
+- Bump Grafana minimum version to v11.6.0 (#1753)
+
+### Fixes
+
+- Fix log context field returning labels (#1737)
+- Fix additional settings config bug (#1630)
+- Dependency updates
+
 ## 4.14.1
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features
 
+- Add LogsSample supplemental query, remove deprecated getDataProvider (#1744)
+- Add Grafana query metadata support (#1743)
 - Allow disabling logs and trace links (#1754)
 - Improve query modification (#1738)
 - Add initial support for SQL abstractions (dsAbstraction) (#1756)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clickhouse-datasource",
-  "version": "4.14.1",
+  "version": "4.15.0",
   "description": "Clickhouse Datasource",
   "engines": {
     "node": ">=20"


### PR DESCRIPTION
Bump version to 4.15.0 and update CHANGELOG.

## What's new

### Features
- Add LogsSample supplemental query, remove deprecated getDataProvider (#1744)
- Add Grafana query metadata support (#1743)
- Allow disabling logs and trace links (#1754)
- Improve query modification (#1738)
- Add initial support for SQL abstractions (dsAbstraction) (#1756)
- Add OpenTelemetry instrumentation (#1734)
- Add field config to trace search results for better default display (#1733)
- Add filterQuery method to datasource (#1732)
- Support grouping orderBy columns by their column hint values (#1695)
- Bump Grafana minimum version to v11.6.0 (#1753)

### Fixes
- Fix log context field returning labels (#1737)
- Fix additional settings config bug (#1630)
- Dependency updates

Made with [Cursor](https://cursor.com)