### PR TITLE
feat(logs): group OTel attributes in log details

### DIFF
--- a/cspell.config.json
+++ b/cspell.config.json
@@ -71,6 +71,7 @@
     "oper",
     "OFREP",
     "otel",
+    "otelcol",
     "semconv",
     "OUTFILE",
     "paulmach",

--- a/src/data/CHDatasource.test.ts
+++ b/src/data/CHDatasource.test.ts
@@ -1955,6 +1955,100 @@ describe('ClickHouseDatasource', () => {
     });
   });
 
+  describe('LogsLabelTypesSupport', () => {
+    let datasource: Datasource;
+    beforeEach(() => {
+      datasource = cloneDeep(mockDatasource);
+    });
+
+    describe('getLabelDisplayTypeFromFrame', () => {
+      it('returns "Resource attributes" for a ResourceAttributes-prefixed key', () => {
+        expect(datasource.getLabelDisplayTypeFromFrame('ResourceAttributes.service.name', undefined, null)).toBe(
+          'Resource attributes'
+        );
+      });
+
+      it('returns "Scope attributes" for a ScopeAttributes-prefixed key', () => {
+        expect(datasource.getLabelDisplayTypeFromFrame('ScopeAttributes.otelcol.name', undefined, null)).toBe(
+          'Scope attributes'
+        );
+      });
+
+      it('returns "Log attributes" for a LogAttributes-prefixed key', () => {
+        expect(datasource.getLabelDisplayTypeFromFrame('LogAttributes.http.status_code', undefined, null)).toBe(
+          'Log attributes'
+        );
+      });
+
+      it('returns null for the Body core column', () => {
+        expect(datasource.getLabelDisplayTypeFromFrame('Body', undefined, null)).toBeNull();
+      });
+
+      it('returns null for the TraceId core column', () => {
+        expect(datasource.getLabelDisplayTypeFromFrame('TraceId', undefined, null)).toBeNull();
+      });
+
+      it('returns null for the bare "ResourceAttributes" without a dot', () => {
+        // The backend's flatten always emits at least one nested key, so the
+        // bare column name never reaches Grafana's label list. Guard against
+        // mis-grouping if a custom schema ever surfaces it.
+        expect(datasource.getLabelDisplayTypeFromFrame('ResourceAttributes', undefined, null)).toBeNull();
+      });
+
+      it('returns null for an arbitrary user-defined column', () => {
+        expect(datasource.getLabelDisplayTypeFromFrame('service_name', undefined, null)).toBeNull();
+      });
+    });
+
+    describe('round-trip with modifyQuery', () => {
+      // Each grouped key, when fed back through modifyQuery, must split the
+      // prefix into a Map column + mapKey so the Filter for value action
+      // hits the right Map(String, String) column. This keeps the Log Details
+      // grouping and the filter routing aligned.
+      const cases = [
+        { prefix: 'ResourceAttributes', mapKey: 'service.name', value: 'my-service' },
+        { prefix: 'ScopeAttributes', mapKey: 'version', value: '1.0' },
+        { prefix: 'LogAttributes', mapKey: 'http.status_code', value: '200' },
+      ];
+
+      cases.forEach(({ prefix, mapKey, value }) => {
+        it(`${prefix}: classifies the key and routes the filter to the Map column`, () => {
+          const labelKey = `${prefix}.${mapKey}`;
+
+          // 1. The grouping classifies it into a non-null section.
+          expect(datasource.getLabelDisplayTypeFromFrame(labelKey, undefined, null)).not.toBeNull();
+
+          // 2. modifyQuery splits the same prefix back into column + mapKey.
+          const queryForPrefix: CHBuilderQuery = {
+            pluginVersion: '',
+            refId: 'A',
+            editorType: EditorType.Builder,
+            rawSql: '',
+            builderOptions: {
+              database: 'default',
+              table: 'logs',
+              queryType: QueryType.Logs,
+              mode: BuilderMode.List,
+              columns: [{ name: prefix, type: 'Map(String, String)' }],
+            },
+          };
+
+          const result = datasource.modifyQuery(queryForPrefix, {
+            type: 'ADD_FILTER',
+            options: { key: labelKey, value },
+          } as any) as CHBuilderQuery;
+
+          expect(result.builderOptions.filters![0]).toMatchObject({
+            mapKey,
+            type: 'Map(String, String)',
+            operator: FilterOperator.Equals,
+            value,
+          });
+        });
+      });
+    });
+  });
+
   describe('getLogRowContext', () => {
     const baseBuilderOptions: QueryBuilderOptions = {
       database: 'default',

--- a/src/data/CHDatasource.ts
+++ b/src/data/CHDatasource.ts
@@ -6,6 +6,7 @@ import {
   DataQueryResponse,
   DataSourceInstanceSettings,
   DataSourceWithLogsContextSupport,
+  DataSourceWithLogsLabelTypesSupport,
   DataSourceWithQueryModificationSupport,
   DataSourceWithSupplementaryQueriesSupport,
   Field,
@@ -63,6 +64,7 @@ export class Datasource
   implements
     DataSourceWithSupplementaryQueriesSupport<CHQuery>,
     DataSourceWithLogsContextSupport<CHQuery>,
+    DataSourceWithLogsLabelTypesSupport,
     DataSourceWithQueryModificationSupport<CHQuery>
 {
   // This enables default annotation support for 7.2+
@@ -487,7 +489,7 @@ export class Datasource
       const isStringFilterAction = action.type === 'ADD_STRING_FILTER' || action.type === 'ADD_STRING_FILTER_OUT';
 
       if (isStringFilterAction) {
-        // has no key — resolve the column name from the log message hint.
+        // has no key; resolve the column name from the log message hint.
         const logMessageColumn = getColumnByHint(query.builderOptions, ColumnHint.LogMessage);
         return logMessageColumn?.alias || logMessageColumn?.name || action.options.key || '';
       }
@@ -1734,6 +1736,37 @@ export class Datasource
   ): ReactNode {
     const contextColumns = this.getLogContextColumnsFromLogRow(row);
     return createReactElement(LogsContextPanel, { columns: contextColumns, datasourceUid: this.uid });
+  }
+
+  // interface DataSourceWithLogsLabelTypesSupport
+  /**
+   * Groups log fields in the Logs Details panel by OTel attribute layer.
+   * The Go backend (`mergeOpenTelemetryLabels` in pkg/plugin/driver.go)
+   * flattens ResourceAttributes / ScopeAttributes / LogAttributes Map
+   * columns into a single `labels` JSON field with prefixed keys
+   * (e.g. "ResourceAttributes.service.name"). This method tells Grafana
+   * how to bucket those keys into named, collapsible sections.
+   *
+   * Returning null leaves the field under Grafana's default "Fields"
+   * section. Filtering is unaffected: `modifyQuery` already splits the
+   * same prefix back when a user clicks "Filter for value", so the
+   * visual grouping and the filter routing stay aligned.
+   *
+   * Strings are plain English; the plugin codebase does not currently
+   * use `@grafana/i18n`, so a future i18n pass would localise these
+   * alongside the rest of the plugin's UI strings.
+   */
+  getLabelDisplayTypeFromFrame(labelKey: string, _frame: DataFrame | undefined, _index: number | null): string | null {
+    if (labelKey.startsWith('ResourceAttributes.')) {
+      return 'Resource attributes';
+    }
+    if (labelKey.startsWith('ScopeAttributes.')) {
+      return 'Scope attributes';
+    }
+    if (labelKey.startsWith('LogAttributes.')) {
+      return 'Log attributes';
+    }
+    return null;
   }
 
   async testDatasource(): Promise<{ status: string; message: string }> {

--- a/src/data/CHDatasource.ts
+++ b/src/data/CHDatasource.ts
@@ -1753,7 +1753,7 @@ export class Datasource
    * visual grouping and the filter routing stay aligned.
    *
    * Strings are plain English; the plugin codebase does not currently
-   * use `@grafana/i18n`, so a future i18n pass would localise these
+   * use `@grafana/i18n`, so a future i18n pass would localize these
    * alongside the rest of the plugin's UI strings.
    */
   getLabelDisplayTypeFromFrame(labelKey: string, _frame: DataFrame | undefined, _index: number | null): string | null {


### PR DESCRIPTION
## Type of Change

- [x] Feature

## Feature

### What is this feature?

Implements `DataSourceWithLogsLabelTypesSupport` so Grafana's Log Details panel groups OTel attributes into named, collapsible sections (Resource attributes, Scope attributes, Log attributes) instead of mixing every key into one flat "Fields" list. Pure frontend opt-in: no SQL change, no schema change, no wire-format change.

### Why is this feature needed?

The Go backend already does the heavy lifting. `mergeOpenTelemetryLabels` in `pkg/plugin/driver.go:639-711` flattens the three OTel Map columns (`ResourceAttributes`, `ScopeAttributes`, `LogAttributes`) into a single `labels` JSON field with prefix-qualified keys (`ResourceAttributes.service.name`, `LogAttributes.http.status_code`, etc.). `pkg/plugin/driver_test.go:49-53` already pins that round-trip.

Grafana's Log Details panel knows how to bucket those keys into named sections via `getLabelDisplayTypeFromFrame`. The detector is structural (`'getLabelDisplayTypeFromFrame' in datasource`) and the rendering uses `<ControlledCollapse label={group}>` per group. The plugin just hadn't opted in.

So today, an OTel-shaped logs query returns a perfectly bucketed wire format and the panel collapses everything back into one alphabetised list. This change wires the opt-in.

### Who is this feature for?

Anyone running OTel logs through ClickHouse and using Grafana's built-in Logs panel in Explore or in dashboards.

### How to test this feature

1. Provision the ClickHouse datasource against the public demo (`sql-clickhouse.clickhouse.com:9440`, user `otel_demo`, default database `otel_v2`).
2. Open Explore -> Logs against this branch's plugin build, run a query that returns the three Map columns:
   ```sql
   SELECT Timestamp AS "timestamp", Body AS "body", SeverityText AS level, TraceId AS traceID,
          ResourceAttributes, ScopeAttributes, LogAttributes, ServiceName
   FROM otel_v2.otel_logs
   ORDER BY timestamp DESC LIMIT 100
   ```
3. Click any log row to open Log Details.
4. Verify three named, collapsible sections appear: "Resource attributes", "Scope attributes" (when populated), "Log attributes". Core columns (Body, Timestamp, TraceId, SeverityText) keep rendering under the panel's default "Fields" section.
5. Click "Filter for value" on any key inside a grouped section and confirm the resulting filter routes to the right `Map(String, String)` column with `mapKey` set. The round-trip Jest test in `CHDatasource.test.ts: describe('round-trip with modifyQuery', ...)` pins this contract; this step is the visual confirmation.

## Screenshots / Videos

Verified in Grafana 12 against the public ClickHouse demo (`sql-clickhouse.clickhouse.com/otel_v2`). The PR-built plugin ran side by side with the marketplace v4.16.0 official plugin, so the `Before` (Official) and `After` (PR Build) shots are identical Explore queries against identical data; only the datasource differs.

| | Before (Official v4.16.0) | After (this PR) |
|---|---|---|
| **Light** | ![Before light](https://raw.githubusercontent.com/alex-fedotyev/clickhouse-datasource/feat/otel-log-label-types-3547-screenshots/pr-screenshots/before-light.png) | ![After light](https://raw.githubusercontent.com/alex-fedotyev/clickhouse-datasource/feat/otel-log-label-types-3547-screenshots/pr-screenshots/after-light.png) |
| **Dark**  | ![Before dark](https://raw.githubusercontent.com/alex-fedotyev/clickhouse-datasource/feat/otel-log-label-types-3547-screenshots/pr-screenshots/before-dark.png)  | ![After dark](https://raw.githubusercontent.com/alex-fedotyev/clickhouse-datasource/feat/otel-log-label-types-3547-screenshots/pr-screenshots/after-dark.png) |

In the `Before` shots, every `LogAttributes.*` and `ResourceAttributes.*` key sits under a single alphabetised `Fields` section. In the `After` shots, "Log attributes" (shown collapsed for clarity; same behaviour expanded) and "Resource attributes" are their own collapsible sections. "Scope attributes" doesn't render here because the demo data doesn't populate scope keys; the unit tests cover that branch directly.

## Please check that:

- [x] Tests for this change have been added/updated. New `describe('LogsLabelTypesSupport', ...)` in `src/data/CHDatasource.test.ts`: 7 unit tests for the prefix classifier and 3 round-trip tests that feed each grouped key back through `modifyQuery` and assert `mapKey` + `Map(String, String)` routing.
- [x] Documentation has been added/updated (where applicable). No user-configurable surface in this PR; the behaviour is implicit from the panel and shows up automatically.

## Special notes for your reviewer

The visual grouping and the filter routing share the same prefix list, so they have to stay in sync. The pre-existing prefix-split logic in `modifyQuery` (`src/data/CHDatasource.ts:443` `if (['ResourceAttributes', 'ScopeAttributes', 'LogAttributes'].includes(...))`) handles the filter side; this PR makes the visual grouping match exactly. The new `describe('round-trip with modifyQuery', ...)` block exercises the full path from `getLabelDisplayTypeFromFrame` (which classifies) to `modifyQuery` (which filters) for each prefix, so any future drift on either side breaks tests.

Scope is deliberately tight: only the three prefixes the backend actually emits, sentence-case strings to mirror Loki's convention (`'Indexed labels' / 'Parsed fields' / 'Structured metadata'` in `public/app/plugins/datasource/loki/datasource.ts:281-295`). Core columns (Body, Timestamp, TraceId, etc.) intentionally stay under the panel's default "Fields" section, again following Loki rather than introducing a redundant "Indexed Columns" header.

No `plugin.json`, `CODEOWNERS`, `CHANGELOG.md`, `package.json`, or schema changes. One drive-by: `src/data/CHDatasource.ts:429` had a stray em-dash in a comment; replaced with a semicolon.

Please add the `changelog` label so this surfaces in the next release notes.
