### PR TITLE
fix(e2e): refresh Cloud datasource UID after rotation

### DIFF
--- a/tests/e2e/queryEditor.spec.ts
+++ b/tests/e2e/queryEditor.spec.ts
@@ -10,12 +10,12 @@ const PLUGIN_TYPE = 'grafana-clickhouse-datasource';
 const isCloudRun = !!process.env.GRAFANA_URL;
 
 // CLOUD_DEFAULT_UID points at `[managed_data_source] - ClickHouse Native (PDC)` on the
-// shared Cloud dev instance. The uid is infra-managed and usually stable, but it can rotate
-// if the datasource is re-provisioned — if Cloud E2E starts failing randomly with
-// datasource-not-found errors, log into the instance, copy the current uid from the
-// /connections/datasources/edit/<uid> URL, and either update this constant or set
-// DS_E2E_UID in the workflow as a quick override.
-const CLOUD_DEFAULT_UID = 'cf1uvcf1yrz0ge';
+// shared Cloud dev instance. The infra team uses a stable `clickhouse-{protocol}-ds-m`
+// naming convention, but if the datasource is ever re-provisioned and Cloud E2E starts
+// failing with datasource-not-found errors, log into the instance, copy the current uid
+// from the /connections/datasources/edit/<uid> URL, and update this constant (or set
+// DS_E2E_UID in the workflow as a quick override).
+const CLOUD_DEFAULT_UID = 'clickhouse-native-ds-m';
 const LOCAL_DEFAULT_UID = 'clickhouse-e2e';
 const DATASOURCE_UID = process.env.DS_E2E_UID || (isCloudRun ? CLOUD_DEFAULT_UID : LOCAL_DEFAULT_UID);
 

--- a/tests/e2e/sqlValidation.spec.ts
+++ b/tests/e2e/sqlValidation.spec.ts
@@ -1,9 +1,20 @@
 import { expect, test } from '@grafana/plugin-e2e';
 import { Page } from '@playwright/test';
 
-// Matches the uid set in provisioning/datasources/clickhouse.yml
-const DATASOURCE_UID = 'clickhouse-e2e';
 const PLUGIN_TYPE = 'grafana-clickhouse-datasource';
+
+// GRAFANA_URL is set only by the Cloud cron workflow (see .github/workflows/cron.yml).
+const isCloudRun = !!process.env.GRAFANA_URL;
+
+// CLOUD_DEFAULT_UID points at `[managed_data_source] - ClickHouse Native (PDC)` on the
+// shared Cloud dev instance. The infra team uses a stable `clickhouse-{protocol}-ds-m`
+// naming convention, but if the datasource is ever re-provisioned and Cloud E2E starts
+// failing with datasource-not-found errors, log into the instance, copy the current uid
+// from the /connections/datasources/edit/<uid> URL, and update this constant (or set
+// DS_E2E_UID in the workflow as a quick override).
+const CLOUD_DEFAULT_UID = 'clickhouse-native-ds-m';
+const LOCAL_DEFAULT_UID = 'clickhouse-e2e';
+const DATASOURCE_UID = process.env.DS_E2E_UID || (isCloudRun ? CLOUD_DEFAULT_UID : LOCAL_DEFAULT_UID);
 
 /**
  * Build an Explore URL with an empty SQL query so the editor opens in


### PR DESCRIPTION
## Type of Change

- [x] 🐛 Bug Fix

---

## Bug Fix

### What is the bug?

The Scheduled Cloud E2E run on `main` started failing because `CLOUD_DEFAULT_UID = 'cf1uvcf1yrz0ge'` no longer exists on the shared Cloud dev instance — the managed datasource was re-provisioned. Every queryEditor test fails with the editor never rendering, and `sqlValidation.spec.ts` (added on `main` after the previous fix and hardcoded to `clickhouse-e2e`) fails universally on Cloud since that uid only exists locally.

### How to reproduce

1. Look at https://github.com/grafana/clickhouse-datasource/actions/runs/24882836740
2. queryEditor + sqlValidation tests fail with `getByRole('code')` timeouts (editor never renders because the datasource doesn't exist).

### Related Issues

Follow-up to #1798. No tracking issue — Cloud cron failure surfaced via the scheduled run.

### Environment

- **ClickHouse version**: managed Cloud
- **Grafana version**: 13.1.0 (cloud `rrc-fast` channel)
- **Plugin version**: main

---

## What changed

The instance now exposes a pair of stable, named datasources:

- `clickhouse-native-ds-m` → `[managed_data_source] - ClickHouse Native (PDC)`
- `clickhouse-http-ds-m` → `[managed_data_source] - ClickHouse HTTP (PDC)`

The new naming convention `clickhouse-{protocol}-ds-m` looks deliberately stable, so this should rotate less frequently than before. [tests/e2e/queryEditor.spec.ts](tests/e2e/queryEditor.spec.ts) now points at the Native uid.

[tests/e2e/sqlValidation.spec.ts](tests/e2e/sqlValidation.spec.ts) gets the same `isCloudRun` + `DS_E2E_UID`-override pattern as queryEditor.spec.ts — so it's no longer broken on Cloud.

---

## Please check that:

- [x] Tests for this change have been added/updated.
- [ ] Documentation has been added/updated (where applicable).

## Special notes for your reviewer

The PR is intentionally minimal — just refreshes the UID and applies the existing cloud-aware pattern to sqlValidation. A larger plan to add an HTTP-protocol matrix is being kept out of this PR; we can pick that up separately if HTTP-mode coverage actually catches bugs we care about.

Verified locally: `npm run e2e -- tests/e2e/queryEditor.spec.ts` — 13/13 pass. Verified on the live cloud instance that `clickhouse-native-ds-m` resolves to the right datasource by browsing `/connections/datasources/edit/clickhouse-native-ds-m`.