### PR TITLE
Release 4.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 4.17.0
+
+### Features
+
+- Allow `$__adhocFilters` macro to work with multiple tables (#1757)
+
+### Performance
+
+- Hold a single `*sql.DB` on `SchemaProvider` and dispose it with the instance (#1819)
+
+### Fixes
+
+- Dedupe autocomplete suggestions and dispose Monaco providers on unmount (#1820)
+- Map adhoc regex operators to `REGEXP` instead of `ILIKE` (#1794)
+- Close `*sql.DB` after each schema introspection query (#1818)
+- Dependency updates
+
 ## 4.16.0
 
 ### Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clickhouse-datasource",
-  "version": "4.16.0",
+  "version": "4.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clickhouse-datasource",
-      "version": "4.16.0",
+      "version": "4.17.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/css": "11.13.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clickhouse-datasource",
-  "version": "4.16.0",
+  "version": "4.17.0",
   "description": "Clickhouse Datasource",
   "engines": {
     "node": ">=20"


### PR DESCRIPTION
## 4.17.0

### Features

- Allow `$__adhocFilters` macro to work with multiple tables (#1757)

### Performance

- Hold a single `*sql.DB` on `SchemaProvider` and dispose it with the instance (#1819)

### Fixes

- Dedupe autocomplete suggestions and dispose Monaco providers on unmount (#1820)
- Map adhoc regex operators to `REGEXP` instead of `ILIKE` (#1794)
- Close `*sql.DB` after each schema introspection query (#1818)
- Dependency updates