### PR TITLE
perf(schema): hold a single *sql.DB on SchemaProvider, dispose with the instance

### DIFF
--- a/pkg/plugin/datasource.go
+++ b/pkg/plugin/datasource.go
@@ -9,6 +9,22 @@ import (
 	"github.com/grafana/sqlds/v5"
 )
 
+// clickhouseInstance wraps the sqlds-managed instance so its Dispose also
+// closes the SchemaProvider's shared *sql.DB. Embedding *sqlds.SQLDatasource
+// promotes every handler method (QueryData, CheckHealth, CallResource, …) so
+// type assertions on instancemgmt.Instance keep working unchanged.
+type clickhouseInstance struct {
+	*sqlds.SQLDatasource
+	schema *SchemaProvider
+}
+
+func (i *clickhouseInstance) Dispose() {
+	i.SQLDatasource.Dispose()
+	if err := i.schema.Close(); err != nil {
+		backend.Logger.Error("failed to close schema provider", "error", err)
+	}
+}
+
 func NewDatasource(ctx context.Context, settings backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
 	clickhousePlugin := Clickhouse{}
 	ds := sqlds.NewDatasource(&clickhousePlugin)
@@ -29,5 +45,16 @@ func NewDatasource(ctx context.Context, settings backend.DataSourceInstanceSetti
 		)
 	}
 
-	return ds.NewDatasource(ctx, settings)
+	inst, err := ds.NewDatasource(ctx, settings)
+	if err != nil {
+		return nil, err
+	}
+	sqlInst, ok := inst.(*sqlds.SQLDatasource)
+	if !ok {
+		// Defensive: if sqlds ever returns a different concrete type we can't
+		// embed it cleanly. Fall back to the unwrapped instance — the schema
+		// DB will then leak on settings change but the plugin still works.
+		return inst, nil
+	}
+	return &clickhouseInstance{SQLDatasource: sqlInst, schema: schemaProvider}, nil
 }

--- a/pkg/plugin/driver_integration_test.go
+++ b/pkg/plugin/driver_integration_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/grafana/grafana-plugin-sdk-go/data/sqlutil"
-	"github.com/grafana/sqlds/v5"
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1327,8 +1326,8 @@ func TestHTTPConnectWithHeaders(t *testing.T) {
 		dsInstance, err := NewDatasource(ctx, settings)
 		assert.Equal(t, nil, err)
 
-		ds, ok := dsInstance.(*sqlds.SQLDatasource)
-		assert.Equal(t, true, ok)
+		ds, ok := dsInstance.(backend.QueryDataHandler)
+		require.True(t, ok, "instance must implement backend.QueryDataHandler")
 
 		// We test that the X-Test header is absent
 		req.PluginContext.DataSourceInstanceSettings = &settings
@@ -1344,8 +1343,8 @@ func TestHTTPConnectWithHeaders(t *testing.T) {
 		dsInstance, err := NewDatasource(ctx, settings)
 		assert.Equal(t, nil, err)
 
-		ds, ok := dsInstance.(*sqlds.SQLDatasource)
-		assert.Equal(t, true, ok)
+		ds, ok := dsInstance.(backend.QueryDataHandler)
+		require.True(t, ok, "instance must implement backend.QueryDataHandler")
 
 		// We test that the X-Test header exists
 		proxy.NonproxyHandler = proxyHandlerGenerator(t, map[string]string{"X-Test": "Hello World!"})
@@ -1361,8 +1360,8 @@ func TestHTTPConnectWithHeaders(t *testing.T) {
 		dsInstance, err := NewDatasource(ctx, settings)
 		assert.Equal(t, nil, err)
 
-		ds, ok := dsInstance.(*sqlds.SQLDatasource)
-		assert.Equal(t, true, ok)
+		ds, ok := dsInstance.(backend.QueryDataHandler)
+		require.True(t, ok, "instance must implement backend.QueryDataHandler")
 
 		// We test that the X-Test header exists
 		proxy.NonproxyHandler = proxyHandlerGenerator(t, map[string]string{"custom-test-header": "value-1", "X-Test": "Hello World!"})
@@ -1378,8 +1377,8 @@ func TestHTTPConnectWithHeaders(t *testing.T) {
 		dsInstance, err := NewDatasource(ctx, settings)
 		assert.Equal(t, nil, err)
 
-		ds, ok := dsInstance.(*sqlds.SQLDatasource)
-		assert.Equal(t, true, ok)
+		ds, ok := dsInstance.(backend.QueryDataHandler)
+		require.True(t, ok, "instance must implement backend.QueryDataHandler")
 
 		// We test that the X-Test header exists
 		proxy.NonproxyHandler = proxyHandlerGenerator(t, map[string]string{"X-Test": "Override"})

--- a/pkg/plugin/schema.go
+++ b/pkg/plugin/schema.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/grafana/clickhouse-datasource/pkg/plugin/schemacache"
@@ -54,12 +55,47 @@ type SchemaProvider struct {
 	clickhousePlugin dbConnector
 	settings         backend.DataSourceInstanceSettings
 
+	// db is the long-lived *sql.DB shared by every schema introspection call.
+	// Lazily built on first use under dbMu and closed by Close. nil after Close.
+	dbMu sync.Mutex
+	db   *sql.DB
+
 	// The three caches below are populated from datasource settings at
 	// construction time. A nil cache means caching is disabled for that
 	// handler — the handler code must treat nil as "always miss, no set".
 	tablesCache  *schemacache.Cache[[]string]
 	columnsCache *schemacache.Cache[map[string][]schemas.Column]
 	valuesCache  *schemacache.Cache[map[string][]string]
+}
+
+// getDB returns the provider's shared *sql.DB, building it on first use.
+// On Connect failure the result is not cached so transient errors recover on
+// the next call. After Close, getDB rebuilds — Close is intended for shutdown
+// but the contract stays simple either way.
+func (p *SchemaProvider) getDB(ctx context.Context) (*sql.DB, error) {
+	p.dbMu.Lock()
+	defer p.dbMu.Unlock()
+	if p.db != nil {
+		return p.db, nil
+	}
+	db, err := p.clickhousePlugin.Connect(ctx, p.settings, nil)
+	if err != nil {
+		return nil, err
+	}
+	p.db = db
+	return db, nil
+}
+
+// Close releases the shared *sql.DB. Safe to call multiple times.
+func (p *SchemaProvider) Close() error {
+	p.dbMu.Lock()
+	defer p.dbMu.Unlock()
+	if p.db == nil {
+		return nil
+	}
+	err := p.db.Close()
+	p.db = nil
+	return err
 }
 
 // Schema implements [schemas.SchemaHandler].
@@ -123,15 +159,10 @@ func (p *SchemaProvider) Tables(ctx context.Context, req *schemas.TablesRequest)
 // singleflight-collapsed caller can reuse the same code path as a
 // cache-disabled caller.
 func (p *SchemaProvider) fetchTables(ctx context.Context) ([]string, error) {
-	ds, err := p.clickhousePlugin.Connect(ctx, p.settings, nil)
+	ds, err := p.getDB(ctx)
 	if err != nil {
 		return nil, err
 	}
-	defer func() {
-		if err := ds.Close(); err != nil {
-			backend.Logger.Error("failed to close database connection", "error", err)
-		}
-	}()
 
 	rows, err := ds.QueryContext(ctx, "SELECT database, name FROM system.tables ORDER BY database, name")
 	if err != nil {
@@ -275,15 +306,10 @@ func (p *SchemaProvider) fetchColumnsForAllTables(ctx context.Context, tables []
 	rawSQL := fmt.Sprintf("SELECT database, table, name, type, comment FROM system.columns WHERE %s ORDER BY database, table, position",
 		strings.Join(whereParts, " OR "))
 
-	ds, err := p.clickhousePlugin.Connect(ctx, p.settings, nil)
+	ds, err := p.getDB(ctx)
 	if err != nil {
 		return nil, err
 	}
-	defer func() {
-		if err := ds.Close(); err != nil {
-			backend.Logger.Error("failed to close database connection", "error", err)
-		}
-	}()
 
 	var currentDb string
 	if len(tableOnlyNames) > 0 {
@@ -337,15 +363,10 @@ func (p *SchemaProvider) fetchColumnsForAllTables(ctx context.Context, tables []
 func (p *SchemaProvider) fetchColumnsForTable(ctx context.Context, table string, headers map[string]string) ([]schemas.Column, error) {
 	database, table := splitTable(table)
 	rawSQL := fmt.Sprintf("DESCRIBE TABLE \"%s\".\"%s\"", database, table)
-	ds, err := p.clickhousePlugin.Connect(ctx, p.settings, nil)
+	ds, err := p.getDB(ctx)
 	if err != nil {
 		return nil, err
 	}
-	defer func() {
-		if err := ds.Close(); err != nil {
-			backend.Logger.Error("failed to close database connection", "error", err)
-		}
-	}()
 	rows, err := ds.QueryContext(ctx, rawSQL)
 	if err != nil {
 		return nil, err
@@ -481,15 +502,10 @@ func (p *SchemaProvider) ColumnValues(ctx context.Context, req *schemas.ColumnVa
 // fetchColumnValues runs the DISTINCT-per-column UNION ALL probe. It is the
 // function wrapped by the cache in [SchemaProvider.ColumnValues].
 func (p *SchemaProvider) fetchColumnValues(ctx context.Context, table string, requestedColumns []string) (map[string][]string, error) {
-	ds, err := p.clickhousePlugin.Connect(ctx, p.settings, nil)
+	ds, err := p.getDB(ctx)
 	if err != nil {
 		return nil, err
 	}
-	defer func() {
-		if err := ds.Close(); err != nil {
-			backend.Logger.Error("failed to close database connection", "error", err)
-		}
-	}()
 
 	columns := requestedColumns
 	if len(columns) == 0 {

--- a/pkg/plugin/schema_test.go
+++ b/pkg/plugin/schema_test.go
@@ -15,11 +15,11 @@ import (
 )
 
 // trackingConnector hands out *sql.DBs and records them so tests can assert
-// each one was closed (OpenConnections == 0) after the call returned.
+// reuse (one DB across calls) and Close behavior at end-of-life.
 type trackingConnector struct {
 	mu       sync.Mutex
 	opened   []*sql.DB
-	connErr  error                                 // injected error from Connect
+	connErr  error                                   // injected error from Connect
 	rowsFn   func(query string) (driver.Rows, error) // injected Query handler
 	connects atomic.Int32
 }
@@ -36,7 +36,7 @@ func (t *trackingConnector) Connect(_ context.Context, _ backend.DataSourceInsta
 	return db, nil
 }
 
-// allClosed: zero open conns on a fresh pool ⇒ DB.Close() ran.
+// allClosed: zero open conns on every handed-out pool ⇒ DB.Close() ran.
 func (t *trackingConnector) allClosed() bool {
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -141,7 +141,9 @@ func describeRows() (driver.Rows, error) {
 	}, nil
 }
 
-func TestFetchTables_ClosesDB_OnSuccess(t *testing.T) {
+// --- success paths still return correct data ---
+
+func TestFetchTables_Success(t *testing.T) {
 	conn := &trackingConnector{rowsFn: func(string) (driver.Rows, error) { return tablesRows() }}
 	p := newProvider(t, conn)
 
@@ -152,41 +154,9 @@ func TestFetchTables_ClosesDB_OnSuccess(t *testing.T) {
 	if want := []string{"default.users", "default.events"}; !equalStrings(tables, want) {
 		t.Errorf("tables = %v, want %v", tables, want)
 	}
-	if conn.openedCount() != 1 {
-		t.Errorf("opened DBs = %d, want 1", conn.openedCount())
-	}
-	if !conn.allClosed() {
-		t.Errorf("DB was not closed after fetchTables; OpenConnections != 0")
-	}
 }
 
-func TestFetchTables_ClosesDB_OnQueryError(t *testing.T) {
-	conn := &trackingConnector{rowsFn: func(string) (driver.Rows, error) {
-		return nil, errors.New("query failed")
-	}}
-	p := newProvider(t, conn)
-
-	if _, err := p.fetchTables(context.Background()); err == nil {
-		t.Fatal("fetchTables: expected error, got nil")
-	}
-	if !conn.allClosed() {
-		t.Errorf("DB was not closed after query error; leak in error path")
-	}
-}
-
-func TestFetchTables_ConnectError_NoDBToClose(t *testing.T) {
-	conn := &trackingConnector{connErr: errors.New("connect failed")}
-	p := newProvider(t, conn)
-
-	if _, err := p.fetchTables(context.Background()); err == nil {
-		t.Fatal("fetchTables: expected connect error, got nil")
-	}
-	if got := conn.openedCount(); got != 0 {
-		t.Errorf("opened DBs = %d, want 0 (no DB on connect failure)", got)
-	}
-}
-
-func TestFetchColumnsForAllTables_ClosesDB_OnSuccess(t *testing.T) {
+func TestFetchColumnsForAllTables_Success(t *testing.T) {
 	conn := &trackingConnector{rowsFn: func(string) (driver.Rows, error) { return columnsRows() }}
 	p := newProvider(t, conn)
 
@@ -197,26 +167,9 @@ func TestFetchColumnsForAllTables_ClosesDB_OnSuccess(t *testing.T) {
 	if got := len(cols["default.users"]); got != 2 {
 		t.Errorf("default.users columns = %d, want 2", got)
 	}
-	if !conn.allClosed() {
-		t.Error("DB was not closed after fetchColumnsForAllTables")
-	}
 }
 
-func TestFetchColumnsForAllTables_ClosesDB_OnQueryError(t *testing.T) {
-	conn := &trackingConnector{rowsFn: func(string) (driver.Rows, error) {
-		return nil, errors.New("query failed")
-	}}
-	p := newProvider(t, conn)
-
-	if _, err := p.fetchColumnsForAllTables(context.Background(), []string{"default.users"}, nil); err == nil {
-		t.Fatal("expected error, got nil")
-	}
-	if !conn.allClosed() {
-		t.Error("DB was not closed after query error")
-	}
-}
-
-func TestFetchColumnsForTable_ClosesDB_OnSuccess(t *testing.T) {
+func TestFetchColumnsForTable_Success(t *testing.T) {
 	conn := &trackingConnector{rowsFn: func(string) (driver.Rows, error) { return describeRows() }}
 	p := newProvider(t, conn)
 
@@ -227,12 +180,33 @@ func TestFetchColumnsForTable_ClosesDB_OnSuccess(t *testing.T) {
 	if len(cols) != 2 {
 		t.Errorf("columns = %d, want 2", len(cols))
 	}
-	if !conn.allClosed() {
-		t.Error("DB was not closed after fetchColumnsForTable")
+}
+
+// --- query-error paths still surface the error and don't cache it ---
+
+func TestFetchTables_QueryErrorIsReturned(t *testing.T) {
+	conn := &trackingConnector{rowsFn: func(string) (driver.Rows, error) {
+		return nil, errors.New("query failed")
+	}}
+	p := newProvider(t, conn)
+
+	if _, err := p.fetchTables(context.Background()); err == nil {
+		t.Fatal("fetchTables: expected error, got nil")
 	}
 }
 
-func TestFetchColumnsForTable_ClosesDB_OnQueryError(t *testing.T) {
+func TestFetchColumnsForAllTables_QueryErrorIsReturned(t *testing.T) {
+	conn := &trackingConnector{rowsFn: func(string) (driver.Rows, error) {
+		return nil, errors.New("query failed")
+	}}
+	p := newProvider(t, conn)
+
+	if _, err := p.fetchColumnsForAllTables(context.Background(), []string{"default.users"}, nil); err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestFetchColumnsForTable_QueryErrorIsReturned(t *testing.T) {
 	conn := &trackingConnector{rowsFn: func(string) (driver.Rows, error) {
 		return nil, errors.New("query failed")
 	}}
@@ -241,12 +215,135 @@ func TestFetchColumnsForTable_ClosesDB_OnQueryError(t *testing.T) {
 	if _, err := p.fetchColumnsForTable(context.Background(), "default.users", nil); err == nil {
 		t.Fatal("expected error, got nil")
 	}
-	if !conn.allClosed() {
-		t.Error("DB was not closed after query error")
+}
+
+// --- held-DB lifecycle ---
+
+func TestGetDB_ReusedAcrossCalls(t *testing.T) {
+	conn := &trackingConnector{rowsFn: func(query string) (driver.Rows, error) {
+		switch {
+		case containsAny(query, "system.tables"):
+			return tablesRows()
+		case containsAny(query, "system.columns"):
+			return columnsRows()
+		case containsAny(query, "DESCRIBE"):
+			return describeRows()
+		}
+		return &fakeRows{cols: []string{"x"}, data: [][]driver.Value{{int64(1)}}}, nil
+	}}
+	p := newProvider(t, conn)
+
+	if _, err := p.fetchTables(context.Background()); err != nil {
+		t.Fatalf("fetchTables: %v", err)
+	}
+	if _, err := p.fetchColumnsForAllTables(context.Background(), []string{"default.users"}, nil); err != nil {
+		t.Fatalf("fetchColumnsForAllTables: %v", err)
+	}
+	if _, err := p.fetchColumnsForTable(context.Background(), "default.users", nil); err != nil {
+		t.Fatalf("fetchColumnsForTable: %v", err)
+	}
+
+	if got := conn.openedCount(); got != 1 {
+		t.Errorf("opened DBs = %d, want 1 (held DB should be reused)", got)
+	}
+	if got := conn.connects.Load(); got != 1 {
+		t.Errorf("Connect calls = %d, want 1", got)
 	}
 }
 
-// Run with -race; catches any sync issue around the new close defers.
+func TestGetDB_ConnectErrorNotCached(t *testing.T) {
+	rows := func(string) (driver.Rows, error) { return tablesRows() }
+	conn := &trackingConnector{rowsFn: rows, connErr: errors.New("transient")}
+	p := newProvider(t, conn)
+
+	// First call fails because Connect errors.
+	if _, err := p.fetchTables(context.Background()); err == nil {
+		t.Fatal("expected connect error, got nil")
+	}
+
+	// Recover from the transient error and retry; the provider must call
+	// Connect again (no sticky cached error).
+	conn.connErr = nil
+	if _, err := p.fetchTables(context.Background()); err != nil {
+		t.Fatalf("retry: %v", err)
+	}
+	if got := conn.connects.Load(); got != 2 {
+		t.Errorf("Connect calls = %d, want 2 (one failed, one succeeded)", got)
+	}
+	if got := conn.openedCount(); got != 1 {
+		t.Errorf("opened DBs = %d, want 1", got)
+	}
+}
+
+func TestClose_ClosesHeldDBAndIsIdempotent(t *testing.T) {
+	conn := &trackingConnector{rowsFn: func(string) (driver.Rows, error) { return tablesRows() }}
+	p := newProvider(t, conn)
+
+	if _, err := p.fetchTables(context.Background()); err != nil {
+		t.Fatalf("fetchTables: %v", err)
+	}
+	if conn.allClosed() {
+		t.Fatal("DB closed before Close was called; held-DB invariant broken")
+	}
+
+	if err := p.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if !conn.allClosed() {
+		t.Error("Close did not close the held DB")
+	}
+
+	// Idempotent: a second Close on a provider with no held DB is a no-op.
+	if err := p.Close(); err != nil {
+		t.Errorf("second Close: %v", err)
+	}
+}
+
+func TestClose_WithoutAnyFetchIsNoOp(t *testing.T) {
+	conn := &trackingConnector{rowsFn: func(string) (driver.Rows, error) { return tablesRows() }}
+	p := newProvider(t, conn)
+
+	if err := p.Close(); err != nil {
+		t.Errorf("Close on never-used provider: %v", err)
+	}
+	if got := conn.openedCount(); got != 0 {
+		t.Errorf("opened DBs = %d, want 0", got)
+	}
+}
+
+// TestGetDB_ConcurrentFirstUse asserts that under simultaneous first-call
+// pressure the provider builds exactly one DB. Run with -race.
+func TestGetDB_ConcurrentFirstUse(t *testing.T) {
+	conn := &trackingConnector{rowsFn: func(string) (driver.Rows, error) { return tablesRows() }}
+	p := newProvider(t, conn)
+
+	const goroutines = 32
+	var ready, start sync.WaitGroup
+	ready.Add(goroutines)
+	start.Add(1)
+	errs := make(chan error, goroutines)
+	for range goroutines {
+		go func() {
+			ready.Done()
+			start.Wait()
+			_, err := p.fetchTables(context.Background())
+			errs <- err
+		}()
+	}
+	ready.Wait()
+	start.Done()
+	for range goroutines {
+		if err := <-errs; err != nil {
+			t.Errorf("fetchTables: %v", err)
+		}
+	}
+
+	if got := conn.openedCount(); got != 1 {
+		t.Errorf("opened DBs = %d under concurrent first-use, want 1", got)
+	}
+}
+
+// Run with -race; catches any sync issue around the held-DB and Close paths.
 func TestSchema_Concurrent_NoRace(t *testing.T) {
 	conn := &trackingConnector{rowsFn: func(query string) (driver.Rows, error) {
 		switch {
@@ -286,9 +383,15 @@ func TestSchema_Concurrent_NoRace(t *testing.T) {
 	}
 	wg.Wait()
 
+	if got := conn.openedCount(); got != 1 {
+		t.Errorf("after concurrent run, opened DBs = %d, want 1 (held DB reused)", got)
+	}
+
+	if err := p.Close(); err != nil {
+		t.Errorf("Close: %v", err)
+	}
 	if !conn.allClosed() {
-		t.Errorf("after %d concurrent calls, %d DBs still hold connections",
-			goroutines*iterations*3, leakedCount(conn))
+		t.Errorf("after Close, %d DBs still hold connections", leakedCount(conn))
 	}
 }
 


### PR DESCRIPTION
## Type of Change

- [x] 🚀 Feature (perf)

---

## Feature

### What is this feature?

Hold one `*sql.DB` on `SchemaProvider`, lazily built on first use, and close it via the datasource instance's `Dispose`. All four schema-introspection paths (`fetchTables`, `fetchColumnsForAllTables`, `fetchColumnsForTable`, `fetchColumnValues`) share it.

### Why is this feature needed?

Follow-up to #1818, which closed the per-call leak. That fix opened-and-closed a fresh `*sql.DB` on every cache miss — so each miss still paid for:

- A new `*tls.Config` with freshly-parsed `X509KeyPair` and `AppendCertsFromPEM` (`getTLSConfig`).
- A new dial + `db.PingContext` round-trip.
- A fresh `clickhouse-go` connection pool that lived for one query and was thrown away.

Heap profiles on a busy deployment attributed ~15% of peak RSS to `x509.parseCertificate` / `pem.Decode` alone — a direct consequence of pool churn. `clickhouse-go`'s connection pool was never given a chance to do its job.

With one held DB:

- TLS parsing happens once per provider lifetime instead of once per uncached schema call.
- `clickhouse-go`'s pool starts pooling: warm conns get reused for subsequent introspection traffic.
- The dial/ping cost amortizes to the first call only.

### How to test this feature

1. Run `go test -race ./pkg/plugin/...` — should pass clean. The new tests cover held-DB reuse, connect-error retry, idempotent `Close`, and concurrent first-use.
2. In a deployment, confirm `connector.Connect` is invoked once per `SchemaProvider` lifetime rather than per uncached schema call.
3. Confirm RSS no longer climbs proportionally to schema-cache miss volume.

---

## What changed

**1. Held DB on `SchemaProvider`.**

```go
type SchemaProvider struct {
    // ...
    dbMu sync.Mutex
    db   *sql.DB
}

func (p *SchemaProvider) getDB(ctx context.Context) (*sql.DB, error) {
    p.dbMu.Lock()
    defer p.dbMu.Unlock()
    if p.db != nil {
        return p.db, nil
    }
    db, err := p.clickhousePlugin.Connect(ctx, p.settings, nil)
    if err != nil {
        return nil, err  // not cached: transient errors recover on next call
    }
    p.db = db
    return db, nil
}

func (p *SchemaProvider) Close() error { /* idempotent */ }
```

All four `fetchX` paths replace `Connect()` + `defer ds.Close()` with a single `getDB(ctx)` call.

**2. Dispose plumbing.** `NewDatasource` now returns a `clickhouseInstance` that embeds `*sqlds.SQLDatasource` and overrides `Dispose`:

```go
type clickhouseInstance struct {
    *sqlds.SQLDatasource
    schema *SchemaProvider
}

func (i *clickhouseInstance) Dispose() {
    i.SQLDatasource.Dispose()
    if err := i.schema.Close(); err != nil {
        backend.Logger.Error("failed to close schema provider", "error", err)
    }
}
```

Embedding `*sqlds.SQLDatasource` promotes every handler method (`QueryData`, `CheckHealth`, `CallResource`, etc.) so type assertions on `instancemgmt.Instance` continue to work unchanged. `instancemgmt.InstanceDisposer` is detected by type assertion at dispose time, so adding `Dispose()` to the wrapper plugs in cleanly.

**3. Tests.** `pkg/plugin/schema_test.go` is updated for the held-DB model:

- `TestGetDB_ReusedAcrossCalls` — multiple fetches share one DB; `Connect` is called exactly once.
- `TestGetDB_ConnectErrorNotCached` — a failing first Connect doesn't poison the next call.
- `TestClose_ClosesHeldDBAndIsIdempotent` — `Close` releases the held DB; second `Close` is a no-op.
- `TestClose_WithoutAnyFetchIsNoOp` — `Close` on a never-used provider is safe.
- `TestGetDB_ConcurrentFirstUse` — 32 goroutines all calling first-time fetch produce exactly one DB (run with `-race`).
- Existing concurrent fan-out test still passes and now also asserts `Close` drains every conn.

## Validation

- `go test -race ./pkg/...` — clean.
- `go vet ./...` — clean.
- `go build ./...` — clean.
- `cspell` — clean on changed files.

## Please check that:

- [x] Tests for this change have been added/updated.
- [x] Documentation has been added/updated (where applicable).

## Special notes for your reviewer

- The `Close`-then-reuse contract: `getDB` rebuilds after `Close`, so a provider can technically be reused after disposal. Not a documented public contract — `Close` is intended for shutdown — but keeping the rebuild path simplifies the lazy-init code and makes the invariant easier to reason about.
- The defensive `inst.(*sqlds.SQLDatasource)` cast in `NewDatasource` falls back to the unwrapped instance if sqlds ever changes its return type. The schema DB would then leak on settings change but the plugin would still work — preferable to a panic on plugin load.
- Lock contention: `dbMu` is held for the entire `Connect` call on first use, which serializes concurrent first-call introspection. This is fine — Connect is ~tens of milliseconds, and serialization only applies to the literal first call after provider construction. Subsequent calls hit the `p.db != nil` fast path.