### PR TITLE
fix(traces): drop LIMIT from single-trace span query (#1541)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,14 @@ services:
       - -c
       - |
         set -e
-        clickhouse-client --host clickhouse-server --multiquery < /data/seed.sql
+        # Load every *.sql fixture under /data in lexicographic order so new
+        # feature-specific fixtures can live alongside seed.sql without
+        # creating merge conflicts when multiple PRs add fixtures at once.
+        # $$f (not $f) so docker-compose passes a literal $ to the shell.
+        for f in /data/*.sql; do
+          echo "Loading fixture: $$f"
+          clickhouse-client --host clickhouse-server --multiquery < "$$f"
+        done
     depends_on:
       clickhouse-server:
         condition: service_healthy

--- a/src/data/sqlGenerator.test.ts
+++ b/src/data/sqlGenerator.test.ts
@@ -231,7 +231,6 @@ describe('SQL Generator', () => {
       `arrayMap(key -> map('key', key, 'value',"ResourceAttributes"[key]), mapKeys("ResourceAttributes")) as serviceTags,`,
       `if("StatusCode" IN ('Error', 'STATUS_CODE_ERROR'), 2, 0) as statusCode`,
       `FROM "default"."otel_traces" WHERE traceID = 'abcdefg'`,
-      'LIMIT 1000',
     ];
 
     const sql = generateSql(opts);
@@ -295,7 +294,6 @@ describe('SQL Generator', () => {
       '"InstrumentationLibraryVersion" as instrumentationLibraryVersion,',
       '"TraceState" as traceState',
       `FROM "default"."otel_traces" WHERE traceID = trace_id AND "Timestamp" >= trace_start AND "Timestamp" <= trace_end`,
-      'LIMIT 1000',
     ];
 
     const sql = generateSql(opts);
@@ -359,7 +357,6 @@ describe('SQL Generator', () => {
       '"InstrumentationLibraryVersion" as instrumentationLibraryVersion,',
       '"TraceState" as traceState',
       `FROM "default"."otel_traces" WHERE traceID = trace_id AND "Timestamp" >= trace_start AND "Timestamp" <= trace_end`,
-      'LIMIT 1000',
     ];
 
     const sql = generateSql(opts);
@@ -407,7 +404,6 @@ describe('SQL Generator', () => {
       `arrayMap(key -> map('key', key, 'value',"ResourceAttributes"[key]), mapKeys("ResourceAttributes")) as serviceTags,`,
       `if("StatusCode" IN ('Error', 'STATUS_CODE_ERROR'), 2, 0) as statusCode`,
       `FROM "default"."otel_traces" WHERE traceID = trace_id AND "Timestamp" >= trace_start AND "Timestamp" <= trace_end`,
-      'LIMIT 1000',
     ];
 
     const sql = generateSql(opts);
@@ -453,11 +449,37 @@ describe('SQL Generator', () => {
       `arrayMap(key -> map('key', key, 'value',"ResourceAttributes"[key]), mapKeys("ResourceAttributes")) as serviceTags,`,
       `if("StatusCode" IN ('Error', 'STATUS_CODE_ERROR'), 2, 0) as statusCode`,
       `FROM "default"."otel_traces" WHERE traceID = 'abcdefg'`,
-      'LIMIT 1000',
     ];
 
     const sql = generateSql(opts);
     expect(sql).toEqual(expectedSqlParts.join(' '));
+  });
+
+  it('regression #1541: trace ID query does not apply LIMIT (spans must not be truncated)', () => {
+    const opts: QueryBuilderOptions = {
+      database: 'default',
+      table: 'otel_traces',
+      queryType: QueryType.Traces,
+      columns: [
+        { name: 'TraceId', type: 'String', hint: ColumnHint.TraceId },
+        { name: 'SpanId', type: 'String', hint: ColumnHint.TraceSpanId },
+        { name: 'Timestamp', type: 'DateTime64(9)', hint: ColumnHint.Time },
+      ],
+      filters: [],
+      meta: {
+        minimized: true,
+        otelEnabled: false,
+        otelVersion: 'latest',
+        isTraceIdMode: true,
+        traceId: 'abcdefg',
+      },
+      // Inherited from the trace-search builder; this is the bug: spans of
+      // the selected trace must not be capped at this number.
+      limit: 3,
+      orderBy: [],
+    };
+    const sql = generateSql(opts);
+    expect(sql).not.toMatch(/\bLIMIT\b/);
   });
 
   it('generates trace search query', () => {

--- a/src/data/sqlGenerator.ts
+++ b/src/data/sqlGenerator.ts
@@ -300,10 +300,10 @@ const generateTraceIdQuery = (options: QueryBuilderOptions): string => {
     queryParts.push(orderBy);
   }
 
-  const limit = getLimit(options.limit);
-  if (limit !== '') {
-    queryParts.push(limit);
-  }
+  // Intentionally no LIMIT: this query is only reached in single-trace mode
+  // (`generateSql` routes here when `isTraceIdMode && traceId` are both set),
+  // and the WHERE clause already narrows to one trace ID. Applying the list's
+  // LIMIT here cuts off spans in the trace waterfall — see #1541.
 
   return concatQueryParts(queryParts);
 };

--- a/tests/e2e/fixtures/trace_spans.sql
+++ b/tests/e2e/fixtures/trace_spans.sql
@@ -1,0 +1,38 @@
+-- Trace-spans fixture for the #1541 trace-viewer LIMIT regression guard.
+--
+-- Self-contained so ordering with seed.sql does not matter. The
+-- docker-compose e2e-data-loader service iterates every *.sql file under
+-- /data in lexicographic order.
+--
+-- The bug: when the user searches traces with a LIMIT (e.g. 3), the plugin
+-- reuses the same LIMIT for the single-trace span query, truncating the
+-- waterfall. Fix drops LIMIT from `generateTraceIdQuery`. The fixture seeds
+-- 5 spans for trace 'e2e-trace-a' so an E2E test can assert the "no LIMIT"
+-- SQL pattern returns all 5 spans.
+
+CREATE DATABASE IF NOT EXISTS e2e_test;
+
+CREATE TABLE IF NOT EXISTS e2e_test.trace_spans
+(
+    Timestamp    DateTime64(9),
+    TraceId      String,
+    SpanId       String,
+    ParentSpanId String,
+    ServiceName  LowCardinality(String),
+    SpanName     LowCardinality(String),
+    Duration     Int64
+)
+ENGINE = MergeTree
+ORDER BY (TraceId, Timestamp);
+
+-- Five spans for 'e2e-trace-a' cover the regression case for #1541 (must
+-- not be truncated at LIMIT 3). The 'e2e-trace-b' row is unrelated noise
+-- so the WHERE TraceId = '…' filter is exercised.
+INSERT INTO e2e_test.trace_spans
+    (Timestamp, TraceId, SpanId, ParentSpanId, ServiceName, SpanName, Duration) VALUES
+    ('2024-03-15 10:00:00', 'e2e-trace-a', 'span-1', '',        'api',    'HTTP GET /',        10000000),
+    ('2024-03-15 10:00:01', 'e2e-trace-a', 'span-2', 'span-1',  'api',    'db.query users',     5000000),
+    ('2024-03-15 10:00:02', 'e2e-trace-a', 'span-3', 'span-1',  'api',    'cache.get profile',  2000000),
+    ('2024-03-15 10:00:03', 'e2e-trace-a', 'span-4', 'span-2',  'db',     'SELECT users',       4000000),
+    ('2024-03-15 10:00:04', 'e2e-trace-a', 'span-5', 'span-3',  'cache',  'GET profile:42',     1000000),
+    ('2024-03-15 10:00:10', 'e2e-trace-b', 'span-9', '',        'worker', 'job.run',            8000000);

--- a/tests/e2e/traceLimit.spec.ts
+++ b/tests/e2e/traceLimit.spec.ts
@@ -102,7 +102,7 @@ test.describe('Trace ID query (#1541)', () => {
   });
 
   test('applying a 3-row LIMIT truncates — confirms the fixture has >3 spans', async ({ page, explorePage }) => {
-    // Complementary assertion: with the old buggy behaviour (LIMIT 3 inherited
+    // Complementary assertion: with the old buggy behavior (LIMIT 3 inherited
     // from the list query), only 3 of the 5 spans would be returned. This
     // test guards against the fixture accidentally seeding <=3 spans, which
     // would make the companion "no LIMIT" assertion above trivially pass.

--- a/tests/e2e/traceLimit.spec.ts
+++ b/tests/e2e/traceLimit.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test, ExplorePage } from '@grafana/plugin-e2e';
-import { Locator, Page } from '@playwright/test';
+import { Page } from '@playwright/test';
 
 // Regression guard for #1541 — Trace viewer LIMIT applies to both list view
 // and trace view.
@@ -18,8 +18,13 @@ import { Locator, Page } from '@playwright/test';
 // column provisioning that isn't currently wired into the e2e setup.
 // Unit tests cover the builder side.
 
-const DATASOURCE_UID = 'clickhouse-e2e';
 const PLUGIN_TYPE = 'grafana-clickhouse-datasource';
+
+const isCloudRun = !!process.env.GRAFANA_URL;
+
+const CLOUD_DEFAULT_UID = 'clickhouse-native-ds-m';
+const LOCAL_DEFAULT_UID = 'clickhouse-e2e';
+const DATASOURCE_UID = process.env.DS_E2E_UID || (isCloudRun ? CLOUD_DEFAULT_UID : LOCAL_DEFAULT_UID);
 
 // The trace_spans fixture in tests/e2e/fixtures/trace_spans.sql seeds five
 // spans for this trace at 2024-03-15 10:00:00–10:00:04 UTC.
@@ -27,10 +32,6 @@ const FIXTURE_FROM_ISO = '2024-03-15T09:45:00.000Z';
 const FIXTURE_TO_ISO = '2024-03-15T10:15:00.000Z';
 const TRACE_ID = 'e2e-trace-a';
 const EXPECTED_SPAN_COUNT = 5;
-
-function queryEditorRow(page: Page): Locator {
-  return page.locator('[data-testid="data-testid Query editor row"], [aria-label="Query editor row"]');
-}
 
 function exploreUrl(from: string, to: string): string {
   const query = {
@@ -71,6 +72,13 @@ async function waitForQueryDataResponseWithBody(explorePage: ExplorePage) {
 }
 
 test.describe('Trace ID query (#1541)', () => {
+  test.beforeEach(() => {
+    test.skip(
+      isCloudRun,
+      'Fixture-data tests depend on the local trace_spans seed (tests/e2e/fixtures/trace_spans.sql) loaded via the e2e-data-loader Docker service, which is not available on Cloud.'
+    );
+  });
+
   test.describe.configure({ mode: 'serial' });
 
   test('single-trace span query returns all spans (no LIMIT truncation)', async ({ page, explorePage }) => {
@@ -84,7 +92,7 @@ test.describe('Trace ID query (#1541)', () => {
     await enterSql(page, sql);
 
     const { responsePromise, getBody } = await waitForQueryDataResponseWithBody(explorePage);
-    await queryEditorRow(page).getByRole('button', { name: 'Run Query' }).click();
+    await page.locator('.query-editor-row').getByRole('button', { name: 'Run Query' }).click();
     await responsePromise;
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -112,7 +120,7 @@ test.describe('Trace ID query (#1541)', () => {
     await enterSql(page, sql);
 
     const { responsePromise, getBody } = await waitForQueryDataResponseWithBody(explorePage);
-    await queryEditorRow(page).getByRole('button', { name: 'Run Query' }).click();
+    await page.locator('.query-editor-row').getByRole('button', { name: 'Run Query' }).click();
     await responsePromise;
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/tests/e2e/traceLimit.spec.ts
+++ b/tests/e2e/traceLimit.spec.ts
@@ -1,0 +1,125 @@
+import { expect, test, ExplorePage } from '@grafana/plugin-e2e';
+import { Locator, Page } from '@playwright/test';
+
+// Regression guard for #1541 — Trace viewer LIMIT applies to both list view
+// and trace view.
+//
+// Before the fix, when a user searched traces with `limit = 3`, clicking
+// through to a single trace reused the same LIMIT clause for the span
+// query, so the waterfall was missing spans. The fix drops LIMIT from
+// `generateTraceIdQuery` (single-trace mode). Unit tests in
+// `src/data/sqlGenerator.test.ts` cover the generator directly. This E2E
+// test runs the SQL the generator now produces against a seeded trace and
+// verifies every span is returned (not truncated at 3) — the end-to-end
+// guarantee the issue was really about.
+//
+// We exercise this via the SQL editor rather than clicking through the
+// Traces query-builder UI because the plugin's Traces builder needs OTel
+// column provisioning that isn't currently wired into the e2e setup.
+// Unit tests cover the builder side.
+
+const DATASOURCE_UID = 'clickhouse-e2e';
+const PLUGIN_TYPE = 'grafana-clickhouse-datasource';
+
+// The trace_spans fixture in tests/e2e/fixtures/trace_spans.sql seeds five
+// spans for this trace at 2024-03-15 10:00:00–10:00:04 UTC.
+const FIXTURE_FROM_ISO = '2024-03-15T09:45:00.000Z';
+const FIXTURE_TO_ISO = '2024-03-15T10:15:00.000Z';
+const TRACE_ID = 'e2e-trace-a';
+const EXPECTED_SPAN_COUNT = 5;
+
+function queryEditorRow(page: Page): Locator {
+  return page.locator('[data-testid="data-testid Query editor row"], [aria-label="Query editor row"]');
+}
+
+function exploreUrl(from: string, to: string): string {
+  const query = {
+    refId: 'A',
+    datasource: { type: PLUGIN_TYPE, uid: DATASOURCE_UID },
+    editorType: 'sql',
+    pluginVersion: '',
+    rawSql: '',
+  };
+  const panes = JSON.stringify({
+    explore: { datasource: DATASOURCE_UID, queries: [query], range: { from, to } },
+  });
+  return `/explore?orgId=1&schemaVersion=1&panes=${encodeURIComponent(panes)}`;
+}
+
+async function enterSql(page: Page, sql: string) {
+  const editor = page.getByRole('code');
+  await editor.click();
+  await page.keyboard.press('ControlOrMeta+a');
+  await page.keyboard.type(sql);
+}
+
+async function waitForQueryDataResponseWithBody(explorePage: ExplorePage) {
+  let body: Record<string, unknown> | null = null;
+  const responsePromise = explorePage.waitForQueryDataResponse(async (r) => {
+    if (!r.ok()) {
+      return false;
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const b: any = await r.json().catch(() => null);
+    if (!Array.isArray(b?.results?.A?.frames)) {
+      return false;
+    }
+    body = b as Record<string, unknown>;
+    return true;
+  });
+  return { responsePromise, getBody: () => body };
+}
+
+test.describe('Trace ID query (#1541)', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  test('single-trace span query returns all spans (no LIMIT truncation)', async ({ page, explorePage }) => {
+    // Mirror the SQL shape the fixed `generateTraceIdQuery` now produces
+    // for a non-OTel trace lookup: SELECT ... WHERE TraceId = '…' with NO
+    // LIMIT clause. Before the fix this SQL had LIMIT 3 appended, cutting
+    // the waterfall.
+    const sql = `SELECT TraceId AS traceID, SpanId AS spanID, ParentSpanId AS parentSpanID, ServiceName AS serviceName, SpanName AS operationName FROM e2e_test.trace_spans WHERE TraceId = '${TRACE_ID}'`;
+
+    await page.goto(exploreUrl(FIXTURE_FROM_ISO, FIXTURE_TO_ISO));
+    await enterSql(page, sql);
+
+    const { responsePromise, getBody } = await waitForQueryDataResponseWithBody(explorePage);
+    await queryEditorRow(page).getByRole('button', { name: 'Run Query' }).click();
+    await responsePromise;
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const frames = (getBody() as any)?.results?.A?.frames;
+    expect(Array.isArray(frames) && frames.length).toBeGreaterThan(0);
+
+    // Sum the row count across the returned data frames. clickhouse-datasource
+    // returns one frame with a values array per column; the number of spans
+    // equals the length of any column's value list.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const firstFrame = frames[0] as any;
+    const anyColumn = firstFrame?.data?.values?.[0];
+    expect(Array.isArray(anyColumn)).toBe(true);
+    expect(anyColumn.length).toBe(EXPECTED_SPAN_COUNT);
+  });
+
+  test('applying a 3-row LIMIT truncates — confirms the fixture has >3 spans', async ({ page, explorePage }) => {
+    // Complementary assertion: with the old buggy behaviour (LIMIT 3 inherited
+    // from the list query), only 3 of the 5 spans would be returned. This
+    // test guards against the fixture accidentally seeding <=3 spans, which
+    // would make the companion "no LIMIT" assertion above trivially pass.
+    const sql = `SELECT TraceId FROM e2e_test.trace_spans WHERE TraceId = '${TRACE_ID}' LIMIT 3`;
+
+    await page.goto(exploreUrl(FIXTURE_FROM_ISO, FIXTURE_TO_ISO));
+    await enterSql(page, sql);
+
+    const { responsePromise, getBody } = await waitForQueryDataResponseWithBody(explorePage);
+    await queryEditorRow(page).getByRole('button', { name: 'Run Query' }).click();
+    await responsePromise;
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const frames = (getBody() as any)?.results?.A?.frames;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const firstFrame = frames?.[0] as any;
+    const anyColumn = firstFrame?.data?.values?.[0];
+    expect(anyColumn.length).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary

- When users search traces with a LIMIT and click into a single trace, the span query currently inherits the same LIMIT, truncating the waterfall.
- `generateSql` only dispatches to `generateTraceIdQuery` when `isTraceIdMode && traceId` are both set, so the WHERE clause already narrows to one trace ID — the LIMIT was redundant and harmful.
- Fix: drop the LIMIT block from `generateTraceIdQuery`; update the five existing trace-ID test expectations; add a regression unit test.

Closes #1541.

## Test plan

- [x] `npx jest src/data/sqlGenerator.test.ts` — 85 pass
- [x] `npm run lint` + `npm run typecheck` clean for the diff
- [x] Local docker stack: fixture `trace_spans.sql` loads (5 spans for `e2e-trace-a`)
- [ ] CI Playwright suite green on merge

## E2E

New `tests/e2e/traceLimit.spec.ts` seeds 5 spans for one trace and runs the SQL shape the fixed `generateTraceIdQuery` now emits, asserting all 5 rows come back. A companion `LIMIT 3` assertion guards against the fixture regressing to ≤3 spans.

`docker-compose.yml`'s e2e-data-loader now iterates every `*.sql` under `/data` in lex order so new fixtures don't need entrypoint changes.