### PR TITLE
fix(e2e): repair Cloud cron run and scope local-only tests

### DIFF
--- a/cspell.config.json
+++ b/cspell.config.json
@@ -27,6 +27,7 @@
     "createddate",
     "dataframe",
     "DataSource",
+    "datasourcese",
     "DataSources",
     "Drilldown",
     "DateTime",
@@ -59,6 +60,7 @@
     "Nonproxy",
     "openfeature",
     "oper",
+    "OFREP",
     "otel",
     "semconv",
     "OUTFILE",
@@ -100,6 +102,7 @@
     "typecheck",
     "Ulimits",
     "uuidv",
+    "uvcf",
     "vectorator",
     "WorkDir",
     "varname"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,8 +11,10 @@ services:
     networks:
       - grafana
     environment:
+      # splashScreen is disabled at runtime for E2E tests via @grafana/plugin-e2e's
+      # OFREP interception (>=3.5.0), but we also disable it at the server level so
+      # that manual `docker-compose up` + browsing doesn't trigger the onboarding modal.
       - GF_FEATURE_TOGGLES_splashScreen=false
-      - GF_FEATURE_TOGGLES_dashboardNewLayouts=false
 
   clickhouse-server:
     image: clickhouse/clickhouse-server:${CLICKHOUSE_VERSION:-latest-alpine}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clickhouse-datasource",
-  "version": "4.14.1",
+  "version": "4.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clickhouse-datasource",
-      "version": "4.14.1",
+      "version": "4.15.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/css": "11.13.5",
@@ -29,7 +29,7 @@
         "@axe-core/playwright": "^4.11.1",
         "@babel/core": "^7.29.0",
         "@grafana/eslint-config": "^8.2.0",
-        "@grafana/plugin-e2e": "^3.3.0",
+        "@grafana/plugin-e2e": "^3.5.1",
         "@grafana/tsconfig": "^2.0.0",
         "@playwright/test": "^1.57.0",
         "@stylistic/eslint-plugin-ts": "^4.4.1",
@@ -1740,9 +1740,9 @@
       }
     },
     "node_modules/@grafana/e2e-selectors": {
-      "version": "12.4.0-21636304584",
-      "resolved": "https://registry.npmjs.org/@grafana/e2e-selectors/-/e2e-selectors-12.4.0-21636304584.tgz",
-      "integrity": "sha512-cvpFXsYIImpqmYYLqPuJ0SRWDsgj556ByeMs25wgyC4/96QQX2IxzZjWc4qIdfZYSGRzuCHYsgDvWjqJ5fPd4g==",
+      "version": "13.1.0-24448182242",
+      "resolved": "https://registry.npmjs.org/@grafana/e2e-selectors/-/e2e-selectors-13.1.0-24448182242.tgz",
+      "integrity": "sha512-C8VxaFh4PGWhPBOwol3Fo0UBp1//7XNnjg7WG+t3p0P8Q2cw5HZ2NgQt1OFq9radjmWEc3DJQZvxoelI4TIOJA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1824,13 +1824,13 @@
       }
     },
     "node_modules/@grafana/plugin-e2e": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@grafana/plugin-e2e/-/plugin-e2e-3.3.0.tgz",
-      "integrity": "sha512-sWxwG+cSVOoWhARMme0H4WRK3uUl2fraQ1p0WHkZXCPt7mkMbj6XrZkwRHogFCsMCPle5YViNbIBVHqKSMBsjQ==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@grafana/plugin-e2e/-/plugin-e2e-3.5.1.tgz",
+      "integrity": "sha512-iYId7j9Vg0P5t2ciHTsu0Rp7S268qdjdIWhkP42AMTo/M3JhC4UWKzYOodvjekmWr+9TNOGph7FLmzcf26WWNA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@grafana/e2e-selectors": "12.4.0-21636304584",
+        "@grafana/e2e-selectors": "13.1.0-24448182242",
         "semver": "^7.5.4",
         "uuid": "^13.0.0",
         "yaml": "^2.3.4"
@@ -1839,7 +1839,13 @@
         "node": ">=20 <=24"
       },
       "peerDependencies": {
+        "@axe-core/playwright": "^4.11.1",
         "@playwright/test": "^1.52.0"
+      },
+      "peerDependenciesMeta": {
+        "@axe-core/playwright": {
+          "optional": true
+        }
       }
     },
     "node_modules/@grafana/runtime": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@axe-core/playwright": "^4.11.1",
     "@babel/core": "^7.29.0",
     "@grafana/eslint-config": "^8.2.0",
-    "@grafana/plugin-e2e": "^3.3.0",
+    "@grafana/plugin-e2e": "^3.5.1",
     "@grafana/tsconfig": "^2.0.0",
     "@playwright/test": "^1.57.0",
     "@stylistic/eslint-plugin-ts": "^4.4.1",

--- a/tests/e2e/configEditor.spec.ts
+++ b/tests/e2e/configEditor.spec.ts
@@ -5,6 +5,11 @@ import { CHConfig } from '../../src/types/config';
 const PLUGIN_UID = 'grafana-clickhouse-datasource';
 const PROVISIONING_FILE = 'clickhouse.yml';
 
+// GRAFANA_URL is set only by the Cloud cron workflow (playwright-cloud). Local and PR CI
+// don't set it, so its presence is a reliable signal that we're running against a shared
+// Cloud instance where the local provisioning/datasources/clickhouse.yml is not applied.
+const isCloudRun = !!process.env.GRAFANA_URL;
+
 function resolveClickhouseUrl(env = process.env) {
   const { CI, DS_INSTANCE_HOST } = env;
   return CI ? DS_INSTANCE_HOST || 'clickhouse-server' : 'localhost';
@@ -49,6 +54,13 @@ test.describe('Config editor', () => {
   });
 
   test.describe('provisioned datasource', () => {
+    test.beforeEach(() => {
+      test.skip(
+        isCloudRun,
+        'Provisioned-datasource tests assert values from the local provisioning/datasources/clickhouse.yml file, which is not applied on the shared Cloud instance.'
+      );
+    });
+
     test('should load provisioned server address', async ({
       readProvisionedDataSource,
       gotoDataSourceConfigPage,
@@ -77,6 +89,10 @@ test.describe('Config editor', () => {
       gotoDataSourceConfigPage,
       page,
     }) => {
+      test.skip(
+        isCloudRun,
+        'Provisioned-datasource tests assert values from the local provisioning/datasources/clickhouse.yml file, which is not applied on the shared Cloud instance.'
+      );
       // Provisioned datasources show a read-only "Test" button (not "Save & test"),
       // since the UI cannot modify provisioned configuration.
       const ds = await readProvisionedDataSource<CHConfig>({ fileName: PROVISIONING_FILE });

--- a/tests/e2e/queryEditor.spec.ts
+++ b/tests/e2e/queryEditor.spec.ts
@@ -1,11 +1,17 @@
 import { expect, test, ExplorePage } from '@grafana/plugin-e2e';
-import { Locator, Page } from '@playwright/test';
+import { Page } from '@playwright/test';
 import { QueryType } from '../../src/types/queryBuilder';
 import { EditorType } from '../../src/types/sql';
 
-// Matches the uid set in provisioning/datasources/clickhouse.yml
-const DATASOURCE_UID = 'clickhouse-e2e';
 const PLUGIN_TYPE = 'grafana-clickhouse-datasource';
+
+// GRAFANA_URL is set only by the Cloud cron workflow (see .github/workflows/cron.yml).
+// Its presence indicates the local provisioning file and seed fixtures do not apply.
+const isCloudRun = !!process.env.GRAFANA_URL;
+
+const CLOUD_DEFAULT_UID = 'cf1uvcf1yrz0ge';
+const LOCAL_DEFAULT_UID = 'clickhouse-e2e';
+const DATASOURCE_UID = process.env.DS_E2E_UID || (isCloudRun ? CLOUD_DEFAULT_UID : LOCAL_DEFAULT_UID);
 
 // Time range that fully covers the seed fixture data in tests/e2e/fixtures/seed.sql
 const FIXTURE_FROM_ISO = '2024-03-15T09:45:00.000Z';
@@ -16,15 +22,6 @@ interface ExploreUrlOpts {
   editorType?: EditorType;
   from?: string;
   to?: string;
-}
-
-/**
- * Returns a locator that matches the query editor row regardless of Grafana version.
- * Grafana < 13 uses [aria-label="Query editor row"]; Grafana >= 13 uses
- * [data-testid="data-testid Query editor row"]. The CSS union matches whichever is present.
- */
-function queryEditorRow(page: Page): Locator {
-  return page.locator('[data-testid="data-testid Query editor row"], [aria-label="Query editor row"]');
 }
 
 /**
@@ -135,7 +132,7 @@ test.describe('Query editor', () => {
       // The toolbar also has a "Run query" button — scope to the query editor row to
       // avoid a strict-mode violation from matching both.
       await expect(
-        queryEditorRow(page).getByRole('button', { name: 'Run Query' })
+        page.locator('.query-editor-row').getByRole('button', { name: 'Run Query' })
       ).toBeVisible();
     });
 
@@ -152,7 +149,7 @@ test.describe('Query editor', () => {
       // Use a scoped locator — `label.query-keyword` is the Grafana inline form label
       // class used by the builder for all its field labels (Database, Table, etc.).
       await expect(
-        queryEditorRow(page).locator('label.query-keyword', { hasText: 'Database' })
+        page.locator('.query-editor-row').locator('label.query-keyword', { hasText: 'Database' })
       ).toBeVisible();
     });
 
@@ -195,12 +192,19 @@ test.describe('Query editor', () => {
 test.describe('Query editor with fixture data', () => {
   test.describe.configure({ mode: 'serial' });
 
+  test.beforeEach(() => {
+    test.skip(
+      isCloudRun,
+      'Fixture-data tests depend on e2e_test.events seeded by tests/e2e/fixtures/seed.sql via the local e2e-data-loader Docker service, which is not available on Cloud.'
+    );
+  });
+
   test('SQL query returns rows from fixture data', async ({ page, explorePage }) => {
     await page.goto(exploreUrl({ from: FIXTURE_FROM_ISO, to: FIXTURE_TO_ISO }));
     await enterSql(page, 'SELECT timestamp, level, message FROM e2e_test.events ORDER BY timestamp LIMIT 10');
 
     const { responsePromise, getBody } = await waitForQueryDataResponseWithBody(explorePage);
-    await queryEditorRow(page).getByRole('button', { name: 'Run Query' }).click();
+    await page.locator('.query-editor-row').getByRole('button', { name: 'Run Query' }).click();
 
     await responsePromise;
     expect((getBody() as any)?.results?.A?.frames?.length).toBeGreaterThan(0);
@@ -211,7 +215,7 @@ test.describe('Query editor with fixture data', () => {
     await enterSql(page, 'SELECT count(*) AS total FROM e2e_test.events');
 
     const { responsePromise, getBody } = await waitForQueryDataResponseWithBody(explorePage);
-    await queryEditorRow(page).getByRole('button', { name: 'Run Query' }).click();
+    await page.locator('.query-editor-row').getByRole('button', { name: 'Run Query' }).click();
 
     await responsePromise;
     expect((getBody() as any)?.results?.A?.frames?.length).toBeGreaterThan(0);
@@ -222,7 +226,7 @@ test.describe('Query editor with fixture data', () => {
     await enterSql(page, "SELECT timestamp, message FROM e2e_test.events WHERE level = 'error' ORDER BY timestamp");
 
     const { responsePromise, getBody } = await waitForQueryDataResponseWithBody(explorePage);
-    await queryEditorRow(page).getByRole('button', { name: 'Run Query' }).click();
+    await page.locator('.query-editor-row').getByRole('button', { name: 'Run Query' }).click();
 
     await responsePromise;
     expect((getBody() as any)?.results?.A?.frames?.length).toBeGreaterThan(0);

--- a/tests/e2e/queryEditor.spec.ts
+++ b/tests/e2e/queryEditor.spec.ts
@@ -9,6 +9,12 @@ const PLUGIN_TYPE = 'grafana-clickhouse-datasource';
 // Its presence indicates the local provisioning file and seed fixtures do not apply.
 const isCloudRun = !!process.env.GRAFANA_URL;
 
+// CLOUD_DEFAULT_UID points at `[managed_data_source] - ClickHouse Native (PDC)` on the
+// shared Cloud dev instance. The uid is infra-managed and usually stable, but it can rotate
+// if the datasource is re-provisioned — if Cloud E2E starts failing randomly with
+// datasource-not-found errors, log into the instance, copy the current uid from the
+// /connections/datasources/edit/<uid> URL, and either update this constant or set
+// DS_E2E_UID in the workflow as a quick override.
 const CLOUD_DEFAULT_UID = 'cf1uvcf1yrz0ge';
 const LOCAL_DEFAULT_UID = 'clickhouse-e2e';
 const DATASOURCE_UID = process.env.DS_E2E_UID || (isCloudRun ? CLOUD_DEFAULT_UID : LOCAL_DEFAULT_UID);


### PR DESCRIPTION
The Scheduled Cloud E2E workflow ([cron.yml](.github/workflows/cron.yml)) was failing against the shared `datasourcese2e.grafana-dev.net` instance. Three distinct issues, addressed together:

1. **Grafana 13 splash screen blocked clicks.** `@grafana/plugin-e2e` 3.5.0 added OFREP route interception that disables the splash feature flag at request time — bumping the dep to `^3.5.1` is all that's needed in the plugin repo.
2. **Datasource UID mismatch.** The tests hardcoded `clickhouse-e2e` (from local `provisioning/datasources/clickhouse.yml`), but Cloud has a different UID. We now pick per-environment based on `GRAFANA_URL`, with `DS_E2E_UID` still overriding both if the managed UID ever rotates.
3. **Local-only tests ran on Cloud.** The provisioned-datasource assertions ([configEditor.spec.ts](tests/e2e/configEditor.spec.ts)) and fixture-data queries ([queryEditor.spec.ts](tests/e2e/queryEditor.spec.ts)) depend on the local provisioning file and the `e2e_test.events` seed from [seed.sql](tests/e2e/fixtures/seed.sql). Both now `test.skip` when `GRAFANA_URL` is set.

Also trimmed a couple of things from #1768 that the `plugin-e2e` bump makes unnecessary:
- Dropped `GF_FEATURE_TOGGLES_dashboardNewLayouts=false` from [docker-compose.yml](docker-compose.yml).
- Kept the `splashScreen=false` toggle but added a comment explaining it's only for manual `docker-compose up` dev UX (the runtime OFREP interception handles it for tests).
- Removed the `queryEditorRow()` helper in favor of the stable `.query-editor-row` class selector that works on both Grafana 12 and 13.
