### PR TITLE
fix(adhoc): map regex operators to REGEXP instead of ILIKE

### DIFF
--- a/src/data/adHocFilter.test.ts
+++ b/src/data/adHocFilter.test.ts
@@ -131,25 +131,25 @@ describe('AdHocManager', () => {
     expect(val).toEqual(`SELECT foo.stuff FROM foo settings additional_table_filters={'foo' : ' key = \\'val\\' '}`);
   });
 
-  it('apply ad hoc filter converts "=~" to "ILIKE"', () => {
+  it('apply ad hoc filter converts "=~" to "REGEXP"', () => {
     const ahm = new AdHocFilter();
     ahm.setTargetTableFromQuery('SELECT * FROM foo');
     const val = ahm.apply('SELECT stuff FROM foo WHERE col = test', [
       { key: 'key', operator: '=~', value: 'val' },
     ] as AdHocVariableFilter[]);
     expect(val).toEqual(
-      `SELECT stuff FROM foo WHERE col = test settings additional_table_filters={'foo' : ' key ILIKE \\'val\\' '}`
+      `SELECT stuff FROM foo WHERE col = test settings additional_table_filters={'foo' : ' key REGEXP \\'val\\' '}`
     );
   });
 
-  it('apply ad hoc filter converts "!~" to "NOT ILIKE"', () => {
+  it('apply ad hoc filter converts "!~" to "NOT REGEXP"', () => {
     const ahm = new AdHocFilter();
     ahm.setTargetTableFromQuery('SELECT * FROM foo');
     const val = ahm.apply('SELECT stuff FROM foo WHERE col = test', [
       { key: 'key', operator: '!~', value: 'val' },
     ] as AdHocVariableFilter[]);
     expect(val).toEqual(
-      `SELECT stuff FROM foo WHERE col = test settings additional_table_filters={'foo' : ' key NOT ILIKE \\'val\\' '}`
+      `SELECT stuff FROM foo WHERE col = test settings additional_table_filters={'foo' : ' key NOT REGEXP \\'val\\' '}`
     );
   });
 
@@ -285,7 +285,13 @@ describe('AdHocManager', () => {
     it('builds filter string with regex operators', () => {
       const ahm = new AdHocFilter();
       const result = ahm.buildFilterString([{ key: 'key', operator: '=~', value: 'val' }] as AdHocVariableFilter[]);
-      expect(result).toEqual(" key ILIKE \\'val\\' ");
+      expect(result).toEqual(" key REGEXP \\'val\\' ");
+    });
+
+    it('builds filter string with negated regex operator', () => {
+      const ahm = new AdHocFilter();
+      const result = ahm.buildFilterString([{ key: 'key', operator: '!~', value: 'val' }] as AdHocVariableFilter[]);
+      expect(result).toEqual(" key NOT REGEXP \\'val\\' ");
     });
 
     it('builds filter string with IN operator', () => {

--- a/src/data/adHocFilter.ts
+++ b/src/data/adHocFilter.ts
@@ -107,11 +107,15 @@ function escapeValueBasedOnOperator(s: string, operator: string): string {
 }
 
 function convertOperatorToClickHouseOperator(operator: string): string {
+  // Grafana's "Matches regex" (=~) and "Does not match regex" (!~) are regex
+  // operators, so map them to ClickHouse's REGEXP. Using ILIKE here produced
+  // semantically wrong filters and prevented index usage for indexed columns
+  // (see grafana/clickhouse-datasource#1443).
   if (operator === '=~') {
-    return 'ILIKE';
+    return 'REGEXP';
   }
   if (operator === '!~') {
-    return 'NOT ILIKE';
+    return 'NOT REGEXP';
   }
   return operator;
 }

--- a/tests/e2e/adhocRegexFilter.spec.ts
+++ b/tests/e2e/adhocRegexFilter.spec.ts
@@ -1,0 +1,150 @@
+import { expect, test, ExplorePage } from '@grafana/plugin-e2e';
+import { Locator, Page } from '@playwright/test';
+
+// Matches the uid set in provisioning/datasources/clickhouse.yml
+const DATASOURCE_UID = 'clickhouse-e2e';
+const PLUGIN_TYPE = 'grafana-clickhouse-datasource';
+
+// Time range that fully covers the seed fixture data in tests/e2e/fixtures/seed.sql
+const FIXTURE_FROM_ISO = '2024-03-15T09:45:00.000Z';
+const FIXTURE_TO_ISO = '2024-03-15T10:15:00.000Z';
+
+function queryEditorRow(page: Page): Locator {
+  return page.locator('[data-testid="data-testid Query editor row"], [aria-label="Query editor row"]');
+}
+
+function exploreUrl(from = FIXTURE_FROM_ISO, to = FIXTURE_TO_ISO): string {
+  const query = {
+    refId: 'A',
+    datasource: { type: PLUGIN_TYPE, uid: DATASOURCE_UID },
+    editorType: 'sql',
+    pluginVersion: '',
+    rawSql: '',
+  };
+  const panes = JSON.stringify({
+    explore: {
+      datasource: DATASOURCE_UID,
+      queries: [query],
+      range: { from, to },
+    },
+  });
+  return `/explore?orgId=1&schemaVersion=1&panes=${encodeURIComponent(panes)}`;
+}
+
+async function enterSql(page: Page, sql: string) {
+  const editor = page.getByRole('code');
+  await editor.click();
+  await page.keyboard.press('ControlOrMeta+a');
+  await page.keyboard.type(sql);
+}
+
+async function waitForQueryDataResponseWithBody(explorePage: ExplorePage) {
+  let body: Record<string, unknown> | null = null;
+  const responsePromise = explorePage.waitForQueryDataResponse(async (r) => {
+    if (!r.ok()) {
+      return false;
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const b: any = await r.json().catch(() => null);
+    if (!Array.isArray(b?.results?.A?.frames)) {
+      return false;
+    }
+    body = b as Record<string, unknown>;
+    return true;
+  });
+  return { responsePromise, getBody: () => body };
+}
+
+// ---------------------------------------------------------------------------
+// Ad-hoc regex-operator filter regression guards (#1443)
+//
+// Unit tests in src/data/adHocFilter.test.ts cover the JS-level mapping of
+// Grafana's `=~` / `!~` operators to ClickHouse `REGEXP` / `NOT REGEXP`.
+// Those tests can't confirm that ClickHouse actually accepts `REGEXP` and
+// `NOT REGEXP` inside `additional_table_filters` — only E2E can.
+//
+// Each test below runs the exact SQL shape AdHocFilter.apply() now produces
+// for a regex ad-hoc filter, against the e2e_test.events fixture. If a
+// future refactor changes the emitted operator in a way ClickHouse rejects,
+// or silently reintroduces ILIKE (which does not honour indexes and is
+// not regex), one of these tests will fail.
+//
+// The previous behaviour translated `=~` to `ILIKE`, which is a LIKE
+// pattern — not a regex — and prevents primary-key skip-index pruning on
+// indexed columns. See the issue for the user-visible consequence.
+// ---------------------------------------------------------------------------
+
+test.describe('Ad-hoc regex operator filters', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  test('REGEXP in additional_table_filters returns matching rows', async ({ page, explorePage }) => {
+    await page.goto(exploreUrl());
+    // Shape produced by AdHocFilter.apply() for a filter like
+    // `{ key: 'message', operator: '=~', value: '^Request' }`.
+    // The fixture has exactly two messages that start with "Request":
+    // "Request received" and "Request processed".
+    await enterSql(
+      page,
+      "SELECT timestamp, message FROM e2e_test.events ORDER BY timestamp SETTINGS additional_table_filters={'events' : ' message REGEXP \\'^Request\\' '}"
+    );
+
+    const { responsePromise, getBody } = await waitForQueryDataResponseWithBody(explorePage);
+    await queryEditorRow(page).getByRole('button', { name: 'Run Query' }).click();
+    await responsePromise;
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const frames = (getBody() as any)?.results?.A?.frames;
+    expect(frames?.length).toBeGreaterThan(0);
+    const messages = frames[0]?.data?.values?.[1];
+    expect(messages).toEqual(['Request received', 'Request processed']);
+  });
+
+  test('NOT REGEXP in additional_table_filters returns the complement', async ({ page, explorePage }) => {
+    await page.goto(exploreUrl());
+    // Shape produced by AdHocFilter.apply() for a filter like
+    // `{ key: 'message', operator: '!~', value: '^Request' }`.
+    // 10 rows in the fixture, 2 start with "Request", so 8 remain.
+    await enterSql(
+      page,
+      "SELECT timestamp, message FROM e2e_test.events ORDER BY timestamp SETTINGS additional_table_filters={'events' : ' message NOT REGEXP \\'^Request\\' '}"
+    );
+
+    const { responsePromise, getBody } = await waitForQueryDataResponseWithBody(explorePage);
+    await queryEditorRow(page).getByRole('button', { name: 'Run Query' }).click();
+    await responsePromise;
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const frames = (getBody() as any)?.results?.A?.frames;
+    expect(frames?.length).toBeGreaterThan(0);
+    const messages = frames[0]?.data?.values?.[1];
+    expect(messages?.length).toBe(8);
+    // None of the remaining rows should start with "Request".
+    expect(messages?.every((m: string) => !m.startsWith('Request'))).toBe(true);
+  });
+
+  test('REGEXP treats the pattern as a regex, not a LIKE pattern', async ({ page, explorePage }) => {
+    await page.goto(exploreUrl());
+    // This test exists specifically to guard against a regression back to
+    // ILIKE. The pattern `^(info|warn)$` is a regex that matches "info" or
+    // "warn" exactly. As an ILIKE pattern it would match nothing (the
+    // characters `^`, `(`, `|`, `)`, `$` are not wildcards in LIKE, and
+    // there is no level literally equal to `^(info|warn)$`). If this test
+    // ever sees zero rows, ILIKE is back.
+    await enterSql(
+      page,
+      "SELECT level FROM e2e_test.events ORDER BY timestamp SETTINGS additional_table_filters={'events' : ' level REGEXP \\'^(info|warn)$\\' '}"
+    );
+
+    const { responsePromise, getBody } = await waitForQueryDataResponseWithBody(explorePage);
+    await queryEditorRow(page).getByRole('button', { name: 'Run Query' }).click();
+    await responsePromise;
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const frames = (getBody() as any)?.results?.A?.frames;
+    expect(frames?.length).toBeGreaterThan(0);
+    const levels: string[] = frames[0]?.data?.values?.[0] ?? [];
+    // Fixture has 5 "info" rows and 1 "warn" row.
+    expect(levels.length).toBe(6);
+    expect(levels.every((l) => l === 'info' || l === 'warn')).toBe(true);
+  });
+});

--- a/tests/e2e/adhocRegexFilter.spec.ts
+++ b/tests/e2e/adhocRegexFilter.spec.ts
@@ -1,17 +1,17 @@
 import { expect, test, ExplorePage } from '@grafana/plugin-e2e';
-import { Locator, Page } from '@playwright/test';
+import { Page } from '@playwright/test';
 
-// Matches the uid set in provisioning/datasources/clickhouse.yml
-const DATASOURCE_UID = 'clickhouse-e2e';
 const PLUGIN_TYPE = 'grafana-clickhouse-datasource';
+
+const isCloudRun = !!process.env.GRAFANA_URL;
+
+const CLOUD_DEFAULT_UID = 'clickhouse-native-ds-m';
+const LOCAL_DEFAULT_UID = 'clickhouse-e2e';
+const DATASOURCE_UID = process.env.DS_E2E_UID || (isCloudRun ? CLOUD_DEFAULT_UID : LOCAL_DEFAULT_UID);
 
 // Time range that fully covers the seed fixture data in tests/e2e/fixtures/seed.sql
 const FIXTURE_FROM_ISO = '2024-03-15T09:45:00.000Z';
 const FIXTURE_TO_ISO = '2024-03-15T10:15:00.000Z';
-
-function queryEditorRow(page: Page): Locator {
-  return page.locator('[data-testid="data-testid Query editor row"], [aria-label="Query editor row"]');
-}
 
 function exploreUrl(from = FIXTURE_FROM_ISO, to = FIXTURE_TO_ISO): string {
   const query = {
@@ -82,6 +82,13 @@ async function waitForQueryDataResponseWithBody(explorePage: ExplorePage) {
 // ---------------------------------------------------------------------------
 
 test.describe('Ad-hoc regex operator filters', () => {
+  test.beforeEach(() => {
+    test.skip(
+      isCloudRun,
+      'Fixture-data tests depend on e2e_test.events seeded by tests/e2e/fixtures/seed.sql via the local e2e-data-loader Docker service, which is not available on Cloud.'
+    );
+  });
+
   test.describe.configure({ mode: 'serial' });
 
   test('REGEXP returns matching rows', async ({ page, explorePage }) => {
@@ -94,7 +101,7 @@ test.describe('Ad-hoc regex operator filters', () => {
     );
 
     const { responsePromise, getBody } = await waitForQueryDataResponseWithBody(explorePage);
-    await queryEditorRow(page).getByRole('button', { name: 'Run Query' }).click();
+    await page.locator('.query-editor-row').getByRole('button', { name: 'Run Query' }).click();
     await responsePromise;
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -117,7 +124,7 @@ test.describe('Ad-hoc regex operator filters', () => {
     );
 
     const { responsePromise, getBody } = await waitForQueryDataResponseWithBody(explorePage);
-    await queryEditorRow(page).getByRole('button', { name: 'Run Query' }).click();
+    await page.locator('.query-editor-row').getByRole('button', { name: 'Run Query' }).click();
     await responsePromise;
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -143,7 +150,7 @@ test.describe('Ad-hoc regex operator filters', () => {
     );
 
     const { responsePromise, getBody } = await waitForQueryDataResponseWithBody(explorePage);
-    await queryEditorRow(page).getByRole('button', { name: 'Run Query' }).click();
+    await page.locator('.query-editor-row').getByRole('button', { name: 'Run Query' }).click();
     await responsePromise;
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/tests/e2e/adhocRegexFilter.spec.ts
+++ b/tests/e2e/adhocRegexFilter.spec.ts
@@ -59,33 +59,33 @@ async function waitForQueryDataResponseWithBody(explorePage: ExplorePage) {
 // Ad-hoc regex-operator filter regression guards (#1443)
 //
 // Unit tests in src/data/adHocFilter.test.ts cover the JS-level mapping of
-// Grafana's `=~` / `!~` operators to ClickHouse `REGEXP` / `NOT REGEXP`.
-// Those tests can't confirm that ClickHouse actually accepts `REGEXP` and
-// `NOT REGEXP` inside `additional_table_filters` — only E2E can.
+// Grafana's `=~` / `!~` operators to ClickHouse `REGEXP` / `NOT REGEXP`
+// and the exact `additional_table_filters={...}` shape AdHocFilter.apply()
+// produces. Those tests can't confirm that ClickHouse actually accepts
+// `REGEXP` and `NOT REGEXP` as a filter operator — only E2E can.
 //
-// Each test below runs the exact SQL shape AdHocFilter.apply() now produces
-// for a regex ad-hoc filter, against the e2e_test.events fixture. If a
-// future refactor changes the emitted operator in a way ClickHouse rejects,
-// or silently reintroduces ILIKE (which does not honour indexes and is
-// not regex), one of these tests will fail.
+// Each test below runs a plain `WHERE ... REGEXP ...` query against the
+// fixture to verify ClickHouse accepts the operator. If a future refactor
+// silently reintroduces ILIKE (which is a LIKE pattern, not a regex), the
+// third test — which uses a regex-only pattern that matches nothing as a
+// LIKE — will fail.
 //
-// The previous behavior translated `=~` to `ILIKE`, which is a LIKE
-// pattern — not a regex — and prevents primary-key skip-index pruning on
-// indexed columns. See the issue for the user-visible consequence.
+// We deliberately avoid typing the full `SETTINGS additional_table_filters={...}`
+// shape through the Monaco editor because Monaco auto-closes `{`, which
+// mangles that syntax on keystroke entry. The unit tests cover the exact
+// shape; the E2E tests cover the operator semantics.
 // ---------------------------------------------------------------------------
 
 test.describe('Ad-hoc regex operator filters', () => {
   test.describe.configure({ mode: 'serial' });
 
-  test('REGEXP in additional_table_filters returns matching rows', async ({ page, explorePage }) => {
+  test('REGEXP returns matching rows', async ({ page, explorePage }) => {
     await page.goto(exploreUrl());
-    // Shape produced by AdHocFilter.apply() for a filter like
-    // `{ key: 'message', operator: '=~', value: '^Request' }`.
     // The fixture has exactly two messages that start with "Request":
     // "Request received" and "Request processed".
     await enterSql(
       page,
-      "SELECT timestamp, message FROM e2e_test.events ORDER BY timestamp SETTINGS additional_table_filters={'events' : ' message REGEXP \\'^Request\\' '}"
+      "SELECT timestamp, message FROM e2e_test.events WHERE message REGEXP '^Request' ORDER BY timestamp"
     );
 
     const { responsePromise, getBody } = await waitForQueryDataResponseWithBody(explorePage);
@@ -99,14 +99,12 @@ test.describe('Ad-hoc regex operator filters', () => {
     expect(messages).toEqual(['Request received', 'Request processed']);
   });
 
-  test('NOT REGEXP in additional_table_filters returns the complement', async ({ page, explorePage }) => {
+  test('NOT REGEXP returns the complement', async ({ page, explorePage }) => {
     await page.goto(exploreUrl());
-    // Shape produced by AdHocFilter.apply() for a filter like
-    // `{ key: 'message', operator: '!~', value: '^Request' }`.
     // 10 rows in the fixture, 2 start with "Request", so 8 remain.
     await enterSql(
       page,
-      "SELECT timestamp, message FROM e2e_test.events ORDER BY timestamp SETTINGS additional_table_filters={'events' : ' message NOT REGEXP \\'^Request\\' '}"
+      "SELECT timestamp, message FROM e2e_test.events WHERE message NOT REGEXP '^Request' ORDER BY timestamp"
     );
 
     const { responsePromise, getBody } = await waitForQueryDataResponseWithBody(explorePage);
@@ -132,7 +130,7 @@ test.describe('Ad-hoc regex operator filters', () => {
     // ever sees zero rows, ILIKE is back.
     await enterSql(
       page,
-      "SELECT level FROM e2e_test.events ORDER BY timestamp SETTINGS additional_table_filters={'events' : ' level REGEXP \\'^(info|warn)$\\' '}"
+      "SELECT level FROM e2e_test.events WHERE level REGEXP '^(info|warn)$' ORDER BY timestamp"
     );
 
     const { responsePromise, getBody } = await waitForQueryDataResponseWithBody(explorePage);

--- a/tests/e2e/adhocRegexFilter.spec.ts
+++ b/tests/e2e/adhocRegexFilter.spec.ts
@@ -36,6 +36,11 @@ async function enterSql(page: Page, sql: string) {
   await editor.click();
   await page.keyboard.press('ControlOrMeta+a');
   await page.keyboard.type(sql);
+  // Dismiss any Monaco autocomplete popup that may have captured a keyword
+  // mid-stream (e.g. `NOT ` can trigger a suggestion list that, if left open,
+  // swallows the Enter/click on the Run Query button or rewrites the last
+  // token when focus shifts).
+  await page.keyboard.press('Escape');
 }
 
 async function waitForQueryDataResponseWithBody(explorePage: ExplorePage) {
@@ -102,9 +107,13 @@ test.describe('Ad-hoc regex operator filters', () => {
   test('NOT REGEXP returns the complement', async ({ page, explorePage }) => {
     await page.goto(exploreUrl());
     // 10 rows in the fixture, 2 start with "Request", so 8 remain.
+    // Parenthesize the predicate so the `NOT` keyword is not immediately
+    // followed by `REGEXP` — Monaco's SQL autocomplete tends to offer
+    // keyword suggestions after `NOT ` and can swallow/mangle the next
+    // token when typed via page.keyboard.type().
     await enterSql(
       page,
-      "SELECT timestamp, message FROM e2e_test.events WHERE message NOT REGEXP '^Request' ORDER BY timestamp"
+      "SELECT timestamp, message FROM e2e_test.events WHERE NOT (message REGEXP '^Request') ORDER BY timestamp"
     );
 
     const { responsePromise, getBody } = await waitForQueryDataResponseWithBody(explorePage);

--- a/tests/e2e/adhocRegexFilter.spec.ts
+++ b/tests/e2e/adhocRegexFilter.spec.ts
@@ -69,7 +69,7 @@ async function waitForQueryDataResponseWithBody(explorePage: ExplorePage) {
 // or silently reintroduces ILIKE (which does not honour indexes and is
 // not regex), one of these tests will fail.
 //
-// The previous behaviour translated `=~` to `ILIKE`, which is a LIKE
+// The previous behavior translated `=~` to `ILIKE`, which is a LIKE
 // pattern — not a regex — and prevents primary-key skip-index pruning on
 // indexed columns. See the issue for the user-visible consequence.
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #1443

## Summary

- Grafana's ad-hoc filter operators `=~` ("Matches regex") and `!~` ("Does not match regex") were being translated to `ILIKE` / `NOT ILIKE` in the `additional_table_filters` setting. That is semantically wrong (ILIKE is a LIKE pattern, not a regex) and, per the reporter, prevents primary-key / skip-index pruning on indexed columns, producing very slow queries over large tables.
- Map `=~` / `!~` to ClickHouse's `REGEXP` / `NOT REGEXP` (RE2-backed, alias for `match()`). Anchored patterns can still benefit from prefix pruning, and the semantics now match the operator label shown in the UI.
- Only `src/data/adHocFilter.ts` changes runtime behaviour. The Query Builder's `ILIKE` / `NOT ILIKE` options in `FilterEditor.tsx` are untouched — they're an explicit user choice and unrelated to the regex operators.