### PR TITLE
fix(validation): replace `js-sql-parser` with existing ClickHouse lexer

### DIFF
--- a/cspell.config.json
+++ b/cspell.config.json
@@ -16,6 +16,7 @@
   "words": [
     "aggregatable",
     "aheads",
+    "ASOF",
     "apikey",
     "buildinfo",
     "CHSQL",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "@grafana/ui": "12.4.2",
         "@openfeature/web-sdk": "^1.7.3",
         "es-toolkit": "^1.45.1",
-        "js-sql-parser": "^1.6.0",
         "pgsql-ast-parser": "^12.0.1",
         "react": "18.3.1",
         "react-dom": "18.3.1",
@@ -12359,12 +12358,6 @@
       "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
       "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==",
       "license": "MIT"
-    },
-    "node_modules/js-sql-parser": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/js-sql-parser/-/js-sql-parser-1.6.0.tgz",
-      "integrity": "sha512-ezHNl95OKis5TzAY180j9fHzIaMr3KDKw1Syf+ABrercb+qADqBdGbQjOb0QtdqdfE97TdF91d3nKbXgtCUwDg==",
-      "license": "ISC"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,6 @@
     "@grafana/ui": "12.4.2",
     "@openfeature/web-sdk": "^1.7.3",
     "es-toolkit": "^1.45.1",
-    "js-sql-parser": "^1.6.0",
     "pgsql-ast-parser": "^12.0.1",
     "react": "18.3.1",
     "react-dom": "18.3.1",

--- a/provisioning/datasources/clickhouse.yml
+++ b/provisioning/datasources/clickhouse.yml
@@ -19,5 +19,9 @@ datasources:
       username: "default"
       port: 9000
       protocol: native
+      # Enables the Monaco SQL validator in the query editor. Turned on in the
+      # E2E datasource so tests/e2e/sqlValidation.spec.ts can regression-guard
+      # against false positives on ClickHouse-specific syntax.
+      validateSql: true
     secureJsonData:
       # password: ""

--- a/src/ch-parser/lexer.ts
+++ b/src/ch-parser/lexer.ts
@@ -145,34 +145,26 @@ export class Lexer {
   }
 
   /**
-   * Parse a unicode quoted string
+   * Parse a Unicode-quoted string or identifier. The opening codepoint is at this.pos
+   * (about to be consumed by this function); closeChar is the single JS codepoint that
+   * terminates the literal. ClickHouse's C++ lexer does this at the UTF-8 byte level
+   * (looking for `E2 80 99` etc.); the JavaScript equivalent operates on BMP codepoints
+   * directly since JS strings are UTF-16 code units, not UTF-8 bytes.
    */
-  private parseUnicodeQuotedString(expectedEndByte: number, successToken: TokenType, errorToken: TokenType): Token {
-    const tokenBegin = this.pos - 3; // Account for the starting quote sequence
+  private parseUnicodeQuotedString(closeChar: string, successToken: TokenType, errorToken: TokenType): Token {
+    const tokenBegin = this.pos;
 
-    while (this.pos + 2 < this.end) {
-      const e2Pos = this.text.indexOf('\u00E2', this.pos);
-      if (e2Pos === -1 || e2Pos + 2 >= this.end) {
-        this.pos = this.end;
-        return new Token(errorToken, tokenBegin, this.pos, this.text.substring(tokenBegin, this.pos));
-      }
+    // Skip the opening quote
+    this.pos++;
 
-      this.pos = e2Pos;
-
-      if (
-        this.text.charCodeAt(this.pos) === 0xe2 &&
-        this.text.charCodeAt(this.pos + 1) === 0x80 &&
-        this.text.charCodeAt(this.pos + 2) === expectedEndByte
-      ) {
-        this.pos += 3; // Skip the closing quote
-        return new Token(successToken, tokenBegin, this.pos, this.text.substring(tokenBegin, this.pos));
-      }
-
-      this.pos++;
+    const closePos = this.text.indexOf(closeChar, this.pos);
+    if (closePos === -1) {
+      this.pos = this.end;
+      return new Token(errorToken, tokenBegin, this.pos, this.text.substring(tokenBegin, this.pos));
     }
 
-    this.pos = this.end;
-    return new Token(errorToken, tokenBegin, this.pos, this.text.substring(tokenBegin, this.pos));
+    this.pos = closePos + 1;
+    return new Token(successToken, tokenBegin, this.pos, this.text.substring(tokenBegin, this.pos));
   }
 
   /**
@@ -576,55 +568,61 @@ export class Lexer {
         return new Token(TokenType.Error, tokenBegin, this.pos, '\\');
       }
 
-      // Handle Unicode special cases
-      case '\u00E2': {
-        // Mathematical minus symbol in UTF-8
-        if (
-          this.pos + 2 < this.end &&
-          this.text.charCodeAt(this.pos + 1) === 0x88 &&
-          this.text.charCodeAt(this.pos + 2) === 0x92
-        ) {
-          this.pos += 3;
-          return new Token(TokenType.Minus, tokenBegin, this.pos, this.text.substring(tokenBegin, this.pos));
-        }
+      // Unicode special cases. ClickHouse's C++ lexer matches these via UTF-8 byte
+      // triples (E2 88 92, E2 80 98, E2 80 9C); JavaScript strings are UTF-16 code
+      // units, so we match the codepoints directly.
 
-        // Unicode quoted string
-        if (
-          this.pos + 2 < this.end &&
-          this.text.charCodeAt(this.pos) === 0xe2 &&
-          this.text.charCodeAt(this.pos + 1) === 0x80 &&
-          (this.text.charCodeAt(this.pos + 2) === 0x98 || this.text.charCodeAt(this.pos + 2) === 0x9c)
-        ) {
-          const expectedEndByte = this.text.charCodeAt(this.pos + 2) + 1;
-          const successToken =
-            this.text.charCodeAt(this.pos + 2) === 0x98 ? TokenType.StringLiteral : TokenType.QuotedIdentifier;
-          const errorToken =
-            this.text.charCodeAt(this.pos + 2) === 0x98
-              ? TokenType.ErrorSingleQuoteIsNotClosed
-              : TokenType.ErrorDoubleQuoteIsNotClosed;
+      // U+2212 MINUS SIGN — treated as a regular minus operator.
+      case '\u2212':
+        return new Token(TokenType.Minus, tokenBegin, ++this.pos, '\u2212');
 
-          this.pos += 3;
-          return this.parseUnicodeQuotedString(expectedEndByte, successToken, errorToken);
-        }
-      }
+      // U+2018 LEFT SINGLE QUOTATION MARK — opens a StringLiteral,
+      // closed by U+2019 RIGHT SINGLE QUOTATION MARK.
+      case '\u2018':
+        return this.parseUnicodeQuotedString(
+          '\u2019',
+          TokenType.StringLiteral,
+          TokenType.ErrorSingleQuoteIsNotClosed
+        );
+
+      // U+201C LEFT DOUBLE QUOTATION MARK — opens a QuotedIdentifier,
+      // closed by U+201D RIGHT DOUBLE QUOTATION MARK.
+      case '\u201C':
+        return this.parseUnicodeQuotedString(
+          '\u201D',
+          TokenType.QuotedIdentifier,
+          TokenType.ErrorDoubleQuoteIsNotClosed
+        );
     }
 
     // Handle special cases
 
     // Dollar sign and here-document
     if (currentChar === '$') {
-      // Try to parse here-doc
+      // Try to parse here-doc ($tag$...$tag$). ClickHouse requires the tag to consist
+      // solely of ASCII word characters (letters, digits, underscore). An empty tag
+      // ($$...$$) is valid by vacuous truth.
       const tokenStream = this.text.substring(this.pos);
       const heredocNameEndPosition = tokenStream.indexOf('$', 1);
 
       if (heredocNameEndPosition !== -1) {
-        const heredocSize = heredocNameEndPosition + 1;
-        const heredoc = tokenStream.substring(0, heredocSize);
+        let tagIsValid = true;
+        for (let i = 1; i < heredocNameEndPosition; i++) {
+          if (!isWordCharASCII(tokenStream[i])) {
+            tagIsValid = false;
+            break;
+          }
+        }
 
-        const heredocEndPosition = tokenStream.indexOf(heredoc, heredocSize);
-        if (heredocEndPosition !== -1) {
-          this.pos += heredocEndPosition + heredocSize;
-          return new Token(TokenType.HereDoc, tokenBegin, this.pos, this.text.substring(tokenBegin, this.pos));
+        if (tagIsValid) {
+          const heredocSize = heredocNameEndPosition + 1;
+          const heredoc = tokenStream.substring(0, heredocSize);
+
+          const heredocEndPosition = tokenStream.indexOf(heredoc, heredocSize);
+          if (heredocEndPosition !== -1) {
+            this.pos += heredocEndPosition + heredocSize;
+            return new Token(TokenType.HereDoc, tokenBegin, this.pos, this.text.substring(tokenBegin, this.pos));
+          }
         }
       }
 

--- a/src/ch-parser/lexer.ts
+++ b/src/ch-parser/lexer.ts
@@ -99,7 +99,8 @@ export class Lexer {
    */
   private parseQuotedHexOrBinString(): Token {
     const tokenBegin = this.pos;
-    const isHex = this.text[this.pos].toLowerCase() === 'x';
+    const leadChar = this.text[this.pos];
+    const isHex = leadChar === 'x' || leadChar === 'X';
 
     // Skip 'x' and opening quote
     this.pos += 2;
@@ -203,13 +204,12 @@ export class Lexer {
         let hex = false;
 
         // Check for hex (0x) or binary (0b) notation
-        if (
-          this.pos + 2 < this.end &&
-          currentChar === '0' &&
-          (this.text[this.pos + 1].toLowerCase() === 'x' || this.text[this.pos + 1].toLowerCase() === 'b')
-        ) {
+        const prefixChar = this.pos + 2 < this.end && currentChar === '0' ? this.text[this.pos + 1] : '';
+        const isHexPrefix = prefixChar === 'x' || prefixChar === 'X';
+        const isBinPrefix = prefixChar === 'b' || prefixChar === 'B';
+        if (isHexPrefix || isBinPrefix) {
           let isValid = false;
-          if (this.text[this.pos + 1].toLowerCase() === 'x') {
+          if (isHexPrefix) {
             if (this.pos + 2 < this.end && isHexDigit(this.text[this.pos + 2])) {
               hex = true;
               isValid = true; // hex
@@ -601,26 +601,28 @@ export class Lexer {
     if (currentChar === '$') {
       // Try to parse here-doc ($tag$...$tag$). ClickHouse requires the tag to consist
       // solely of ASCII word characters (letters, digits, underscore). An empty tag
-      // ($$...$$) is valid by vacuous truth.
-      const tokenStream = this.text.substring(this.pos);
-      const heredocNameEndPosition = tokenStream.indexOf('$', 1);
+      // ($$...$$) is valid by vacuous truth. We scan using absolute positions in
+      // this.text rather than taking a substring of the remaining input, which
+      // would allocate O(n) per $ — a real hot path in queries with many Grafana
+      // macros ($__timeFilter, ${variable}, ...).
+      const tagEndPos = this.text.indexOf('$', this.pos + 1);
 
-      if (heredocNameEndPosition !== -1) {
+      if (tagEndPos !== -1) {
         let tagIsValid = true;
-        for (let i = 1; i < heredocNameEndPosition; i++) {
-          if (!isWordCharASCII(tokenStream[i])) {
+        for (let i = this.pos + 1; i < tagEndPos; i++) {
+          if (!isWordCharASCII(this.text[i])) {
             tagIsValid = false;
             break;
           }
         }
 
         if (tagIsValid) {
-          const heredocSize = heredocNameEndPosition + 1;
-          const heredoc = tokenStream.substring(0, heredocSize);
+          const heredocSize = tagEndPos - this.pos + 1;
+          const heredoc = this.text.substring(this.pos, this.pos + heredocSize);
 
-          const heredocEndPosition = tokenStream.indexOf(heredoc, heredocSize);
-          if (heredocEndPosition !== -1) {
-            this.pos += heredocEndPosition + heredocSize;
+          const heredocEndPos = this.text.indexOf(heredoc, this.pos + heredocSize);
+          if (heredocEndPos !== -1) {
+            this.pos = heredocEndPos + heredocSize;
             return new Token(TokenType.HereDoc, tokenBegin, this.pos, this.text.substring(tokenBegin, this.pos));
           }
         }
@@ -632,11 +634,11 @@ export class Lexer {
       }
     }
 
-    // Hex or binary string literals
+    // Hex or binary string literals (x'AB' / X'AB' / b'101' / B'101')
     if (
       this.pos + 2 < this.end &&
       this.text[this.pos + 1] === "'" &&
-      (currentChar.toLowerCase() === 'x' || currentChar.toLowerCase() === 'b')
+      (currentChar === 'x' || currentChar === 'X' || currentChar === 'b' || currentChar === 'B')
     ) {
       return this.parseQuotedHexOrBinString();
     }

--- a/src/ch-parser/types.ts
+++ b/src/ch-parser/types.ts
@@ -184,12 +184,22 @@ export class Token {
   begin: number;
   end: number;
   text: string;
+  private _upperText?: string;
 
   constructor(type: TokenType, begin: number, end: number, text: string) {
     this.type = type;
     this.begin = begin;
     this.end = end;
     this.text = text;
+  }
+
+  /**
+   * Lazily-cached uppercase form of the token text, used for case-insensitive
+   * keyword comparisons. Avoids re-allocating an uppercase copy on every
+   * isKeyword/matchKeyword call from the parser's hot loops.
+   */
+  private upperText(): string {
+    return (this._upperText ??= this.text.toUpperCase());
   }
 
   size(): number {
@@ -200,16 +210,17 @@ export class Token {
     return this.type !== TokenType.Whitespace && this.type !== TokenType.Comment;
   }
 
+  /**
+   * Returns true if this token is a BareWord matching the given keyword
+   * case-insensitively. Callers should pass the keyword in uppercase
+   * (all internal call sites already do, e.g. `matchKeyword('SELECT')`).
+   */
   matchKeyword(keyword: string): boolean {
-    return (
-      this.type === TokenType.BareWord &&
-      keywords.has(keyword.toUpperCase()) &&
-      this.text.toUpperCase() === keyword.toUpperCase()
-    );
+    return this.type === TokenType.BareWord && this.upperText() === keyword;
   }
 
   isKeyword(): boolean {
-    return this.type === TokenType.BareWord && keywords.has(this.text.toUpperCase());
+    return this.type === TokenType.BareWord && keywords.has(this.upperText());
   }
 
   isError(): boolean {

--- a/src/ch-parser/types.ts
+++ b/src/ch-parser/types.ts
@@ -72,6 +72,7 @@ export enum TokenType {
 }
 
 export const keywords = new Set([
+  // Standard SQL clauses
   'SELECT',
   'FROM',
   'WHERE',
@@ -111,6 +112,68 @@ export const keywords = new Set([
   'NULL',
   'ASC',
   'DESC',
+
+  // ClickHouse-specific SELECT clauses
+  'PREWHERE',
+  'FINAL',
+  'SAMPLE',
+  'SETTINGS',
+  'FORMAT',
+  'INTERVAL',
+
+  // JOIN modifiers
+  'ASOF',
+  'ANY',
+  'ANTI',
+  'SEMI',
+  'GLOBAL',
+  'LATERAL',
+  'ARRAY',
+
+  // CTE
+  'RECURSIVE',
+
+  // ORDER BY / LIMIT modifiers
+  'NULLS',
+  'FIRST',
+  'LAST',
+  'TIES',
+
+  // DML
+  'INSERT',
+  'INTO',
+  'VALUES',
+  'UPDATE',
+  'DELETE',
+  'SET',
+  'TRUNCATE',
+
+  // DDL
+  'CREATE',
+  'ALTER',
+  'DROP',
+  'RENAME',
+  'TABLE',
+  'DATABASE',
+  'VIEW',
+  'MATERIALIZED',
+  'INDEX',
+  'DICTIONARY',
+  'FUNCTION',
+  'TEMPORARY',
+  'IF',
+  'TO',
+
+  // Window functions
+  'OVER',
+  'WINDOW',
+  'PARTITION',
+  'PRECEDING',
+  'FOLLOWING',
+  'CURRENT',
+  'UNBOUNDED',
+  'RANGE',
+  'ROWS',
 ]);
 
 /**

--- a/src/data/validate.test.ts
+++ b/src/data/validate.test.ts
@@ -1,37 +1,107 @@
 import { validate } from './validate';
 
-jest.mock('js-sql-parser', () => {
-  return {
-    parse: jest.fn(),
-  };
-});
-
 describe('Validate', () => {
-  it('should be valid', () => {
-    const sql = 'select foo from bar';
-    const v = validate(sql);
-    expect(v.valid).toBe(true);
-  });
-
-  it('should not be valid', async () => {
-    (await import('js-sql-parser')).parse.mockImplementationOnce(() => {
-      throw {
-        message: 'foo\nbar\njunk\nexpected',
-        hash: {
-          text: 'foo',
-          loc: {
-            first_line: 1,
-            last_line: 1,
-            first_column: 1,
-            last_column: 3,
-          },
-        },
-      };
+  describe('valid SQL', () => {
+    it('handles a basic SELECT', () => {
+      expect(validate('SELECT foo FROM bar').valid).toBe(true);
     });
 
-    const sql = 'invalid sql';
-    const v = validate(sql);
-    expect(v.valid).toBe(false);
-    expect(v.error?.expected).toBe('expected');
+    it('handles ClickHouse FINAL keyword', () => {
+      expect(validate('SELECT * FROM table FINAL').valid).toBe(true);
+    });
+
+    it('handles ClickHouse PREWHERE', () => {
+      expect(validate('SELECT * FROM t PREWHERE x > 1 WHERE y > 2').valid).toBe(true);
+    });
+
+    it('handles ClickHouse ARRAY JOIN', () => {
+      expect(validate('SELECT * FROM t ARRAY JOIN arr').valid).toBe(true);
+    });
+
+    it('handles ClickHouse SETTINGS', () => {
+      expect(validate("SELECT * FROM t SETTINGS max_rows_to_read = 1000").valid).toBe(true);
+    });
+
+    it('handles ClickHouse GLOBAL IN', () => {
+      expect(validate('SELECT * FROM t WHERE id GLOBAL IN (SELECT id FROM t2)').valid).toBe(true);
+    });
+
+    it('handles ClickHouse ASOF JOIN', () => {
+      expect(validate('SELECT * FROM t1 ASOF JOIN t2 ON t1.id = t2.id').valid).toBe(true);
+    });
+
+    it('handles ClickHouse :: cast operator', () => {
+      expect(validate("SELECT '2024-01-01'::DateTime FROM t").valid).toBe(true);
+    });
+
+    it('handles Grafana $__timeFilter macro', () => {
+      expect(validate('SELECT * FROM t WHERE $__timeFilter(timestamp)').valid).toBe(true);
+    });
+
+    it('handles Grafana $__interval macro', () => {
+      expect(validate('SELECT toStartOfInterval(ts, INTERVAL $__interval second) FROM t').valid).toBe(true);
+    });
+
+    it('handles Grafana ${variable} template variables', () => {
+      expect(validate('SELECT * FROM t WHERE service = ${service}').valid).toBe(true);
+    });
+
+    it('handles single-line comments', () => {
+      expect(validate('SELECT * FROM t -- this is a comment').valid).toBe(true);
+    });
+
+    it('handles block comments', () => {
+      expect(validate('SELECT /* comment */ * FROM t').valid).toBe(true);
+    });
+
+    it('handles hex numbers', () => {
+      expect(validate('SELECT 0xFF FROM t').valid).toBe(true);
+    });
+  });
+
+  describe('invalid SQL', () => {
+    it('catches an unclosed single-quoted string', () => {
+      const v = validate("SELECT * FROM t WHERE name = 'unclosed");
+      expect(v.valid).toBe(false);
+      expect(v.error?.message).toBe('Single quoted string is not closed');
+    });
+
+    it('catches an unclosed double-quoted identifier', () => {
+      const v = validate('SELECT "unclosed FROM t');
+      expect(v.valid).toBe(false);
+      expect(v.error?.message).toBe('Double quoted string is not closed');
+    });
+
+    it('catches an unclosed backtick identifier', () => {
+      const v = validate('SELECT `unclosed FROM t');
+      expect(v.valid).toBe(false);
+      expect(v.error?.message).toBe('Back quoted string is not closed');
+    });
+
+    it('catches an unclosed block comment', () => {
+      const v = validate('SELECT * FROM t /* unclosed comment');
+      expect(v.valid).toBe(false);
+      expect(v.error?.message).toBe('Multiline comment is not closed');
+    });
+
+    it('catches a stray exclamation mark', () => {
+      const v = validate('SELECT * FROM t WHERE x ! 1');
+      expect(v.valid).toBe(false);
+      expect(v.error?.message).toBe('Exclamation mark can only occur in != operator');
+    });
+
+    it('reports the correct line number for an error on line 2', () => {
+      const sql = 'SELECT *\nFROM t WHERE name = \'unclosed';
+      const v = validate(sql);
+      expect(v.valid).toBe(false);
+      expect(v.error?.startLine).toBe(2);
+    });
+
+    it('reports the correct column for an error', () => {
+      const sql = "SELECT 'unclosed";
+      const v = validate(sql);
+      expect(v.valid).toBe(false);
+      expect(v.error?.startCol).toBe(8); // quote starts at col 8
+    });
   });
 });

--- a/src/data/validate.test.ts
+++ b/src/data/validate.test.ts
@@ -57,6 +57,28 @@ describe('Validate', () => {
     it('handles hex numbers', () => {
       expect(validate('SELECT 0xFF FROM t').valid).toBe(true);
     });
+
+    it('handles Unicode smart single quotes as string literals', () => {
+      // U+2018 … U+2019 around "hello"
+      expect(validate('SELECT \u2018hello\u2019 FROM t').valid).toBe(true);
+    });
+
+    it('handles Unicode smart double quotes as identifiers', () => {
+      // U+201C … U+201D around "name"
+      expect(validate('SELECT \u201Cname\u201D FROM t').valid).toBe(true);
+    });
+
+    it('handles Unicode minus sign (U+2212) as a minus operator', () => {
+      expect(validate('SELECT 1 \u2212 2 FROM t').valid).toBe(true);
+    });
+
+    it('handles heredoc with word-char tag', () => {
+      expect(validate("SELECT $foo$ anything goes 'here' $foo$ FROM t").valid).toBe(true);
+    });
+
+    it('handles heredoc with empty tag', () => {
+      expect(validate('SELECT $$ hello world $$ FROM t').valid).toBe(true);
+    });
   });
 
   describe('invalid SQL', () => {
@@ -102,6 +124,18 @@ describe('Validate', () => {
       const v = validate(sql);
       expect(v.valid).toBe(false);
       expect(v.error?.startCol).toBe(8); // quote starts at col 8
+    });
+
+    it('catches an unclosed Unicode smart single quote', () => {
+      const v = validate('SELECT \u2018unclosed FROM t');
+      expect(v.valid).toBe(false);
+      expect(v.error?.message).toBe('Single quoted string is not closed');
+    });
+
+    it('catches an unclosed Unicode smart double quote', () => {
+      const v = validate('SELECT \u201Cunclosed FROM t');
+      expect(v.valid).toBe(false);
+      expect(v.error?.message).toBe('Double quoted string is not closed');
     });
   });
 });

--- a/src/data/validate.ts
+++ b/src/data/validate.ts
@@ -1,4 +1,5 @@
-import * as parser from 'js-sql-parser';
+import { Lexer } from 'ch-parser/lexer';
+import { getErrorTokenDescription } from 'ch-parser/types';
 
 export interface Error {
   startLine: number;
@@ -14,60 +15,37 @@ export interface Validation {
   error?: Error;
 }
 
-export interface ParseError {
-  message: string;
-  hash: {
-    text: string;
-    loc: {
-      first_line: number;
-      last_line: number;
-      first_column: number;
-      last_column: number;
-    };
+function offsetToLineCol(sql: string, offset: number): { line: number; col: number } {
+  const lines = sql.substring(0, offset).split('\n');
+  return {
+    line: lines.length,
+    col: lines[lines.length - 1].length + 1,
   };
 }
 
-// the sql parser only handles generic syntax, allow any clickhouse specific syntax
-const allow = ['INTERVAL'];
-
 export function validate(sql: string): Validation {
-  try {
-    parser.parse(sql);
-    return { valid: true };
-  } catch (e: any) {
-    const err = e as ParseError;
-    const parts = err.message.split('\n');
-    const loc = err.hash.loc;
-    const lines = sql.split('\n');
-    const line = lines[loc.first_line - 1];
-    const bad = line.substring(loc.first_column, loc.last_column);
-    if (allow.includes(bad.toUpperCase())) {
-      return { valid: true };
+  const lexer = new Lexer(sql);
+  while (true) {
+    const token = lexer.nextToken();
+    if (token.isEnd()) {
+      break;
     }
-
-    if (line.trim() === bad) {
-      // issue is on next line
-      const nextLine = lines[loc.first_line];
-      if (nextLine?.trim().startsWith('$')) {
-        return { valid: true };
-      }
+    if (token.isError()) {
+      const start = offsetToLineCol(sql, token.begin);
+      const end = offsetToLineCol(sql, token.end);
+      const description = getErrorTokenDescription(token.type);
+      return {
+        valid: false,
+        error: {
+          startLine: start.line,
+          endLine: end.line,
+          startCol: start.col,
+          endCol: end.col,
+          message: description,
+          expected: description,
+        },
+      };
     }
-
-    const badSection = line.substring(loc.last_column + 1);
-    if (badSection.trim().startsWith('$')) {
-      return { valid: true };
-    }
-
-    return {
-      valid: false,
-      error: {
-        startLine: loc.first_line,
-        endLine: loc.last_line,
-        startCol: loc.first_column + 1,
-        endCol: loc.last_column + 1,
-        message: e.message,
-        expected: parts[3],
-      },
-    };
   }
+  return { valid: true };
 }

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -1,1 +1,0 @@
-declare module 'js-sql-parser';

--- a/tests/e2e/sqlValidation.spec.ts
+++ b/tests/e2e/sqlValidation.spec.ts
@@ -66,7 +66,7 @@ async function expectHasErrorMarker(page: Page) {
  * ASOF JOIN, :: cast, etc.) as errors, producing red squiggles in the SQL editor
  * whenever `validateSql` was enabled. This suite exercises the full wiring —
  * user types SQL → onKeyUp → validate() → setModelMarkers() → Monaco renders — so
- * if anyone re-introduces a parser that misrecognises these constructs, the
+ * if anyone re-introduces a parser that misidentifies these constructs, the
  * regression shows up as a failing test here rather than as a user complaint.
  */
 test.describe('SQL editor validation', () => {

--- a/tests/e2e/sqlValidation.spec.ts
+++ b/tests/e2e/sqlValidation.spec.ts
@@ -1,0 +1,105 @@
+import { expect, test } from '@grafana/plugin-e2e';
+import { Page } from '@playwright/test';
+
+// Matches the uid set in provisioning/datasources/clickhouse.yml
+const DATASOURCE_UID = 'clickhouse-e2e';
+const PLUGIN_TYPE = 'grafana-clickhouse-datasource';
+
+/**
+ * Build an Explore URL with an empty SQL query so the editor opens in
+ * SQL Editor mode with no pre-existing content.
+ */
+function exploreUrl(): string {
+  const query: Record<string, unknown> = {
+    refId: 'A',
+    datasource: { type: PLUGIN_TYPE, uid: DATASOURCE_UID },
+    editorType: 'sql',
+    pluginVersion: '',
+    rawSql: '',
+  };
+
+  const panes = JSON.stringify({
+    explore: {
+      datasource: DATASOURCE_UID,
+      queries: [query],
+      range: { from: 'now-1h', to: 'now' },
+    },
+  });
+
+  return `/explore?orgId=1&schemaVersion=1&panes=${encodeURIComponent(panes)}`;
+}
+
+/**
+ * Type SQL into the Monaco editor. Clicks to focus, selects all existing
+ * content, then types the replacement query. Each keystroke triggers the
+ * editor's onKeyUp handler, which runs validate() and writes Monaco markers.
+ */
+async function enterSql(page: Page, sql: string) {
+  const editor = page.getByRole('code');
+  await editor.click();
+  await page.keyboard.press('ControlOrMeta+a');
+  await page.keyboard.type(sql);
+}
+
+/**
+ * Monaco renders validation errors by adding the `squiggly-error` CSS class
+ * to inline decoration spans under the offending tokens. Counting instances
+ * of that class gives a DOM-level read of what the user sees.
+ *
+ * The typed SQL is committed synchronously but Monaco schedules decoration
+ * rendering on the next animation frame, so we give it a brief moment before
+ * asserting.
+ */
+async function expectNoErrorMarkers(page: Page) {
+  await expect(async () => {
+    await expect(page.locator('.squiggly-error')).toHaveCount(0);
+  }).toPass({ timeout: 2000 });
+}
+
+async function expectHasErrorMarker(page: Page) {
+  await expect(page.locator('.squiggly-error').first()).toBeVisible({ timeout: 2000 });
+}
+
+/**
+ * Regression guard for the js-sql-parser false-positive bug: that parser flagged
+ * valid ClickHouse-specific syntax (FINAL, PREWHERE, ARRAY JOIN, SETTINGS,
+ * ASOF JOIN, :: cast, etc.) as errors, producing red squiggles in the SQL editor
+ * whenever `validateSql` was enabled. This suite exercises the full wiring —
+ * user types SQL → onKeyUp → validate() → setModelMarkers() → Monaco renders — so
+ * if anyone re-introduces a parser that misrecognises these constructs, the
+ * regression shows up as a failing test here rather than as a user complaint.
+ */
+test.describe('SQL editor validation', () => {
+  const validClickhouseQueries: Array<{ name: string; sql: string }> = [
+    { name: 'FINAL keyword', sql: 'SELECT * FROM test.events FINAL' },
+    { name: 'PREWHERE clause', sql: 'SELECT * FROM t PREWHERE x > 1 WHERE y > 2' },
+    { name: 'ARRAY JOIN', sql: 'SELECT * FROM t ARRAY JOIN arr' },
+    { name: 'SETTINGS', sql: 'SELECT * FROM t SETTINGS max_rows_to_read = 1000' },
+    { name: 'GLOBAL IN', sql: 'SELECT * FROM t WHERE id GLOBAL IN (SELECT id FROM t2)' },
+    { name: 'ASOF JOIN', sql: 'SELECT * FROM t1 ASOF JOIN t2 ON t1.id = t2.id' },
+    { name: ':: cast operator', sql: "SELECT '2024-01-01'::DateTime FROM t" },
+    { name: 'Grafana $__timeFilter macro', sql: 'SELECT * FROM t WHERE $__timeFilter(timestamp)' },
+    { name: 'Grafana ${variable} template', sql: 'SELECT * FROM t WHERE service = ${service}' },
+  ];
+
+  for (const { name, sql } of validClickhouseQueries) {
+    test(`does not flag ${name} as invalid`, async ({ page }) => {
+      await page.goto(exploreUrl());
+      await enterSql(page, sql);
+      await expectNoErrorMarkers(page);
+    });
+  }
+
+  // Control test: without this, all the positive assertions above would still
+  // pass if validation were silently disabled (no validator → no markers). This
+  // confirms the editor → validator → Monaco marker pipeline is actually wired.
+  //
+  // We use an unclosed `/*` block comment rather than an unclosed string, because
+  // Monaco's auto-close-bracket feature inserts a matching `'` as you type, which
+  // defeats the unclosed-string case.
+  test('flags a genuine error (unclosed block comment)', async ({ page }) => {
+    await page.goto(exploreUrl());
+    await enterSql(page, 'SELECT * FROM t /* unclosed comment');
+    await expectHasErrorMarker(page);
+  });
+});


### PR DESCRIPTION
`js-sql-parser` flagged valid ClickHouse-specific syntax (`FINAL`, `PREWHERE`, `ARRAY JOIN`, `SETTINGS`, `ASOF JOIN`, `::` cast, etc.) as errors, producing false red squiggles in the SQL editor for users who had SQL validation enabled.

The codebase already contains a TypeScript port of ClickHouse's own C++ lexer (`src/ch-parser/lexer.ts`), originally added for autocomplete and covering the full ClickHouse token set including heredocs, nested block comments, hex/binary literals, and ClickHouse-specific operators. This lexer emits typed error tokens (`ErrorSingleQuoteIsNotClosed`, `ErrorMultilineCommentIsNotClosed`, etc.) and handles all ClickHouse syntax correctly by design.

### Validation switch-over

- Replaced `js-sql-parser` in `validate.ts` with a pass over the existing lexer
- Rewrote the test suite with real behavioural tests covering both valid ClickHouse syntax and genuine error cases
- Removed `js-sql-parser` from `package.json` entirely

### Lexer parity fixes

While verifying the port against ClickHouse's `src/Parsers/Lexer.cpp`, three deviations came to light and are fixed in this PR:

- **Unicode handling matches JS codepoints, not UTF-8 bytes.** The original port translated C++ byte-level checks (`E2 80 98`, `E2 88 92`) literally, so U+2018/U+2019 smart quotes and U+2212 minus only fired on mojibake input. Now matched directly as JS codepoints.
- **Heredoc tag validation.** `$tag$...$tag$` now requires the tag to consist solely of ASCII word characters, matching `Lexer.cpp`. Empty tags (`$$...$$`) remain valid.
- **Expanded keyword set.** Added ClickHouse dialect keywords to the autocomplete/parser keyword list: `PREWHERE`, `FINAL`, `SAMPLE`, `SETTINGS`, `FORMAT`, `INTERVAL`, JOIN modifiers (`ASOF`, `ANY`, `ANTI`, `SEMI`, `GLOBAL`, `LATERAL`, `ARRAY`), CTE (`RECURSIVE`), ORDER/LIMIT modifiers (`NULLS`, `FIRST`, `LAST`, `TIES`), DML verbs, common DDL, and window-function clauses.

### Performance

The validator runs on every keyup, so allocations in the lexer hot path matter. Three changes:

- **Heredoc scan no longer allocates the rest of the input per `$`.** The old code did `tokenStream.indexOf('$', 1)` on a fresh `.substring()` of the remaining input, then scanned again for the closing tag. Now it works in absolute positions against `this.text`, eliminating the O(n) allocation per heredoc attempt.
- **Lazy uppercase cache on `Token`.** `matchKeyword` and `isKeyword` were re-uppercasing the token text on every call from the parser's hot loops. The uppercase form is now lazily cached on the token.
- **Removed `.toLowerCase()` on single-char comparisons.** Number-literal parsing compared `c.toLowerCase() === 'e'` and `'p'`, allocating a new string per character. Replaced with direct case-insensitive char-code checks.

### Tests

- Unit tests: added coverage for Unicode smart quotes (both valid and unterminated), the U+2212 minus operator, and heredocs with word-char and empty tags. Full suite passes (670 tests).
- E2E regression guard (`tests/e2e/sqlValidation.spec.ts`): drives the real Monaco editor through the full pipeline (onKeyUp → validate → `setModelMarkers` → DOM) and asserts no `.squiggly-error` decorations appear for each ClickHouse-specific construct the old parser choked on. A negative control (unclosed block comment) confirms the validator is wired up, so the positive assertions can't pass vacuously. Requires `validateSql: true` in the provisioned e2e datasource.