### PR TITLE
fix(config): trim whitespace from host setting

### DIFF
--- a/pkg/plugin/settings.go
+++ b/pkg/plugin/settings.go
@@ -85,10 +85,10 @@ func LoadSettings(ctx context.Context, config backend.DataSourceInstanceSettings
 
 	// Deprecated: Replaced with Host for v4. Deserializes "server" field for old v3 configs.
 	if jsonData["server"] != nil {
-		settings.Host = jsonData["server"].(string)
+		settings.Host = strings.TrimSpace(jsonData["server"].(string))
 	}
 	if jsonData["host"] != nil {
-		settings.Host = jsonData["host"].(string)
+		settings.Host = strings.TrimSpace(jsonData["host"].(string))
 	}
 
 	if jsonData["port"] != nil {

--- a/pkg/plugin/settings_test.go
+++ b/pkg/plugin/settings_test.go
@@ -294,6 +294,50 @@ func TestLoadSettings(t *testing.T) {
 				wantErr: nil,
 				testCtx: ctx,
 			},
+			{
+				name: "should trim whitespace from host",
+				args: args{
+					config: backend.DataSourceInstanceSettings{
+						JSONData:                []byte(`{"host": "  ch.example.com  ", "port": 443}`),
+						DecryptedSecureJSONData: map[string]string{},
+					},
+				},
+				wantSettings: Settings{
+					Host:                  "ch.example.com",
+					Port:                  443,
+					ConnMaxLifetime:       "5",
+					DialTimeout:           "10",
+					MaxIdleConns:          "25",
+					MaxOpenConns:          "50",
+					QueryTimeout:          "60",
+					EnableSchemaCache:     true,
+					SchemaCacheTTLSeconds: 60,
+				},
+				wantErr: nil,
+				testCtx: ctx,
+			},
+			{
+				name: "should trim whitespace from v3 server field",
+				args: args{
+					config: backend.DataSourceInstanceSettings{
+						JSONData:                []byte(`{"server": "  ch.example.com  ", "port": 443}`),
+						DecryptedSecureJSONData: map[string]string{},
+					},
+				},
+				wantSettings: Settings{
+					Host:                  "ch.example.com",
+					Port:                  443,
+					ConnMaxLifetime:       "5",
+					DialTimeout:           "10",
+					MaxIdleConns:          "25",
+					MaxOpenConns:          "50",
+					QueryTimeout:          "60",
+					EnableSchemaCache:     true,
+					SchemaCacheTTLSeconds: 60,
+				},
+				wantErr: nil,
+				testCtx: ctx,
+			},
 		}
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
@@ -321,6 +365,7 @@ func TestLoadSettings(t *testing.T) {
 			description string
 		}{
 			{jsonData: `{ "host": "", "port": 443 }`, password: "", wantErr: ErrorMessageInvalidHost, description: "should capture empty server name"},
+			{jsonData: `{ "host": "   ", "port": 443 }`, password: "", wantErr: ErrorMessageInvalidHost, description: "should capture whitespace-only server name"},
 			{jsonData: `{ "host": "foo" }`, password: "", wantErr: ErrorMessageInvalidPort, description: "should capture nil port"},
 			{jsonData: `  "host": "foo", "port": 443, "username" : "foo" }`, password: "", wantErr: ErrorMessageInvalidJSON, description: "should capture invalid json"},
 		}


### PR DESCRIPTION
## Summary

When the user typed a leading or trailing space in the Server address field, Save and Test would fail with a confusing connection error instead of a clear validation message. A whitespace-only host slipped past both the frontend's `if (!jsonData.host)` check (truthy in JS) and the backend's `Host == ""` check, so the request hit the ClickHouse driver with a malformed hostname and died there.

This fixes it in `LoadSettings` by trimming whitespace when reading both the v4 `host` field and the legacy v3 `server` field. One change covers V1 editor, V2 editor (gated on `newClickhouseConfigPageDesign`), provisioning YAML, and any API-driven config.

After the fix:
- `"   "` -> trimmed to `""` -> existing `ErrorMessageInvalidHost` triggers with a clear message
- `"  ch.example.com  "` -> trimmed to `"ch.example.com"` -> connection works

The pattern matches existing whitespace handling in the same file (`headerName = strings.TrimSpace(...)`) and on the frontend (`HttpHeadersConfigV2.tsx`, `AliasTableConfigV2.tsx`).

Fixes #1823

## Test plan

- [x] `go test ./pkg/plugin/... -run TestLoadSettings -v` passes (added 2 positive cases for v4 `host` and v3 `server` trimming, 1 negative case for whitespace-only host)
- [x] `go test ./pkg/...` full suite green
- [x] `go vet ./pkg/...` clean