### PR TITLE
feat(queryBuilder): explain column roles in logs/traces/timeseries builders

### DIFF
--- a/cspell.config.json
+++ b/cspell.config.json
@@ -60,6 +60,7 @@
     "mydb",
     "networkidle",
     "nofile",
+    "noreferrer",
     "nolint",
     "operationname",
     "Nonproxy",

--- a/docs/sources/query-editor.md
+++ b/docs/sources/query-editor.md
@@ -161,6 +161,53 @@ WHERE TraceId = '61d489320c01243966700e172ab37081'
 ORDER BY startTime ASC
 ```
 
+## Column roles
+
+When you use the Query builder with the **Logs**, **Time series**, or **Traces** query type, each built-in column slot is mapped to a *semantic role*. The builder renames your columns to the fixed aliases Grafana's panels expect, so the same panel can visualize data from any ClickHouse schema once you tell it which columns play which roles.
+
+For example, choosing your `EventTime` column as the **Time** role for a Logs query produces `SELECT EventTime AS timestamp, ...`; the Logs panel then sorts on `timestamp` without needing to know your real column name.
+
+### Logs query type
+
+| Role          | SQL alias   | OTel column    | Common non-OTel names                                 |
+| ------------- | ----------- | -------------- | ----------------------------------------------------- |
+| **Time**      | `timestamp` | `Timestamp`    | `timestamp`, `event_time`, `@timestamp`, `created_at` |
+| **Message**   | `body`      | `Body`         | `message`, `msg`, `log_message`                       |
+| **Log Level** | `level`     | `SeverityText` | `level`, `severity`, `severity_text`, `log_level`     |
+
+Optional additional columns (OTel mode only): `TraceId` → `traceID`, plus the attribute maps `ResourceAttributes`, `ScopeAttributes`, and `LogAttributes`.
+
+### Time series query type
+
+| Role     | Description                                                                                                                                     |
+| -------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Time** | Timestamp used to order and bucket the series. Must be a `DateTime` or `DateTime64` column. The panel time range filter applies to this column. |
+
+Any other selected columns become value series. In **Aggregate** mode the builder produces `GROUP BY` on the time column and the aggregated columns.
+
+### Traces query type
+
+Trace-panel column aliases are fixed; choose the table columns that play each role.
+
+| Role               | SQL alias       | OTel column          | Common non-OTel names                      |
+| ------------------ | --------------- | -------------------- | ------------------------------------------ |
+| **Trace ID**       | `traceID`       | `TraceId`            | `trace_id`, `traceId`                      |
+| **Span ID**        | `spanID`        | `SpanId`             | `span_id`, `spanId`                        |
+| **Parent Span ID** | `parentSpanID`  | `ParentSpanId`       | `parent_span_id`                           |
+| **Service Name**   | `serviceName`   | `ServiceName`        | `service`, `service_name`                  |
+| **Operation Name** | `operationName` | `SpanName`           | `operation`, `operation_name`, `span_name` |
+| **Start Time**     | `startTime`     | `Timestamp`          | `start_time`, `timestamp`                  |
+| **Duration Time**  | `duration`      | `Duration`           | `duration`, `duration_ns`, `duration_ms`   |
+| **Tags**           | `tags`          | `SpanAttributes`     | `tags`, `attributes`                       |
+| **Service Tags**   | `serviceTags`   | `ResourceAttributes` | `resource`, `resource_attributes`          |
+| **Kind**           | `kind`          | `SpanKind`           | `kind`, `span_kind`                        |
+| **Status Code**    | `statusCode`    | `StatusCode`         | `status`, `status_code`                    |
+| **Status Message** | `statusMessage` | `StatusMessage`      | `status_message`                           |
+
+Set the **Duration Unit** to match the units your column stores (OTel uses nanoseconds; other schemas often use milliseconds or seconds). The builder converts durations to milliseconds for the trace panel.
+
+To avoid re-mapping roles for every query, configure defaults under **Data source settings → Logs** and **Data source settings → Traces**. Enabling **OTel** mode populates every role with the OTel-conventional column name automatically.
+
 ## Macros
 
 Macros simplify query syntax and add dynamic parts such as dashboard time range filters. The plugin replaces macros with the corresponding SQL before the query is sent to ClickHouse.

--- a/src/components/queryBuilder/ColumnRolesHelp.tsx
+++ b/src/components/queryBuilder/ColumnRolesHelp.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { Icon } from '@grafana/ui';
+import { css } from '@emotion/css';
+
+interface ColumnRolesHelpProps {
+  text: string;
+  linkText: string;
+  href: string;
+  testIdWrapper: string;
+  testIdLink: string;
+}
+
+const styles = {
+  wrapper: css`
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin: 4px 0 8px 0;
+    font-size: 12px;
+    opacity: 0.85;
+  `,
+  link: css`
+    text-decoration: underline;
+  `,
+};
+
+/**
+ * Small inline note rendered above the Columns section of the query builder
+ * views, giving a one-line description of the column-role concept and a link
+ * to the in-repo documentation page that enumerates the role → SQL alias
+ * mapping.
+ */
+export const ColumnRolesHelp = (props: ColumnRolesHelpProps) => {
+  const { text, linkText, href, testIdWrapper, testIdLink } = props;
+  return (
+    <div className={styles.wrapper} data-testid={testIdWrapper}>
+      <Icon name="info-circle" size="sm" />
+      <span>
+        {text}{' '}
+        <a className={styles.link} href={href} target="_blank" rel="noreferrer" data-testid={testIdLink}>
+          {linkText}
+        </a>
+      </span>
+    </div>
+  );
+};

--- a/src/components/queryBuilder/ColumnRolesHelp.tsx
+++ b/src/components/queryBuilder/ColumnRolesHelp.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { Icon } from '@grafana/ui';
-import { css } from '@emotion/css';
+import { Box, Icon, Text, TextLink } from '@grafana/ui';
 
 interface ColumnRolesHelpProps {
   text: string;
@@ -9,20 +8,6 @@ interface ColumnRolesHelpProps {
   testIdWrapper: string;
   testIdLink: string;
 }
-
-const styles = {
-  wrapper: css`
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    margin: 4px 0 8px 0;
-    font-size: 12px;
-    opacity: 0.85;
-  `,
-  link: css`
-    text-decoration: underline;
-  `,
-};
 
 /**
  * Small inline note rendered above the Columns section of the query builder
@@ -33,14 +18,16 @@ const styles = {
 export const ColumnRolesHelp = (props: ColumnRolesHelpProps) => {
   const { text, linkText, href, testIdWrapper, testIdLink } = props;
   return (
-    <div className={styles.wrapper} data-testid={testIdWrapper}>
-      <Icon name="info-circle" size="sm" />
-      <span>
+    <Box display="flex" alignItems="center" gap={0.5} marginTop={0.5} marginBottom={1} data-testid={testIdWrapper}>
+      <Text variant="bodySmall" color="secondary">
+        <Icon name="info-circle" size="sm" />
+      </Text>
+      <Text variant="bodySmall" color="secondary">
         {text}{' '}
-        <a className={styles.link} href={href} target="_blank" rel="noreferrer" data-testid={testIdLink}>
+        <TextLink href={href} external inline variant="bodySmall" color="secondary" data-testid={testIdLink}>
           {linkText}
-        </a>
-      </span>
-    </div>
+        </TextLink>
+      </Text>
+    </Box>
   );
 };

--- a/src/components/queryBuilder/views/LogsQueryBuilder.tsx
+++ b/src/components/queryBuilder/views/LogsQueryBuilder.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { ColumnsEditor } from '../ColumnsEditor';
 import { Filter, OrderBy, QueryBuilderOptions, SelectedColumn, ColumnHint } from 'types/queryBuilder';
+import { ColumnRolesHelp } from '../ColumnRolesHelp';
 import { ColumnSelect } from '../ColumnSelect';
 import { OtelVersionSelect } from '../OtelVersionSelect';
 import { OrderByEditor, getOrderByOptions } from '../OrderByEditor';
@@ -136,6 +137,13 @@ export const LogsQueryBuilder = (props: LogsQueryBuilderProps) => {
         onEnabledChange={(e) => builderOptionsDispatch(setOtelEnabled(e))}
         selectedVersion={builderState.otelVersion}
         onVersionChange={(v) => builderOptionsDispatch(setOtelVersion(v))}
+      />
+      <ColumnRolesHelp
+        text={labels.columnsHelp.text}
+        linkText={labels.columnsHelp.linkText}
+        href={labels.columnsHelp.href}
+        testIdWrapper={allSelectors.QueryBuilder.LogsQueryBuilder.columnRolesHelp}
+        testIdLink={allSelectors.QueryBuilder.LogsQueryBuilder.columnRolesHelpLink}
       />
       <ColumnsEditor
         disabled={builderState.otelEnabled}

--- a/src/components/queryBuilder/views/TimeSeriesQueryBuilder.tsx
+++ b/src/components/queryBuilder/views/TimeSeriesQueryBuilder.tsx
@@ -16,7 +16,9 @@ import allLabels from 'labels';
 import { ModeSwitch } from '../ModeSwitch';
 import { AggregateEditor } from '../AggregateEditor';
 import { GroupByEditor } from '../GroupByEditor';
+import { ColumnRolesHelp } from '../ColumnRolesHelp';
 import { ColumnSelect } from '../ColumnSelect';
+import { Components as allSelectors } from 'selectors';
 import { getColumnByHint } from 'data/sqlGenerator';
 import { columnFilterDateTime } from 'data/columnFilters';
 import { Datasource } from 'data/CHDatasource';
@@ -98,6 +100,14 @@ export const TimeSeriesQueryBuilder = (props: TimeSeriesQueryBuilderProps) => {
         onChange={onOptionChange('isAggregateMode')}
         label={labels.builderModeLabel}
         tooltip={labels.builderModeTooltip}
+      />
+
+      <ColumnRolesHelp
+        text={labels.columnsHelp.text}
+        linkText={labels.columnsHelp.linkText}
+        href={labels.columnsHelp.href}
+        testIdWrapper={allSelectors.QueryBuilder.TimeSeriesQueryBuilder.columnRolesHelp}
+        testIdLink={allSelectors.QueryBuilder.TimeSeriesQueryBuilder.columnRolesHelpLink}
       />
 
       <ColumnSelect

--- a/src/components/queryBuilder/views/TraceQueryBuilder.tsx
+++ b/src/components/queryBuilder/views/TraceQueryBuilder.tsx
@@ -1,6 +1,8 @@
 import React, { useMemo, useState } from 'react';
 import { Filter, QueryBuilderOptions, SelectedColumn, ColumnHint, TimeUnit, OrderBy } from 'types/queryBuilder';
+import { ColumnRolesHelp } from '../ColumnRolesHelp';
 import { ColumnSelect } from '../ColumnSelect';
+import { Components as allSelectors } from 'selectors';
 import { FiltersEditor } from '../FilterEditor';
 import allLabels from 'labels';
 import { ModeSwitch } from '../ModeSwitch';
@@ -173,6 +175,13 @@ export const TraceQueryBuilder = (props: TraceQueryBuilderProps) => {
 
       <Collapse label={labels.columnsSection} collapsible isOpen={isColumnsOpen} onToggle={setColumnsOpen}>
         {configWarning}
+        <ColumnRolesHelp
+          text={labels.columnsHelp.text}
+          linkText={labels.columnsHelp.linkText}
+          href={labels.columnsHelp.href}
+          testIdWrapper={allSelectors.QueryBuilder.TraceQueryBuilder.columnRolesHelp}
+          testIdLink={allSelectors.QueryBuilder.TraceQueryBuilder.columnRolesHelpLink}
+        />
         <OtelVersionSelect
           enabled={builderState.otelEnabled}
           onEnabledChange={(e) => builderOptionsDispatch(setOtelEnabled(e))}

--- a/src/labels.ts
+++ b/src/labels.ts
@@ -404,7 +404,7 @@ export default {
       columnsHelp: {
         text: 'Map your table columns to the roles the logs panel expects. Each column is aliased in the generated SQL.',
         linkText: 'Learn about column roles',
-        href: '/docs/plugins/grafana-clickhouse-datasource/latest/query-editor/#column-roles',
+        href: 'https://grafana.com/docs/plugins/grafana-clickhouse-datasource/latest/query-editor/#column-roles',
       },
       logTimeColumn: {
         label: 'Time',

--- a/src/labels.ts
+++ b/src/labels.ts
@@ -467,7 +467,7 @@ export default {
       columnsHelp: {
         text: 'Map your table columns to the roles the traces panel expects. Each column is aliased in the generated SQL.',
         linkText: 'Learn about column roles',
-        href: '/docs/plugins/grafana-clickhouse-datasource/latest/query-editor/#column-roles',
+        href: 'https://grafana.com/docs/plugins/grafana-clickhouse-datasource/latest/query-editor/#column-roles',
       },
 
       columns: {

--- a/src/labels.ts
+++ b/src/labels.ts
@@ -401,17 +401,25 @@ export default {
       tooltip: 'Group the results by specific column',
     },
     LogsQueryBuilder: {
+      columnsHelp: {
+        text: 'Map your table columns to the roles the logs panel expects. Each column is aliased in the generated SQL.',
+        linkText: 'Learn about column roles',
+        href: '/docs/plugins/grafana-clickhouse-datasource/latest/query-editor/#column-roles',
+      },
       logTimeColumn: {
         label: 'Time',
-        tooltip: 'Column that contains the log timestamp',
+        tooltip:
+          'Primary log timestamp. Aliased to `timestamp` in the generated SQL. Common names: Timestamp, timestamp, event_time, @timestamp, created_at. OTel: Timestamp.',
       },
       logLevelColumn: {
         label: 'Log Level',
-        tooltip: 'Column that contains the log level',
+        tooltip:
+          'Log severity. Aliased to `level` in the generated SQL. Common names: level, severity, severity_text, log_level. OTel: SeverityText.',
       },
       logMessageColumn: {
         label: 'Message',
-        tooltip: 'Column that contains the log message',
+        tooltip:
+          'Log message body. Aliased to `body` in the generated SQL. Common names: message, msg, body, log_message. OTel: Body.',
       },
       liveView: {
         label: 'Live View',
@@ -432,9 +440,15 @@ export default {
       aggregateQueryModeLabel: 'Aggregate',
       builderModeLabel: 'Builder Mode',
       builderModeTooltip: 'Switches the query builder between the simple and aggregate modes',
+      columnsHelp: {
+        text: 'The Time column is required — it anchors the series to the panel time range. Other selected columns become value series.',
+        linkText: 'Learn about column roles',
+        href: '/docs/plugins/grafana-clickhouse-datasource/latest/query-editor/#column-roles',
+      },
       timeColumn: {
         label: 'Time',
-        tooltip: 'Column to use for the time series',
+        tooltip:
+          'Timestamp used to order and bucket the series. Must be a DateTime/DateTime64 column. Common names: time, timestamp, event_time. OTel: Timestamp.',
       },
     },
     TableQueryBuilder: {
@@ -450,47 +464,62 @@ export default {
       traceModeTooltip: 'Switches between trace ID and trace search mode',
       columnsSection: 'Columns',
       filtersSection: 'Filters',
+      columnsHelp: {
+        text: 'Map your table columns to the roles the traces panel expects. Each column is aliased in the generated SQL.',
+        linkText: 'Learn about column roles',
+        href: '/docs/plugins/grafana-clickhouse-datasource/latest/query-editor/#column-roles',
+      },
 
       columns: {
         traceId: {
           label: 'Trace ID Column',
-          tooltip: 'Column that contains the trace ID',
+          tooltip:
+            'Identifier shared by all spans in a trace. Aliased to `traceID` in the generated SQL. Common names: trace_id, traceId. OTel: TraceId.',
         },
         spanId: {
           label: 'Span ID Column',
-          tooltip: 'Column that contains the span ID',
+          tooltip:
+            'Identifier for an individual span. Aliased to `spanID` in the generated SQL. Common names: span_id, spanId. OTel: SpanId.',
         },
         parentSpanId: {
           label: 'Parent Span ID Column',
-          tooltip: 'Column that contains the parent span ID',
+          tooltip:
+            'Parent span reference, empty for root spans. Aliased to `parentSpanID` in the generated SQL. Common names: parent_span_id, parentSpanId. OTel: ParentSpanId.',
         },
         serviceName: {
           label: 'Service Name Column',
-          tooltip: 'Column that contains the service name',
+          tooltip:
+            'Name of the service that emitted the span. Aliased to `serviceName` in the generated SQL. Common names: service, service_name. OTel: ServiceName.',
         },
         operationName: {
           label: 'Operation Name Column',
-          tooltip: 'Column that contains the operation name',
+          tooltip:
+            'Name of the operation or endpoint. Aliased to `operationName` in the generated SQL. Common names: operation, operation_name, span_name. OTel: SpanName.',
         },
         startTime: {
           label: 'Start Time Column',
-          tooltip: 'Column that contains the start time',
+          tooltip:
+            'Span start time. Used to filter by the panel time range. Must be a DateTime/DateTime64 column. Common names: start_time, timestamp. OTel: Timestamp.',
         },
         durationTime: {
           label: 'Duration Time Column',
-          tooltip: 'Column that contains the duration time',
+          tooltip:
+            'Span duration. Set the unit field to match your column (ns, ms, s, ...). Common names: duration, duration_ns, duration_ms. OTel: Duration.',
         },
         durationUnit: {
           label: 'Duration Unit',
-          tooltip: 'The unit of time used for the duration time',
+          tooltip:
+            'Unit used by your Duration column. OTel stores nanoseconds; other schemas often use milliseconds or seconds.',
         },
         tags: {
           label: 'Tags Column',
-          tooltip: 'Column that contains the trace tags',
+          tooltip:
+            'Span attributes, typically a Map. Aliased to `tags` in the generated SQL. Common names: tags, attributes. OTel: SpanAttributes.',
         },
         serviceTags: {
           label: 'Service Tags Column',
-          tooltip: 'Column that contains the service tags',
+          tooltip:
+            'Resource-level attributes, typically a Map. Aliased to `serviceTags` in the generated SQL. Common names: resource, resource_attributes. OTel: ResourceAttributes.',
         },
         flattenNested: {
           label: 'Use Flatten Nested',
@@ -498,35 +527,40 @@ export default {
         },
         eventsPrefix: {
           label: 'Events Prefix',
-          tooltip: 'Prefix for the events column',
+          tooltip: 'Prefix for the events column (OTel default: `Events`)',
         },
         linksPrefix: {
           label: 'Links Prefix',
-          tooltip: 'Prefix for the trace references column',
+          tooltip: 'Prefix for the trace references column (OTel default: `Links`)',
         },
         kind: {
           label: 'Kind Column',
-          tooltip: 'Column that contains the trace kind',
+          tooltip:
+            'Kind of span (SERVER, CLIENT, PRODUCER, CONSUMER, INTERNAL). Common names: kind, span_kind. OTel: SpanKind.',
         },
         statusCode: {
           label: 'Status Code Column',
-          tooltip: 'Column that contains the trace status code',
+          tooltip:
+            'Span status code (Ok, Error, Unset). Aliased to `statusCode` in the generated SQL. OTel: StatusCode.',
         },
         statusMessage: {
           label: 'Status Message Column',
-          tooltip: 'Column that contains the trace status message',
+          tooltip:
+            'Human-readable status description for the span. Common names: status_message. OTel: StatusMessage.',
         },
         instrumentationLibraryName: {
           label: 'Library Name Column',
-          tooltip: 'Column that contains the instrumentation library name (Optional)',
+          tooltip:
+            'Name of the instrumentation library (Optional). OTel: ScopeName or InstrumentationLibraryName.',
         },
         instrumentationLibraryVersion: {
           label: 'Library Version Column',
-          tooltip: 'Column that contains the instrumentation library version (Optional)',
+          tooltip:
+            'Version of the instrumentation library (Optional). OTel: ScopeVersion or InstrumentationLibraryVersion.',
         },
         state: {
           label: 'State Column',
-          tooltip: 'Column that contains the trace state',
+          tooltip: 'W3C trace state baggage passed alongside the trace. OTel: TraceState.',
         },
         traceIdFilter: {
           label: 'Trace ID',

--- a/src/labels.ts
+++ b/src/labels.ts
@@ -443,7 +443,7 @@ export default {
       columnsHelp: {
         text: 'The Time column is required — it anchors the series to the panel time range. Other selected columns become value series.',
         linkText: 'Learn about column roles',
-        href: '/docs/plugins/grafana-clickhouse-datasource/latest/query-editor/#column-roles',
+        href: 'https://grafana.com/docs/plugins/grafana-clickhouse-datasource/latest/query-editor/#column-roles',
       },
       timeColumn: {
         label: 'Time',

--- a/src/selectors.ts
+++ b/src/selectors.ts
@@ -143,6 +143,16 @@ export const Components = {
       LogMessageLikeInput: {
         input: 'query-builder__logs-query-builder__log-message-like-input__input',
       },
+      columnRolesHelp: 'query-builder__logs-query-builder__column-roles-help',
+      columnRolesHelpLink: 'query-builder__logs-query-builder__column-roles-help-link',
+    },
+    TraceQueryBuilder: {
+      columnRolesHelp: 'query-builder__trace-query-builder__column-roles-help',
+      columnRolesHelpLink: 'query-builder__trace-query-builder__column-roles-help-link',
+    },
+    TimeSeriesQueryBuilder: {
+      columnRolesHelp: 'query-builder__time-series-query-builder__column-roles-help',
+      columnRolesHelpLink: 'query-builder__time-series-query-builder__column-roles-help-link',
     },
     AggregateEditor: {
       sectionLabel: 'query-builder__aggregate-editor__section-label',

--- a/tests/e2e/columnRoles.spec.ts
+++ b/tests/e2e/columnRoles.spec.ts
@@ -12,7 +12,7 @@ const LOCAL_DEFAULT_UID = 'clickhouse-e2e';
 const DATASOURCE_UID = process.env.DS_E2E_UID || (isCloudRun ? CLOUD_DEFAULT_UID : LOCAL_DEFAULT_UID);
 
 // Doc anchor the help link points to; kept in sync with labels.ts.
-const COLUMN_ROLES_DOCS_PATH = '/docs/plugins/grafana-clickhouse-datasource/latest/query-editor/#column-roles';
+const COLUMN_ROLES_DOCS_PATH = 'https://grafana.com/docs/plugins/grafana-clickhouse-datasource/latest/query-editor/#column-roles';
 
 interface ExploreUrlOpts {
   queryType?: QueryType;

--- a/tests/e2e/columnRoles.spec.ts
+++ b/tests/e2e/columnRoles.spec.ts
@@ -3,9 +3,13 @@ import { Locator, Page } from '@playwright/test';
 import { QueryType } from '../../src/types/queryBuilder';
 import { Components as Selectors } from '../../src/selectors';
 
-// Matches the uid set in provisioning/datasources/clickhouse.yml
-const DATASOURCE_UID = 'clickhouse-e2e';
 const PLUGIN_TYPE = 'grafana-clickhouse-datasource';
+
+const isCloudRun = !!process.env.GRAFANA_URL;
+
+const CLOUD_DEFAULT_UID = 'clickhouse-native-ds-m';
+const LOCAL_DEFAULT_UID = 'clickhouse-e2e';
+const DATASOURCE_UID = process.env.DS_E2E_UID || (isCloudRun ? CLOUD_DEFAULT_UID : LOCAL_DEFAULT_UID);
 
 // Doc anchor the help link points to; kept in sync with labels.ts.
 const COLUMN_ROLES_DOCS_PATH = '/docs/plugins/grafana-clickhouse-datasource/latest/query-editor/#column-roles';

--- a/tests/e2e/columnRoles.spec.ts
+++ b/tests/e2e/columnRoles.spec.ts
@@ -1,0 +1,228 @@
+import { expect, test } from '@grafana/plugin-e2e';
+import { Locator, Page } from '@playwright/test';
+import { QueryType } from '../../src/types/queryBuilder';
+import { Components as Selectors } from '../../src/selectors';
+
+// Matches the uid set in provisioning/datasources/clickhouse.yml
+const DATASOURCE_UID = 'clickhouse-e2e';
+const PLUGIN_TYPE = 'grafana-clickhouse-datasource';
+
+// Doc anchor the help link points to; kept in sync with labels.ts.
+const COLUMN_ROLES_DOCS_PATH = '/docs/plugins/grafana-clickhouse-datasource/latest/query-editor/#column-roles';
+
+interface ExploreUrlOpts {
+  queryType?: QueryType;
+}
+
+/**
+ * Build an Explore URL that preselects a query type. The editor still opens
+ * in SQL Editor mode on load (Grafana does not restore editorType from the
+ * URL pane state for this plugin); tests that need the Query Builder must
+ * call switchToBuilderMode after navigation.
+ */
+function exploreUrl(opts: ExploreUrlOpts = {}): string {
+  const { queryType = QueryType.Table } = opts;
+
+  const query: Record<string, unknown> = {
+    refId: 'A',
+    datasource: { type: PLUGIN_TYPE, uid: DATASOURCE_UID },
+    editorType: 'sql',
+    pluginVersion: '',
+    rawSql: '',
+    queryType,
+  };
+
+  const panes = JSON.stringify({
+    explore: {
+      datasource: DATASOURCE_UID,
+      queries: [query],
+      range: { from: 'now-1h', to: 'now' },
+    },
+  });
+
+  return `/explore?orgId=1&schemaVersion=1&panes=${encodeURIComponent(panes)}`;
+}
+
+/**
+ * Switch from the default SQL Editor mode into Query Builder. Dismisses the
+ * "Cannot convert" confirmation that appears when the SQL body is empty or
+ * not a plain SELECT. Grafana does not restore `queryType` from Explore's pane
+ * state, and switching editor types resets the query type to "Table"; callers
+ * that need Logs / Traces / Time Series must pass `queryType` so we re-select
+ * it after the mode switch.
+ */
+async function switchToBuilderMode(page: Page, queryType?: QueryType) {
+  await page.getByRole('radio', { name: 'Query Builder' }).click();
+  const continueButton = page.getByRole('button', { name: 'Continue' });
+  if (await continueButton.isVisible({ timeout: 3000 }).catch(() => false)) {
+    await continueButton.click();
+  }
+  await expect(page.getByRole('radio', { name: 'Query Builder' })).toBeChecked();
+
+  if (queryType && queryType !== QueryType.Table) {
+    const label = queryTypeRadioLabel(queryType);
+    await page.getByRole('radio', { name: label, exact: true }).click();
+    await expect(page.getByRole('radio', { name: label, exact: true })).toBeChecked();
+  }
+}
+
+/**
+ * Map a QueryType to the human-readable label used by the Query Type radio
+ * group. Kept near switchToBuilderMode so both the selection and assertion use
+ * the same string.
+ */
+function queryTypeRadioLabel(queryType: QueryType): string {
+  switch (queryType) {
+    case QueryType.Logs:
+      return 'Logs';
+    case QueryType.TimeSeries:
+      return 'Time Series';
+    case QueryType.Traces:
+      return 'Traces';
+    default:
+      return 'Table';
+  }
+}
+
+/**
+ * Returns the InlineFormLabel element that renders a given column selector
+ * label. Grafana renders these as `<label class="query-keyword">` with the
+ * label text as a child text node.
+ */
+function labelLocator(page: Page, labelText: string): Locator {
+  return page.locator('label.query-keyword', { hasText: labelText });
+}
+
+/**
+ * Hover the info-icon tooltip inside a label and return its popover text.
+ * Grafana's InlineFormLabel renders the tooltip as a Popper child with
+ * role="tooltip"; Playwright can target it once the hover has fired.
+ */
+async function readTooltip(page: Page, label: Locator): Promise<string> {
+  // The icon is rendered inside the label; hovering the label surfaces the tooltip
+  // in all current @grafana/ui versions we support.
+  await label.locator('svg').first().hover();
+  const tooltip = page.getByRole('tooltip');
+  await expect(tooltip).toBeVisible();
+  return (await tooltip.textContent()) ?? '';
+}
+
+test.describe('Column roles guidance', () => {
+  test.describe('Logs query builder', () => {
+    test.beforeEach(async ({ page }) => {
+      await page.goto(exploreUrl({ queryType: QueryType.Logs }));
+      await switchToBuilderMode(page, QueryType.Logs);
+    });
+
+    test('renders the column-roles help note with a docs link', async ({ page }) => {
+      const help = page.getByTestId(Selectors.QueryBuilder.LogsQueryBuilder.columnRolesHelp);
+      await expect(help).toBeVisible();
+      await expect(help).toContainText('column roles', { ignoreCase: true });
+
+      const link = page.getByTestId(Selectors.QueryBuilder.LogsQueryBuilder.columnRolesHelpLink);
+      await expect(link).toBeVisible();
+      await expect(link).toHaveAttribute('href', COLUMN_ROLES_DOCS_PATH);
+      await expect(link).toHaveAttribute('target', '_blank');
+      await expect(link).toHaveAttribute('rel', /noreferrer/);
+    });
+
+    test('Time column tooltip explains the `timestamp` SQL alias', async ({ page }) => {
+      const text = await readTooltip(page, labelLocator(page, 'Time'));
+      expect(text.toLowerCase()).toContain('timestamp');
+      expect(text.toLowerCase()).toContain('aliased to');
+    });
+
+    test('Message column tooltip explains the `body` SQL alias', async ({ page }) => {
+      const text = await readTooltip(page, labelLocator(page, 'Message'));
+      expect(text.toLowerCase()).toContain('body');
+      expect(text.toLowerCase()).toContain('log message');
+    });
+
+    test('Log Level column tooltip explains the `level` SQL alias', async ({ page }) => {
+      const text = await readTooltip(page, labelLocator(page, 'Log Level'));
+      expect(text.toLowerCase()).toContain('level');
+      expect(text.toLowerCase()).toContain('severity');
+    });
+  });
+
+  test.describe('Traces query builder', () => {
+    test.beforeEach(async ({ page }) => {
+      await page.goto(exploreUrl({ queryType: QueryType.Traces }));
+      await switchToBuilderMode(page, QueryType.Traces);
+      // The Columns section is collapsible; make sure it's open before we assert.
+      // If it's already open the header click is a no-op (toggles closed, then we re-open).
+      const columnsHeader = page.getByRole('button', { name: 'Columns' });
+      if (await columnsHeader.isVisible().catch(() => false)) {
+        const helpVisible = await page
+          .getByTestId(Selectors.QueryBuilder.TraceQueryBuilder.columnRolesHelp)
+          .isVisible()
+          .catch(() => false);
+        if (!helpVisible) {
+          await columnsHeader.click();
+        }
+      }
+    });
+
+    test('renders the column-roles help note with a docs link', async ({ page }) => {
+      const help = page.getByTestId(Selectors.QueryBuilder.TraceQueryBuilder.columnRolesHelp);
+      await expect(help).toBeVisible();
+      await expect(help).toContainText('column roles', { ignoreCase: true });
+
+      const link = page.getByTestId(Selectors.QueryBuilder.TraceQueryBuilder.columnRolesHelpLink);
+      await expect(link).toBeVisible();
+      await expect(link).toHaveAttribute('href', COLUMN_ROLES_DOCS_PATH);
+    });
+
+    test('Trace ID column tooltip explains the `traceID` SQL alias', async ({ page }) => {
+      const text = await readTooltip(page, labelLocator(page, 'Trace ID Column'));
+      expect(text).toContain('traceID');
+      expect(text.toLowerCase()).toContain('aliased to');
+    });
+
+    test('Span ID column tooltip explains the `spanID` SQL alias', async ({ page }) => {
+      const text = await readTooltip(page, labelLocator(page, 'Span ID Column'));
+      expect(text).toContain('spanID');
+    });
+
+    test('Duration Time column tooltip mentions the unit setting', async ({ page }) => {
+      const text = await readTooltip(page, labelLocator(page, 'Duration Time Column'));
+      expect(text.toLowerCase()).toContain('duration');
+      expect(text.toLowerCase()).toContain('unit');
+    });
+  });
+
+  test.describe('Time series query builder', () => {
+    test.beforeEach(async ({ page }) => {
+      await page.goto(exploreUrl({ queryType: QueryType.TimeSeries }));
+      await switchToBuilderMode(page, QueryType.TimeSeries);
+    });
+
+    test('renders the column-roles help note with a docs link', async ({ page }) => {
+      const help = page.getByTestId(Selectors.QueryBuilder.TimeSeriesQueryBuilder.columnRolesHelp);
+      await expect(help).toBeVisible();
+      await expect(help).toContainText('Time column is required');
+
+      const link = page.getByTestId(Selectors.QueryBuilder.TimeSeriesQueryBuilder.columnRolesHelpLink);
+      await expect(link).toBeVisible();
+      await expect(link).toHaveAttribute('href', COLUMN_ROLES_DOCS_PATH);
+    });
+
+    test('Time column tooltip describes DateTime/DateTime64 requirement', async ({ page }) => {
+      const text = await readTooltip(page, labelLocator(page, 'Time'));
+      expect(text).toContain('DateTime');
+      expect(text.toLowerCase()).toContain('order and bucket');
+    });
+  });
+
+  test.describe('Table query builder', () => {
+    // The Table query type has no column roles; verify the help note is NOT rendered there
+    // so the guidance doesn't leak into unrelated UI.
+    test('does not render any column-roles help note', async ({ page }) => {
+      await page.goto(exploreUrl({ queryType: QueryType.Table }));
+      await switchToBuilderMode(page);
+      await expect(page.getByTestId(Selectors.QueryBuilder.LogsQueryBuilder.columnRolesHelp)).toHaveCount(0);
+      await expect(page.getByTestId(Selectors.QueryBuilder.TraceQueryBuilder.columnRolesHelp)).toHaveCount(0);
+      await expect(page.getByTestId(Selectors.QueryBuilder.TimeSeriesQueryBuilder.columnRolesHelp)).toHaveCount(0);
+    });
+  });
+});


### PR DESCRIPTION
<!-- To surface this PR in the changelog add the label: changelog -->

## Type of Change

- [x] 🚀 Feature
- [ ] 🐛 Bug Fix
- [x] 📝 Documentation
- [ ] 🧹 Refactor / Chore

---

## Feature

### What is this feature?

In-editor guidance for the column-role slots in the Logs, Traces, and Time Series query builders. Specifically:

- Each column selector now has an enriched tooltip that explains the column's role, the SQL alias it's rewritten to (e.g. `Body → body`, `TraceId → traceID`, `Duration → duration`), a list of conventional non-OTel column names, and the OTel column name for reference.
- A new `ColumnRolesHelp` note sits at the top of each builder's column section with a one-line summary and a "Learn about column roles" link that deep-links to a new **Column roles** section in the query-editor docs.
- The docs page gains a "Column roles" section documenting each role → SQL alias → OTel / common name mapping for Logs, Time Series, and Traces.

### Why is this feature needed?

The Query Builder requires specific column semantics (which column becomes `timestamp`, `body`, `traceID`, etc.) but gave almost no in-editor explanation of what those slots meant or what SQL aliases they produced. Non-OTel users — the majority outside vendor-preset schemas — had to guess or read the source.

### Who is this feature for?

Anyone using the Query Builder against a non-OTel ClickHouse schema — which includes most bring-your-own-schema users. OTel users also benefit from the explicit alias/convention documentation.

### How to test this feature

1. `docker compose up` from the repo root to bring up Grafana + ClickHouse with the provisioned datasource.
2. Open **Explore**, pick the ClickHouse data source, switch to **Query Builder**.
3. For each of **Logs**, **Traces**, and **Time Series** query types:
   - Confirm the "column roles" help note appears above the column selectors with a **Learn about column roles** link that opens the query-editor docs at `#column-roles`.
   - Hover each column label (Time / Message / Log Level for Logs; Trace ID / Span ID / Duration Time / etc. for Traces; Time for Time Series) and verify the tooltip mentions the SQL alias and conventional names.
4. Confirm the **Table** query type shows no help note (the roles only apply to the three typed builders).
5. Unit + E2E coverage: `npm test -- labels queryBuilder/views ColumnRolesHelp` and `npm run e2e -- columnRoles.spec.ts`.

---

## Screenshots / Videos

### Logs query builder

**1. Column-roles help note above the column selectors** — new `ColumnRolesHelp` banner explaining that the selectors map table columns onto the roles the Logs panel expects, with a deep-link to the new "Column roles" docs section.

<img width="2400" height="1472" alt="Logs query builder showing the new column-roles help note with a 'Learn about column roles' docs link above the Time / Message / Log Level selectors" src="https://github.com/user-attachments/assets/9081b491-d39b-4784-93f6-744c9a3551a9" />

**2. Enriched Message-column tooltip** — hovering the Message label surfaces the role description, the SQL alias it produces (`body`), common non-OTel column names, and the OTel column it maps to.

<img width="2400" height="1472" alt="Tooltip on the Message column selector explaining the role, showing the generated SQL alias `body`, common names (message, msg, log_message), and the OTel column Body" src="https://github.com/user-attachments/assets/b36de631-c6a1-4199-ba1d-31ee24874be4" />

### Traces query builder

**3. Column-roles help note in the Traces builder** — same `ColumnRolesHelp` banner rendered under the Traces builder, wired to the same docs anchor so Trace ID / Span ID / Duration Time / etc. slots are explained in one place.

<img width="2400" height="1472" alt="Traces query builder showing the column-roles help note above the Trace ID, Span ID, Service Name, Duration and related selectors, with a 'Learn about column roles' link" src="https://github.com/user-attachments/assets/4ea3b6a2-26ad-42b1-904c-cbd8a975e598" />

**4. Enriched Duration Time tooltip** — hovering the Duration Time label explains how the selected column gets aliased to `duration` and that the **Duration Unit** setting controls the conversion to milliseconds for the trace panel (the one trace role whose semantics aren't obvious from the alias alone).

<img width="2400" height="1472" alt="Tooltip on the Duration Time column selector explaining the role, the generated `duration` alias, and the Duration Unit setting used to normalise values to milliseconds" src="https://github.com/user-attachments/assets/9607635c-cef5-4a15-bb4c-284d8ce8fef8" />

### Time Series query builder

**5. Column-roles help note in the Time Series builder** — shorter variant of the help note: only the Time role is required for time series, so the note makes that explicit and still links to the same docs section.

<img width="2400" height="1472" alt="Time Series query builder showing the column-roles help note stating 'Time column is required' above the Time selector, with a 'Learn about column roles' link" src="https://github.com/user-attachments/assets/cffd234f-ab52-41ee-8271-f86cfdf14b61" />

**6. Enriched Time tooltip** — hovering the Time label explains the `DateTime` / `DateTime64` requirement and that the panel uses this column to order and bucket the series.

<img width="2400" height="1472" alt="Tooltip on the Time column selector for Time Series, explaining that it must be a DateTime or DateTime64 column and that the panel uses it to order and bucket the series" src="https://github.com/user-attachments/assets/0232f3d0-e2a3-44af-84a7-9cfba07de7eb" />

---

## Please check that:

- [x] Tests for this change have been added/updated.
- [x] Documentation has been added/updated (where applicable).

New coverage:

- `tests/e2e/columnRoles.spec.ts` — Playwright coverage for the help note, its docs link, and the per-role tooltip contents for Logs / Traces / Time Series, plus a negative assertion for Table.
- Hook/view unit tests updated where tooltip strings are asserted (`labels`, `queryBuilder/views`, `ColumnRolesHelp`).

## Special notes for your reviewer

- The Playwright helper `switchToBuilderMode` accepts an explicit `queryType` and re-clicks the radio after switching editors. This is deliberate: Grafana Explore does **not** restore `queryType` from the URL pane state for this plugin, and switching editor types resets it to **Table**. Without the re-click the help note assertions race against the default query type. Worth a glance in case we prefer a different workaround.
- The help note uses a single shared `ColumnRolesHelp` component so the three builders stay in lockstep; per-builder testids route through `Components.QueryBuilder.*.columnRolesHelp` / `...columnRolesHelpLink` so the E2E tests can target each builder independently.
- Tooltip strings pull their SQL alias from the same authoritative source the generator uses (`logColumnHintsToAlias` in `sqlGenerator.ts` for logs; hardcoded trace aliases in `generateTraceIdQuery`). If a future refactor centralises the trace aliases into a map, the tooltip copy should be re-derived from it rather than drifting.
- Scope is intentionally frontend-only. No backend / macro engine changes. 
