### PR TITLE
feat(queryBuilder): add SchemaPicker for cascading schema navigation

### DIFF
--- a/src/components/queryBuilder/SchemaPicker.test.tsx
+++ b/src/components/queryBuilder/SchemaPicker.test.tsx
@@ -1,0 +1,310 @@
+import React from 'react';
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import { SchemaPicker, SchemaPickerValue } from './SchemaPicker';
+import { Datasource } from '../../data/CHDatasource';
+import { TableColumn } from 'types/queryBuilder';
+
+// Order matters: 'attrs' first so cascade-cascade tests can navigate down to 'service'.
+// react-select does not wrap with ArrowDown, so navigating away from the last option
+// keeps focus on it.
+const mapColumns: readonly TableColumn[] = [
+  { name: 'attrs', type: 'Map(String, String)', picklistValues: [] },
+  { name: 'service', type: 'String', picklistValues: [] },
+];
+
+const buildDatasource = (overrides: Partial<Datasource> = {}): Datasource => {
+  const ds = {} as Datasource;
+  ds.getDefaultDatabase = jest.fn(() => '');
+  ds.fetchDatabases = jest.fn(() => Promise.resolve(['default', 'analytics']));
+  ds.fetchTables = jest.fn(() => Promise.resolve(['events', 'logs']));
+  ds.fetchColumns = jest.fn(() => Promise.resolve([...mapColumns]));
+  ds.fetchUniqueMapKeys = jest.fn(() => Promise.resolve(['service.name', 'http.status']));
+  return Object.assign(ds, overrides);
+};
+
+describe('SchemaPicker', () => {
+  describe("level='database'", () => {
+    it('renders only the database selector', async () => {
+      const datasource = buildDatasource();
+      const result = await waitFor(() =>
+        render(<SchemaPicker datasource={datasource} level="database" value={{}} onChange={() => {}} />)
+      );
+      expect(result.getAllByRole('combobox')).toHaveLength(1);
+      expect(result.getByText('Database')).toBeInTheDocument();
+      expect(result.queryByText('Table')).not.toBeInTheDocument();
+      expect(result.queryByText('Column')).not.toBeInTheDocument();
+    });
+
+    it('emits the selected database', async () => {
+      const datasource = buildDatasource();
+      const onChange = jest.fn();
+      const result = await waitFor(() =>
+        render(<SchemaPicker datasource={datasource} level="database" value={{}} onChange={onChange} />)
+      );
+
+      const combobox = result.getByRole('combobox');
+      fireEvent.keyDown(combobox, { key: 'ArrowDown' });
+      fireEvent.keyDown(combobox, { key: 'Enter' });
+
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledWith({
+        database: 'default',
+        table: '',
+        column: '',
+        mapKey: '',
+      });
+    });
+  });
+
+  describe("level='table'", () => {
+    it('renders database and table selectors', async () => {
+      const datasource = buildDatasource();
+      const result = await waitFor(() =>
+        render(
+          <SchemaPicker datasource={datasource} level="table" value={{ database: 'default' }} onChange={() => {}} />
+        )
+      );
+      expect(result.getAllByRole('combobox')).toHaveLength(2);
+      expect(result.getByText('Database')).toBeInTheDocument();
+      expect(result.getByText('Table')).toBeInTheDocument();
+    });
+
+    it('disables the table selector until a database is selected', async () => {
+      const datasource = buildDatasource();
+      const result = await waitFor(() =>
+        render(<SchemaPicker datasource={datasource} level="table" value={{}} onChange={() => {}} />)
+      );
+      // The Table label still renders, but the underlying combobox is non-interactive
+      // and Grafana's Select hides the combobox role when disabled.
+      expect(result.getByText('Table')).toBeInTheDocument();
+      expect(result.getAllByRole('combobox')).toHaveLength(1);
+    });
+
+    it('clears the table when the database changes', async () => {
+      const datasource = buildDatasource();
+      const onChange = jest.fn();
+      const value: SchemaPickerValue = { database: 'default', table: 'events' };
+      const result = await waitFor(() =>
+        render(<SchemaPicker datasource={datasource} level="table" value={value} onChange={onChange} />)
+      );
+
+      const [databaseCombobox] = result.getAllByRole('combobox');
+      fireEvent.keyDown(databaseCombobox, { key: 'ArrowDown' });
+      fireEvent.keyDown(databaseCombobox, { key: 'ArrowDown' });
+      fireEvent.keyDown(databaseCombobox, { key: 'Enter' });
+
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledWith({
+        database: 'analytics',
+        table: '',
+        column: '',
+        mapKey: '',
+      });
+    });
+
+    it('emits a table selection without disturbing the database', async () => {
+      const datasource = buildDatasource();
+      const onChange = jest.fn();
+      const value: SchemaPickerValue = { database: 'default' };
+      const result = await waitFor(() =>
+        render(<SchemaPicker datasource={datasource} level="table" value={value} onChange={onChange} />)
+      );
+
+      const [, tableCombobox] = result.getAllByRole('combobox');
+      fireEvent.keyDown(tableCombobox, { key: 'ArrowDown' });
+      fireEvent.keyDown(tableCombobox, { key: 'Enter' });
+
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledWith({
+        database: 'default',
+        table: 'events',
+        column: '',
+        mapKey: '',
+      });
+    });
+  });
+
+  describe("level='column' (default)", () => {
+    it('renders database, table, and column selectors', async () => {
+      const datasource = buildDatasource();
+      const result = await waitFor(() =>
+        render(
+          <SchemaPicker datasource={datasource} value={{ database: 'default', table: 'events' }} onChange={() => {}} />
+        )
+      );
+      expect(result.getAllByRole('combobox')).toHaveLength(3);
+      expect(result.getByText('Database')).toBeInTheDocument();
+      expect(result.getByText('Table')).toBeInTheDocument();
+      expect(result.getByText('Column')).toBeInTheDocument();
+    });
+
+    it('clears the column when the table changes', async () => {
+      const datasource = buildDatasource();
+      const onChange = jest.fn();
+      const value: SchemaPickerValue = { database: 'default', table: 'events', column: 'service' };
+      const result = await waitFor(() =>
+        render(<SchemaPicker datasource={datasource} value={value} onChange={onChange} />)
+      );
+
+      const [, tableCombobox] = result.getAllByRole('combobox');
+      fireEvent.keyDown(tableCombobox, { key: 'ArrowDown' });
+      fireEvent.keyDown(tableCombobox, { key: 'ArrowDown' });
+      fireEvent.keyDown(tableCombobox, { key: 'Enter' });
+
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledWith({
+        database: 'default',
+        table: 'logs',
+        column: '',
+        mapKey: '',
+      });
+    });
+  });
+
+  describe("level='mapKey'", () => {
+    it('shows the Map Key selector when the selected column is a Map type', async () => {
+      const datasource = buildDatasource();
+      const value: SchemaPickerValue = { database: 'default', table: 'events', column: 'attrs' };
+      const result = await waitFor(() =>
+        render(<SchemaPicker datasource={datasource} level="mapKey" value={value} onChange={() => {}} />)
+      );
+      await waitFor(() => expect(result.getAllByRole('combobox')).toHaveLength(4));
+      expect(result.getByText('Map Key')).toBeInTheDocument();
+    });
+
+    it('hides the Map Key selector when the selected column is not a Map type', async () => {
+      const datasource = buildDatasource();
+      const value: SchemaPickerValue = { database: 'default', table: 'events', column: 'service' };
+      const result = await waitFor(() =>
+        render(<SchemaPicker datasource={datasource} level="mapKey" value={value} onChange={() => {}} />)
+      );
+      await waitFor(() => expect(datasource.fetchColumns).toHaveBeenCalled());
+      expect(result.queryByText('Map Key')).not.toBeInTheDocument();
+      expect(result.getAllByRole('combobox')).toHaveLength(3);
+    });
+
+    it('emits the chosen map key alongside the existing selection', async () => {
+      const datasource = buildDatasource();
+      const onChange = jest.fn();
+      const value: SchemaPickerValue = { database: 'default', table: 'events', column: 'attrs' };
+      const result = await waitFor(() =>
+        render(<SchemaPicker datasource={datasource} level="mapKey" value={value} onChange={onChange} />)
+      );
+
+      await waitFor(() => expect(result.getAllByRole('combobox')).toHaveLength(4));
+      const comboboxes = result.getAllByRole('combobox');
+      const mapKeyCombobox = comboboxes[3];
+      fireEvent.keyDown(mapKeyCombobox, { key: 'ArrowDown' });
+      fireEvent.keyDown(mapKeyCombobox, { key: 'Enter' });
+
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledWith({
+        database: 'default',
+        table: 'events',
+        column: 'attrs',
+        mapKey: 'service.name',
+      });
+    });
+
+    it('clears the map key when the column changes', async () => {
+      const datasource = buildDatasource();
+      const onChange = jest.fn();
+      const value: SchemaPickerValue = {
+        database: 'default',
+        table: 'events',
+        column: 'attrs',
+        mapKey: 'service.name',
+      };
+      const result = await waitFor(() =>
+        render(<SchemaPicker datasource={datasource} level="mapKey" value={value} onChange={onChange} />)
+      );
+
+      await waitFor(() => expect(result.getAllByRole('combobox')).toHaveLength(4));
+      const [, , columnCombobox] = result.getAllByRole('combobox');
+      // Open the menu and move past the current selection to a different option
+      // (mock columns: ['service', 'attrs']; current is 'attrs', so navigate to 'service').
+      fireEvent.keyDown(columnCombobox, { key: 'ArrowDown' });
+      fireEvent.keyDown(columnCombobox, { key: 'ArrowDown' });
+      fireEvent.keyDown(columnCombobox, { key: 'Enter' });
+
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          database: 'default',
+          table: 'events',
+          mapKey: '',
+        })
+      );
+      const [emitted] = onChange.mock.calls[0];
+      expect(emitted.column).not.toBe('attrs');
+    });
+  });
+
+  describe('cross-level cascade invalidation', () => {
+    it('clears table, column, and mapKey when the database changes at mapKey depth', async () => {
+      const datasource = buildDatasource();
+      const onChange = jest.fn();
+      const value: SchemaPickerValue = {
+        database: 'default',
+        table: 'events',
+        column: 'attrs',
+        mapKey: 'service.name',
+      };
+      const result = await waitFor(() =>
+        render(<SchemaPicker datasource={datasource} level="mapKey" value={value} onChange={onChange} />)
+      );
+
+      const [databaseCombobox] = result.getAllByRole('combobox');
+      fireEvent.keyDown(databaseCombobox, { key: 'ArrowDown' });
+      fireEvent.keyDown(databaseCombobox, { key: 'ArrowDown' });
+      fireEvent.keyDown(databaseCombobox, { key: 'Enter' });
+
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledWith({
+        database: 'analytics',
+        table: '',
+        column: '',
+        mapKey: '',
+      });
+    });
+  });
+
+  describe('custom labels', () => {
+    it('overrides the visible labels via the labels prop', async () => {
+      const datasource = buildDatasource();
+      const result = await waitFor(() =>
+        render(
+          <SchemaPicker
+            datasource={datasource}
+            level="column"
+            value={{ database: 'default', table: 'events' }}
+            onChange={() => {}}
+            labels={{ database: 'Schema', table: 'Source', column: 'Field' }}
+          />
+        )
+      );
+      expect(result.getByText('Schema')).toBeInTheDocument();
+      expect(result.getByText('Source')).toBeInTheDocument();
+      expect(result.getByText('Field')).toBeInTheDocument();
+      expect(result.queryByText('Database')).not.toBeInTheDocument();
+    });
+
+    it('falls back to defaults for any unspecified label', async () => {
+      const datasource = buildDatasource();
+      const result = await waitFor(() =>
+        render(
+          <SchemaPicker
+            datasource={datasource}
+            level="column"
+            value={{ database: 'default', table: 'events' }}
+            onChange={() => {}}
+            labels={{ database: 'Schema' }}
+          />
+        )
+      );
+      expect(result.getByText('Schema')).toBeInTheDocument();
+      expect(result.getByText('Table')).toBeInTheDocument();
+      expect(result.getByText('Column')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/queryBuilder/SchemaPicker.test.tsx
+++ b/src/components/queryBuilder/SchemaPicker.test.tsx
@@ -307,4 +307,42 @@ describe('SchemaPicker', () => {
       expect(result.getByText('Column')).toBeInTheDocument();
     });
   });
+
+  describe('clearing a selection', () => {
+    const fullValue: SchemaPickerValue = {
+      database: 'default',
+      table: 'events',
+      column: 'attrs',
+      mapKey: 'service.name',
+    };
+
+    it('clears the database and every downstream field without throwing', async () => {
+      const datasource = buildDatasource();
+      const onChange = jest.fn();
+      const result = await waitFor(() =>
+        render(<SchemaPicker datasource={datasource} level="mapKey" value={fullValue} onChange={onChange} />)
+      );
+
+      const [databaseCombobox] = result.getAllByRole('combobox');
+      fireEvent.keyDown(databaseCombobox, { key: 'Backspace' });
+
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledWith({ database: '', table: '', column: '', mapKey: '' });
+    });
+
+    it('clears the column and its map key without disturbing the database or table', async () => {
+      const datasource = buildDatasource();
+      const onChange = jest.fn();
+      const result = await waitFor(() =>
+        render(<SchemaPicker datasource={datasource} level="mapKey" value={fullValue} onChange={onChange} />)
+      );
+
+      await waitFor(() => expect(result.getAllByRole('combobox')).toHaveLength(4));
+      const [, , columnCombobox] = result.getAllByRole('combobox');
+      fireEvent.keyDown(columnCombobox, { key: 'Backspace' });
+
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledWith({ database: 'default', table: 'events', column: '', mapKey: '' });
+    });
+  });
 });

--- a/src/components/queryBuilder/SchemaPicker.tsx
+++ b/src/components/queryBuilder/SchemaPicker.tsx
@@ -1,0 +1,172 @@
+import React from 'react';
+import { SelectableValue } from '@grafana/data';
+import { InlineFormLabel, Select } from '@grafana/ui';
+import { Datasource } from 'data/CHDatasource';
+import useColumns from 'hooks/useColumns';
+import useDatabases from 'hooks/useDatabases';
+import useTables from 'hooks/useTables';
+import useUniqueMapKeys from 'hooks/useUniqueMapKeys';
+import labels from 'labels';
+import { styles } from 'styles';
+
+/**
+ * How deep the cascading picker goes. Each level builds on the one above.
+ *  - 'database': database picker only
+ *  - 'table': database + table
+ *  - 'column': database + table + column (default)
+ *  - 'mapKey': database + table + column + map key (when the column is a Map type)
+ */
+export type SchemaPickerLevel = 'database' | 'table' | 'column' | 'mapKey';
+
+/** Selected schema parts. Downstream fields are cleared when an upstream field changes. */
+export interface SchemaPickerValue {
+  database?: string;
+  table?: string;
+  column?: string;
+  mapKey?: string;
+}
+
+export interface SchemaPickerProps {
+  datasource: Datasource;
+  value: SchemaPickerValue;
+  onChange: (value: SchemaPickerValue) => void;
+  /** How deep the cascade renders. Defaults to 'column'. */
+  level?: SchemaPickerLevel;
+  /** Override visible labels per level. */
+  labels?: Partial<Record<SchemaPickerLevel, string>>;
+}
+
+const LEVEL_ORDER: SchemaPickerLevel[] = ['database', 'table', 'column', 'mapKey'];
+const MAP_TYPE_PREFIX = 'Map(';
+
+function levelIndex(level: SchemaPickerLevel): number {
+  return LEVEL_ORDER.indexOf(level);
+}
+
+/**
+ * Reusable cascading schema picker: Database -> Table -> Column -> Map Key.
+ *
+ * Reuses the existing schema-fetch hooks (useDatabases, useTables, useColumns,
+ * useUniqueMapKeys) so it stays consistent with the rest of the query builder.
+ *
+ * Usage: pick a depth via the `level` prop. Changing a parent value clears
+ * every downstream selection in a single onChange emission.
+ */
+export const SchemaPicker = (props: SchemaPickerProps) => {
+  const { datasource, value, onChange, level = 'column', labels: labelOverrides } = props;
+  const maxLevel = levelIndex(level);
+
+  const databases = useDatabases(datasource);
+  const tables = useTables(datasource, value.database || '');
+  const columns = useColumns(datasource, value.database || '', value.table || '');
+
+  const selectedColumn = columns.find((c) => c.name === value.column);
+  const isMapColumn = selectedColumn ? selectedColumn.type.startsWith(MAP_TYPE_PREFIX) : false;
+  const mapColumnName = isMapColumn && value.column ? value.column : '';
+  const mapKeys = useUniqueMapKeys(datasource, mapColumnName, value.database || '', value.table || '');
+
+  const labelText = (key: SchemaPickerLevel, fallback: string): string => labelOverrides?.[key] ?? fallback;
+
+  const handleDatabaseChange = (selected: SelectableValue<string>) => {
+    onChange({ database: selected.value || '', table: '', column: '', mapKey: '' });
+  };
+
+  const handleTableChange = (selected: SelectableValue<string>) => {
+    onChange({ ...value, table: selected.value || '', column: '', mapKey: '' });
+  };
+
+  const handleColumnChange = (selected: SelectableValue<string>) => {
+    onChange({ ...value, column: selected.value || '', mapKey: '' });
+  };
+
+  const handleMapKeyChange = (selected: SelectableValue<string>) => {
+    onChange({ ...value, mapKey: selected.value || '' });
+  };
+
+  const databaseTooltip = labels.components.DatabaseSelect.tooltip;
+  const tableTooltip = labels.components.TableSelect.tooltip;
+
+  const showTable = maxLevel >= 1;
+  const showColumn = maxLevel >= 2;
+  const showMapKey = maxLevel >= 3 && isMapColumn && Boolean(value.column);
+
+  return (
+    <>
+      <div className="gf-form">
+        <InlineFormLabel width={10} className="query-keyword" tooltip={databaseTooltip}>
+          {labelText('database', labels.components.DatabaseSelect.label)}
+        </InlineFormLabel>
+        <Select
+          className={`width-15 ${styles.Common.inlineSelect}`}
+          options={databases.map((d) => ({ label: d, value: d }))}
+          value={value.database || null}
+          onChange={handleDatabaseChange}
+          menuPlacement={'bottom'}
+          allowCustomValue
+          isClearable
+          placeholder={labels.components.DatabaseSelect.empty}
+          aria-label={labelText('database', labels.components.DatabaseSelect.label)}
+        />
+      </div>
+
+      {showTable && (
+        <div className="gf-form">
+          <InlineFormLabel width={10} className="query-keyword" tooltip={tableTooltip}>
+            {labelText('table', labels.components.TableSelect.label)}
+          </InlineFormLabel>
+          <Select
+            className={`width-15 ${styles.Common.inlineSelect}`}
+            options={tables.map((t) => ({ label: t, value: t }))}
+            value={value.table || null}
+            onChange={handleTableChange}
+            menuPlacement={'bottom'}
+            allowCustomValue
+            isClearable
+            disabled={!value.database}
+            placeholder={labels.components.TableSelect.empty}
+            aria-label={labelText('table', labels.components.TableSelect.label)}
+          />
+        </div>
+      )}
+
+      {showColumn && (
+        <div className="gf-form">
+          <InlineFormLabel width={10} className="query-keyword">
+            {labelText('column', 'Column')}
+          </InlineFormLabel>
+          <Select
+            className={`width-15 ${styles.Common.inlineSelect}`}
+            options={columns.map((c) => ({ label: c.name, value: c.name, description: c.type }))}
+            value={value.column || null}
+            onChange={handleColumnChange}
+            menuPlacement={'bottom'}
+            allowCustomValue
+            isClearable
+            disabled={!value.table}
+            placeholder={'<select column>'}
+            aria-label={labelText('column', 'Column')}
+          />
+        </div>
+      )}
+
+      {showMapKey && (
+        <div className="gf-form">
+          <InlineFormLabel width={10} className="query-keyword">
+            {labelText('mapKey', 'Map Key')}
+          </InlineFormLabel>
+          <Select
+            className={`width-15 ${styles.Common.inlineSelect}`}
+            options={mapKeys.map((k) => ({ label: k, value: k }))}
+            value={value.mapKey || null}
+            onChange={handleMapKeyChange}
+            menuPlacement={'bottom'}
+            allowCustomValue
+            isClearable
+            placeholder={'<select key>'}
+            aria-label={labelText('mapKey', 'Map Key')}
+          />
+        </div>
+      )}
+    </>
+  );
+};

--- a/src/components/queryBuilder/SchemaPicker.tsx
+++ b/src/components/queryBuilder/SchemaPicker.tsx
@@ -1,13 +1,12 @@
 import React from 'react';
 import { SelectableValue } from '@grafana/data';
-import { InlineFormLabel, Select } from '@grafana/ui';
+import { InlineField, InlineFieldRow, Select } from '@grafana/ui';
 import { Datasource } from 'data/CHDatasource';
 import useColumns from 'hooks/useColumns';
 import useDatabases from 'hooks/useDatabases';
 import useTables from 'hooks/useTables';
 import useUniqueMapKeys from 'hooks/useUniqueMapKeys';
 import labels from 'labels';
-import { styles } from 'styles';
 
 /**
  * How deep the cascading picker goes. Each level builds on the one above.
@@ -38,6 +37,7 @@ export interface SchemaPickerProps {
 
 const LEVEL_ORDER: SchemaPickerLevel[] = ['database', 'table', 'column', 'mapKey'];
 const MAP_TYPE_PREFIX = 'Map(';
+const LABEL_WIDTH = 20;
 
 function levelIndex(level: SchemaPickerLevel): number {
   return LEVEL_ORDER.indexOf(level);
@@ -65,22 +65,51 @@ export const SchemaPicker = (props: SchemaPickerProps) => {
   const mapColumnName = isMapColumn && value.column ? value.column : '';
   const mapKeys = useUniqueMapKeys(datasource, mapColumnName, value.database || '', value.table || '');
 
+  // Build the option lists. The Select component drops the controlled value when
+  // it isn't present in the options, so append the current value if the fetched
+  // list doesn't include it (e.g. loading a saved query before the list resolves).
+  const databaseOptions: Array<SelectableValue<string>> = databases.map((d) => ({ label: d, value: d }));
+  if (value.database && !databases.includes(value.database)) {
+    databaseOptions.push({ label: value.database, value: value.database });
+  }
+
+  const tableOptions: Array<SelectableValue<string>> = tables.map((t) => ({ label: t, value: t }));
+  if (value.table && !tables.includes(value.table)) {
+    tableOptions.push({ label: value.table, value: value.table });
+  }
+
+  const columnOptions: Array<SelectableValue<string>> = columns.map((c) => ({
+    label: c.name,
+    value: c.name,
+    description: c.type,
+  }));
+  if (value.column && !columns.some((c) => c.name === value.column)) {
+    columnOptions.push({ label: value.column, value: value.column });
+  }
+
+  const mapKeyOptions: Array<SelectableValue<string>> = mapKeys.map((k) => ({ label: k, value: k }));
+  if (value.mapKey && !mapKeys.includes(value.mapKey)) {
+    mapKeyOptions.push({ label: value.mapKey, value: value.mapKey });
+  }
+
   const labelText = (key: SchemaPickerLevel, fallback: string): string => labelOverrides?.[key] ?? fallback;
 
-  const handleDatabaseChange = (selected: SelectableValue<string>) => {
-    onChange({ database: selected.value || '', table: '', column: '', mapKey: '' });
+  // Grafana passes `null` to onChange when a clearable Select is cleared, so guard
+  // the dereference. Clearing a parent also clears every downstream selection.
+  const handleDatabaseChange = (selected: SelectableValue<string> | null) => {
+    onChange({ database: selected?.value || '', table: '', column: '', mapKey: '' });
   };
 
-  const handleTableChange = (selected: SelectableValue<string>) => {
-    onChange({ ...value, table: selected.value || '', column: '', mapKey: '' });
+  const handleTableChange = (selected: SelectableValue<string> | null) => {
+    onChange({ ...value, table: selected?.value || '', column: '', mapKey: '' });
   };
 
-  const handleColumnChange = (selected: SelectableValue<string>) => {
-    onChange({ ...value, column: selected.value || '', mapKey: '' });
+  const handleColumnChange = (selected: SelectableValue<string> | null) => {
+    onChange({ ...value, column: selected?.value || '', mapKey: '' });
   };
 
-  const handleMapKeyChange = (selected: SelectableValue<string>) => {
-    onChange({ ...value, mapKey: selected.value || '' });
+  const handleMapKeyChange = (selected: SelectableValue<string> | null) => {
+    onChange({ ...value, mapKey: selected?.value || '' });
   };
 
   const databaseTooltip = labels.components.DatabaseSelect.tooltip;
@@ -92,80 +121,81 @@ export const SchemaPicker = (props: SchemaPickerProps) => {
 
   return (
     <>
-      <div className="gf-form">
-        <InlineFormLabel width={10} className="query-keyword" tooltip={databaseTooltip}>
-          {labelText('database', labels.components.DatabaseSelect.label)}
-        </InlineFormLabel>
-        <Select
-          className={`width-15 ${styles.Common.inlineSelect}`}
-          options={databases.map((d) => ({ label: d, value: d }))}
-          value={value.database || null}
-          onChange={handleDatabaseChange}
-          menuPlacement={'bottom'}
-          allowCustomValue
-          isClearable
-          placeholder={labels.components.DatabaseSelect.empty}
-          aria-label={labelText('database', labels.components.DatabaseSelect.label)}
-        />
-      </div>
-
-      {showTable && (
-        <div className="gf-form">
-          <InlineFormLabel width={10} className="query-keyword" tooltip={tableTooltip}>
-            {labelText('table', labels.components.TableSelect.label)}
-          </InlineFormLabel>
+      <InlineFieldRow>
+        <InlineField
+          label={labelText('database', labels.components.DatabaseSelect.label)}
+          labelWidth={LABEL_WIDTH}
+          tooltip={databaseTooltip}
+          grow
+        >
           <Select
-            className={`width-15 ${styles.Common.inlineSelect}`}
-            options={tables.map((t) => ({ label: t, value: t }))}
-            value={value.table || null}
-            onChange={handleTableChange}
+            options={databaseOptions}
+            value={value.database || null}
+            onChange={handleDatabaseChange}
             menuPlacement={'bottom'}
             allowCustomValue
             isClearable
-            disabled={!value.database}
-            placeholder={labels.components.TableSelect.empty}
-            aria-label={labelText('table', labels.components.TableSelect.label)}
+            placeholder={labels.components.DatabaseSelect.empty}
+            aria-label={labelText('database', labels.components.DatabaseSelect.label)}
           />
-        </div>
+        </InlineField>
+      </InlineFieldRow>
+
+      {showTable && (
+        <InlineFieldRow>
+          <InlineField
+            label={labelText('table', labels.components.TableSelect.label)}
+            labelWidth={LABEL_WIDTH}
+            tooltip={tableTooltip}
+            disabled={!value.database}
+            grow
+          >
+            <Select
+              options={tableOptions}
+              value={value.table || null}
+              onChange={handleTableChange}
+              menuPlacement={'bottom'}
+              allowCustomValue
+              isClearable
+              placeholder={labels.components.TableSelect.empty}
+              aria-label={labelText('table', labels.components.TableSelect.label)}
+            />
+          </InlineField>
+        </InlineFieldRow>
       )}
 
       {showColumn && (
-        <div className="gf-form">
-          <InlineFormLabel width={10} className="query-keyword">
-            {labelText('column', 'Column')}
-          </InlineFormLabel>
-          <Select
-            className={`width-15 ${styles.Common.inlineSelect}`}
-            options={columns.map((c) => ({ label: c.name, value: c.name, description: c.type }))}
-            value={value.column || null}
-            onChange={handleColumnChange}
-            menuPlacement={'bottom'}
-            allowCustomValue
-            isClearable
-            disabled={!value.table}
-            placeholder={'<select column>'}
-            aria-label={labelText('column', 'Column')}
-          />
-        </div>
+        <InlineFieldRow>
+          <InlineField label={labelText('column', 'Column')} labelWidth={LABEL_WIDTH} disabled={!value.table} grow>
+            <Select
+              options={columnOptions}
+              value={value.column || null}
+              onChange={handleColumnChange}
+              menuPlacement={'bottom'}
+              allowCustomValue
+              isClearable
+              placeholder={'<select column>'}
+              aria-label={labelText('column', 'Column')}
+            />
+          </InlineField>
+        </InlineFieldRow>
       )}
 
       {showMapKey && (
-        <div className="gf-form">
-          <InlineFormLabel width={10} className="query-keyword">
-            {labelText('mapKey', 'Map Key')}
-          </InlineFormLabel>
-          <Select
-            className={`width-15 ${styles.Common.inlineSelect}`}
-            options={mapKeys.map((k) => ({ label: k, value: k }))}
-            value={value.mapKey || null}
-            onChange={handleMapKeyChange}
-            menuPlacement={'bottom'}
-            allowCustomValue
-            isClearable
-            placeholder={'<select key>'}
-            aria-label={labelText('mapKey', 'Map Key')}
-          />
-        </div>
+        <InlineFieldRow>
+          <InlineField label={labelText('mapKey', 'Map Key')} labelWidth={LABEL_WIDTH} grow>
+            <Select
+              options={mapKeyOptions}
+              value={value.mapKey || null}
+              onChange={handleMapKeyChange}
+              menuPlacement={'bottom'}
+              allowCustomValue
+              isClearable
+              placeholder={'<select key>'}
+              aria-label={labelText('mapKey', 'Map Key')}
+            />
+          </InlineField>
+        </InlineFieldRow>
       )}
     </>
   );


### PR DESCRIPTION
## Type of Change

- [x] Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Refactor
- [ ] Chore

## Feature

### What

Adds `src/components/queryBuilder/SchemaPicker.tsx`, a reusable cascading picker for **Database -> Table -> Column -> Map Key** with a configurable depth. The depth is controlled by a `level` prop:

| `level` | Renders |
| ------- | ------- |
| `'database'` | Database |
| `'table'` | Database + Table |
| `'column'` (default) | Database + Table + Column |
| `'mapKey'` | Database + Table + Column + Map Key (Map Key only when the selected column is a `Map(...)` type) |

Reuses the existing `useDatabases`, `useTables`, `useColumns`, and `useUniqueMapKeys` hooks, so it stays consistent with the rest of the query builder. Changing a parent value clears every downstream selection in a single `onChange` emission.

The component API:

```ts
export type SchemaPickerLevel = 'database' | 'table' | 'column' | 'mapKey';

export interface SchemaPickerValue {
  database?: string;
  table?: string;
  column?: string;
  mapKey?: string;
}

export interface SchemaPickerProps {
  datasource: Datasource;
  value: SchemaPickerValue;
  onChange: (value: SchemaPickerValue) => void;
  level?: SchemaPickerLevel;
  labels?: Partial<Record<SchemaPickerLevel, string>>;
}
```

No consumer migrates in this PR.

### Why

This is the foundation for several upcoming editor improvements. The depth-mode design lets the same primitive cover:

- variable editor improvements (column-values + Map keys),
- annotation editor improvements (deployment / event change detection on Map keys),
- datasource configuration (replacing the plain `<Input>` text fields for default database / table),
- the upcoming Compact Query Mode (override picker above `CompactMetricsBar`),
- consolidation of the existing `DatabaseTableSelect` cascade.

Each of those is tracked as a separate ticket so this PR can stay small and focused. Sub-150-line, single-concern PRs in this repo land same-day to two days based on the recent review cadence (#1818, #1819, #1820), so I want to get the primitive in first and migrate consumers behind it.

### Who

Anyone who edits the ClickHouse datasource: query authors, dashboard authors, and the upcoming variable / annotation flows.

### How to test

1. `yarn jest src/components/queryBuilder/SchemaPicker.test.tsx` (15 tests covering all four depth modes, cascade invalidation, and the `labels` override).
2. `yarn jest` (701 tests pass, no regressions).
3. `npm run lint` and `npm run prettier:check`: clean for the new files. The remaining warnings are pre-existing on `main`.
4. The PR has no consumer in this branch, so manual UI testing was done against a local visual harness rendered inside the existing query editor in Grafana 12 (see screenshots below); the harness is **not** part of this diff.

## Screenshots / Videos

Verified in Grafana 12 against the public ClickHouse demo (`sql-clickhouse.clickhouse.com/otel_v2`) using a temporary harness that renders the picker at all four depths. The harness lives on a throwaway branch (`feat/schema-picker-harness`) and is **not** part of this PR.

### Dark theme

Empty state, all four levels:

![SchemaPicker dark, empty](https://raw.githubusercontent.com/alex-fedotyev/clickhouse-datasource/feat/schema-picker-harness/pr-screenshots/schema-picker-dark-empty.png)

Populated, levels database / table:

![SchemaPicker dark, populated top](https://raw.githubusercontent.com/alex-fedotyev/clickhouse-datasource/feat/schema-picker-harness/pr-screenshots/schema-picker-dark-populated-top.png)

Populated, levels column / mapKey (LogAttributes is a Map column, so the Map Key picker appears):

![SchemaPicker dark, populated bottom](https://raw.githubusercontent.com/alex-fedotyev/clickhouse-datasource/feat/schema-picker-harness/pr-screenshots/schema-picker-dark-populated-bottom.png)

### Light theme

Empty state:

![SchemaPicker light, empty](https://raw.githubusercontent.com/alex-fedotyev/clickhouse-datasource/feat/schema-picker-harness/pr-screenshots/schema-picker-light-empty.png)

Populated, levels database / table / column:

![SchemaPicker light, populated top](https://raw.githubusercontent.com/alex-fedotyev/clickhouse-datasource/feat/schema-picker-harness/pr-screenshots/schema-picker-light-populated-top.png)

Populated mapKey level alongside the existing query builder Database / Table picker (visual parity check):

![SchemaPicker light, mapKey populated](https://raw.githubusercontent.com/alex-fedotyev/clickhouse-datasource/feat/schema-picker-harness/pr-screenshots/schema-picker-light-mapkey-populated.png)

The picker reuses the same `gf-form` / `InlineFormLabel` / `Select` primitives as `DatabaseTableSelect` and `ColumnSelect`, so the rendering stays consistent with the rest of the editor. You can see this in the last screenshot, where the harness pickers above and the query builder pickers below have identical labels, spacing, and dropdown chrome.

## Please check that:

- [x] Tests added / updated (`SchemaPicker.test.tsx`, 15 cases)
- [ ] Docs updated (no user-visible config in this PR; consumers will document their own surfaces)

## Special notes for your reviewer

- The component intentionally has no consumer in this PR. Migrations land separately so review can stay focused on the primitive.
- Cascade invalidation is verified by unit tests. A user changing the database with `level='mapKey'` selected gets a single `onChange` emission with `table`, `column`, and `mapKey` cleared.
- The Map Key picker only renders when `level='mapKey'` AND the selected column type starts with `Map(`. For non-Map columns at `level='mapKey'`, the picker behaves exactly like `level='column'`.
- I did not introduce a `columnFilter` prop or other speculative API. They can be added when a consumer actually needs them.
- The deprecated `Select` warning is pre-existing in this directory; switching to `Combobox` would diverge from `DatabaseTableSelect` / `ColumnSelect`. Happy to do the migration as a separate PR if useful.

Add the `changelog` label.
