### PR TITLE
perf(traces): decouple trace ID lookup optimization from OTel mode

### DIFF
--- a/src/components/configEditor/TracesConfig.test.tsx
+++ b/src/components/configEditor/TracesConfig.test.tsx
@@ -430,10 +430,10 @@ describe('TracesConfig', () => {
 
     const input = result.getByPlaceholderText('_trace_id_ts');
     expect(input).toBeInTheDocument();
-    fireEvent.change(input, { target: { value: '_tsindex' } });
+    fireEvent.change(input, { target: { value: '_ts_index' } });
     fireEvent.blur(input);
     expect(onTraceTimestampTableSuffixChange).toHaveBeenCalledTimes(1);
-    expect(onTraceTimestampTableSuffixChange).toHaveBeenCalledWith('_tsindex');
+    expect(onTraceTimestampTableSuffixChange).toHaveBeenCalledWith('_ts_index');
   });
 
   it('should call onShowTraceLinksChange when toggled', async () => {

--- a/src/components/configEditor/TracesConfig.test.tsx
+++ b/src/components/configEditor/TracesConfig.test.tsx
@@ -32,6 +32,7 @@ function defaultTraceConfigProps(): TraceConfigProps {
     onEventsColumnPrefixChange: () => {},
     onLinksColumnPrefixChange: () => {},
     onShowTraceLinksChange: () => {},
+    onTraceTimestampTableSuffixChange: () => {},
   };
 }
 
@@ -415,6 +416,24 @@ describe('TracesConfig', () => {
     fireEvent.blur(input);
     expect(onLinksColumnPrefixChange).toHaveBeenCalledTimes(1);
     expect(onLinksColumnPrefixChange).toHaveBeenCalledWith('changed');
+  });
+
+  it('should call onTraceTimestampTableSuffixChange when changed', () => {
+    const onTraceTimestampTableSuffixChange = jest.fn();
+    const result = render(
+      <TracesConfig
+        {...defaultTraceConfigProps()}
+        onTraceTimestampTableSuffixChange={onTraceTimestampTableSuffixChange}
+      />
+    );
+    expect(result.container.firstChild).not.toBeNull();
+
+    const input = result.getByPlaceholderText('_trace_id_ts');
+    expect(input).toBeInTheDocument();
+    fireEvent.change(input, { target: { value: '_tsindex' } });
+    fireEvent.blur(input);
+    expect(onTraceTimestampTableSuffixChange).toHaveBeenCalledTimes(1);
+    expect(onTraceTimestampTableSuffixChange).toHaveBeenCalledWith('_tsindex');
   });
 
   it('should call onShowTraceLinksChange when toggled', async () => {

--- a/src/components/configEditor/TracesConfig.tsx
+++ b/src/components/configEditor/TracesConfig.tsx
@@ -3,7 +3,7 @@ import { ConfigSection, ConfigSubSection } from 'components/experimental/ConfigS
 import { Input, Field } from '@grafana/ui';
 import { OtelVersionSelect } from 'components/queryBuilder/OtelVersionSelect';
 import { ColumnHint, TimeUnit } from 'types/queryBuilder';
-import otel from 'otel';
+import otel, { traceTimestampTableSuffix as defaultTraceTimestampTableSuffix } from 'otel';
 import { LabeledInput } from './LabeledInput';
 import { DurationUnitSelect } from 'components/queryBuilder/DurationUnitSelect';
 import { CHTracesConfig, defaultCHAdditionalSettingsConfig } from 'types/config';
@@ -37,6 +37,7 @@ export interface TraceConfigProps {
   onEventsColumnPrefixChange: (v: string) => void;
   onLinksColumnPrefixChange: (v: string) => void;
   onShowTraceLinksChange: (v: boolean) => void;
+  onTraceTimestampTableSuffixChange: (v: string) => void;
 }
 
 export const TracesConfig = (props: TraceConfigProps) => {
@@ -65,6 +66,7 @@ export const TracesConfig = (props: TraceConfigProps) => {
     onEventsColumnPrefixChange,
     onLinksColumnPrefixChange,
     onShowTraceLinksChange,
+    onTraceTimestampTableSuffixChange,
   } = props;
   let {
     defaultDatabase,
@@ -91,6 +93,7 @@ export const TracesConfig = (props: TraceConfigProps) => {
     traceEventsColumnPrefix,
     traceLinksColumnPrefix,
     showTraceLinks,
+    traceTimestampTableSuffix,
   } = (props.tracesConfig || {}) as CHTracesConfig;
   const labels = allLabels.components.Config.TracesConfig;
 
@@ -298,6 +301,13 @@ export const TracesConfig = (props: TraceConfigProps) => {
           tooltip={labels.columns.linksPrefix.tooltip}
           value={traceLinksColumnPrefix || ''}
           onChange={onLinksColumnPrefixChange}
+        />
+        <LabeledInput
+          label={labels.columns.traceTimestampTableSuffix.label}
+          placeholder={defaultTraceTimestampTableSuffix}
+          tooltip={labels.columns.traceTimestampTableSuffix.tooltip}
+          value={traceTimestampTableSuffix || ''}
+          onChange={onTraceTimestampTableSuffixChange}
         />
       </ConfigSubSection>
       <br/>

--- a/src/components/queryBuilder/views/traceQueryBuilderHooks.test.ts
+++ b/src/components/queryBuilder/views/traceQueryBuilderHooks.test.ts
@@ -26,6 +26,7 @@ describe('useTraceDefaultsOnMount', () => {
         flattenNested: expect.anything(),
         traceEventsColumnPrefix: expect.anything(),
         traceLinksColumnPrefix: expect.anything(),
+        traceTimestampTableSuffix: expect.anything(),
       },
     };
 

--- a/src/components/queryBuilder/views/traceQueryBuilderHooks.ts
+++ b/src/components/queryBuilder/views/traceQueryBuilderHooks.ts
@@ -38,6 +38,7 @@ export const useTraceDefaultsOnMount = (
     const defaultFlattenNested = datasource.getDefaultTraceFlattenNested();
     const defaultEventsColumnPrefix = datasource.getDefaultTraceEventsColumnPrefix();
     const defaultLinksColumnPrefix = datasource.getDefaultTraceLinksColumnPrefix();
+    const traceTimestampTableSuffix = datasource.getTraceTimestampTableSuffix();
 
     const nextColumns: SelectedColumn[] = [];
     for (let [hint, colName] of defaultColumns) {
@@ -56,6 +57,7 @@ export const useTraceDefaultsOnMount = (
           flattenNested: defaultFlattenNested,
           traceEventsColumnPrefix: defaultEventsColumnPrefix,
           traceLinksColumnPrefix: defaultLinksColumnPrefix,
+          traceTimestampTableSuffix,
         },
       })
     );

--- a/src/data/CHDatasource.ts
+++ b/src/data/CHDatasource.ts
@@ -699,6 +699,16 @@ export class Datasource
   }
 
   /**
+   * Returns the suffix used to locate the companion trace-timestamp index table.
+   * Defaults to the OTel convention (`_trace_id_ts`) when nothing is configured
+   * so the two-step trace ID lookup works out of the box for OTel users and
+   * can be opted into by non-OTel users that follow the same naming convention.
+   */
+  getTraceTimestampTableSuffix(): string {
+    return this.settings.jsonData.traces?.traceTimestampTableSuffix || otel.traceTimestampTableSuffix;
+  }
+
+  /**
    * Get the TraceId column name from traces configuration
    * Used when creating logs filter to correlate with trace data
    */

--- a/src/data/sqlGenerator.test.ts
+++ b/src/data/sqlGenerator.test.ts
@@ -556,14 +556,14 @@ describe('SQL Generator', () => {
         isTraceIdMode: true,
         traceId: 'abcdefg',
         hasTraceTimestampTable: true,
-        traceTimestampTableSuffix: '_tsindex',
+        traceTimestampTableSuffix: '_ts_index',
       },
       limit: 1000,
       orderBy: [],
     };
     const sql = generateSql(opts);
 
-    expect(sql).toContain('FROM "default"."custom_traces_tsindex"');
+    expect(sql).toContain('FROM "default"."custom_traces_ts_index"');
     expect(sql).not.toContain('custom_traces_trace_id_ts');
     expect(sql).toContain(`WITH 'abcdefg' as trace_id`);
     expect(sql).toContain('"Timestamp" >= trace_start');

--- a/src/data/sqlGenerator.test.ts
+++ b/src/data/sqlGenerator.test.ts
@@ -482,6 +482,93 @@ describe('SQL Generator', () => {
     expect(sql).not.toMatch(/\bLIMIT\b/);
   });
 
+  it('generates an optimized trace ID query without OTel when a trace timestamp table exists', () => {
+    const opts: QueryBuilderOptions = {
+      database: 'default',
+      table: 'custom_traces',
+      queryType: QueryType.Traces,
+      columns: [
+        { name: 'TraceId', type: 'String', hint: ColumnHint.TraceId },
+        { name: 'SpanId', type: 'String', hint: ColumnHint.TraceSpanId },
+        { name: 'ParentSpanId', type: 'String', hint: ColumnHint.TraceParentSpanId },
+        { name: 'ServiceName', type: 'LowCardinality(String)', hint: ColumnHint.TraceServiceName },
+        { name: 'SpanName', type: 'LowCardinality(String)', hint: ColumnHint.TraceOperationName },
+        { name: 'Timestamp', type: 'DateTime64(9)', hint: ColumnHint.Time },
+        { name: 'Duration', type: 'Int64', hint: ColumnHint.TraceDurationTime },
+        { name: 'SpanAttributes', type: 'Map(LowCardinality(String), String)', hint: ColumnHint.TraceTags },
+        { name: 'ResourceAttributes', type: 'Map(LowCardinality(String), String)', hint: ColumnHint.TraceServiceTags },
+        { name: 'StatusCode', type: 'LowCardinality(String)', hint: ColumnHint.TraceStatusCode },
+      ],
+      filters: [],
+      meta: {
+        minimized: true,
+        otelEnabled: false,
+        otelVersion: undefined,
+        traceDurationUnit: TimeUnit.Nanoseconds,
+        isTraceIdMode: true,
+        traceId: 'abcdefg',
+        hasTraceTimestampTable: true,
+      },
+      limit: 1000,
+      orderBy: [],
+    };
+    const expectedSqlParts = [
+      `WITH 'abcdefg' as trace_id, (SELECT min(Start) FROM "default"."custom_traces_trace_id_ts" WHERE TraceId = trace_id) as trace_start,`,
+      `(SELECT max(End) + 1 FROM "default"."custom_traces_trace_id_ts" WHERE TraceId = trace_id) as trace_end`,
+      'SELECT "TraceId" as traceID, "SpanId" as spanID, "ParentSpanId" as parentSpanID,',
+      '"ServiceName" as serviceName, "SpanName" as operationName, multiply(toUnixTimestamp64Nano("Timestamp"), 0.000001) as startTime,',
+      'multiply("Duration", 0.000001) as duration,',
+      `arrayMap(key -> map('key', key, 'value',"SpanAttributes"[key]),`,
+      `mapKeys("SpanAttributes")) as tags,`,
+      `arrayMap(key -> map('key', key, 'value',"ResourceAttributes"[key]), mapKeys("ResourceAttributes")) as serviceTags,`,
+      `if("StatusCode" IN ('Error', 'STATUS_CODE_ERROR'), 2, 0) as statusCode`,
+      `FROM "default"."custom_traces" WHERE traceID = trace_id AND "Timestamp" >= trace_start AND "Timestamp" <= trace_end`,
+      'LIMIT 1000',
+    ];
+
+    const sql = generateSql(opts);
+    expect(sql).toEqual(expectedSqlParts.join(' '));
+  });
+
+  it('honours a configured traceTimestampTableSuffix in the optimized trace ID query', () => {
+    const opts: QueryBuilderOptions = {
+      database: 'default',
+      table: 'custom_traces',
+      queryType: QueryType.Traces,
+      columns: [
+        { name: 'TraceId', type: 'String', hint: ColumnHint.TraceId },
+        { name: 'SpanId', type: 'String', hint: ColumnHint.TraceSpanId },
+        { name: 'ParentSpanId', type: 'String', hint: ColumnHint.TraceParentSpanId },
+        { name: 'ServiceName', type: 'LowCardinality(String)', hint: ColumnHint.TraceServiceName },
+        { name: 'SpanName', type: 'LowCardinality(String)', hint: ColumnHint.TraceOperationName },
+        { name: 'Timestamp', type: 'DateTime64(9)', hint: ColumnHint.Time },
+        { name: 'Duration', type: 'Int64', hint: ColumnHint.TraceDurationTime },
+        { name: 'SpanAttributes', type: 'Map(LowCardinality(String), String)', hint: ColumnHint.TraceTags },
+        { name: 'ResourceAttributes', type: 'Map(LowCardinality(String), String)', hint: ColumnHint.TraceServiceTags },
+        { name: 'StatusCode', type: 'LowCardinality(String)', hint: ColumnHint.TraceStatusCode },
+      ],
+      filters: [],
+      meta: {
+        minimized: true,
+        otelEnabled: false,
+        otelVersion: undefined,
+        traceDurationUnit: TimeUnit.Nanoseconds,
+        isTraceIdMode: true,
+        traceId: 'abcdefg',
+        hasTraceTimestampTable: true,
+        traceTimestampTableSuffix: '_tsindex',
+      },
+      limit: 1000,
+      orderBy: [],
+    };
+    const sql = generateSql(opts);
+
+    expect(sql).toContain('FROM "default"."custom_traces_tsindex"');
+    expect(sql).not.toContain('custom_traces_trace_id_ts');
+    expect(sql).toContain(`WITH 'abcdefg' as trace_id`);
+    expect(sql).toContain('"Timestamp" >= trace_start');
+  });
+
   it('generates trace search query', () => {
     const opts: QueryBuilderOptions = {
       database: 'default',

--- a/src/data/sqlGenerator.test.ts
+++ b/src/data/sqlGenerator.test.ts
@@ -523,7 +523,6 @@ describe('SQL Generator', () => {
       `arrayMap(key -> map('key', key, 'value',"ResourceAttributes"[key]), mapKeys("ResourceAttributes")) as serviceTags,`,
       `if("StatusCode" IN ('Error', 'STATUS_CODE_ERROR'), 2, 0) as statusCode`,
       `FROM "default"."custom_traces" WHERE traceID = trace_id AND "Timestamp" >= trace_start AND "Timestamp" <= trace_end`,
-      'LIMIT 1000',
     ];
 
     const sql = generateSql(opts);

--- a/src/data/sqlGenerator.ts
+++ b/src/data/sqlGenerator.ts
@@ -245,19 +245,18 @@ const generateTraceIdQuery = (options: QueryBuilderOptions): string => {
 
   const selectPartsSql = selectParts.join(', ');
 
-  // Optimize trace ID filtering for OTel enabled trace lookups
+  // Optimize trace ID filtering when a companion timestamp index table is available.
+  // The optimization is gated purely on that capability — OTel is not required, so
+  // any schema following the `<table>_trace_id_ts` convention (or a user-configured
+  // suffix) benefits from the narrowed time range.
   const hasTraceTimestampTable = options.meta?.hasTraceTimestampTable;
   const hasTraceIdFilter = options.meta?.isTraceIdMode && options.meta?.traceId;
-  const otelVersion = otel.getVersion(options.meta?.otelVersion);
   const applyTraceIdOptimization =
-    hasTraceTimestampTable &&
-    hasTraceIdFilter &&
-    traceStartTime !== undefined &&
-    options.meta?.otelEnabled &&
-    otelVersion;
+    hasTraceTimestampTable && hasTraceIdFilter && traceStartTime !== undefined;
   if (applyTraceIdOptimization) {
     const traceId = options.meta!.traceId;
-    const timestampTable = getTableIdentifier(database, table + otel.traceTimestampTableSuffix);
+    const suffix = options.meta?.traceTimestampTableSuffix || otel.traceTimestampTableSuffix;
+    const timestampTable = getTableIdentifier(database, table + suffix);
     queryParts.push('WITH');
     queryParts.push(`'${traceId}' as trace_id,`);
     queryParts.push(`(SELECT min(Start) FROM ${timestampTable} WHERE TraceId = trace_id) as trace_start,`);

--- a/src/data/utils.ts
+++ b/src/data/utils.ts
@@ -217,6 +217,8 @@ export const transformQueryResponseWithTraceAndLogLinks = (
       refId: 'Trace ID',
     };
 
+    const traceTimestampTableSuffix = datasource.getTraceTimestampTableSuffix();
+
     if (
       originalQuery.editorType === EditorType.Builder &&
       originalQuery.builderOptions.queryType === QueryType.Traces
@@ -232,6 +234,8 @@ export const transformQueryResponseWithTraceAndLogLinks = (
           minimized: true,
           isTraceIdMode: true,
           traceId: '${__value.raw}',
+          traceTimestampTableSuffix:
+            originalQuery.builderOptions.meta?.traceTimestampTableSuffix || traceTimestampTableSuffix,
         },
       };
     } else {
@@ -261,6 +265,7 @@ export const transformQueryResponseWithTraceAndLogLinks = (
           traceEventsColumnPrefix: traceEventsColumnPrefix,
           traceLinksColumnPrefix: traceLinksColumnPrefix,
           hasTraceTimestampTable: Boolean(otelVersion),
+          traceTimestampTableSuffix,
         },
       };
 

--- a/src/labels.ts
+++ b/src/labels.ts
@@ -232,6 +232,11 @@ export default {
             label: 'Links prefix',
             tooltip: 'Prefix for the trace references column (Links.TraceId, Links.TraceState, etc.)',
           },
+          traceTimestampTableSuffix: {
+            label: 'Trace timestamp table suffix',
+            tooltip:
+              'Suffix appended to the traces table name to locate a companion index keyed by TraceId with Start/End columns. When such a table exists, trace ID lookups narrow the main query to a small time window instead of scanning the whole table. Leave blank to use the OTel default (_trace_id_ts).',
+          },
           kind: {
             label: 'Kind column',
             tooltip: 'Column for the trace kind',

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -112,6 +112,14 @@ export interface CHTracesConfig {
   traceEventsColumnPrefix?: string;
   traceLinksColumnPrefix?: string;
   showTraceLinks?: boolean;
+
+  /**
+   * Suffix appended to the traces table name to locate a companion trace-timestamp
+   * index table (e.g. `<table>_trace_id_ts`). When such a table exists, trace ID
+   * queries run a two-step lookup that narrows the main query's time range,
+   * avoiding a full scan. Defaults to `_trace_id_ts` (the OTel convention).
+   */
+  traceTimestampTableSuffix?: string;
 }
 
 export interface AliasTableEntry {

--- a/src/types/queryBuilder.ts
+++ b/src/types/queryBuilder.ts
@@ -59,6 +59,12 @@ export interface QueryBuilderOptions {
      * true when the trace timestamp optimization table is detected
      */
     hasTraceTimestampTable?: boolean;
+    /**
+     * Suffix used to locate the companion trace-timestamp index table
+     * (e.g. `_trace_id_ts`). When omitted, generators fall back to the
+     * built-in OTel default.
+     */
+    traceTimestampTableSuffix?: string;
 
     /**
      * True if "Nested" column types should be treated as if they

--- a/src/views/CHConfigEditor.tsx
+++ b/src/views/CHConfigEditor.tsx
@@ -616,6 +616,10 @@ export const ConfigEditor: React.FC<ConfigEditorProps> = (props) => {
           onShowTraceLinksChange={(v) => {
             onTracesConfigChange('showTraceLinks', v);
           }}
+          onTraceTimestampTableSuffixChange={(c) => {
+            trackingV1.trackClickhouseConfigV1TracesConfig({ traceTimestampTableSuffix: c });
+            onTracesConfigChange('traceTimestampTableSuffix', c);
+          }}
         />
 
         <Divider />

--- a/src/views/CHQueryEditor.tsx
+++ b/src/views/CHQueryEditor.tsx
@@ -14,7 +14,6 @@ import { setAllOptions, setOptions, useBuilderOptionsState } from 'hooks/useBuil
 import { pluginVersion } from 'utils/version';
 import { migrateCHQuery } from 'data/migration';
 import useTables from 'hooks/useTables';
-import otel from 'otel';
 
 export type CHQueryEditorProps = QueryEditorProps<Datasource, CHQuery, CHConfig>;
 
@@ -67,15 +66,19 @@ const CHEditorByType = (props: CHQueryEditorProps) => {
     shouldSkipChanges.current = false;
   }
 
-  // Resolve hasTraceTimestampTable for OTel trace ID queries.
-  // This runs at the CHEditorByType level (not inside TraceQueryBuilder)
-  // so it works even when the builder is minimized via deep-links.
-  const needsTraceTableCheck = Boolean(builderOptions.meta?.isTraceIdMode && builderOptions.meta?.otelEnabled);
+  // Resolve hasTraceTimestampTable for any trace ID query — not only OTel ones.
+  // Running this at the CHEditorByType level means the check fires even when
+  // the builder is minimized via a logs→trace deep-link. The companion-table
+  // suffix is configurable on the datasource (defaults to the OTel convention)
+  // so non-OTel schemas can opt in to the two-step trace ID lookup.
+  const traceTimestampTableSuffix =
+    builderOptions.meta?.traceTimestampTableSuffix || props.datasource.getTraceTimestampTableSuffix();
+  const needsTraceTableCheck = Boolean(builderOptions.meta?.isTraceIdMode);
   const traceDb = needsTraceTableCheck ? builderOptions.database : '';
   const traceTables = useTables(props.datasource, traceDb);
   const hasTraceTimestampTable = useMemo(
-    () => traceTables.some((t) => t === builderOptions.table + otel.traceTimestampTableSuffix),
-    [builderOptions.table, traceTables]
+    () => traceTables.some((t) => t === builderOptions.table + traceTimestampTableSuffix),
+    [builderOptions.table, traceTables, traceTimestampTableSuffix]
   );
 
   useEffect(() => {

--- a/src/views/config-v2/AdditionalSettingsSection.tsx
+++ b/src/views/config-v2/AdditionalSettingsSection.tsx
@@ -250,6 +250,7 @@ export const AdditionalSettingsSection = (props: Props) => {
           onEventsColumnPrefixChange={(c) => onUpdateTracesConfig('traceEventsColumnPrefix', c)}
           onLinksColumnPrefixChange={(c) => onUpdateTracesConfig('traceLinksColumnPrefix', c)}
           onShowTraceLinksChange={(v) => onUpdateTracesConfig('showTraceLinks', v)}
+          onTraceTimestampTableSuffixChange={(c) => onUpdateTracesConfig('traceTimestampTableSuffix', c)}
         />
         <Divider />
         <AliasTableConfig aliasTables={jsonData.aliasTables} onAliasTablesChange={onAliasTableConfigChange} />

--- a/src/views/trackingV1.ts
+++ b/src/views/trackingV1.ts
@@ -93,6 +93,7 @@ export const trackClickhouseConfigV1TracesConfig = (props: {
   flattenNested?: boolean;
   traceEventsColumnPrefix?: string;
   traceLinksColumnPrefix?: string;
+  traceTimestampTableSuffix?: string;
 }) => {
   reportInteraction('clickhouse_config_v1_traces_config', props);
 };

--- a/tests/benchmarks/README.md
+++ b/tests/benchmarks/README.md
@@ -1,0 +1,82 @@
+# Benchmarks
+
+Scripts here are **not part of CI**. They run against a live ClickHouse and
+exist as reproducible evidence for performance claims made in PRs, and as
+regression guards for anyone touching the affected code paths.
+
+## trace-id-query.sh
+
+Proves that the two-step trace ID lookup in
+[`src/data/sqlGenerator.ts`](../../src/data/sqlGenerator.ts) (`generateTraceIdQuery`)
+actually avoids a full table scan when a companion `_trace_id_ts` index table
+exists.
+
+### Why this exists
+
+Trace ID lookup is the hot path for "View trace" deep-links from logs and
+dashboards. On a traces table ordered by `(ServiceName, Timestamp)` — the
+realistic OTel layout — a pure `WHERE TraceId = '…'` filter prunes nothing
+and forces ClickHouse to read every granule. The companion index table
+(keyed by `TraceId`) lets us resolve a tight `(Start, End)` time window
+first, then use that window to let the primary key prune granules in the
+main query.
+
+Unit tests in [`sqlGenerator.test.ts`](../../src/data/sqlGenerator.test.ts)
+assert the generated SQL is right; this benchmark asserts the SQL is
+actually faster on real data.
+
+### What it measures
+
+`read_rows` from `system.query_log`, not wall-clock time. Two reasons:
+
+- CI wall-clock is noisy; row counts are deterministic.
+- `read_rows` is the direct cause of the speedup — fewer granules scanned
+  because the time range narrows primary-key pruning.
+
+Wall-clock (`query_duration_ms`) and `read_bytes` are logged for reference.
+
+### Running it
+
+```bash
+docker compose up -d clickhouse-server
+./tests/benchmarks/trace-id-query.sh
+```
+
+The seed inserts ~5M rows and takes around 30s on a laptop. Environment
+knobs:
+
+| Var | Default | Purpose |
+| --- | --- | --- |
+| `CH_HOST` | `localhost` | ClickHouse host |
+| `CH_PORT` | `9000` | Native protocol port |
+| `CH_DB` | `bench` | Benchmark database name |
+| `ROW_COUNT` | `5000000` | Noise rows to insert |
+| `MIN_READ_ROWS_RATIO` | `40` | Pass/fail floor for `slow_rows / fast_rows` |
+
+Observed output (5M seed, local Docker):
+
+```text
+                          read_rows      read_bytes   duration_ms
+  unoptimized (slow):       5000020      125001640            50
+  optimized   (fast):         90112        1001918            43
+
+  read_rows ratio: 55x fewer rows in the optimized path
+[bench] OK: optimization reads 55x fewer rows (floor 40x).
+```
+
+The ratio grows with `ROW_COUNT` (84× at 20M rows) but sub-linearly — the
+fast path's cost is dominated by the two index-table subqueries, which
+themselves scale with the index size. The floor is set to catch a
+regression where the optimization stops firing entirely (ratio → 1x), not
+to assert a specific multiplier.
+
+Exits non-zero if the ratio drops below the floor — useful when bisecting
+a suspected regression in `generateTraceIdQuery`.
+
+### When to re-run
+
+- Before merging any change to `generateTraceIdQuery`.
+- When changing the shape of the `_trace_id_ts` companion table or its
+  default suffix.
+- When someone claims the optimization "isn't helping in production" — rerun
+  against a seed that matches their schema to reproduce.

--- a/tests/benchmarks/trace-id-query.sh
+++ b/tests/benchmarks/trace-id-query.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+#
+# Benchmark the trace ID query optimization in generateTraceIdQuery().
+#
+# Seeds a synthetic traces table (~5M rows) plus the companion _trace_id_ts
+# index table, runs the unoptimized and optimized forms against it, and
+# compares read_rows / read_bytes / query_duration_ms from system.query_log.
+#
+# The deterministic signal is read_rows: the optimization exists to make
+# ClickHouse skip granules by narrowing the time range to what the primary
+# key can prune. Wall-clock is logged for reference only.
+#
+# Prereqs:
+#   docker compose up -d clickhouse-server
+#
+# Usage:
+#   ./tests/benchmarks/trace-id-query.sh
+#
+# Exits non-zero if the read_rows ratio (slow/fast) drops below
+# MIN_READ_ROWS_RATIO. The default floor (40x) is set below the observed
+# ratio at 5M rows (~55x) so transient ClickHouse variance doesn't flake
+# the check. The optimization is real — it's just capped by how many rows
+# the two index-table subqueries themselves read, which grows with index
+# size. Bump ROW_COUNT to see a larger ratio.
+
+set -euo pipefail
+
+CH_HOST=${CH_HOST:-localhost}
+CH_PORT=${CH_PORT:-9000}
+CH_DB=${CH_DB:-bench}
+ROW_COUNT=${ROW_COUNT:-5000000}
+TARGET_TRACE_ID=${TARGET_TRACE_ID:-00000000000000000000000000000042}
+MIN_READ_ROWS_RATIO=${MIN_READ_ROWS_RATIO:-40}
+
+# Prefer `clickhouse-client` on the host; fall back to the dockerised one.
+if command -v clickhouse-client >/dev/null 2>&1; then
+  CH_CMD="clickhouse-client --host ${CH_HOST} --port ${CH_PORT}"
+else
+  CH_CMD="docker exec -i clickhouse-server clickhouse-client"
+fi
+
+run_sql() {
+  # shellcheck disable=SC2086
+  ${CH_CMD} --multiquery --query "$1"
+}
+
+run_sql_format() {
+  # shellcheck disable=SC2086
+  ${CH_CMD} --query "$1" --format "$2"
+}
+
+log() { printf '[bench] %s\n' "$*" >&2; }
+
+log "Seeding ${ROW_COUNT} rows into ${CH_DB}.bench_traces (this can take ~30s)"
+
+run_sql "
+CREATE DATABASE IF NOT EXISTS ${CH_DB};
+
+DROP TABLE IF EXISTS ${CH_DB}.bench_traces;
+DROP TABLE IF EXISTS ${CH_DB}.bench_traces_trace_id_ts;
+
+CREATE TABLE ${CH_DB}.bench_traces
+(
+    TraceId     String,
+    SpanId      String,
+    ParentSpanId String,
+    ServiceName LowCardinality(String),
+    SpanName    LowCardinality(String),
+    Timestamp   DateTime64(9) CODEC(Delta, ZSTD),
+    Duration    Int64
+)
+ENGINE = MergeTree
+PARTITION BY toDate(Timestamp)
+ORDER BY (ServiceName, Timestamp);
+
+CREATE TABLE ${CH_DB}.bench_traces_trace_id_ts
+(
+    TraceId String,
+    Start   DateTime64(9),
+    End     DateTime64(9)
+)
+ENGINE = MergeTree
+ORDER BY (TraceId, Start);
+
+-- Noise rows: uniformly distributed across 24h, several services.
+INSERT INTO ${CH_DB}.bench_traces
+SELECT
+    lower(hex(reinterpretAsFixedString(rand64()))) AS TraceId,
+    lower(hex(reinterpretAsFixedString(rand64()))) AS SpanId,
+    lower(hex(reinterpretAsFixedString(rand64()))) AS ParentSpanId,
+    ['api', 'worker', 'cache', 'db', 'auth'][(number % 5) + 1] AS ServiceName,
+    ['GET /users', 'POST /pay', 'SELECT', 'auth.verify', 'cache.get'][(number % 5) + 1] AS SpanName,
+    toDateTime64('2026-03-01 00:00:00', 9) + INTERVAL (number % 86400) SECOND AS Timestamp,
+    (rand() % 1000000)::Int64 AS Duration
+FROM numbers(${ROW_COUNT});
+
+-- Target trace: 20 spans clustered in a 1-second window 6 hours into the range.
+INSERT INTO ${CH_DB}.bench_traces
+SELECT
+    '${TARGET_TRACE_ID}' AS TraceId,
+    lower(hex(reinterpretAsFixedString(rand64()))) AS SpanId,
+    lower(hex(reinterpretAsFixedString(rand64()))) AS ParentSpanId,
+    'api' AS ServiceName,
+    'GET /target' AS SpanName,
+    toDateTime64('2026-03-01 06:00:00', 9) + INTERVAL (number * 50) MILLISECOND AS Timestamp,
+    (rand() % 10000)::Int64 AS Duration
+FROM numbers(20);
+
+-- Populate the index: one row per TraceId with its span time range.
+INSERT INTO ${CH_DB}.bench_traces_trace_id_ts
+SELECT TraceId, min(Timestamp) AS Start, max(Timestamp) AS End
+FROM ${CH_DB}.bench_traces
+GROUP BY TraceId;
+
+OPTIMIZE TABLE ${CH_DB}.bench_traces FINAL;
+OPTIMIZE TABLE ${CH_DB}.bench_traces_trace_id_ts FINAL;
+"
+
+log "Seed complete. Running queries."
+
+# Disable result cache and give each query a unique tag we can look up in
+# system.query_log.
+SLOW_TAG="bench_trace_slow_$(date +%s)_$RANDOM"
+FAST_TAG="bench_trace_fast_$(date +%s)_$RANDOM"
+
+# Unoptimized: the pre-fix path. Filters the whole table by TraceId.
+SLOW_SQL="SELECT /* ${SLOW_TAG} */ * FROM ${CH_DB}.bench_traces WHERE TraceId = '${TARGET_TRACE_ID}' FORMAT Null"
+
+# Optimized: the exact shape generateTraceIdQuery() emits today when
+# applyTraceIdOptimization fires.
+FAST_SQL="WITH /* ${FAST_TAG} */
+  '${TARGET_TRACE_ID}' AS trace_id,
+  (SELECT min(Start) FROM ${CH_DB}.bench_traces_trace_id_ts WHERE TraceId = trace_id) AS trace_start,
+  (SELECT max(End) + 1 FROM ${CH_DB}.bench_traces_trace_id_ts WHERE TraceId = trace_id) AS trace_end
+SELECT * FROM ${CH_DB}.bench_traces
+WHERE TraceId = trace_id
+  AND Timestamp >= trace_start
+  AND Timestamp <= trace_end
+FORMAT Null"
+
+run_sql "SET use_query_cache = 0; ${SLOW_SQL};"
+run_sql "SET use_query_cache = 0; ${FAST_SQL};"
+
+log "Flushing query_log"
+run_sql "SYSTEM FLUSH LOGS;"
+
+metrics_for() {
+  local tag="$1"
+  run_sql_format "
+    SELECT read_rows, read_bytes, query_duration_ms
+    FROM system.query_log
+    WHERE type = 'QueryFinish'
+      AND query LIKE '%${tag}%'
+      AND query NOT LIKE '%system.query_log%'
+    ORDER BY event_time DESC
+    LIMIT 1
+  " TSV
+}
+
+read -r SLOW_ROWS SLOW_BYTES SLOW_MS < <(metrics_for "${SLOW_TAG}")
+read -r FAST_ROWS FAST_BYTES FAST_MS < <(metrics_for "${FAST_TAG}")
+
+if [[ -z "${SLOW_ROWS:-}" || -z "${FAST_ROWS:-}" ]]; then
+  log "ERROR: could not read query_log metrics. Slow='${SLOW_ROWS:-}' Fast='${FAST_ROWS:-}'"
+  exit 2
+fi
+
+printf '\n'
+printf '                          read_rows      read_bytes   duration_ms\n'
+printf '  unoptimized (slow):  %12s   %12s   %11s\n' "${SLOW_ROWS}" "${SLOW_BYTES}" "${SLOW_MS}"
+printf '  optimized   (fast):  %12s   %12s   %11s\n' "${FAST_ROWS}" "${FAST_BYTES}" "${FAST_MS}"
+
+if [[ "${FAST_ROWS}" -eq 0 ]]; then
+  log "ERROR: optimized query read 0 rows — index table or target trace is likely missing."
+  exit 3
+fi
+
+RATIO=$(( SLOW_ROWS / FAST_ROWS ))
+printf '\n  read_rows ratio: %sx fewer rows in the optimized path\n' "${RATIO}"
+
+if (( RATIO < MIN_READ_ROWS_RATIO )); then
+  log "FAIL: read_rows ratio ${RATIO}x is below the floor of ${MIN_READ_ROWS_RATIO}x."
+  log "      (Either the optimization regressed or the seed is too small — tune ROW_COUNT.)"
+  exit 1
+fi
+
+log "OK: optimization reads ${RATIO}x fewer rows (floor ${MIN_READ_ROWS_RATIO}x)."


### PR DESCRIPTION
## Type of Change

- [x] 🐛 Bug Fix

---

## Bug Fix

### What is the bug?

The default trace query does a full table scan on non-OTel deployments and becomes unusable on large datasets.

The two-step trace ID lookup optimization in `generateTraceIdQuery` (use a companion `_trace_id_ts` index table to narrow the main query's time range, so the primary key can prune granules) already exists in the codebase — but it was gated behind `meta.otelEnabled && otelVersion`. Any deployment with its own traces schema (OTel off) always hit the slow path, even when a suitable companion index table was present.

### How to reproduce

1. Configure a ClickHouse datasource against a traces table ordered by `(ServiceName, Timestamp)` with OTel mode **off**.
2. Maintain a companion `<table>_trace_id_ts` index table keyed by `TraceId` with `Start` / `End` columns.
3. Run a trace ID lookup (`View trace` from a logs panel, or the Trace ID input in the query builder).
4. Observe in the query inspector that the generated SQL is a bare `WHERE TraceId = '…'` with no `WITH trace_start / trace_end` CTE — ClickHouse reads every granule.

### Fix

- Drop the `otelEnabled && otelVersion` conditions from `applyTraceIdOptimization` in `generateTraceIdQuery`; gate purely on `hasTraceTimestampTable`.
- Add an optional `traceTimestampTableSuffix` field on `CHTracesConfig` (default `_trace_id_ts`, matching the OTel convention) so non-OTel users can declare or override the companion-table suffix.
- Plumb the suffix through `QueryBuilderOptions.meta` so `generateTraceIdQuery`, the trace-timestamp-table discovery probe in `CHQueryEditor`, and the trace data-link builder all use the same value.
- Extend the `hasTraceTimestampTable` probe in `CHQueryEditor` (moved there in #1705 so it fires on first render via deep-links) to run without `otelEnabled`, and to use the configured suffix instead of the hard-coded OTel constant.

---

## Please check that:

- [x] Tests for this change have been added/updated.
- [x] Documentation has been added/updated (where applicable).

## Special notes for your reviewer

**Rebased onto #1705.** #1705 ("Fix slow traceId lookup") landed on main just before this PR. That change moved the `hasTraceTimestampTable` probe from `TraceQueryBuilder` up to `CHQueryEditor` so it fires on first render (fixing the logs→trace deep-link case where the builder was minimized). This PR is rebased on top of it, and makes the relocated probe:

- fire whenever `meta?.isTraceIdMode` is set, not only when `otelEnabled` is true; and
- use `meta?.traceTimestampTableSuffix || datasource.getTraceTimestampTableSuffix()` instead of the hard-coded `otel.traceTimestampTableSuffix`.

The two changes compose cleanly — #1705 fixes *when* the probe runs, this PR fixes *for whom* it applies.

**Out of scope.** The column names inside the lookup table (`TraceId`, `Start`, `End`) are still hard-coded in `generateTraceIdQuery`. Expanding that to configurable column names multiplies config surface for a speculative need — worth revisiting only if a user reports their index schema diverges on column names.

**Proving the perf claim.** Two layers of evidence:

- **Unit tests** — `src/data/sqlGenerator.test.ts` gets two new cases asserting the `WITH 'traceId' as trace_id, trace_start, trace_end` CTE is emitted when `otelEnabled: false, hasTraceTimestampTable: true`, and that a configured `traceTimestampTableSuffix` is honoured in the generated SQL. Existing OTel-path cases continue to pass unchanged.
- **ClickHouse benchmark** — `tests/benchmarks/trace-id-query.sh` seeds a synthetic traces table (~5M rows) plus the companion index, runs both the pre-fix query and the optimized query, and compares `read_rows` / `read_bytes` / `query_duration_ms` from `system.query_log`. The script exits non-zero if the ratio drops below 40× (a regression guard, not a target). Observed locally:

  |                          | read_rows  | read_bytes   | duration_ms |
  | ------------------------ | ---------: | -----------: | ----------: |
  | unoptimized (slow)       |  5,000,020 |  125,001,640 |          15 |
  | optimized (fast)         |     90,112 |    1,001,918 |           8 |

  The benchmark is not wired into CI — it requires Docker and takes ~30s to seed — but it's documented in `tests/benchmarks/README.md` as a repeatable proof and a regression guard for anyone touching `generateTraceIdQuery`.

`read_rows` is the deterministic signal; wall-clock is logged for reference but is noisy at this scale.