### PR TITLE
fix(headers): forward X-Grafana-User to ClickHouse when enabled

### DIFF
--- a/cspell.config.json
+++ b/cspell.config.json
@@ -28,6 +28,7 @@
     "concats",
     "createddate",
     "dataframe",
+    "dataproxy",
     "DataSource",
     "datasourcese",
     "DataSources",

--- a/docs/sources/configure.md
+++ b/docs/sources/configure.md
@@ -225,6 +225,37 @@ Once you have configured your ClickHouse connection settings, click **Save & tes
 
 If the test fails, refer to [Troubleshoot ClickHouse data source issues](/docs/plugins/grafana-clickhouse-datasource/<CLICKHOUSE_PLUGIN_VERSION>/troubleshooting/) for common configuration errors and solutions.
 
+## Forward Grafana HTTP headers
+
+When you use the **HTTP** protocol, you can propagate Grafana's per-request HTTP headers end-to-end to ClickHouse. This attaches context about the originating Grafana user, dashboard, and panel to every query so you can drive query-log attribution, quotas, and row policies from ClickHouse.
+
+To enable it, expand **Optional HTTP settings** on the data source and turn on **Forward Grafana HTTP headers to data source**.
+
+{{< admonition type="note" >}}
+This setting is only available on the HTTP protocol. The native protocol does not carry HTTP headers.
+{{< /admonition >}}
+
+When the toggle is on, the following headers are forwarded on each ClickHouse connection:
+
+| Header | Source |
+| ------ | ------ |
+| `X-Grafana-User` | The logged-in Grafana user's login. Populated from the plugin's request context, so you do not need to enable the Grafana `dataproxy.send_user_header` setting for this plugin. |
+| `X-Dashboard-Uid`, `X-Panel-Id`, `X-Panel-Plugin-Id`, `X-Dashboard-Title`, `X-Panel-Title` | Identifiers set by Grafana when the query originates from a dashboard panel. |
+| `X-Grafana-Org-Id`, `X-Query-Group-Id`, `X-Grafana-From-Expr`, `X-Datasource-Uid` | Request-context headers set by Grafana core. |
+
+### Use cases
+
+- **Query-log attribution** — ClickHouse records the forwarded headers in `system.query_log.http_user_agent` and related fields, so operators can correlate queries back to the Grafana user and dashboard that triggered them.
+- **Row policies and quotas** — ClickHouse [row policies](https://clickhouse.com/docs/en/operations/access-rights/#row-policies) and [quotas](https://clickhouse.com/docs/en/operations/quotas) can key on the `X-Grafana-User` header, so a single shared ClickHouse account can still enforce per-viewer access rules.
+
+### Connection pool implications
+
+With header forwarding enabled, connections are keyed by the forwarded header set, which means each distinct Grafana user opens their own ClickHouse connection. Expect the connection count to scale with concurrent unique users and size `max_connections` on your ClickHouse server accordingly.
+
+### Custom headers
+
+To forward headers other than the Grafana-set ones — for example, bearer tokens or tenant identifiers — add them as **Custom HTTP headers** in the same **Optional HTTP settings** panel. Custom headers are sent on every query regardless of the **Forward Grafana HTTP headers** toggle.
+
 ## Provision the data source
 
 You can define the data source in YAML files as part of the Grafana provisioning system. For more information, refer to [Provisioning Grafana data sources](https://grafana.com/docs/grafana/latest/administration/provisioning/#data-sources).

--- a/pkg/plugin/driver.go
+++ b/pkg/plugin/driver.go
@@ -385,8 +385,34 @@ func (h *Clickhouse) MutateQueryData(
 		ctx = context.WithValue(ctx, grafanaHeadersKey, gh)
 	}
 
+	injectGrafanaUserHeader(ctx, req)
+
 	req = preprocessGrafanaSQL(req)
 	return ctx, req
+}
+
+// injectGrafanaUserHeader populates X-Grafana-User from the request's user
+// context when "Forward Grafana HTTP Headers" is enabled. Grafana's
+// `dataproxy.send_user_header` setting only adds the header to the proxy
+// path (core HTTP datasources); plugin-initiated connections never see it,
+// so downstream ClickHouse loses the user attribution that operators expect
+// when the toggle is on. See #1451.
+func injectGrafanaUserHeader(ctx context.Context, req *backend.QueryDataRequest) {
+	if req == nil || req.PluginContext.DataSourceInstanceSettings == nil {
+		return
+	}
+	if req.GetHTTPHeader("X-Grafana-User") != "" {
+		return
+	}
+	settings, err := LoadSettings(ctx, *req.PluginContext.DataSourceInstanceSettings)
+	if err != nil || !settings.ForwardGrafanaHeaders {
+		return
+	}
+	user := backend.UserFromContext(ctx)
+	if user == nil || user.Login == "" {
+		return
+	}
+	req.SetHTTPHeader("X-Grafana-User", user.Login)
 }
 
 func preprocessGrafanaSQL(req *backend.QueryDataRequest) *backend.QueryDataRequest {

--- a/pkg/plugin/driver_test.go
+++ b/pkg/plugin/driver_test.go
@@ -425,3 +425,78 @@ func TestMutateQuery_GrafanaMetadata(t *testing.T) {
 		assert.NotEqual(t, ctx, newCtx)
 	})
 }
+
+func TestMutateQueryData_XGrafanaUserForwarding(t *testing.T) {
+	h := &Clickhouse{}
+
+	newRequest := func(forward bool) *backend.QueryDataRequest {
+		jsonBytes, _ := json.Marshal(map[string]any{
+			"host":                  "localhost",
+			"port":                  9000,
+			"forwardGrafanaHeaders": forward,
+		})
+		return &backend.QueryDataRequest{
+			PluginContext: backend.PluginContext{
+				DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{
+					JSONData: jsonBytes,
+				},
+			},
+			Headers: map[string]string{},
+		}
+	}
+
+	t.Run("populates X-Grafana-User from context when forwardGrafanaHeaders is enabled", func(t *testing.T) {
+		req := newRequest(true)
+		ctx := backend.WithUser(t.Context(), &backend.User{Login: "alice"})
+
+		h.MutateQueryData(ctx, req)
+
+		assert.Equal(t, "alice", req.GetHTTPHeader("X-Grafana-User"))
+	})
+
+	t.Run("does not inject when forwardGrafanaHeaders is disabled", func(t *testing.T) {
+		req := newRequest(false)
+		ctx := backend.WithUser(t.Context(), &backend.User{Login: "alice"})
+
+		h.MutateQueryData(ctx, req)
+
+		assert.Empty(t, req.GetHTTPHeader("X-Grafana-User"))
+	})
+
+	t.Run("does not override header already set by Grafana proxy", func(t *testing.T) {
+		req := newRequest(true)
+		req.SetHTTPHeader("X-Grafana-User", "from-proxy")
+		ctx := backend.WithUser(t.Context(), &backend.User{Login: "alice"})
+
+		h.MutateQueryData(ctx, req)
+
+		assert.Equal(t, "from-proxy", req.GetHTTPHeader("X-Grafana-User"))
+	})
+
+	t.Run("no user in context is a no-op", func(t *testing.T) {
+		req := newRequest(true)
+
+		h.MutateQueryData(t.Context(), req)
+
+		assert.Empty(t, req.GetHTTPHeader("X-Grafana-User"))
+	})
+
+	t.Run("nil DataSourceInstanceSettings is a no-op", func(t *testing.T) {
+		req := &backend.QueryDataRequest{Headers: map[string]string{}}
+		ctx := backend.WithUser(t.Context(), &backend.User{Login: "alice"})
+
+		// Should not panic and should not set the header.
+		h.MutateQueryData(ctx, req)
+
+		assert.Empty(t, req.GetHTTPHeader("X-Grafana-User"))
+	})
+
+	t.Run("empty Login is a no-op", func(t *testing.T) {
+		req := newRequest(true)
+		ctx := backend.WithUser(t.Context(), &backend.User{Login: ""})
+
+		h.MutateQueryData(ctx, req)
+
+		assert.Empty(t, req.GetHTTPHeader("X-Grafana-User"))
+	})
+}


### PR DESCRIPTION
## Summary

- Populate `X-Grafana-User` from the plugin's request-user context when "Forward Grafana HTTP Headers" is enabled on the datasource, so operators can attribute ClickHouse queries back to the Grafana user who ran them

## User-facing impact

When `forwardGrafanaHeaders` is enabled on the datasource and a Grafana user runs a query:

- **Before:** ClickHouse saw no `X-Grafana-User` header. `system.query_log.http_user_agent` showed only the generic `grafana/<ver> clickhouse-datasource/<ver>` string, and row policies / quotas could not key on the originating user.
- **After:** ClickHouse sees `X-Grafana-User: <login>` on every query, matching the behavior of the Altinity plugin. Existing ClickHouse policies, quotas, and query-log attribution keyed on that header begin working.

No behavior change when `forwardGrafanaHeaders` is off. No new datasource settings.

## Why

Grafana's `dataproxy.send_user_header = true` only injects `X-Grafana-User` on the Grafana *proxy* path (core HTTP datasources routed through Grafana's HTTP proxy). Plugin-initiated connections — including this one — never hit that middleware, so the header never reaches ClickHouse. Users on the [#1451](https://github.com/grafana/clickhouse-datasource/issues/1451) thread have observed that the Altinity plugin forwards the user header end-to-end while this plugin silently drops it.

## What changed

[pkg/plugin/driver.go:391](pkg/plugin/driver.go#L391) — new `injectGrafanaUserHeader` helper, called from `MutateQueryData`:

1. Gated on `settings.ForwardGrafanaHeaders == true` (the existing "Forward Grafana HTTP Headers" toggle). No new config surface.
2. Only populates the header if Grafana didn't already set it (preserves proxy-path compatibility).
3. Reads the user via `backend.UserFromContext(ctx)`, which is already the canonical source — the existing `MutateQuery` path uses it to emit the `grafana_user:<login>` query comment.
4. Calls `req.SetHTTPHeader("X-Grafana-User", user.Login)`, which sqlds picks up via `req.GetHTTPHeaders()` on the next hop, threads through `ConnectionArgs`, and our existing `extractForwardedHeadersFromMessage` → `opts.HttpHeaders` path forwards to the ClickHouse HTTP client.

Connection caching is unaffected: since `EnableMultipleConnections` is already on when `forwardGrafanaHeaders` is set ([pkg/plugin/datasource.go:17](pkg/plugin/datasource.go#L17)), sqlds keys the connection pool on `ConnectionArgs`, so different Grafana users get separate connections with their own baked-in headers.

## Docs

[docs/sources/configure.md](docs/sources/configure.md) — new **Forward Grafana HTTP headers** section covering:

- When the toggle applies (HTTP protocol only) and how to enable it from **Optional HTTP settings**
- The full header set that gets forwarded, including the note that `X-Grafana-User` is now populated from the plugin request context — operators no longer need `[dataproxy] send_user_header = true` in the Grafana configuration for this plugin
- Use cases: query-log attribution, ClickHouse row policies, and quotas keyed on `X-Grafana-User`
- Connection-pool sizing implications (per-user ClickHouse connections when forwarding is on)
- Relationship to **Custom HTTP headers** (always sent, independent of the toggle)

Addresses @alyssajoyner's review comment.

## Testing

- `go test ./pkg/plugin/` — all pass, including six new subtests in `TestMutateQueryData_XGrafanaUserForwarding`:
  - populates `X-Grafana-User` when the toggle is on
  - no-op when the toggle is off
  - does not override a header Grafana already set on the proxy path
  - no-op when there is no user in context (ephemeral system queries)
  - no-op when `DataSourceInstanceSettings` is nil (defensive guard)
  - no-op when `user.Login` is empty

### Manual verification

With an echo-server pointed at ClickHouse's ingress:
- Enable `forwardGrafanaHeaders: true` on the datasource
- Run a query as user `alice`
- Echo-server shows `X-Grafana-User: alice` on the HTTP request
- Toggling the datasource setting off removes the header on next connection

Fixes #1451