### PR TITLE
fix(adhoc): support Map-typed columns in ad-hoc filters

### DIFF
--- a/cspell.config.json
+++ b/cspell.config.json
@@ -91,6 +91,7 @@
     "sqlutil",
     "stagename",
     "stretchr",
+    "subkey",
     "subquery",
     "subqueries",
     "subresource",

--- a/src/data/CHDatasource.test.ts
+++ b/src/data/CHDatasource.test.ts
@@ -12,7 +12,14 @@ import { DataQuery } from '@grafana/schema';
 import { mockDatasource } from '__mocks__/datasource';
 import { cloneDeep } from 'lodash';
 import { of } from 'rxjs';
-import { BuilderMode, ColumnHint, FilterOperator, OrderByDirection, QueryBuilderOptions, QueryType } from 'types/queryBuilder';
+import {
+  BuilderMode,
+  ColumnHint,
+  FilterOperator,
+  OrderByDirection,
+  QueryBuilderOptions,
+  QueryType,
+} from 'types/queryBuilder';
 import { CHBuilderQuery, CHQuery, CHSqlQuery, EditorType } from 'types/sql';
 import { AdHocFilter } from './adHocFilter';
 import { Datasource } from './CHDatasource';
@@ -139,7 +146,7 @@ describe('ClickHouseDatasource', () => {
       // Setup ad-hoc filters
       const adHocFilters = [
         { key: 'column', operator: '=', value: 'value' },
-        { key: 'column.nested', operator: '=', value: 'value2' }
+        { key: 'column.nested', operator: '=', value: 'value2' },
       ];
 
       // Mock getAdhocFilters to return our test filters
@@ -184,12 +191,14 @@ describe('ClickHouseDatasource', () => {
 
       // Mock the template variable resolution
       const spyOnReplace = jest.spyOn(templateSrvMock, 'replace').mockImplementation(() => resolvedSql);
-      const spyOnGetVars = jest.spyOn(templateSrvMock, 'getVariables').mockImplementation(() => [{name: 'clickhouse_adhoc_use_json'}]);
+      const spyOnGetVars = jest
+        .spyOn(templateSrvMock, 'getVariables')
+        .mockImplementation(() => [{ name: 'clickhouse_adhoc_use_json' }]);
 
       // Setup ad-hoc filters
       const adHocFilters = [
         { key: 'column', operator: '=', value: 'value' },
-        { key: 'column.nested', operator: '=', value: 'value2' }
+        { key: 'column.nested', operator: '=', value: 'value2' },
       ];
 
       // Mock getAdhocFilters to return our test filters
@@ -215,7 +224,6 @@ describe('ClickHouseDatasource', () => {
       // Verify that the final query contains the ad-hoc filters
       expect(result.rawSql).toEqual(sqlWithAdHocFilters);
     });
-
 
     it('should expand $__adHocFilters macro with single quotes', async () => {
       const query = {
@@ -584,6 +592,107 @@ describe('ClickHouseDatasource', () => {
       );
 
       expect(values).toEqual([{ text: 'value1' }, { text: 'value2' }]);
+    });
+  });
+
+  describe('Map type ad-hoc filters (#1434)', () => {
+    it('expands Map-typed columns into one tag key per discovered map key', async () => {
+      jest.spyOn(templateSrvMock, 'replace').mockImplementation(() => 'db.events');
+      const ds = cloneDeep(mockDatasource);
+      ds.settings.jsonData.defaultDatabase = 'db';
+      ds.settings.jsonData.defaultTable = 'events';
+      // system.columns → two columns, one Map-typed.
+      const columnsFrame = arrayToDataFrame([
+        { name: 'level', type: 'String', table: 'events' },
+        { name: 'labels', type: 'Map(String, String)', table: 'events' },
+      ]);
+      // fetchUniqueMapKeys → distinct map keys for `labels`.
+      const mapKeysFrame = arrayToDataFrame([{ keys: 'http.method' }, { keys: 'http.status' }]);
+      jest.spyOn(ds, 'query').mockImplementation((request) => {
+        const sql = request.targets[0].rawSql ?? '';
+        if (sql.includes('arrayJoin(labels.keys)')) {
+          return of({ data: [mapKeysFrame] });
+        }
+        return of({ data: [columnsFrame] });
+      });
+
+      const keys = await ds.getTagKeys();
+      expect(keys).toEqual([
+        { text: 'events.level' },
+        { text: 'events.labels.http.method' },
+        { text: 'events.labels.http.status' },
+      ]);
+    });
+
+    it('falls back to a flat Map column entry when no table context is available', async () => {
+      jest.spyOn(templateSrvMock, 'replace').mockImplementation(() => 'db');
+      const ds = cloneDeep(mockDatasource);
+      ds.settings.jsonData.defaultDatabase = 'db';
+      const columnsFrame = arrayToDataFrame([{ name: 'labels', type: 'Map(String, String)', table: 'events' }]);
+      jest.spyOn(ds, 'query').mockImplementation(() => of({ data: [columnsFrame] }));
+
+      const keys = await ds.getTagKeys();
+      // No `db.table` context → we don't fan out mapKeys probes; show the
+      // raw Map column entry instead of crashing or emitting `[object Object]`.
+      expect(keys).toEqual([{ text: 'events.labels' }]);
+    });
+
+    it('rewrites dotted Map keys into bracket access in fetchTagValuesFromSchema', async () => {
+      jest.spyOn(templateSrvMock, 'replace').mockImplementation(() => 'db.events');
+      const ds = cloneDeep(mockDatasource);
+      ds.settings.jsonData.defaultDatabase = 'db';
+      const columnsFrame = arrayToDataFrame([{ name: 'labels', type: 'Map(String, String)', table: 'events' }]);
+      const mapKeysFrame = arrayToDataFrame([{ keys: 'http.method' }]);
+      const valuesFrame = arrayToDataFrame([{ val: 'GET' }, { val: 'POST' }]);
+
+      const spyOnQuery = jest.spyOn(ds, 'query').mockImplementation((request) => {
+        const sql = request.targets[0].rawSql ?? '';
+        if (sql.includes('arrayJoin(labels.keys)')) {
+          return of({ data: [mapKeysFrame] });
+        }
+        if (sql.includes("labels['http.method']")) {
+          return of({ data: [valuesFrame] });
+        }
+        return of({ data: [columnsFrame] });
+      });
+
+      await ds.getTagKeys(); // populates the mapColumnsByTable cache
+      const values = await ds.getTagValues({ key: 'events.labels.http.method' });
+      expect(values).toEqual([{ text: 'GET' }, { text: 'POST' }]);
+      expect(spyOnQuery).toHaveBeenCalledWith(
+        expect.objectContaining({
+          targets: expect.arrayContaining([
+            expect.objectContaining({
+              rawSql: "select distinct labels['http.method'] from db.events limit 1000",
+            }),
+          ]),
+        })
+      );
+    });
+
+    it('publishes the Map-column set to the AdHocFilter for escapeKey rewriting', async () => {
+      jest.spyOn(templateSrvMock, 'replace').mockImplementation(() => 'db.events');
+      const ds = cloneDeep(mockDatasource);
+      ds.settings.jsonData.defaultDatabase = 'db';
+      const columnsFrame = arrayToDataFrame([
+        { name: 'labels', type: 'Map(String, String)', table: 'events' },
+        { name: 'other_map', type: 'Nullable(Map(String, String))', table: 'events' },
+      ]);
+      const mapKeysFrame = arrayToDataFrame([{ keys: 'a' }]);
+      jest.spyOn(ds, 'query').mockImplementation((request) => {
+        const sql = request.targets[0].rawSql ?? '';
+        if (sql.includes('.keys)')) {
+          return of({ data: [mapKeysFrame] });
+        }
+        return of({ data: [columnsFrame] });
+      });
+
+      await ds.getTagKeys();
+      const published = ds.adHocFilter.getMapColumns();
+      expect(published.has('labels')).toBe(true);
+      expect(published.has('other_map')).toBe(true);
+      // OTel fallback names remain in the set for back-compat.
+      expect(published.has('LogAttributes')).toBe(true);
     });
   });
 
@@ -1063,7 +1172,7 @@ describe('ClickHouseDatasource', () => {
                 value: 'error',
                 type: 'string',
                 filterType: 'custom',
-                condition: 'AND'
+                condition: 'AND',
               },
             ],
           },
@@ -1205,7 +1314,16 @@ describe('ClickHouseDatasource', () => {
           ...query,
           builderOptions: {
             ...query.builderOptions,
-            filters: [{ condition: 'AND', key: 'level', type: 'string', filterType: 'custom', operator: FilterOperator.Equals, value: 'debug' }],
+            filters: [
+              {
+                condition: 'AND',
+                key: 'level',
+                type: 'string',
+                filterType: 'custom',
+                operator: FilterOperator.Equals,
+                value: 'debug',
+              },
+            ],
           },
         };
 
@@ -1249,7 +1367,16 @@ describe('ClickHouseDatasource', () => {
           ...query,
           builderOptions: {
             ...query.builderOptions,
-            filters: [{ condition: 'AND', key: 'level', type: 'string', filterType: 'custom', operator: FilterOperator.Equals, value: 'info' }],
+            filters: [
+              {
+                condition: 'AND',
+                key: 'level',
+                type: 'string',
+                filterType: 'custom',
+                operator: FilterOperator.Equals,
+                value: 'info',
+              },
+            ],
           },
         };
 
@@ -1276,7 +1403,16 @@ describe('ClickHouseDatasource', () => {
           ...query,
           builderOptions: {
             ...query.builderOptions,
-            filters: [{ condition: 'AND', key: 'level', type: 'string', filterType: 'custom', operator: FilterOperator.NotEquals, value: 'info' }],
+            filters: [
+              {
+                condition: 'AND',
+                key: 'level',
+                type: 'string',
+                filterType: 'custom',
+                operator: FilterOperator.NotEquals,
+                value: 'info',
+              },
+            ],
           },
         };
 
@@ -1296,7 +1432,16 @@ describe('ClickHouseDatasource', () => {
           ...query,
           builderOptions: {
             ...query.builderOptions,
-            filters: [{ condition: 'AND', key: 'level', type: 'string', filterType: 'custom', operator: FilterOperator.NotEquals, value: 'error' }],
+            filters: [
+              {
+                condition: 'AND',
+                key: 'level',
+                type: 'string',
+                filterType: 'custom',
+                operator: FilterOperator.NotEquals,
+                value: 'error',
+              },
+            ],
           },
         };
 
@@ -1436,7 +1581,17 @@ describe('ClickHouseDatasource', () => {
           builderOptions: {
             ...query.builderOptions,
             columns: [{ name: 'SeverityText', hint: ColumnHint.LogLevel, type: 'string' }],
-            filters: [{ condition: 'AND', key: '', hint: ColumnHint.LogLevel, type: 'string', filterType: 'custom', operator: FilterOperator.Equals, value: 'debug' }],
+            filters: [
+              {
+                condition: 'AND',
+                key: '',
+                hint: ColumnHint.LogLevel,
+                type: 'string',
+                filterType: 'custom',
+                operator: FilterOperator.Equals,
+                value: 'debug',
+              },
+            ],
           },
         };
 
@@ -1545,7 +1700,10 @@ describe('ClickHouseDatasource', () => {
 
     it('returns query unchanged for non-Builder editorType', () => {
       const sqlQuery: CHSqlQuery = { pluginVersion: '', refId: 'A', editorType: EditorType.SQL, rawSql: 'SELECT 1' };
-      const result = datasource.modifyQuery(sqlQuery, { type: 'ADD_FILTER', options: { key: 'level', value: 'info' } } as any);
+      const result = datasource.modifyQuery(sqlQuery, {
+        type: 'ADD_FILTER',
+        options: { key: 'level', value: 'info' },
+      } as any);
       expect(result).toBe(sqlQuery);
     });
 

--- a/src/data/CHDatasource.test.ts
+++ b/src/data/CHDatasource.test.ts
@@ -610,7 +610,7 @@ describe('ClickHouseDatasource', () => {
       const mapKeysFrame = arrayToDataFrame([{ keys: 'http.method' }, { keys: 'http.status' }]);
       jest.spyOn(ds, 'query').mockImplementation((request) => {
         const sql = request.targets[0].rawSql ?? '';
-        if (sql.includes('arrayJoin(labels.keys)')) {
+        if (sql.includes('arrayJoin("labels".keys)')) {
           return of({ data: [mapKeysFrame] });
         }
         return of({ data: [columnsFrame] });
@@ -647,7 +647,7 @@ describe('ClickHouseDatasource', () => {
 
       const spyOnQuery = jest.spyOn(ds, 'query').mockImplementation((request) => {
         const sql = request.targets[0].rawSql ?? '';
-        if (sql.includes('arrayJoin(labels.keys)')) {
+        if (sql.includes('arrayJoin("labels".keys)')) {
           return of({ data: [mapKeysFrame] });
         }
         if (sql.includes("labels['http.method']")) {
@@ -664,6 +664,77 @@ describe('ClickHouseDatasource', () => {
           targets: expect.arrayContaining([
             expect.objectContaining({
               rawSql: "select distinct labels['http.method'] from db.events limit 1000",
+            }),
+          ]),
+        })
+      );
+    });
+
+    it('looks up per-table Map columns using the bare table name even when source is db.table', async () => {
+      // Regression: mapColumnsByTable is populated from system.columns
+      // (keyed by bare table name), but fetchTagValuesFromSchema passes
+      // `db.table` as the source. The lookup must normalize the prefix so
+      // the per-table set is hit — without this the code falls back to a
+      // flattened union, which can mis-detect Map columns when two tables
+      // share a column name (one Map, one scalar).
+      jest.spyOn(templateSrvMock, 'replace').mockImplementation(() => 'db.events');
+      const ds = cloneDeep(mockDatasource);
+      ds.settings.jsonData.defaultDatabase = 'db';
+      const columnsFrame = arrayToDataFrame([
+        // `labels` is Map in `events` but a String in `other` — the lookup
+        // must scope by table.
+        { name: 'labels', type: 'Map(String, String)', table: 'events' },
+        { name: 'labels', type: 'String', table: 'other' },
+      ]);
+      const mapKeysFrame = arrayToDataFrame([{ keys: 'region' }]);
+      const valuesFrame = arrayToDataFrame([{ val: 'eu' }]);
+
+      jest.spyOn(ds, 'query').mockImplementation((request) => {
+        const sql = request.targets[0].rawSql ?? '';
+        if (sql.includes('arrayJoin("labels".keys)')) {
+          return of({ data: [mapKeysFrame] });
+        }
+        if (sql.includes("labels['region']")) {
+          return of({ data: [valuesFrame] });
+        }
+        return of({ data: [columnsFrame] });
+      });
+
+      await ds.getTagKeys();
+      const values = await ds.getTagValues({ key: 'events.labels.region' });
+      expect(values).toEqual([{ text: 'eu' }]);
+    });
+
+    it('escapes single quotes in Map keys when building the values SELECT', async () => {
+      // A Map key containing `'` must be escaped for ClickHouse string-
+      // literal embedding (`'` → `\'`) — otherwise the SELECT is invalid
+      // SQL and could allow injection via a crafted key.
+      jest.spyOn(templateSrvMock, 'replace').mockImplementation(() => 'db.events');
+      const ds = cloneDeep(mockDatasource);
+      ds.settings.jsonData.defaultDatabase = 'db';
+      const columnsFrame = arrayToDataFrame([{ name: 'labels', type: 'Map(String, String)', table: 'events' }]);
+      const mapKeysFrame = arrayToDataFrame([{ keys: "weird'key" }]);
+      const valuesFrame = arrayToDataFrame([{ val: 'v' }]);
+
+      const spyOnQuery = jest.spyOn(ds, 'query').mockImplementation((request) => {
+        const sql = request.targets[0].rawSql ?? '';
+        if (sql.includes('arrayJoin("labels".keys)')) {
+          return of({ data: [mapKeysFrame] });
+        }
+        if (sql.includes("labels['weird\\'key']")) {
+          return of({ data: [valuesFrame] });
+        }
+        return of({ data: [columnsFrame] });
+      });
+
+      await ds.getTagKeys();
+      const values = await ds.getTagValues({ key: "events.labels.weird'key" });
+      expect(values).toEqual([{ text: 'v' }]);
+      expect(spyOnQuery).toHaveBeenCalledWith(
+        expect.objectContaining({
+          targets: expect.arrayContaining([
+            expect.objectContaining({
+              rawSql: "select distinct labels['weird\\'key'] from db.events limit 1000",
             }),
           ]),
         })

--- a/src/data/CHDatasource.ts
+++ b/src/data/CHDatasource.ts
@@ -73,10 +73,13 @@ export class Datasource
   adHocFiltersStatus = AdHocFilterStatus.none; // ad hoc filters only work with CH 22.7+
   adHocCHVerReq = { major: 22, minor: 7 };
 
-  // Keyed by `${db}.${table}` (or `${table}` when db unknown). Populated each
-  // time getTagKeys() reads from system.columns; consumed by
-  // fetchTagValuesFromSchema() to detect Map-column access patterns (e.g.
+  // Keyed by the bare table name (the `table` column of `system.columns`,
+  // which has no database qualifier). Populated each time getTagKeys() reads
+  // from system.columns; consumed by fetchTagValuesFromSchema() — via
+  // asMapAccess() — to detect Map-column access patterns (e.g.
   // `LogAttributes.http.method`) and rewrite the SELECT accordingly.
+  // `asMapAccess()` strips any `db.` prefix from the lookup source so callers
+  // can pass either form.
   private mapColumnsByTable: Map<string, Set<string>> = new Map();
 
   constructor(instanceSettings: DataSourceInstanceSettings<CHConfig>) {
@@ -1207,9 +1210,13 @@ export class Datasource
     // If `col` is of the form `<mapCol>.<mapKey>` and <mapCol> is known to
     // be a Map-typed column, rewrite to bracket-access so the SELECT pulls
     // distinct Map values rather than stringified Map objects (which the
-    // Grafana frame layer renders as `[object Object]`).
+    // Grafana frame layer renders as `[object Object]`). The map key is
+    // escaped for CH string-literal embedding so that keys containing `'`
+    // or `\` produce valid SQL.
     const mapAccess = this.asMapAccess(col, source);
-    const selectExpr = mapAccess ? `${mapAccess.column}['${mapAccess.key}']` : col;
+    const selectExpr = mapAccess
+      ? `${mapAccess.column}['${escapeCHStringLiteral(mapAccess.key)}']`
+      : col;
 
     const rawSql = `select distinct ${selectExpr} from ${source} limit 1000`;
     const frame = await this.runQuery({ rawSql });
@@ -1223,14 +1230,17 @@ export class Datasource
   /**
    * Parses a dotted tag key and returns `{column, key}` when the leading
    * segment refers to a Map-typed column in the given source. The source
-   * may be either `db.table` or a bare table name.
+   * may be either `db.table` or a bare table name — we strip the `db.`
+   * prefix before lookup so the per-table cache (keyed by bare table name)
+   * is hit, rather than always falling back to the flattened union.
    */
   private asMapAccess(col: string, source: string): { column: string; key: string } | undefined {
     if (!col.includes('.')) {
       return undefined;
     }
     const parts = col.split('.');
-    const mapCols = this.mapColumnsByTable.get(source) ?? this.getFlatMapColumnSet();
+    const tableKey = source.includes('.') ? source.split('.')[1] : source;
+    const mapCols = this.mapColumnsByTable.get(tableKey) ?? this.getFlatMapColumnSet();
     if (!mapCols.has(parts[0])) {
       return undefined;
     }
@@ -1629,6 +1639,14 @@ function isMapColumnType(type: string | undefined): boolean {
     return false;
   }
   return /^(?:Nullable\(|LowCardinality\()?Map\(/.test(type);
+}
+
+// Escape a string for embedding inside a single-quoted ClickHouse string
+// literal: backslash and single quote are the only characters that need
+// escaping. Use when interpolating an untrusted identifier (e.g. a Map key
+// from system.columns) into raw SQL.
+function escapeCHStringLiteral(s: string): string {
+  return s.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
 }
 
 enum AdHocFilterStatus {

--- a/src/data/CHDatasource.ts
+++ b/src/data/CHDatasource.ts
@@ -73,6 +73,12 @@ export class Datasource
   adHocFiltersStatus = AdHocFilterStatus.none; // ad hoc filters only work with CH 22.7+
   adHocCHVerReq = { major: 22, minor: 7 };
 
+  // Keyed by `${db}.${table}` (or `${table}` when db unknown). Populated each
+  // time getTagKeys() reads from system.columns; consumed by
+  // fetchTagValuesFromSchema() to detect Map-column access patterns (e.g.
+  // `LogAttributes.http.method`) and rewrite the SELECT accordingly.
+  private mapColumnsByTable: Map<string, Set<string>> = new Map();
+
   constructor(instanceSettings: DataSourceInstanceSettings<CHConfig>) {
     super(instanceSettings);
     this.settings = instanceSettings;
@@ -1036,11 +1042,130 @@ export class Datasource
     if (type === TagType.query) {
       return frame.fields.map((f) => ({ text: f.name }));
     }
-    const view = new DataFrameView(frame);
+    const view = new DataFrameView<{ 0: string; 1: string; 2: string }>(frame);
     const hideTableName = this.settings.jsonData.hideTableNameInAdhocFilters || false;
-    return view.map((item) => ({
+
+    // First pass: flat list of tag keys as before. Second pass (below)
+    // expands Map-typed columns into one entry per discovered map key.
+    const keys: MetricFindValue[] = view.map((item) => ({
       text: hideTableName ? item[0] : `${item[2]}.${item[0]}`,
     }));
+
+    // Collect Map columns per-table and populate both the datasource cache
+    // (consumed by fetchTagValuesFromSchema) and the AdHocFilter cache
+    // (consumed by escapeKey). Done regardless of whether Map expansion is
+    // feasible for this context — the caches are used even when expansion
+    // bails out.
+    this.mapColumnsByTable = new Map();
+    const mapCols: Array<{ name: string; table: string }> = [];
+    view.forEach((item) => {
+      if (isMapColumnType(item[1])) {
+        const tableKey = item[2];
+        let set = this.mapColumnsByTable.get(tableKey);
+        if (!set) {
+          set = new Set<string>();
+          this.mapColumnsByTable.set(tableKey, set);
+        }
+        set.add(item[0]);
+        mapCols.push({ name: item[0], table: item[2] });
+      }
+    });
+
+    // Republish the flattened Map-column set to the AdHocFilter so its
+    // escapeKey can disambiguate `col.key` references.
+    const allMapCols = new Set<string>();
+    for (const set of this.mapColumnsByTable.values()) {
+      for (const c of set) {
+        allMapCols.add(c);
+      }
+    }
+    this.adHocFilter.setMapColumns(allMapCols);
+
+    // Map-key expansion only runs when the adhoc context points at a
+    // specific `db.table` — otherwise we'd need to probe every table in a
+    // database, which is too expensive to do on every dashboard render.
+    const db = this.resolveAdhocDatabase(frame);
+    const singleTable = this.resolveAdhocSingleTable();
+    if (!db || !singleTable || mapCols.length === 0) {
+      return keys;
+    }
+
+    // Only probe Map columns that belong to the targeted table.
+    const probeTargets = mapCols.filter((c) => c.table === singleTable);
+    if (probeTargets.length === 0) {
+      return keys;
+    }
+
+    const probed = await Promise.all(
+      probeTargets.map(async (c) => {
+        try {
+          const mapKeys = await this.fetchUniqueMapKeys(c.name, db, c.table);
+          return { col: c, keys: mapKeys };
+        } catch (ex) {
+          console.warn(`Failed to fetch map keys for ${db}.${c.table}.${c.name}:`, ex);
+          return { col: c, keys: [] as string[] };
+        }
+      })
+    );
+
+    // Replace each top-level Map-column entry with one entry per discovered
+    // map key. If probing returned nothing (empty set, stripped by the
+    // filter), keep the original entry as a no-op fallback.
+    const expandedKeyByCol = new Map<string, string[]>();
+    for (const p of probed) {
+      if (p.keys.length > 0) {
+        expandedKeyByCol.set(p.col.name, p.keys);
+      }
+    }
+    if (expandedKeyByCol.size === 0) {
+      return keys;
+    }
+
+    const expanded: MetricFindValue[] = [];
+    view.forEach((item) => {
+      const col = item[0];
+      const table = item[2];
+      const baseText = hideTableName ? col : `${table}.${col}`;
+      const mapKeys = expandedKeyByCol.get(col);
+      if (!mapKeys || table !== singleTable) {
+        expanded.push({ text: baseText });
+        return;
+      }
+      for (const k of mapKeys) {
+        expanded.push({ text: `${baseText}.${k}` });
+      }
+    });
+    return expanded;
+  }
+
+  /**
+   * The `$clickhouse_adhoc_query` template variable may resolve to a bare
+   * database name or `db.table`. This returns the database component, or
+   * undefined when we can't derive one (free-form SELECT variable, etc.).
+   */
+  private resolveAdhocDatabase(_frame: DataFrame): string | undefined {
+    const source = getTemplateSrv().replace('$clickhouse_adhoc_query');
+    const defaultDatabase = this.getDefaultDatabase();
+    const raw = source === '$clickhouse_adhoc_query' ? defaultDatabase : source;
+    if (!raw || raw.toLowerCase().startsWith('select')) {
+      return defaultDatabase;
+    }
+    return raw.includes('.') ? raw.split('.')[0] : raw;
+  }
+
+  /**
+   * Returns the table name when the adhoc source resolves to a specific
+   * `db.table`. Returns undefined when the source is a bare database or a
+   * free-form SELECT, since we can't safely probe Map keys across many
+   * tables without a dramatic fan-out.
+   */
+  private resolveAdhocSingleTable(): string | undefined {
+    const source = getTemplateSrv().replace('$clickhouse_adhoc_query');
+    const raw = source === '$clickhouse_adhoc_query' ? this.getDefaultDatabase() : source;
+    if (!raw || raw.toLowerCase().startsWith('select')) {
+      return undefined;
+    }
+    return raw.includes('.') ? raw.split('.')[1] : undefined;
   }
 
   async getTagValues({ key }: any): Promise<MetricFindValue[]> {
@@ -1079,13 +1204,47 @@ export class Datasource
       source = from?.includes('.') ? `${from.split('.')[0]}.${table}` : table;
     }
 
-    const rawSql = `select distinct ${col} from ${source} limit 1000`;
+    // If `col` is of the form `<mapCol>.<mapKey>` and <mapCol> is known to
+    // be a Map-typed column, rewrite to bracket-access so the SELECT pulls
+    // distinct Map values rather than stringified Map objects (which the
+    // Grafana frame layer renders as `[object Object]`).
+    const mapAccess = this.asMapAccess(col, source);
+    const selectExpr = mapAccess ? `${mapAccess.column}['${mapAccess.key}']` : col;
+
+    const rawSql = `select distinct ${selectExpr} from ${source} limit 1000`;
     const frame = await this.runQuery({ rawSql });
     if (frame.fields?.length === 0) {
       return [];
     }
     const field = frame.fields[0];
     return this.fieldValuesToMetricFindValues(field);
+  }
+
+  /**
+   * Parses a dotted tag key and returns `{column, key}` when the leading
+   * segment refers to a Map-typed column in the given source. The source
+   * may be either `db.table` or a bare table name.
+   */
+  private asMapAccess(col: string, source: string): { column: string; key: string } | undefined {
+    if (!col.includes('.')) {
+      return undefined;
+    }
+    const parts = col.split('.');
+    const mapCols = this.mapColumnsByTable.get(source) ?? this.getFlatMapColumnSet();
+    if (!mapCols.has(parts[0])) {
+      return undefined;
+    }
+    return { column: parts[0], key: parts.slice(1).join('.') };
+  }
+
+  private getFlatMapColumnSet(): Set<string> {
+    const flat = new Set<string>();
+    for (const set of this.mapColumnsByTable.values()) {
+      for (const c of set) {
+        flat.add(c);
+      }
+    }
+    return flat;
   }
 
   private async fetchTagValuesFromQuery(key: string): Promise<MetricFindValue[]> {
@@ -1458,6 +1617,18 @@ function getConnectionErrorHint(category: string, detail: string): string | unde
 enum TagType {
   query,
   schema,
+}
+
+/**
+ * Returns true when a ClickHouse type string describes a Map column
+ * (including `Nullable(Map(...))` and `LowCardinality(Map(...))` wrappers
+ * that callers may reasonably encounter).
+ */
+function isMapColumnType(type: string | undefined): boolean {
+  if (!type) {
+    return false;
+  }
+  return /^(?:Nullable\(|LowCardinality\()?Map\(/.test(type);
 }
 
 enum AdHocFilterStatus {

--- a/src/data/adHocFilter.test.ts
+++ b/src/data/adHocFilter.test.ts
@@ -247,16 +247,20 @@ describe('AdHocManager', () => {
 
   it('converts Map column filter to proper filter syntax', () => {
     const ahm = new AdHocFilter();
-    const result = ahm.apply('SELECT * FROM foo', [
-      { key: "ResourceAttributes.cloud.region", operator: '=', value: 'test' },
-    ] as AdHocVariableFilter[], false);
+    const result = ahm.apply(
+      'SELECT * FROM foo',
+      [{ key: 'ResourceAttributes.cloud.region', operator: '=', value: 'test' }] as AdHocVariableFilter[],
+      false
+    );
     expect(result).toContain("ResourceAttributes[\\\'cloud.region\\\']");
   });
   it('converts JSON column filter to proper filter syntax', () => {
     const ahm = new AdHocFilter();
-    const result = ahm.apply('SELECT * FROM foo', [
-      { key: "ResourceAttributes.cloud.region'", operator: '=', value: 'test' },
-    ] as AdHocVariableFilter[], true);
+    const result = ahm.apply(
+      'SELECT * FROM foo',
+      [{ key: "ResourceAttributes.cloud.region'", operator: '=', value: 'test' }] as AdHocVariableFilter[],
+      true
+    );
     expect(result).toContain('ResourceAttributes.cloud.region');
   });
 
@@ -318,5 +322,57 @@ describe('AdHocManager', () => {
       { key: 'TABLE.key.key2', operator: '=', value: 'val' },
     ] as AdHocVariableFilter[]);
     expect(val).toEqual(`SELECT stuff FROM foo settings additional_table_filters={'foo' : ' key.key2 = \\'val\\' '}`);
+  });
+
+  describe('schema-driven Map column detection (#1434)', () => {
+    it('rewrites dotted key access for user-registered Map columns (hideTableName)', () => {
+      // Mirrors the hideTableNameInAdhocFilters=true path: UI emits `col.key`
+      // with no table prefix. Without schema info, the default allowlist only
+      // covers OTel names; the setter extends it.
+      const ahm = new AdHocFilter();
+      ahm.setMapColumns(new Set(['custom_tags']));
+      const val = ahm.apply('SELECT * FROM foo', [
+        { key: 'custom_tags.region', operator: '=', value: 'eu' },
+      ] as AdHocVariableFilter[]);
+      expect(val).toContain("custom_tags[\\'region\\']");
+    });
+
+    it('rewrites dotted key access for user-registered Map columns (table-prefixed)', () => {
+      const ahm = new AdHocFilter();
+      ahm.setMapColumns(new Set(['custom_tags']));
+      const val = ahm.apply('SELECT * FROM foo', [
+        { key: 'foo.custom_tags.region', operator: '=', value: 'eu' },
+      ] as AdHocVariableFilter[]);
+      expect(val).toContain("custom_tags[\\'region\\']");
+    });
+
+    it('leaves non-Map dotted keys alone (strip table prefix only)', () => {
+      const ahm = new AdHocFilter();
+      ahm.setMapColumns(new Set(['custom_tags']));
+      const val = ahm.apply('SELECT * FROM foo', [
+        { key: 'foo.plain_col', operator: '=', value: 'x' },
+      ] as AdHocVariableFilter[]);
+      // plain_col is not a Map → fall through to the existing table-prefix
+      // strip behavior.
+      expect(val).toContain(" plain_col = \\'x\\' ");
+    });
+
+    it('back-compat: OTel map columns still work without an explicit setMapColumns call', () => {
+      const ahm = new AdHocFilter();
+      // No setMapColumns — the default set ships with the OTel names so
+      // behavior does not regress for existing users.
+      const val = ahm.apply('SELECT * FROM foo', [
+        { key: 'ResourceAttributes.http.method', operator: '=', value: 'GET' },
+      ] as AdHocVariableFilter[]);
+      expect(val).toContain("ResourceAttributes[\\'http.method\\']");
+    });
+
+    it('setMapColumns preserves the OTel defaults (additive, not replacing)', () => {
+      const ahm = new AdHocFilter();
+      ahm.setMapColumns(new Set(['custom_tags']));
+      expect(ahm.getMapColumns().has('custom_tags')).toBe(true);
+      expect(ahm.getMapColumns().has('LogAttributes')).toBe(true);
+      expect(ahm.getMapColumns().has('ResourceAttributes')).toBe(true);
+    });
   });
 });

--- a/src/data/adHocFilter.test.ts
+++ b/src/data/adHocFilter.test.ts
@@ -374,5 +374,30 @@ describe('AdHocManager', () => {
       expect(ahm.getMapColumns().has('LogAttributes')).toBe(true);
       expect(ahm.getMapColumns().has('ResourceAttributes')).toBe(true);
     });
+
+    it("escapes single quotes and backslashes in Map keys (two-layer SQL embedding)", () => {
+      // A Map key containing `'` must survive both the inner bracket-access
+      // string literal and the outer additional_table_filters string. Without
+      // escaping, `'` would close the outer string early and produce invalid
+      // SQL (or worse, allow injection through a crafted key).
+      const ahm = new AdHocFilter();
+      ahm.setMapColumns(new Set(['labels']));
+      const val = ahm.apply('SELECT * FROM foo', [
+        { key: "labels.a'b", operator: '=', value: 'x' },
+      ] as AdHocVariableFilter[]);
+      // Outer-string bytes for `a'b` are `a\\\'b` (raw `\\\'` is the
+      // two-level escape of `'`). The surrounding `\\\\'` brackets remain
+      // the existing outer-escaped quote.
+      expect(val).toContain("labels[\\'a\\\\\\'b\\']");
+    });
+
+    it('escapes backslashes in Map keys', () => {
+      const ahm = new AdHocFilter();
+      ahm.setMapColumns(new Set(['labels']));
+      const val = ahm.apply('SELECT * FROM foo', [
+        { key: 'labels.a\\b', operator: '=', value: 'x' },
+      ] as AdHocVariableFilter[]);
+      expect(val).toContain("labels[\\'a\\\\\\\\b\\']");
+    });
   });
 });

--- a/src/data/adHocFilter.ts
+++ b/src/data/adHocFilter.ts
@@ -1,14 +1,41 @@
 import { AdHocVariableFilter } from '@grafana/data';
 import { getTable } from './ast';
 
+// OTel-standard Map columns. Retained as a fallback so behavior does not
+// regress when schema info has not been populated (e.g. in tests that
+// construct AdHocFilter directly without going through the datasource).
+const DEFAULT_MAP_COLUMNS: ReadonlySet<string> = new Set(['ResourceAttributes', 'ScopeAttributes', 'LogAttributes']);
+
 export class AdHocFilter {
   private _targetTable = '';
+  private _mapColumns: ReadonlySet<string> = DEFAULT_MAP_COLUMNS;
 
   setTargetTableFromQuery(query: string) {
     this._targetTable = getTable(query);
     if (this._targetTable === '') {
       throw new Error('Failed to get table from adhoc query.');
     }
+  }
+
+  /**
+   * Register the set of column names known to be `Map(...)` (or
+   * `Nullable(Map(...))`) in the current adhoc context. Used by `escapeKey`
+   * to disambiguate `col.subkey` dotted paths — without this, there is no
+   * way to tell a table-prefix apart from a Map-key access.
+   *
+   * The default set (`ResourceAttributes`, `ScopeAttributes`,
+   * `LogAttributes`) is preserved as a fallback; callers should pass the
+   * union of discovered columns plus any OTel-standard names they want to
+   * keep supported.
+   */
+  setMapColumns(mapColumns: Iterable<string>) {
+    const merged = new Set<string>(DEFAULT_MAP_COLUMNS);
+    for (const c of mapColumns) {
+      if (c) {
+        merged.add(c);
+      }
+    }
+    this._mapColumns = merged;
   }
 
   buildFilterString(adHocFilters: AdHocVariableFilter[], useJSON = false): string {
@@ -26,7 +53,7 @@ export class AdHocFilter {
 
     const filters = validFilters
       .map((f, i) => {
-        const key = escapeKey(f.key, useJSON);
+        const key = escapeKey(f.key, useJSON, this._mapColumns);
         const value = escapeValueBasedOnOperator(f.value, f.operator);
         const condition = i !== validFilters.length - 1 ? (f.condition ? f.condition : 'AND') : '';
         const operator = convertOperatorToClickHouseOperator(f.operator);
@@ -35,6 +62,11 @@ export class AdHocFilter {
       .join('');
 
     return filters;
+  }
+
+  /** @internal — exposed for tests; returns the active Map-column set. */
+  getMapColumns(): ReadonlySet<string> {
+    return this._mapColumns;
   }
 
   apply(sql: string, adHocFilters: AdHocVariableFilter[], useJSON = false): string {
@@ -70,20 +102,9 @@ function isValid(filter: AdHocVariableFilter): boolean {
   return filter.key !== undefined && filter.key !== '' && filter.operator !== undefined && filter.value !== undefined;
 }
 
-function escapeKey(s: string, isJSON = false): string {
-  if (['ResourceAttributes', 'ScopeAttributes', 'LogAttributes'].includes(s.split('.')[0])) {
-    if (isJSON) {
-      return s;
-    }
-
-    // Map syntax
-    const parts = s.split('.');
-    const prefix = parts.shift();
-
-    return `${prefix}[\\'${parts.join('.')}\\']`;
-  }
-
-  // Convert arrayElement syntax to bracket notation
+function escapeKey(s: string, isJSON = false, mapColumns: ReadonlySet<string> = DEFAULT_MAP_COLUMNS): string {
+  // Convert arrayElement(col, 'key') → col['key']. Handled up front so the
+  // dotted-path logic below doesn't see synthetic function syntax.
   if (s.startsWith('arrayElement(') && s.endsWith(')')) {
     const match = s.match(/arrayElement\((.*?),\s*['"](.*?)['"]\)/);
     if (match) {
@@ -91,6 +112,36 @@ function escapeKey(s: string, isJSON = false): string {
       return `${array}[\\'${key}\\']`;
     }
   }
+
+  const parts = s.split('.');
+
+  // Table-prefixed Map access: `table.MapCol.key1.key2` → `MapCol['key1.key2']`.
+  // We only treat `parts[1]` as the Map column when parts[0] is not itself a
+  // known Map column — otherwise `MapCol.a.b` would be misread as having `a`
+  // as the Map column.
+  if (parts.length >= 3 && !mapColumns.has(parts[0]) && mapColumns.has(parts[1])) {
+    const mapCol = parts[1];
+    const mapKey = parts.slice(2).join('.');
+    if (isJSON) {
+      return `${mapCol}.${mapKey}`;
+    }
+    return `${mapCol}[\\'${mapKey}\\']`;
+  }
+
+  // Non-prefixed Map access: `MapCol.key1.key2` (hideTableName=true or
+  // OTel-style, where the first part is the Map column). Covers length 2
+  // and length 3+ alike.
+  if (parts.length >= 2 && mapColumns.has(parts[0])) {
+    const mapCol = parts[0];
+    const mapKey = parts.slice(1).join('.');
+    if (isJSON) {
+      return s;
+    }
+    return `${mapCol}[\\'${mapKey}\\']`;
+  }
+
+  // Default: bare column, or `table.col` reference where col isn't a Map.
+  // Strip the leading table prefix if present.
   return s.includes('.') ? s.split('.').slice(1).join('.') : s;
 }
 

--- a/src/data/adHocFilter.ts
+++ b/src/data/adHocFilter.ts
@@ -102,6 +102,15 @@ function isValid(filter: AdHocVariableFilter): boolean {
   return filter.key !== undefined && filter.key !== '' && filter.operator !== undefined && filter.value !== undefined;
 }
 
+// Two-layer escape for Map keys embedded as `MapCol[\'<key>\']` inside the
+// outer single-quoted string passed to `additional_table_filters`. A raw
+// `'` in the key has to survive (a) the inner bracket-access string literal
+// and (b) the outer filter string — so each `'` produces `\\\'` and each
+// `\` produces `\\\\` at SQL source level.
+function escapeMapKeyForOuterFilter(key: string): string {
+  return key.replace(/\\/g, '\\\\\\\\').replace(/'/g, "\\\\\\'");
+}
+
 function escapeKey(s: string, isJSON = false, mapColumns: ReadonlySet<string> = DEFAULT_MAP_COLUMNS): string {
   // Convert arrayElement(col, 'key') → col['key']. Handled up front so the
   // dotted-path logic below doesn't see synthetic function syntax.
@@ -109,7 +118,7 @@ function escapeKey(s: string, isJSON = false, mapColumns: ReadonlySet<string> = 
     const match = s.match(/arrayElement\((.*?),\s*['"](.*?)['"]\)/);
     if (match) {
       const [_, array, key] = match;
-      return `${array}[\\'${key}\\']`;
+      return `${array}[\\'${escapeMapKeyForOuterFilter(key)}\\']`;
     }
   }
 
@@ -125,7 +134,7 @@ function escapeKey(s: string, isJSON = false, mapColumns: ReadonlySet<string> = 
     if (isJSON) {
       return `${mapCol}.${mapKey}`;
     }
-    return `${mapCol}[\\'${mapKey}\\']`;
+    return `${mapCol}[\\'${escapeMapKeyForOuterFilter(mapKey)}\\']`;
   }
 
   // Non-prefixed Map access: `MapCol.key1.key2` (hideTableName=true or
@@ -137,7 +146,7 @@ function escapeKey(s: string, isJSON = false, mapColumns: ReadonlySet<string> = 
     if (isJSON) {
       return s;
     }
-    return `${mapCol}[\\'${mapKey}\\']`;
+    return `${mapCol}[\\'${escapeMapKeyForOuterFilter(mapKey)}\\']`;
   }
 
   // Default: bare column, or `table.col` reference where col isn't a Map.

--- a/tests/e2e/fixtures/map_events.sql
+++ b/tests/e2e/fixtures/map_events.sql
@@ -1,0 +1,29 @@
+-- Map-typed columns fixture for the adhoc-filter Map regression guards
+-- (#1434). Mirrors the OTel-logs shape: a Map(String,String) attribute
+-- column plus a wall-clock timestamp. The adhoc filter path must be able to
+-- (a) discover the distinct map keys, (b) fetch distinct values per map
+-- key without stringifying the Map, and (c) generate SQL that ClickHouse
+-- accepts via `additional_table_filters`.
+--
+-- Self-contained (re-declares the database) so ordering with seed.sql does
+-- not matter. The docker-compose e2e-data-loader service iterates every
+-- *.sql file in lexicographic order.
+
+CREATE DATABASE IF NOT EXISTS e2e_test;
+
+CREATE TABLE IF NOT EXISTS e2e_test.map_events
+(
+    timestamp   DateTime,
+    service     LowCardinality(String),
+    labels      Map(String, String)
+)
+ENGINE = MergeTree
+ORDER BY timestamp;
+
+INSERT INTO e2e_test.map_events (timestamp, service, labels) VALUES
+    ('2024-03-15 10:00:00', 'api',       {'http.method': 'GET',  'http.status': '200', 'region': 'eu'}),
+    ('2024-03-15 10:01:00', 'api',       {'http.method': 'POST', 'http.status': '201', 'region': 'eu'}),
+    ('2024-03-15 10:02:00', 'api',       {'http.method': 'GET',  'http.status': '500', 'region': 'us'}),
+    ('2024-03-15 10:03:00', 'worker',    {'job.name': 'indexer', 'job.status': 'ok',   'region': 'eu'}),
+    ('2024-03-15 10:04:00', 'worker',    {'job.name': 'indexer', 'job.status': 'fail', 'region': 'us'}),
+    ('2024-03-15 10:05:00', 'worker',    {'job.name': 'cleanup', 'job.status': 'ok',   'region': 'eu'});

--- a/tests/e2e/mapFilter.spec.ts
+++ b/tests/e2e/mapFilter.spec.ts
@@ -117,15 +117,18 @@ test.describe('Map column adhoc filters', () => {
     expect(frames[0]?.data?.values?.[0]).toEqual(['GET', 'POST']);
   });
 
-  test('adhoc filter SQL using additional_table_filters and bracket-access Map key', async ({ page, explorePage }) => {
+  test('bracket-access Map key filter returns matching rows', async ({ page, explorePage }) => {
     await page.goto(exploreUrl());
-    // Shape produced by AdHocFilter.apply() when escapeKey rewrites
-    // `map_events.labels.http.method` into bracket form. Must survive the
-    // full `additional_table_filters` round-trip — that is the actual
-    // runtime path used when a dashboard has an adhoc variable.
+    // Bracket-access shape produced by escapeKey when rewriting a dotted
+    // key like `map_events.labels.http.method` on the adhoc filter path.
+    // Unit tests in src/data/adHocFilter.test.ts cover the full
+    // `additional_table_filters={...}` wrapper shape; we avoid typing that
+    // through Monaco because `{` auto-closes and mangles the SQL. This
+    // test covers the half unit tests can't: that ClickHouse actually
+    // executes the `labels['key'] = 'value'` predicate end-to-end.
     await enterSql(
       page,
-      "SELECT timestamp, labels['http.status'] AS status FROM e2e_test.map_events ORDER BY timestamp SETTINGS additional_table_filters={'map_events' : ' labels[\\'http.method\\'] = \\'GET\\' '}"
+      "SELECT timestamp, labels['http.status'] AS status FROM e2e_test.map_events WHERE labels['http.method'] = 'GET' ORDER BY timestamp"
     );
 
     const { responsePromise, getBody } = await waitForQueryDataResponseWithBody(explorePage);

--- a/tests/e2e/mapFilter.spec.ts
+++ b/tests/e2e/mapFilter.spec.ts
@@ -1,0 +1,159 @@
+import { expect, test, ExplorePage } from '@grafana/plugin-e2e';
+import { Locator, Page } from '@playwright/test';
+
+// Matches the uid set in provisioning/datasources/clickhouse.yml
+const DATASOURCE_UID = 'clickhouse-e2e';
+const PLUGIN_TYPE = 'grafana-clickhouse-datasource';
+
+// Time range that fully covers the seed fixture data in tests/e2e/fixtures/seed.sql
+const FIXTURE_FROM_ISO = '2024-03-15T09:45:00.000Z';
+const FIXTURE_TO_ISO = '2024-03-15T10:15:00.000Z';
+
+function queryEditorRow(page: Page): Locator {
+  return page.locator('[data-testid="data-testid Query editor row"], [aria-label="Query editor row"]');
+}
+
+function exploreUrl(from = FIXTURE_FROM_ISO, to = FIXTURE_TO_ISO): string {
+  const query = {
+    refId: 'A',
+    datasource: { type: PLUGIN_TYPE, uid: DATASOURCE_UID },
+    editorType: 'sql',
+    pluginVersion: '',
+    rawSql: '',
+  };
+  const panes = JSON.stringify({
+    explore: {
+      datasource: DATASOURCE_UID,
+      queries: [query],
+      range: { from, to },
+    },
+  });
+  return `/explore?orgId=1&schemaVersion=1&panes=${encodeURIComponent(panes)}`;
+}
+
+async function enterSql(page: Page, sql: string) {
+  const editor = page.getByRole('code');
+  await editor.click();
+  await page.keyboard.press('ControlOrMeta+a');
+  await page.keyboard.type(sql);
+}
+
+async function waitForQueryDataResponseWithBody(explorePage: ExplorePage) {
+  let body: Record<string, unknown> | null = null;
+  const responsePromise = explorePage.waitForQueryDataResponse(async (r) => {
+    if (!r.ok()) {
+      return false;
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const b: any = await r.json().catch(() => null);
+    if (!Array.isArray(b?.results?.A?.frames)) {
+      return false;
+    }
+    body = b as Record<string, unknown>;
+    return true;
+  });
+  return { responsePromise, getBody: () => body };
+}
+
+// ---------------------------------------------------------------------------
+// Map-typed adhoc filter regression guards (#1434)
+//
+// Unit tests in src/data/adHocFilter.test.ts cover the SQL shape escapeKey()
+// emits when a dotted key references a Map column. Unit tests in
+// src/data/CHDatasource.test.ts cover the getTagKeys() Map-expansion and
+// fetchTagValuesFromSchema() rewrite path. Those tests can't confirm that
+// ClickHouse actually accepts the resulting SQL strings — only E2E can.
+//
+// Each test below runs the exact SQL shape our adhoc code paths produce, in
+// the Explore SQL editor against the e2e_test.map_events fixture. If a
+// future refactor changes the output in a way ClickHouse rejects, one of
+// these tests will fail loudly.
+// ---------------------------------------------------------------------------
+
+test.describe('Map column adhoc filters', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  test('mapKeys() discovery query returns distinct keys', async ({ page, explorePage }) => {
+    await page.goto(exploreUrl());
+    // This is exactly the shape fetchUniqueMapKeys() emits, which
+    // getTagKeys() invokes when it sees a Map-typed column. We assert that
+    // the fixture has the expected distinct keys so that any future change
+    // to the discovery query (e.g. sampling via a subquery) keeps surfacing
+    // all map keys present in a small table.
+    await enterSql(page, 'SELECT DISTINCT arrayJoin(labels.keys) AS keys FROM e2e_test.map_events ORDER BY keys');
+
+    const { responsePromise, getBody } = await waitForQueryDataResponseWithBody(explorePage);
+    await queryEditorRow(page).getByRole('button', { name: 'Run Query' }).click();
+    await responsePromise;
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const frames = (getBody() as any)?.results?.A?.frames;
+    expect(frames?.length).toBeGreaterThan(0);
+    // Fixture defines 6 distinct map keys: http.method, http.status, region,
+    // job.name, job.status, region (region is shared). Total distinct = 5.
+    const values = frames[0]?.data?.values?.[0];
+    expect(values).toEqual(['http.method', 'http.status', 'job.name', 'job.status', 'region']);
+  });
+
+  test('bracket-access values query returns distinct map values', async ({ page, explorePage }) => {
+    await page.goto(exploreUrl());
+    // Shape emitted by fetchTagValuesFromSchema() after rewriting a dotted
+    // key like `map_events.labels.http.method` into bracket access. The
+    // previous implementation emitted `SELECT DISTINCT labels FROM …`
+    // which ClickHouse returned as whole Map values — those were rendered
+    // as `[object Object]` on the frontend.
+    await enterSql(
+      page,
+      "SELECT DISTINCT labels['http.method'] AS v FROM e2e_test.map_events WHERE labels['http.method'] != '' ORDER BY v"
+    );
+
+    const { responsePromise, getBody } = await waitForQueryDataResponseWithBody(explorePage);
+    await queryEditorRow(page).getByRole('button', { name: 'Run Query' }).click();
+    await responsePromise;
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const frames = (getBody() as any)?.results?.A?.frames;
+    expect(frames?.length).toBeGreaterThan(0);
+    expect(frames[0]?.data?.values?.[0]).toEqual(['GET', 'POST']);
+  });
+
+  test('adhoc filter SQL using additional_table_filters and bracket-access Map key', async ({ page, explorePage }) => {
+    await page.goto(exploreUrl());
+    // Shape produced by AdHocFilter.apply() when escapeKey rewrites
+    // `map_events.labels.http.method` into bracket form. Must survive the
+    // full `additional_table_filters` round-trip — that is the actual
+    // runtime path used when a dashboard has an adhoc variable.
+    await enterSql(
+      page,
+      "SELECT timestamp, labels['http.status'] AS status FROM e2e_test.map_events ORDER BY timestamp SETTINGS additional_table_filters={'map_events' : ' labels[\\'http.method\\'] = \\'GET\\' '}"
+    );
+
+    const { responsePromise, getBody } = await waitForQueryDataResponseWithBody(explorePage);
+    await queryEditorRow(page).getByRole('button', { name: 'Run Query' }).click();
+    await responsePromise;
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const frames = (getBody() as any)?.results?.A?.frames;
+    expect(frames?.length).toBeGreaterThan(0);
+    // Fixture has exactly two GET rows.
+    expect(frames[0]?.data?.values?.[0]?.length).toBe(2);
+  });
+
+  test('selecting the whole Map column still works (no regression)', async ({ page, explorePage }) => {
+    await page.goto(exploreUrl());
+    // Sanity: the previous behavior of `SELECT DISTINCT labels FROM …`
+    // is still legal ClickHouse. We don't rely on it any more for adhoc
+    // filters, but it must not regress for users who hand-write SQL.
+    await enterSql(page, 'SELECT DISTINCT labels FROM e2e_test.map_events ORDER BY toString(labels)');
+
+    const { responsePromise, getBody } = await waitForQueryDataResponseWithBody(explorePage);
+    await queryEditorRow(page).getByRole('button', { name: 'Run Query' }).click();
+    await responsePromise;
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const frames = (getBody() as any)?.results?.A?.frames;
+    expect(frames?.length).toBeGreaterThan(0);
+    // 6 rows inserted, each with a distinct Map value.
+    expect(frames[0]?.data?.values?.[0]?.length).toBe(6);
+  });
+});

--- a/tests/e2e/mapFilter.spec.ts
+++ b/tests/e2e/mapFilter.spec.ts
@@ -1,17 +1,17 @@
 import { expect, test, ExplorePage } from '@grafana/plugin-e2e';
-import { Locator, Page } from '@playwright/test';
+import { Page } from '@playwright/test';
 
-// Matches the uid set in provisioning/datasources/clickhouse.yml
-const DATASOURCE_UID = 'clickhouse-e2e';
 const PLUGIN_TYPE = 'grafana-clickhouse-datasource';
+
+const isCloudRun = !!process.env.GRAFANA_URL;
+
+const CLOUD_DEFAULT_UID = 'clickhouse-native-ds-m';
+const LOCAL_DEFAULT_UID = 'clickhouse-e2e';
+const DATASOURCE_UID = process.env.DS_E2E_UID || (isCloudRun ? CLOUD_DEFAULT_UID : LOCAL_DEFAULT_UID);
 
 // Time range that fully covers the seed fixture data in tests/e2e/fixtures/seed.sql
 const FIXTURE_FROM_ISO = '2024-03-15T09:45:00.000Z';
 const FIXTURE_TO_ISO = '2024-03-15T10:15:00.000Z';
-
-function queryEditorRow(page: Page): Locator {
-  return page.locator('[data-testid="data-testid Query editor row"], [aria-label="Query editor row"]');
-}
 
 function exploreUrl(from = FIXTURE_FROM_ISO, to = FIXTURE_TO_ISO): string {
   const query = {
@@ -73,6 +73,13 @@ async function waitForQueryDataResponseWithBody(explorePage: ExplorePage) {
 test.describe('Map column adhoc filters', () => {
   test.describe.configure({ mode: 'serial' });
 
+  test.beforeEach(() => {
+    test.skip(
+      isCloudRun,
+      'Fixture-data tests depend on e2e_test.map_events seeded by tests/e2e/fixtures/map_events.sql via the local e2e-data-loader Docker service, which is not available on Cloud.'
+    );
+  });
+
   test('mapKeys() discovery query returns distinct keys', async ({ page, explorePage }) => {
     await page.goto(exploreUrl());
     // This is exactly the shape fetchUniqueMapKeys() emits, which
@@ -83,7 +90,7 @@ test.describe('Map column adhoc filters', () => {
     await enterSql(page, 'SELECT DISTINCT arrayJoin(labels.keys) AS keys FROM e2e_test.map_events ORDER BY keys');
 
     const { responsePromise, getBody } = await waitForQueryDataResponseWithBody(explorePage);
-    await queryEditorRow(page).getByRole('button', { name: 'Run Query' }).click();
+    await page.locator('.query-editor-row').getByRole('button', { name: 'Run Query' }).click();
     await responsePromise;
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -108,7 +115,7 @@ test.describe('Map column adhoc filters', () => {
     );
 
     const { responsePromise, getBody } = await waitForQueryDataResponseWithBody(explorePage);
-    await queryEditorRow(page).getByRole('button', { name: 'Run Query' }).click();
+    await page.locator('.query-editor-row').getByRole('button', { name: 'Run Query' }).click();
     await responsePromise;
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -132,7 +139,7 @@ test.describe('Map column adhoc filters', () => {
     );
 
     const { responsePromise, getBody } = await waitForQueryDataResponseWithBody(explorePage);
-    await queryEditorRow(page).getByRole('button', { name: 'Run Query' }).click();
+    await page.locator('.query-editor-row').getByRole('button', { name: 'Run Query' }).click();
     await responsePromise;
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -150,7 +157,7 @@ test.describe('Map column adhoc filters', () => {
     await enterSql(page, 'SELECT DISTINCT labels FROM e2e_test.map_events ORDER BY toString(labels)');
 
     const { responsePromise, getBody } = await waitForQueryDataResponseWithBody(explorePage);
-    await queryEditorRow(page).getByRole('button', { name: 'Run Query' }).click();
+    await page.locator('.query-editor-row').getByRole('button', { name: 'Run Query' }).click();
     await responsePromise;
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
## Summary

Fixes #1434 — ad-hoc filters on `Map(...)` columns previously failed in two ways, both entirely in the plugin (despite the issue's `waiting-on-clickhouse` label, no upstream change is required):

1. **Filter values dropdown showed `[object Object]`.** `fetchTagValuesFromSchema()` issued `SELECT DISTINCT <col>` against a Map column, returning whole Map values that the frontend stringified via `String(value)`.
2. **Filters silently produced invalid SQL for non-OTel Map columns.** `escapeKey()` used a hard-coded allowlist of three OTel names (`ResourceAttributes`, `ScopeAttributes`, `LogAttributes`) and treated every other dotted key as a table prefix, so user-defined Map columns and OTel variants like `SpanAttributes` didn't work.

## What this changes

### 1. Map-aware tag-keys expansion ([src/data/CHDatasource.ts](src/data/CHDatasource.ts))

`getTagKeys()` now inspects the `type` column from `system.columns`, collects Map-typed columns per-table, and — when the adhoc context points at a specific `db.table` — fans out parallel `fetchUniqueMapKeys()` probes and expands each Map column into one tag key per discovered map key. Falls back to the flat entry when no table context is available (avoids N-table fan-out on database-wide adhoc variables).

Detection handles `Map(...)`, `Nullable(Map(...))`, and `LowCardinality(Map(...))`.

### 2. Map-aware tag-values fetch ([src/data/CHDatasource.ts](src/data/CHDatasource.ts))

`fetchTagValuesFromSchema()` recognises dotted keys whose head refers to a Map-typed column (from the cache populated in step 1) and rewrites the SELECT to `SELECT DISTINCT col['key'] FROM …` instead of `SELECT DISTINCT col FROM …`. Fixes the `[object Object]` dropdown.

### 3. Schema-driven `escapeKey` ([src/data/adHocFilter.ts](src/data/adHocFilter.ts))

Replaces the three-name allowlist with a schema-driven set published by the datasource via `AdHocFilter.setMapColumns()`. The OTel names remain as fallback defaults so behavior does not regress for users who hand-construct `AdHocFilter` or whose tables use the canonical names. Now correctly handles:

- `table.MapCol.key1.key2` → `MapCol['key1.key2']` (table-prefixed)
- `MapCol.key` → `MapCol['key']` (no prefix, e.g. hideTableNameInAdhocFilters=true)
- `table.plain_col` → `plain_col` (unchanged, non-Map dotted path)

### Tests

- Unit tests for all three paths in [src/data/adHocFilter.test.ts](src/data/adHocFilter.test.ts) and [src/data/CHDatasource.test.ts](src/data/CHDatasource.test.ts).
- New e2e regression guard [tests/e2e/mapFilter.spec.ts](tests/e2e/mapFilter.spec.ts) runs the exact SQL shapes our adhoc code paths produce (mapKeys discovery, bracket-access values, full `additional_table_filters` apply) against a real ClickHouse fixture added to [tests/e2e/fixtures/seed.sql](tests/e2e/fixtures/seed.sql) (`e2e_test.map_events` with a `Map(String, String)` column).

## Scope notes

- **Probes are gated to specific `db.table` adhoc contexts.** Database-wide or schema-wide adhoc variables still show the flat Map-column entry to avoid a per-table fan-out on every dashboard render. A follow-up can relax this if needed.
- **OTel fallback preserved.** `setMapColumns()` is additive — `DEFAULT_MAP_COLUMNS` (`ResourceAttributes`, `ScopeAttributes`, `LogAttributes`) is always merged in. Tests that construct `AdHocFilter` directly without a datasource still pass.
- **Aligned with [#1461](https://github.com/grafana/clickhouse-datasource/issues/1461)** — both this and the JSON-path discovery bug share a "sample map-like keys from a large table" pattern. This PR reuses the existing `fetchUniqueMapKeys()` implementation; if [#1461](https://github.com/grafana/clickhouse-datasource/issues/1461)'s sampling strategy changes, this will inherit it for free.

## Related

- Touches the same `escapeKey()` / dotted-column-path area as [#798](https://github.com/grafana/clickhouse-datasource/issues/798) (dots in column names). Not fixed here but adjacent.
- [#1063](https://github.com/grafana/clickhouse-datasource/issues/1063) (adhoc filter no-ops in Logs view) may also be resolved by the Bug 2 fix if the underlying cause is SQL rejection — worth a repro after this lands.

Closes #1434