### PR TITLE
fix(config-v2): trim whitespace from host on blur

### DIFF
--- a/src/views/config-v2/ServerAndEncryptionSection.test.tsx
+++ b/src/views/config-v2/ServerAndEncryptionSection.test.tsx
@@ -45,6 +45,60 @@ describe('ServerAndEncryptionSection', () => {
     expect(onOptionsChangeMock).toHaveBeenCalled();
   });
 
+  it('trims leading and trailing whitespace from host on blur', () => {
+    const props = createTestProps({
+      options: {
+        jsonData: {
+          host: '  clickhouse-example.com  ',
+          secure: false,
+          protocol: Protocol.Native,
+          port: undefined,
+          pdcInjected: false,
+        },
+        secureJsonData: {},
+        secureJsonFields: {},
+      },
+      mocks: {
+        onOptionsChange: onOptionsChangeMock,
+      },
+    });
+    render(<ServerAndEncryptionSection {...props} />);
+
+    const input = screen.getByTestId('clickhouse-v2-config-host-input');
+    fireEvent.blur(input);
+
+    expect(onOptionsChangeMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        jsonData: expect.objectContaining({ host: 'clickhouse-example.com' }),
+      })
+    );
+  });
+
+  it('shows server address error when host is whitespace-only on blur', () => {
+    const props = createTestProps({
+      options: {
+        jsonData: {
+          host: '   ',
+          secure: false,
+          protocol: Protocol.Native,
+          port: undefined,
+          pdcInjected: false,
+        },
+        secureJsonData: {},
+        secureJsonFields: {},
+      },
+      mocks: {
+        onOptionsChange: onOptionsChangeMock,
+      },
+    });
+    render(<ServerAndEncryptionSection {...props} />);
+
+    const input = screen.getByTestId('clickhouse-v2-config-host-input');
+    fireEvent.blur(input);
+
+    expect(screen.getByText(/server address required/i)).toBeInTheDocument();
+  });
+
   it('updates protocol value on radio button toggle', () => {
     render(<ServerAndEncryptionSection {...defaultProps} />);
 

--- a/src/views/config-v2/ServerAndEncryptionSection.tsx
+++ b/src/views/config-v2/ServerAndEncryptionSection.tsx
@@ -63,8 +63,10 @@ export const ServerAndEncryptionSection = (props: Props) => {
 
   useEffect(() => {
     // Always clear errors eagerly when the user fills in a field, regardless of
-    // whether the ValidationAPI is available
-    if (jsonData.host) {
+    // whether the ValidationAPI is available. Whitespace-only is treated as
+    // empty so the user gets a clear field-level error instead of a
+    // confusing connection failure later.
+    if (jsonData.host?.trim()) {
       setFieldErrors((prev) => {
         const next = { ...prev };
         delete next.host;
@@ -85,7 +87,7 @@ export const ServerAndEncryptionSection = (props: Props) => {
     }
     return validation.registerValidation(() => {
       const errors: Record<string, string> = {};
-      if (!jsonData.host) {
+      if (!jsonData.host?.trim()) {
         errors.host = labels.serverAddress.error;
       }
       if (!jsonData.port) {
@@ -163,7 +165,14 @@ export const ServerAndEncryptionSection = (props: Props) => {
             placeholder={labels.serverAddress.placeholder}
             onBlur={(e) => {
               trackClickhouseConfigV2HostInput();
-              if (!e.currentTarget.value) {
+              const trimmed = e.currentTarget.value.trim();
+              if (trimmed !== e.currentTarget.value) {
+                onOptionsChange({
+                  ...options,
+                  jsonData: { ...options.jsonData, host: trimmed },
+                });
+              }
+              if (!trimmed) {
                 setFieldErrors((prev) => ({ ...prev, host: labels.serverAddress.error }));
                 validation?.setError('host', labels.serverAddress.error);
               }


### PR DESCRIPTION
## Summary

Companion to #1830. The backend `LoadSettings` fix in that PR catches whitespace at submission time so Save and Test stops failing silently, but the V2 config editor's frontend validation still treats whitespace-only as valid input (truthy `if (jsonData.host)` check). That means whitespace-only or whitespace-padded values pass inline validation without any visual feedback.

This PR fixes the V2 frontend behavior:

- The validation effect's host checks use `.trim()` so whitespace-only is treated as empty.
- The host input's onBlur trims `e.currentTarget.value` and persists the cleaned value back via `onOptionsChange`. Whitespace-only triggers the existing "Server address required" inline error.

V2 is gated on the `newClickhouseConfigPageDesign` feature flag and is the upcoming default config experience. Pattern matches existing whitespace handling in this directory: `HttpHeadersConfigV2.tsx:35` (`header.name.trim()`) and `AliasTableConfigV2.tsx:58-61` (alias entry trim).

Fixes #1823 (in combination with #1830 on the backend).

## Test plan

- [x] `yarn jest --testPathPattern='config-v2/ServerAndEncryptionSection'` passes (10/10, 2 new cases)
  - trims leading and trailing whitespace from host on blur
  - shows "Server address required" when host is whitespace-only on blur
- [x] `yarn jest --testPathPattern='config-v2'` full V2 suite green (45/45)
- [x] `yarn lint` no errors (69 pre-existing warnings unchanged)

## Note on V1

The legacy V1 editor (`src/views/CHConfigEditor.tsx`) has the same JS truthy bug but is the deprecated default and will go away when the V2 feature flag becomes the default. The backend fix in #1830 covers it at submission time, so I'm not touching V1 here.