### PR TITLE
Fix SQL mode showing each table entry twice

### DIFF
--- a/src/components/SqlEditor.test.tsx
+++ b/src/components/SqlEditor.test.tsx
@@ -19,8 +19,8 @@ const mockMonaco = {
     getLanguages: () => [],
     register: jest.fn(),
     setMonarchTokensProvider: jest.fn(),
-    registerCompletionItemProvider: jest.fn(),
-    registerDocumentFormattingEditProvider: jest.fn(),
+    registerCompletionItemProvider: jest.fn(() => ({ dispose: jest.fn() })),
+    registerDocumentFormattingEditProvider: jest.fn(() => ({ dispose: jest.fn() })),
   },
 };
 

--- a/src/components/SqlEditor.tsx
+++ b/src/components/SqlEditor.tsx
@@ -2,7 +2,7 @@ import React, { useRef } from 'react';
 import { QueryEditorProps } from '@grafana/data';
 import { CodeEditor, monacoTypes } from '@grafana/ui';
 import { Datasource } from 'data/CHDatasource';
-import { registerSQL, Range, Fetcher } from './sqlProvider';
+import { registerSQL, Range, Fetcher, SQLRegistration } from './sqlProvider';
 import { CHConfig } from 'types/config';
 import { CHQuery, EditorType, CHSqlQuery } from 'types/sql';
 import { styles } from 'styles';
@@ -35,6 +35,7 @@ function setupAutoSize(editor: monacoTypes.editor.IStandaloneCodeEditor) {
 export const SqlEditor = (props: SqlEditorProps) => {
   const { query, onChange, datasource } = props;
   const editorRef = useRef<monacoTypes.editor.IStandaloneCodeEditor | null>(null);
+  const sqlRegistrationRef = useRef<SQLRegistration | null>(null);
   const sqlQuery = query as CHSqlQuery;
   const queryType = sqlQuery.queryType || QueryType.Table;
 
@@ -77,7 +78,9 @@ export const SqlEditor = (props: SqlEditorProps) => {
 
   const handleMount = (editor: monacoTypes.editor.IStandaloneCodeEditor, monaco: typeof monacoTypes) => {
     editorRef.current = editor;
-    const me = registerSQL('sql', editor, _getSuggestions);
+    const registration = registerSQL('sql', editor, _getSuggestions);
+    sqlRegistrationRef.current = registration;
+    const me = registration.editor;
     setupAutoSize(editor);
     editor.onKeyUp((e: any) => {
       if (datasource.settings.jsonData.validateSql) {
@@ -101,6 +104,10 @@ export const SqlEditor = (props: SqlEditorProps) => {
 
   const onEditorWillUnmount = () => {
     editorRef.current = null;
+    if (sqlRegistrationRef.current) {
+      sqlRegistrationRef.current.dispose();
+      sqlRegistrationRef.current = null;
+    }
   };
   const triggerFormat = () => {
     if (editorRef.current !== null) {

--- a/src/components/sqlProvider.ts
+++ b/src/components/sqlProvider.ts
@@ -54,19 +54,15 @@ export function formatSql(rawSql: string, tabWidth = 4): string {
   return formatted;
 }
 
-export function registerSQL(lang: string, editor: MonacoEditor, fetchSuggestions: Fetcher) {
-  // show options outside query editor
+export interface SQLRegistration {
+  editor: typeof monaco.editor;
+  dispose: () => void;
+}
+
+export function registerSQL(lang: string, editor: MonacoEditor, fetchSuggestions: Fetcher): SQLRegistration {
   editor.updateOptions({ fixedOverflowWidgets: true, scrollBeyondLastLine: false });
 
-  // const registeredLang = monaco.languages.getLanguages().find((l: Lang) => l.id === lang);
-  // if (registeredLang !== undefined) {
-  //   return monaco.editor;
-  // }
-
-  // monaco.languages.register({ id: lang });
-
-  // just extend sql for now so we get syntax highlighting
-  monaco.languages.registerCompletionItemProvider('sql', {
+  const completionDisposable = monaco.languages.registerCompletionItemProvider('sql', {
     triggerCharacters: [' ', '.', '$'],
     provideCompletionItems: async (model: Model, position: Position) => {
       const word = model.getWordUntilPosition(position);
@@ -81,7 +77,7 @@ export function registerSQL(lang: string, editor: MonacoEditor, fetchSuggestions
     },
   });
 
-  monaco.languages.registerDocumentFormattingEditProvider('sql', {
+  const formattingDisposable = monaco.languages.registerDocumentFormattingEditProvider('sql', {
     provideDocumentFormattingEdits(model, options) {
       return [
         {
@@ -92,5 +88,11 @@ export function registerSQL(lang: string, editor: MonacoEditor, fetchSuggestions
     },
   });
 
-  return monaco.editor;
+  return {
+    editor: monaco.editor,
+    dispose: () => {
+      completionDisposable.dispose();
+      formattingDisposable.dispose();
+    },
+  };
 }


### PR DESCRIPTION
## Type of Change

_Please check the relevant option._

- [ ] 🚀 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧹 Refactor / Chore

---

## Bug Fix

### What is the bug?

In SQL mode, each table entry appears twice (or more) in the autocomplete suggestions. `registerSQL()` in `sqlProvider.ts` calls `monaco.languages.registerCompletionItemProvider()` and `registerDocumentFormattingEditProvider()` every time the SQL editor mounts, but never disposes of the previous registrations. Since Monaco stacks providers rather than replacing them, each editor remount (e.g. switching between Builder and SQL mode, or navigating between panels) adds another provider returning the same suggestions, causing duplicate table entries that multiply with each remount.

### How to reproduce

1. Open a ClickHouse datasource query editor and switch to SQL mode
2. Start typing a `FROM` clause to trigger table autocomplete — observe suggestions
3. Switch to Builder mode, then back to SQL mode
4. Trigger table autocomplete again — each table now appears twice
5. Repeat switching — duplicates multiply with each remount

### Related Issues

Closes HDX-3957

---

## Please check that:

- [x] Tests for this change have been added/updated.
- [ ] Documentation has been added/updated (where applicable).

## Special notes for your reviewer

This is a minimal, targeted fix. The root cause is that Monaco's `registerCompletionItemProvider` and `registerDocumentFormattingEditProvider` return `IDisposable` objects that must be disposed to remove the provider. Without disposal, providers accumulate and each one independently returns the full set of suggestions, leading to duplicates.

`registerSQL()` now returns an `SQLRegistration` object that captures both disposables and exposes a `dispose()` method. `SqlEditor` stores this in a ref and calls `dispose()` in `onEditorWillUnmount`.

All 64 existing test suites (592 tests) continue to pass.