### PR TITLE
fix(logs): preserve secondary ORDER BY and surface errors in log context

### DIFF
--- a/src/data/CHDatasource.test.ts
+++ b/src/data/CHDatasource.test.ts
@@ -1496,4 +1496,115 @@ describe('ClickHouseDatasource', () => {
       expect(result).toBe(query);
     });
   });
+
+  describe('getLogRowContext', () => {
+    const baseBuilderOptions: QueryBuilderOptions = {
+      database: 'default',
+      table: 'logs',
+      queryType: QueryType.Logs,
+      mode: BuilderMode.List,
+      columns: [
+        { name: 'timestamp', type: 'DateTime64(9)', hint: ColumnHint.Time },
+        { name: 'body', type: 'String', hint: ColumnHint.LogMessage },
+      ],
+      filters: [],
+      orderBy: [
+        { name: 'timestamp', hint: ColumnHint.Time, dir: OrderByDirection.DESC },
+        { name: 'offset', dir: OrderByDirection.ASC },
+      ],
+    };
+
+    const baseQuery: CHBuilderQuery = {
+      pluginVersion: '',
+      refId: 'A',
+      editorType: EditorType.Builder,
+      rawSql: '',
+      builderOptions: baseBuilderOptions,
+    };
+
+    const makeRow = () => {
+      const frame = toDataFrame({ fields: [{ name: 'timestamp', values: [1700000000000] }] });
+      return {
+        entryFieldIndex: 0,
+        rowIndex: 0,
+        dataFrame: frame,
+        timeEpochNs: '1700000000000000000',
+        entry: '',
+        hasAnsi: false,
+        hasUnescapedContent: false,
+        labels: {},
+        logLevel: 'info',
+        raw: '',
+        timeFromNow: '',
+        timeEpochMs: 1700000000000,
+        timeLocal: '',
+        timeUtc: '',
+        uid: '',
+      } as any;
+    };
+
+    const contextOptions = {
+      direction: 'BACKWARD' as any,
+      limit: 10,
+    };
+
+    it('preserves secondary ORDER BY entries (e.g. `offset ASC`) as tiebreakers', async () => {
+      const ds = cloneDeep(mockDatasource);
+      // Force a single context column so we don't hit the "no columns" guard.
+      jest.spyOn(ds, 'getLogContextColumnsFromLogRow').mockReturnValue([{ name: 'service', value: 'web' }]);
+      const querySpy = jest
+        .spyOn(ds, 'query')
+        .mockImplementation((_req) => of({ data: [toDataFrame([])] }));
+
+      const query = cloneDeep(baseQuery);
+      await ds.getLogRowContext(makeRow(), contextOptions, query);
+
+      expect(querySpy).toHaveBeenCalledTimes(1);
+      const request = querySpy.mock.calls[0][0] as DataQueryRequest<CHQuery>;
+      const sent = request.targets[0] as CHBuilderQuery;
+      const orderBy = sent.builderOptions.orderBy ?? [];
+
+      // Primary entry is the time column (inserted by getLogRowContext).
+      expect(orderBy[0]).toMatchObject({ hint: ColumnHint.Time });
+      // User's secondary entry survives as a tiebreaker.
+      expect(orderBy).toContainEqual(
+        expect.objectContaining({ name: 'offset', dir: OrderByDirection.ASC })
+      );
+      // Original time-column entry is not duplicated.
+      const timeEntries = orderBy.filter(
+        (e) => e.hint === ColumnHint.Time || e.name === 'timestamp'
+      );
+      expect(timeEntries).toHaveLength(1);
+    });
+
+    it('surfaces the underlying ClickHouse error text instead of swallowing it', async () => {
+      const ds = cloneDeep(mockDatasource);
+      jest.spyOn(ds, 'getLogContextColumnsFromLogRow').mockReturnValue([{ name: 'service', value: 'web' }]);
+      jest.spyOn(ds, 'query').mockImplementation((_req) => {
+        // Observable that errors with a ClickHouse-shaped error payload.
+        return new (require('rxjs').Observable)((subscriber: any) => {
+          subscriber.error({ data: { message: 'Code: 47. DB::Exception: Unknown identifier: offset' } });
+        });
+      });
+
+      await expect(ds.getLogRowContext(makeRow(), contextOptions, cloneDeep(baseQuery))).rejects.toThrow(
+        /Unknown identifier: offset/
+      );
+    });
+
+    it('surfaces errors reported on DataQueryResponse.errors[]', async () => {
+      const ds = cloneDeep(mockDatasource);
+      jest.spyOn(ds, 'getLogContextColumnsFromLogRow').mockReturnValue([{ name: 'service', value: 'web' }]);
+      jest.spyOn(ds, 'query').mockImplementation((_req) =>
+        of({
+          data: [],
+          errors: [{ message: 'Code: 62. DB::Exception: Syntax error' } as any],
+        })
+      );
+
+      await expect(ds.getLogRowContext(makeRow(), contextOptions, cloneDeep(baseQuery))).rejects.toThrow(
+        /Syntax error/
+      );
+    });
+  });
 });

--- a/src/data/CHDatasource.ts
+++ b/src/data/CHDatasource.ts
@@ -1249,12 +1249,29 @@ export class Datasource
       throw new Error('Missing time column for log context');
     }
 
+    // Preserve the user's secondary ORDER BY (e.g. `offset ASC` alongside
+    // `timestamp DESC`) so rows with identical timestamps keep their
+    // stable order in the log-context view. The time column is forced to
+    // the front because context pagination uses it; the user's remaining
+    // ORDER BY entries ride along as tiebreakers. Drop any existing entry
+    // that targets the same time column to avoid duplicating it. See #1293.
+    const originalOrderBy = builderOptions.orderBy ?? [];
     builderOptions.orderBy = [];
     builderOptions.orderBy.push({
       name: '',
       hint: timeColumn.hint!,
       dir: options.direction === LogRowContextQueryDirection.Forward ? OrderByDirection.ASC : OrderByDirection.DESC,
     });
+    for (const entry of originalOrderBy) {
+      const targetsTimeColumn =
+        entry.hint === ColumnHint.Time ||
+        entry.hint === ColumnHint.FilterTime ||
+        (!!entry.name && entry.name === timeColumn.name);
+      if (targetsTimeColumn) {
+        continue;
+      }
+      builderOptions.orderBy.push(entry);
+    }
 
     builderOptions.filters = [];
     builderOptions.filters.push({
@@ -1290,7 +1307,39 @@ export class Datasource
       targets: [contextQuery],
     } as DataQueryRequest<CHQuery>;
 
-    return await firstValueFrom(this.query(req));
+    // Surface the underlying ClickHouse error instead of letting Grafana
+    // wrap it in the generic "Error loading more logs" banner. The observable
+    // returned by `this.query(req)` can reject with a structured error or emit
+    // a `DataQueryResponse` with a populated `errors`/`error` field. In both
+    // cases we want the original server message to reach the user. See #1362.
+    let response: DataQueryResponse;
+    try {
+      response = await firstValueFrom(this.query(req));
+    } catch (err) {
+      const detail = this.extractQueryErrorMessage(err);
+      throw new Error(detail ? `Log context query failed: ${detail}` : 'Log context query failed');
+    }
+
+    const responseError = response?.errors?.find((e) => !!e?.message)?.message;
+    if (responseError) {
+      throw new Error(`Log context query failed: ${responseError}`);
+    }
+
+    return response;
+  }
+
+  private extractQueryErrorMessage(err: unknown): string | undefined {
+    if (!err) {
+      return undefined;
+    }
+    if (typeof err === 'string') {
+      return err;
+    }
+    if (typeof err === 'object') {
+      const anyErr = err as { data?: { message?: string }; message?: string; statusText?: string };
+      return anyErr.data?.message || anyErr.message || anyErr.statusText;
+    }
+    return undefined;
   }
 
   /**


### PR DESCRIPTION
## Summary

- Preserve the user's secondary ORDER BY entries (e.g. `offset ASC` alongside `timestamp DESC`) when building the log-context query, so rows with identical timestamps keep their stable order in the context view
- Surface the underlying ClickHouse error text instead of letting Grafana wrap every failure in the generic "Error loading more logs" banner

## Why

Two long-standing papercuts in the log-context flow:

**#1293 — ORDER BY is stripped.** `getLogRowContext` cleared `builderOptions.orderBy` and pushed only the time column. Users who ordered their logs by `timestamp DESC, offset ASC` (a common OTel/Vector pattern to break ties on bursty sub-millisecond events) lost the `offset` tiebreaker as soon as they clicked "Show context", so the context panel showed rows out of order relative to the Logs panel they just came from.

**#1362 — Errors are swallowed.** The final `firstValueFrom(this.query(req))` had no error wrapping, so when the context query failed (misconfigured Context Columns, permission errors, JSON-path issues), Grafana fell back to the panel's generic "Error loading more logs" banner. The actual ClickHouse message — the one that tells you *why* the query failed — never reached the user.

## What changed

[src/data/CHDatasource.ts](src/data/CHDatasource.ts) — `getLogRowContext`:

1. Capture the original `builderOptions.orderBy`, push the time column as the primary ORDER BY (context pagination depends on it), then re-append the remaining entries as tiebreakers. Skip any that already target the time column (by `ColumnHint.Time`/`FilterTime` or by name) so it isn't duplicated.
2. Wrap the final query call in a try/catch. On rejection, extract the ClickHouse error text from `err.data.message` / `err.message`. On resolved-but-errored responses, read `response.errors[].message`. Re-throw as `Log context query failed: <upstream>` so the real message reaches the Grafana error banner.

## Testing

- `npx jest src/data/CHDatasource.test.ts` — all 82 tests pass, including 3 new ones in a `getLogRowContext` block:
  - ORDER BY preservation: confirms the time column is primary, `offset ASC` survives as tiebreaker, and the time column isn't duplicated
  - Error surfacing from a rejected Observable
  - Error surfacing from `DataQueryResponse.errors[]`
- `npx tsc --noEmit` — clean
- `npx eslint src/data/CHDatasource.ts src/data/CHDatasource.test.ts` — no new warnings

### Why no Playwright E2E

The Grafana log-row-context UI is a hover-to-reveal button on rendered log rows in Explore, gated behind context-column provisioning in the datasource jsonData and multi-timestamp seed data. Reliably reproducing that flow in Playwright would require substantial new fixture and provisioning scaffolding, while the changes in this PR are pure SQL generation + error propagation — both fully covered by unit tests. Happy to add E2E in a follow-up if reviewers disagree.

Fixes #1293
Fixes #1362