### PR TITLE
add stalebot to close issues and PRs with no activity

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,47 @@
+name: 'Close stale issues and PRs'
+
+on:
+  schedule:
+    - cron: '30 1 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v10
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          operations-per-run: 750
+          # start from the oldest issues/PRs when performing stale operations
+          ascending: true
+          days-before-issue-stale: 365
+          days-before-issue-close: 30
+          stale-issue-label: stale
+          exempt-issue-labels: no stalebot,type/epic
+          stale-issue-message: >
+            This issue has been automatically marked as stale because it has not had
+            activity in the last year. It will be closed in 30 days if no further activity occurs. Please
+            feel free to leave a comment if you believe the issue is still relevant.
+            Thank you for your contributions!
+          close-issue-message: >
+            This issue has been automatically closed because it has not had any further
+            activity in the last 30 days. Thank you for your contributions!
+          days-before-pr-stale: 30
+          days-before-pr-close: 14
+          stale-pr-label: stale
+          exempt-pr-labels: no stalebot
+          stale-pr-message: >
+            This pull request has been automatically marked as stale because it has not had
+            activity in the last 30 days. It will be closed in 2 weeks if no further activity occurs. Please
+            feel free to give a status update or ping for review. Thank you for your contributions!
+          close-pr-message: >
+            This pull request has been automatically closed because it has not had any further
+            activity in the last 2 weeks. Thank you for your contributions!
+          # Remove the PR head branch when the stale workflow closes the PR (requires contents: write)
+          delete-branch: true


### PR DESCRIPTION
- modeled after the stalebot in grafana/grafana
- marks PRs without activity as stale after 30 days (deletes 14 days after that)
- marks issues without activity as stale after 365 days (deletes 30 days after that)
- should run on a cron, but can also be triggered manually
