### PR TITLE
fix(schema): close *sql.DB after each schema introspection query

### DIFF
--- a/pkg/plugin/driver.go
+++ b/pkg/plugin/driver.go
@@ -284,7 +284,13 @@ func (h *Clickhouse) Connect(
 		return nil, backend.DownstreamError(fmt.Errorf("failed to create ClickHouse client"))
 	}
 
-	return db, settings.isValid()
+	// Honor the (nil-resource-on-error) contract so callers can rely on
+	// `if err != nil { return err }` without leaking the *sql.DB.
+	if err := settings.isValid(); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+	return db, nil
 }
 
 // Converters defines list of data type converters

--- a/pkg/plugin/schema.go
+++ b/pkg/plugin/schema.go
@@ -120,6 +120,11 @@ func (p *SchemaProvider) fetchTables(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer func() {
+		if err := ds.Close(); err != nil {
+			backend.Logger.Error("failed to close database connection", "error", err)
+		}
+	}()
 
 	rows, err := ds.QueryContext(ctx, "SELECT database, name FROM system.tables ORDER BY database, name")
 	if err != nil {
@@ -267,6 +272,11 @@ func (p *SchemaProvider) fetchColumnsForAllTables(ctx context.Context, tables []
 	if err != nil {
 		return nil, err
 	}
+	defer func() {
+		if err := ds.Close(); err != nil {
+			backend.Logger.Error("failed to close database connection", "error", err)
+		}
+	}()
 
 	var currentDb string
 	if len(tableOnlyNames) > 0 {
@@ -324,6 +334,11 @@ func (p *SchemaProvider) fetchColumnsForTable(ctx context.Context, table string,
 	if err != nil {
 		return nil, err
 	}
+	defer func() {
+		if err := ds.Close(); err != nil {
+			backend.Logger.Error("failed to close database connection", "error", err)
+		}
+	}()
 	rows, err := ds.QueryContext(ctx, rawSQL)
 	if err != nil {
 		return nil, err
@@ -334,9 +349,6 @@ func (p *SchemaProvider) fetchColumnsForTable(ctx context.Context, table string,
 		}
 	}()
 	cols := make([]schemas.Column, 0)
-	if err != nil {
-		return nil, err
-	}
 	for rows.Next() {
 		var name string
 		var chType string

--- a/pkg/plugin/schema.go
+++ b/pkg/plugin/schema.go
@@ -2,6 +2,8 @@ package plugin
 
 import (
 	"context"
+	"database/sql"
+	"encoding/json"
 	"fmt"
 	"sort"
 	"strings"
@@ -11,6 +13,11 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	schemas "github.com/grafana/schemads"
 )
+
+// dbConnector is the SchemaProvider's view of Clickhouse, narrowed for tests.
+type dbConnector interface {
+	Connect(ctx context.Context, config backend.DataSourceInstanceSettings, message json.RawMessage) (*sql.DB, error)
+}
 
 var (
 	numberOperators = []schemas.Operator{
@@ -44,7 +51,7 @@ var (
 )
 
 type SchemaProvider struct {
-	clickhousePlugin *Clickhouse
+	clickhousePlugin dbConnector
 	settings         backend.DataSourceInstanceSettings
 
 	// The three caches below are populated from datasource settings at

--- a/pkg/plugin/schema_test.go
+++ b/pkg/plugin/schema_test.go
@@ -1,0 +1,330 @@
+package plugin
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"encoding/json"
+	"errors"
+	"io"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+)
+
+// trackingConnector hands out *sql.DBs and records them so tests can assert
+// each one was closed (OpenConnections == 0) after the call returned.
+type trackingConnector struct {
+	mu       sync.Mutex
+	opened   []*sql.DB
+	connErr  error                                 // injected error from Connect
+	rowsFn   func(query string) (driver.Rows, error) // injected Query handler
+	connects atomic.Int32
+}
+
+func (t *trackingConnector) Connect(_ context.Context, _ backend.DataSourceInstanceSettings, _ json.RawMessage) (*sql.DB, error) {
+	t.connects.Add(1)
+	if t.connErr != nil {
+		return nil, t.connErr
+	}
+	db := sql.OpenDB(&fakeDriverConnector{rowsFn: t.rowsFn})
+	t.mu.Lock()
+	t.opened = append(t.opened, db)
+	t.mu.Unlock()
+	return db, nil
+}
+
+// allClosed: zero open conns on a fresh pool ⇒ DB.Close() ran.
+func (t *trackingConnector) allClosed() bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	for _, db := range t.opened {
+		if db.Stats().OpenConnections != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func (t *trackingConnector) openedCount() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return len(t.opened)
+}
+
+// Minimal driver/connector implementing only what schema.go touches.
+
+type fakeDriverConnector struct {
+	rowsFn func(query string) (driver.Rows, error)
+}
+
+func (c *fakeDriverConnector) Connect(context.Context) (driver.Conn, error) {
+	return &fakeConn{rowsFn: c.rowsFn}, nil
+}
+func (c *fakeDriverConnector) Driver() driver.Driver { return fakeDriver{} }
+
+type fakeDriver struct{}
+
+func (fakeDriver) Open(string) (driver.Conn, error) { return nil, errors.New("unused") }
+
+type fakeConn struct {
+	rowsFn func(query string) (driver.Rows, error)
+}
+
+func (c *fakeConn) Prepare(string) (driver.Stmt, error) { return nil, errors.New("not implemented") }
+func (c *fakeConn) Close() error                        { return nil }
+func (c *fakeConn) Begin() (driver.Tx, error)           { return nil, errors.New("not implemented") }
+
+// QueryerContext lets database/sql skip Prepare.
+func (c *fakeConn) QueryContext(_ context.Context, query string, _ []driver.NamedValue) (driver.Rows, error) {
+	return c.rowsFn(query)
+}
+
+type fakeRows struct {
+	cols []string
+	data [][]driver.Value
+	idx  int
+}
+
+func (r *fakeRows) Columns() []string { return r.cols }
+func (r *fakeRows) Close() error      { return nil }
+func (r *fakeRows) Next(dest []driver.Value) error {
+	if r.idx >= len(r.data) {
+		return io.EOF
+	}
+	row := r.data[r.idx]
+	for i := range dest {
+		dest[i] = row[i]
+	}
+	r.idx++
+	return nil
+}
+
+func newProvider(t *testing.T, conn *trackingConnector) *SchemaProvider {
+	t.Helper()
+	return &SchemaProvider{
+		clickhousePlugin: conn,
+		settings:         backend.DataSourceInstanceSettings{},
+	}
+}
+
+func tablesRows() (driver.Rows, error) {
+	return &fakeRows{
+		cols: []string{"database", "name"},
+		data: [][]driver.Value{
+			{"default", "users"},
+			{"default", "events"},
+			{"system", "tables"}, // skipped by schema.go
+		},
+	}, nil
+}
+
+func columnsRows() (driver.Rows, error) {
+	return &fakeRows{
+		cols: []string{"database", "table", "name", "type", "comment"},
+		data: [][]driver.Value{
+			{"default", "users", "id", "UInt64", ""},
+			{"default", "users", "name", "String", "user display name"},
+		},
+	}, nil
+}
+
+func describeRows() (driver.Rows, error) {
+	return &fakeRows{
+		cols: []string{"name", "type", "default_type", "default_expression", "comment", "codec_expression", "ttl_expression"},
+		data: [][]driver.Value{
+			{"id", "UInt64", "", "", "", "", ""},
+			{"name", "String", "", "", "", "", ""},
+		},
+	}, nil
+}
+
+func TestFetchTables_ClosesDB_OnSuccess(t *testing.T) {
+	conn := &trackingConnector{rowsFn: func(string) (driver.Rows, error) { return tablesRows() }}
+	p := newProvider(t, conn)
+
+	tables, err := p.fetchTables(context.Background())
+	if err != nil {
+		t.Fatalf("fetchTables: %v", err)
+	}
+	if want := []string{"default.users", "default.events"}; !equalStrings(tables, want) {
+		t.Errorf("tables = %v, want %v", tables, want)
+	}
+	if conn.openedCount() != 1 {
+		t.Errorf("opened DBs = %d, want 1", conn.openedCount())
+	}
+	if !conn.allClosed() {
+		t.Errorf("DB was not closed after fetchTables; OpenConnections != 0")
+	}
+}
+
+func TestFetchTables_ClosesDB_OnQueryError(t *testing.T) {
+	conn := &trackingConnector{rowsFn: func(string) (driver.Rows, error) {
+		return nil, errors.New("query failed")
+	}}
+	p := newProvider(t, conn)
+
+	if _, err := p.fetchTables(context.Background()); err == nil {
+		t.Fatal("fetchTables: expected error, got nil")
+	}
+	if !conn.allClosed() {
+		t.Errorf("DB was not closed after query error; leak in error path")
+	}
+}
+
+func TestFetchTables_ConnectError_NoDBToClose(t *testing.T) {
+	conn := &trackingConnector{connErr: errors.New("connect failed")}
+	p := newProvider(t, conn)
+
+	if _, err := p.fetchTables(context.Background()); err == nil {
+		t.Fatal("fetchTables: expected connect error, got nil")
+	}
+	if got := conn.openedCount(); got != 0 {
+		t.Errorf("opened DBs = %d, want 0 (no DB on connect failure)", got)
+	}
+}
+
+func TestFetchColumnsForAllTables_ClosesDB_OnSuccess(t *testing.T) {
+	conn := &trackingConnector{rowsFn: func(string) (driver.Rows, error) { return columnsRows() }}
+	p := newProvider(t, conn)
+
+	cols, err := p.fetchColumnsForAllTables(context.Background(), []string{"default.users"}, nil)
+	if err != nil {
+		t.Fatalf("fetchColumnsForAllTables: %v", err)
+	}
+	if got := len(cols["default.users"]); got != 2 {
+		t.Errorf("default.users columns = %d, want 2", got)
+	}
+	if !conn.allClosed() {
+		t.Error("DB was not closed after fetchColumnsForAllTables")
+	}
+}
+
+func TestFetchColumnsForAllTables_ClosesDB_OnQueryError(t *testing.T) {
+	conn := &trackingConnector{rowsFn: func(string) (driver.Rows, error) {
+		return nil, errors.New("query failed")
+	}}
+	p := newProvider(t, conn)
+
+	if _, err := p.fetchColumnsForAllTables(context.Background(), []string{"default.users"}, nil); err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !conn.allClosed() {
+		t.Error("DB was not closed after query error")
+	}
+}
+
+func TestFetchColumnsForTable_ClosesDB_OnSuccess(t *testing.T) {
+	conn := &trackingConnector{rowsFn: func(string) (driver.Rows, error) { return describeRows() }}
+	p := newProvider(t, conn)
+
+	cols, err := p.fetchColumnsForTable(context.Background(), "default.users", nil)
+	if err != nil {
+		t.Fatalf("fetchColumnsForTable: %v", err)
+	}
+	if len(cols) != 2 {
+		t.Errorf("columns = %d, want 2", len(cols))
+	}
+	if !conn.allClosed() {
+		t.Error("DB was not closed after fetchColumnsForTable")
+	}
+}
+
+func TestFetchColumnsForTable_ClosesDB_OnQueryError(t *testing.T) {
+	conn := &trackingConnector{rowsFn: func(string) (driver.Rows, error) {
+		return nil, errors.New("query failed")
+	}}
+	p := newProvider(t, conn)
+
+	if _, err := p.fetchColumnsForTable(context.Background(), "default.users", nil); err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !conn.allClosed() {
+		t.Error("DB was not closed after query error")
+	}
+}
+
+// Run with -race; catches any sync issue around the new close defers.
+func TestSchema_Concurrent_NoRace(t *testing.T) {
+	conn := &trackingConnector{rowsFn: func(query string) (driver.Rows, error) {
+		switch {
+		case containsAny(query, "system.tables"):
+			return tablesRows()
+		case containsAny(query, "system.columns"):
+			return columnsRows()
+		case containsAny(query, "DESCRIBE"):
+			return describeRows()
+		}
+		return &fakeRows{cols: []string{"x"}, data: [][]driver.Value{{int64(1)}}}, nil
+	}}
+	p := newProvider(t, conn)
+
+	const goroutines = 16
+	const iterations = 25
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for range goroutines {
+		go func() {
+			defer wg.Done()
+			for range iterations {
+				if _, err := p.fetchTables(context.Background()); err != nil {
+					t.Errorf("fetchTables: %v", err)
+					return
+				}
+				if _, err := p.fetchColumnsForAllTables(context.Background(), []string{"default.users"}, nil); err != nil {
+					t.Errorf("fetchColumnsForAllTables: %v", err)
+					return
+				}
+				if _, err := p.fetchColumnsForTable(context.Background(), "default.users", nil); err != nil {
+					t.Errorf("fetchColumnsForTable: %v", err)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+
+	if !conn.allClosed() {
+		t.Errorf("after %d concurrent calls, %d DBs still hold connections",
+			goroutines*iterations*3, leakedCount(conn))
+	}
+}
+
+func leakedCount(c *trackingConnector) int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	leaked := 0
+	for _, db := range c.opened {
+		if db.Stats().OpenConnections != 0 {
+			leaked++
+		}
+	}
+	return leaked
+}
+
+func containsAny(s string, sub string) bool {
+	return len(s) >= len(sub) && indexOf(s, sub) >= 0
+}
+
+func indexOf(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
## Type of Change

- [x] 🐛 Bug Fix

---

## Bug Fix

### What is the bug?

Three of the four schema-introspection paths in `SchemaProvider` open a `*sql.DB` via `Clickhouse.Connect` and never close it:

| Function | Closes `ds`? |
| --- | --- |
| `fetchTables` ([schema.go:118](https://github.com/grafana/clickhouse-datasource/blob/main/pkg/plugin/schema.go#L118)) | ❌ |
| `fetchColumnsForAllTables` ([schema.go:229](https://github.com/grafana/clickhouse-datasource/blob/main/pkg/plugin/schema.go#L229)) | ❌ |
| `fetchColumnsForTable` ([schema.go:320](https://github.com/grafana/clickhouse-datasource/blob/main/pkg/plugin/schema.go#L320)) | ❌ |
| `fetchColumnValues` ([schema.go:464](https://github.com/grafana/clickhouse-datasource/blob/main/pkg/plugin/schema.go#L464)) | ✅ |

Every cache miss therefore leaves a fresh `*sql.DB` reachable from GC. Each leaked DB carries:

- A new `*tls.Config` with freshly-parsed `X509KeyPair` and `AppendCertsFromPEM`.
- A new connection pool inside `clickhouse-go`, with TLS-configured connections.
- Per-conn `bytes.Buffer` instances retained at peak size by `clickhouse-go`'s HTTP transport.
- Per-conn `flate.Writer` instances allocated for response decompression.

In a heap profile of a busy deployment the three corresponding hot paths (`x509.parseCertificate` / `pem.Decode`, `bytes.(*Buffer).grow`, `flate.NewWriter`) accumulated proportionally to query volume, with RSS climbing steadily until the pod was replaced. The schema cache from #1787 reduces miss frequency but does not bound the leak — each miss still leaks one DB.

### How to reproduce

1. Enable schema caching with the default 60s TTL.
2. Drive a workload that produces unique schema-cache keys (different ad-hoc filter table sets, different column-list requests).
3. Watch the plugin RSS climb monotonically over hours; check `pprof heap` and look for retained `clickhouse.HTTPClient` / `tls.Config` instances rooted in goroutines that never exit.

### Related Issues

Internal investigation reported in conversation; no public issue.

### Environment

- **Plugin version**: v4.16.0 (any version on which the schema-cache code path exists; pre-cache versions had the same leak driven by every query rather than every miss).

---

## What changed

**1. Close the leaked `*sql.DB` at three sites.** Add a deferred `ds.Close()` to `fetchTables`, `fetchColumnsForAllTables`, and `fetchColumnsForTable`, mirroring the existing pattern already in `fetchColumnValues`:

```go
defer func() {
    if err := ds.Close(); err != nil {
        backend.Logger.Error("failed to close database connection", "error", err)
    }
}()
```

Also drop a dead `if err != nil { return nil, err }` block that `staticcheck` was flagging (`nilness: impossible condition`).

**2. Tighten Connect's contract.** `Clickhouse.Connect` previously returned `db, settings.isValid()` — non-nil DB *and* non-nil error in the corner case. Replaced with the standard Go convention "non-nil err implies nil resource":

```go
if err := settings.isValid(); err != nil {
    _ = db.Close()
    return nil, err
}
return db, nil
```

The branch is unreachable today (a successful `PingContext` implies a non-empty `Host:Port` that `isValid` would have already accepted), but on paper the contract was leaky and callers couldn't rely on `if err != nil { return err }`. This change makes the contract honest for every Connect caller (including `sqlds`).

**3. Tests.** Adds `pkg/plugin/schema_test.go` with a stdlib-only fake driver/connector pair. No new dependency. Covers:

- Success path closes the DB (`fetchTables`, `fetchColumnsForAllTables`, `fetchColumnsForTable`).
- Query error path still closes the DB (cleanup runs on error returns).
- Connect error path opens no DB (nothing to close).
- Concurrent invocation across all three fetches is race-clean (`go test -race`).

To enable testability without sqlmock or testcontainers, `SchemaProvider.clickhousePlugin` is narrowed from `*Clickhouse` to a small consumer-defined `dbConnector` interface. `*Clickhouse` continues to satisfy it via duck typing; constructor signature unchanged; no caller updates needed.

## Validation

- `go test -race ./pkg/...` clean.
- `go vet ./...` clean.
- `go build ./...` clean.
- `cspell` clean on all changed files.

## Please check that:

- [x] Tests for this change have been added/updated.
- [x] Documentation has been added/updated (where applicable).

## Special notes for your reviewer

- The longer-term fix is to hold a single `*sql.DB` on `SchemaProvider`, constructed once from `p.settings` and reused for the lifetime of the provider. That would also collapse TLS parsing to once per provider instead of once per uncached query, and is what `clickhouse-go`'s connection pool is designed for. Out of scope here; happy to follow up.
- The `bytes.Buffer` and `flate.NewWriter` accumulation are properties of `clickhouse-go`'s HTTP transport and require an upstream change there to fully resolve. This PR removes the multiplier (number of leaked pools) so the per-conn cost stays bounded by the pool we keep.
- The Connect-contract branch is not directly exercisable today because the only path that can hit it (`isValid` returning non-nil after a successful ping) is contradictory in practice. The fix is defensive against future ordering changes; explicit unit coverage would require restructuring `Connect` purely to make the dead branch reachable, which is worse than the comment we have.