### PR TITLE
feat(config): introduce single-table mode for logs and traces configuration

### DIFF
--- a/docs/sources/configure.md
+++ b/docs/sources/configure.md
@@ -165,6 +165,17 @@ When **Secure connection** is enabled, the following TLS settings become availab
 | **Client Cert**     | PEM-encoded client certificate (required when TLS Client Auth is enabled).                                                     |
 | **Client Key**      | PEM-encoded client private key (required when TLS Client Auth is enabled).                                                     |
 
+### Configuration mode
+
+Use **Configuration mode** to choose how the data source is used by the query builder.
+
+| Mode | Description |
+|------|-------------|
+| **All databases** | Allows queries against any database and table the ClickHouse user can read. Use this mode for general exploration and dashboards that query multiple tables. |
+| **Single source** | Focuses the data source on one logs or traces table. Choose a **Signal type**, then configure the database, table, and column mappings for that source. |
+
+Use **Single source** when the data source is dedicated to one logs or traces table, such as an OpenTelemetry table. This keeps the logs or traces schema settings with the selected source and avoids reconfiguring column mappings in each query.
+
 ### Additional settings
 
 | Setting              | Description                                                           |
@@ -195,6 +206,8 @@ The data source includes a dedicated configuration section for log queries. Thes
 | **Log Message column**   | The column containing the log message body.                                                                                                                                                                                                                 |
 | **Context columns**      | Comma-separated list of columns included alongside log messages for additional context.                                                                                                                                                                     |
 
+When **Configuration mode** is set to **Single source** and **Signal type** is set to **Logs**, these settings define the focused logs source.
+
 ### Traces configuration
 
 The data source includes a dedicated configuration section for trace queries. These settings control the default column mappings used by the [traces query builder](/docs/plugins/grafana-clickhouse-datasource/<CLICKHOUSE_PLUGIN_VERSION>/query-editor/#traces-query-builder):
@@ -208,6 +221,8 @@ The data source includes a dedicated configuration section for trace queries. Th
 | **Flatten nested**         | Enable if your traces table was created with `flatten_nested=1`.                                                             |
 
 When **Use OTel** is disabled, you can manually configure columns for Trace ID, Span ID, Parent Span ID, Service Name, Operation Name, Start Time, Duration, Tags, Service Tags, Kind, Status Code, Status Message, State, and Instrumentation Library.
+
+When **Configuration mode** is set to **Single source** and **Signal type** is set to **Traces**, these settings define the focused traces source.
 
 ### Private data source connect
 
@@ -272,8 +287,18 @@ datasources:
       port: 9000
       protocol: native
       username: grafana_reader
+      # configMode: classic          # "classic" for all databases, "single-table" for single source
+      # signalType: logs             # "logs" or "traces"; used when configMode is "single-table"
       # defaultDatabase: <string>
       # defaultTable: <string>
+      # logs:
+      #   defaultDatabase: <string>
+      #   defaultTable: <string>
+      #   otelEnabled: <bool>
+      # traces:
+      #   defaultDatabase: <string>
+      #   defaultTable: <string>
+      #   otelEnabled: <bool>
       # secure: <bool>
       # tlsSkipVerify: <bool>
       # tlsAuth: <bool>
@@ -313,7 +338,14 @@ resource "grafana_data_source" "clickhouse" {
     protocol         = "native"
     username         = "grafana_reader"
     tlsSkipVerify    = false
+    # configMode     = "classic" # or "single-table"
+    # signalType     = "logs"    # or "traces"; used when configMode is "single-table"
     # defaultDatabase = "mydb"
+    # logs            = {
+    #   defaultDatabase = "otel"
+    #   defaultTable    = "otel_logs"
+    #   otelEnabled     = true
+    # }
     # dialTimeout     = "10"
     # queryTimeout    = "60"
     # validateSql     = true

--- a/docs/sources/query-editor.md
+++ b/docs/sources/query-editor.md
@@ -46,6 +46,8 @@ The query editor appears in [Explore](https://grafana.com/docs/grafana/latest/vi
 - **Type-specific options** — Configure columns, filters, grouping, sorting, limit (max rows), and (for traces) trace ID. The builder generates the SQL for you.
 - **SQL preview** — At the bottom of the builder, you can see the generated SQL. You can switch to SQL mode to edit it manually.
 
+If the data source is configured in **Single source** mode, the query builder uses the configured logs or traces source as its default database, table, and column mapping.
+
 ## Build queries
 
 You can build queries using the **SQL editor** (raw SQL) or the **Query builder**. Queries can include macros for dynamic parts such as time range filters.
@@ -254,7 +256,7 @@ Trace-panel column aliases are fixed; choose the table columns that play each ro
 
 Set the **Duration Unit** to match the units your column stores (OTel uses nanoseconds; other schemas often use milliseconds or seconds). The builder converts durations to milliseconds for the trace panel.
 
-To avoid re-mapping roles for every query, configure defaults under **Data source settings → Logs** and **Data source settings → Traces**. Enabling **OTel** mode populates every role with the OTel-conventional column name automatically.
+To avoid re-mapping roles for every query, configure defaults under **Data source settings → Logs** and **Data source settings → Traces**, or use **Single source** mode when a data source is dedicated to one logs or traces table. Enabling **OTel** mode populates every role with the OTel-conventional column name automatically.
 
 ## Macros
 

--- a/src/components/configEditor/LogsConfig.tsx
+++ b/src/components/configEditor/LogsConfig.tsx
@@ -5,13 +5,14 @@ import { OtelVersionSelect } from 'components/queryBuilder/OtelVersionSelect';
 import { ColumnHint } from 'types/queryBuilder';
 import otel from 'otel';
 import { LabeledInput } from './LabeledInput';
-import { CHLogsConfig, defaultCHAdditionalSettingsConfig } from 'types/config';
+import { CHLogsConfig, ConfigMode, defaultCHAdditionalSettingsConfig } from 'types/config';
 import allLabels from 'labels';
 import { columnLabelToPlaceholder } from 'data/utils';
 import { Switch } from 'components/queryBuilder/Switch';
 
 interface LogsConfigProps {
   logsConfig?: CHLogsConfig;
+  variant?: ConfigMode;
   onDefaultDatabaseChange: (v: string) => void;
   onDefaultTableChange: (v: string) => void;
   onOtelEnabledChange: (v: boolean) => void;
@@ -53,6 +54,7 @@ export const LogsConfig = (props: LogsConfigProps) => {
     showLogLinks,
   } = props.logsConfig || {};
   const labels = allLabels.components.Config.LogsConfig;
+  const sectionLabels = props.variant === 'single-table' ? labels.variants.singleTable : labels;
 
   const otelConfig = otel.getVersion(otelVersion);
   if (otelEnabled && otelConfig) {
@@ -66,7 +68,7 @@ export const LogsConfig = (props: LogsConfigProps) => {
     onContextColumnsChange(columns.map((c) => c.trim()).filter((c) => c));
 
   return (
-    <ConfigSection title={labels.title} description={labels.description}>
+    <ConfigSection title={sectionLabels.title} description={sectionLabels.description}>
       <div id="logs-config" />
       <Field label={labels.defaultDatabase.label} description={labels.defaultDatabase.description}>
         <Input

--- a/src/components/configEditor/TracesConfig.tsx
+++ b/src/components/configEditor/TracesConfig.tsx
@@ -6,13 +6,14 @@ import { ColumnHint, TimeUnit } from 'types/queryBuilder';
 import otel, { traceTimestampTableSuffix as defaultTraceTimestampTableSuffix } from 'otel';
 import { LabeledInput } from './LabeledInput';
 import { DurationUnitSelect } from 'components/queryBuilder/DurationUnitSelect';
-import { CHTracesConfig, defaultCHAdditionalSettingsConfig } from 'types/config';
+import { CHTracesConfig, ConfigMode, defaultCHAdditionalSettingsConfig } from 'types/config';
 import allLabels from 'labels';
 import { columnLabelToPlaceholder } from 'data/utils';
 import { Switch } from 'components/queryBuilder/Switch';
 
 export interface TraceConfigProps {
   tracesConfig?: CHTracesConfig;
+  variant?: ConfigMode;
   onDefaultDatabaseChange: (v: string) => void;
   onDefaultTableChange: (v: string) => void;
   onOtelEnabledChange: (v: boolean) => void;
@@ -96,6 +97,7 @@ export const TracesConfig = (props: TraceConfigProps) => {
     traceTimestampTableSuffix,
   } = (props.tracesConfig || {}) as CHTracesConfig;
   const labels = allLabels.components.Config.TracesConfig;
+  const sectionLabels = props.variant === 'single-table' ? labels.variants.singleTable : labels;
 
   const otelConfig = otel.getVersion(otelVersion);
   if (otelEnabled && otelConfig) {
@@ -121,7 +123,7 @@ export const TracesConfig = (props: TraceConfigProps) => {
   }
 
   return (
-    <ConfigSection title={labels.title} description={labels.description}>
+    <ConfigSection title={sectionLabels.title} description={sectionLabels.description}>
       <div id="traces-config" />
       <Field label={labels.defaultDatabase.label} description={labels.defaultDatabase.description}>
         <Input

--- a/src/data/utils.test.ts
+++ b/src/data/utils.test.ts
@@ -219,6 +219,25 @@ describe('applyTraceSearchFieldConfig', () => {
 });
 
 describe('transformQueryResponseWithTraceAndLogLinks', () => {
+  const configureOtelLogs = (datasource: Datasource) => {
+    datasource.settings.jsonData.logs = {
+      defaultDatabase: 'otel',
+      defaultTable: 'otel_logs',
+      otelEnabled: true,
+      otelVersion: 'latest',
+    };
+  };
+
+  const configureOtelTraces = (datasource: Datasource) => {
+    datasource.settings.jsonData.traces = {
+      defaultDatabase: 'otel',
+      defaultTable: 'otel_traces',
+      otelEnabled: true,
+      otelVersion: 'latest',
+      durationUnit: TimeUnit.Nanoseconds,
+    };
+  };
+
   const buildTestRequestResponse = (
     builderOptions: Partial<QueryBuilderOptions>
   ): [DataQueryRequest<CHQuery>, DataQueryResponse] => {
@@ -267,6 +286,7 @@ describe('transformQueryResponseWithTraceAndLogLinks', () => {
 
   it('inserts links into trace query. Copy trace columns, default log columns.', async () => {
     const mockDatasource = newMockDatasource();
+    configureOtelLogs(mockDatasource);
     const getDefaultTraceDatabase = jest.spyOn(mockDatasource, 'getDefaultTraceDatabase');
     const getDefaultTraceTable = jest.spyOn(mockDatasource, 'getDefaultTraceTable');
     const getDefaultTraceColumns = jest.spyOn(mockDatasource, 'getDefaultTraceColumns');
@@ -295,6 +315,7 @@ describe('transformQueryResponseWithTraceAndLogLinks', () => {
 
   it('inserts links into logs query. Copy logs columns, default trace columns.', async () => {
     const mockDatasource = newMockDatasource();
+    configureOtelTraces(mockDatasource);
     jest.spyOn(mockDatasource, 'fetchColumns').mockResolvedValue([]);
     const getDefaultTraceDatabase = jest.spyOn(mockDatasource, 'getDefaultTraceDatabase');
     const getDefaultTraceTable = jest.spyOn(mockDatasource, 'getDefaultTraceTable');
@@ -329,6 +350,7 @@ describe('transformQueryResponseWithTraceAndLogLinks', () => {
   it('includes TraceId filter in View logs link query using configured column', async () => {
     const mockDatasource = newMockDatasource();
     // Mock that TraceId is configured
+    jest.spyOn(mockDatasource, 'getDefaultLogsTable').mockReturnValue('logs');
     jest.spyOn(mockDatasource, 'getDefaultLogsColumns').mockReturnValue(new Map([[ColumnHint.TraceId, 'TraceId']]));
 
     const builderOptions: Partial<QueryBuilderOptions> = {
@@ -570,6 +592,14 @@ describe('transformQueryResponseWithTraceAndLogLinks', () => {
 
     it('logs→trace link without OTel generates rawSql without _trace_id_ts optimization', async () => {
       const mockDatasource = newMockDatasource();
+      mockDatasource.settings.jsonData.traces = {
+        defaultDatabase: 'otel',
+        defaultTable: 'otel_traces',
+        traceIdColumn: 'TraceId',
+        startTimeColumn: 'Timestamp',
+        durationColumn: 'Duration',
+        durationUnit: TimeUnit.Nanoseconds,
+      };
       jest.spyOn(mockDatasource, 'fetchColumns').mockResolvedValue([]);
 
       const builderOptions: Partial<QueryBuilderOptions> = {
@@ -623,6 +653,7 @@ describe('transformQueryResponseWithTraceAndLogLinks', () => {
 
   it('does not inject "View trace" link when showTraceLinks is false', async () => {
     const mockDatasource = newMockDatasource();
+    configureOtelLogs(mockDatasource);
     mockDatasource.settings.jsonData.traces = { showTraceLinks: false };
 
     const builderOptions: Partial<QueryBuilderOptions> = {
@@ -653,6 +684,43 @@ describe('transformQueryResponseWithTraceAndLogLinks', () => {
 
     const links = out?.data[0]?.fields[0]?.config?.links;
     expect(links).toBeDefined();
+    expect(links?.find((link: any) => link.title === 'View trace')).toBeDefined();
+    expect(links?.find((link: any) => link.title === 'View logs')).toBeUndefined();
+  });
+
+  it('does not inject "View trace" for a logs-only single-table datasource', async () => {
+    const mockDatasource = newMockDatasource();
+    mockDatasource.settings.jsonData.configMode = 'single-table';
+    mockDatasource.settings.jsonData.signalType = 'logs';
+    configureOtelLogs(mockDatasource);
+
+    const builderOptions: Partial<QueryBuilderOptions> = {
+      queryType: QueryType.Logs,
+    };
+
+    const [request, response] = buildTestRequestResponse(builderOptions);
+    const out = await transformQueryResponseWithTraceAndLogLinks(mockDatasource, request, response);
+
+    const links = out?.data[0]?.fields[0]?.config?.links;
+    expect(links?.find((link: any) => link.title === 'View trace')).toBeUndefined();
+    expect(links?.find((link: any) => link.title === 'View logs')).toBeDefined();
+  });
+
+  it('does not inject "View logs" for a traces-only single-table datasource', async () => {
+    const mockDatasource = newMockDatasource();
+    mockDatasource.settings.jsonData.configMode = 'single-table';
+    mockDatasource.settings.jsonData.signalType = 'traces';
+    configureOtelTraces(mockDatasource);
+
+    const builderOptions: Partial<QueryBuilderOptions> = {
+      queryType: QueryType.Traces,
+      columns: [{ name: 'TraceId', hint: ColumnHint.TraceId }],
+    };
+
+    const [request, response] = buildTestRequestResponse(builderOptions);
+    const out = await transformQueryResponseWithTraceAndLogLinks(mockDatasource, request, response);
+
+    const links = out?.data[0]?.fields[0]?.config?.links;
     expect(links?.find((link: any) => link.title === 'View trace')).toBeDefined();
     expect(links?.find((link: any) => link.title === 'View logs')).toBeUndefined();
   });

--- a/src/data/utils.ts
+++ b/src/data/utils.ts
@@ -574,7 +574,16 @@ export const transformQueryResponseWithTraceAndLogLinks = async (
     }
     traceLogsQuery.format = mapQueryBuilderOptionsToGrafanaFormat(traceLogsQuery.builderOptions);
     traceField.config.links = [];
-    if (datasource.settings.jsonData.traces?.showTraceLinks !== false) {
+    const canLinkToTraces =
+      originalQuery.editorType === EditorType.Builder && originalQuery.builderOptions.queryType === QueryType.Traces
+        ? true
+        : canBuildTraceLink(datasource);
+    const canLinkToLogs =
+      originalQuery.editorType === EditorType.Builder && originalQuery.builderOptions.queryType === QueryType.Logs
+        ? true
+        : canBuildLogsLink(datasource);
+
+    if (datasource.settings.jsonData.traces?.showTraceLinks !== false && canLinkToTraces) {
       traceField.config.links!.push({
         title: 'View trace',
         targetBlank: openInNewWindow,
@@ -591,7 +600,7 @@ export const transformQueryResponseWithTraceAndLogLinks = async (
         },
       });
     }
-    if (datasource.settings.jsonData.logs?.showLogLinks !== false) {
+    if (datasource.settings.jsonData.logs?.showLogLinks !== false && canLinkToLogs) {
       traceField.config.links!.push({
         title: 'View logs',
         targetBlank: openInNewWindow,
@@ -606,6 +615,16 @@ export const transformQueryResponseWithTraceAndLogLinks = async (
   }
 
   return res;
+};
+
+const canBuildTraceLink = (datasource: Datasource): boolean => {
+  const traceColumns = datasource.getDefaultTraceColumns();
+  return Boolean(datasource.getDefaultTraceTable() && traceColumns.get(ColumnHint.TraceId));
+};
+
+const canBuildLogsLink = (datasource: Datasource): boolean => {
+  const logColumns = datasource.getDefaultLogsColumns();
+  return Boolean(datasource.getDefaultLogsTable() && logColumns.get(ColumnHint.TraceId));
 };
 
 // The name of the dataframe field containing labels

--- a/src/labels.ts
+++ b/src/labels.ts
@@ -169,6 +169,12 @@ export default {
       TracesConfig: {
         title: 'Traces configuration',
         description: '(Optional) Default settings for trace queries',
+        variants: {
+          singleTable: {
+            title: 'Traces Table & Schema',
+            description: 'Configure the database, table, and column mappings for trace queries.',
+          },
+        },
         defaultDatabase: {
           label: 'Default trace database',
           description: 'the default database used by the trace query builder',
@@ -275,6 +281,12 @@ export default {
       LogsConfig: {
         title: 'Logs configuration',
         description: '(Optional) default settings for log queries',
+        variants: {
+          singleTable: {
+            title: 'Logs Table & Schema',
+            description: 'Configure the database, table, and column mappings for log queries.',
+          },
+        },
         defaultDatabase: {
           label: 'Default log database',
           description: 'the default database used by the logs query builder',

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -2,6 +2,16 @@ import { DataSourceJsonData, KeyValue } from '@grafana/data';
 import otel, { defaultLogsTable, defaultTraceTable } from 'otel';
 import { TimeUnit } from './queryBuilder';
 
+export type SignalType = 'logs' | 'traces';
+
+/**
+ * Configuration mode controls the datasource UI layout:
+ * - 'classic': Full access to all databases/tables.
+ * - 'single-table': Focused on one table. The user picks a signal type
+ *   and configures the schema inline.
+ */
+export type ConfigMode = 'classic' | 'single-table';
+
 export interface CHConfig extends DataSourceJsonData {
   /**
    * The version of the plugin this config was saved with
@@ -45,6 +55,17 @@ export interface CHConfig extends DataSourceJsonData {
   hideTableNameInAdhocFilters?: boolean;
 
   pdcInjected?: boolean;
+
+  /**
+   * Configuration mode: 'classic' (all databases) or 'single-table' (focused).
+   * Defaults to 'classic' when unset.
+   */
+  configMode?: ConfigMode;
+
+  /**
+   * Signal type for single-table mode. Declares what the configured table contains.
+   */
+  signalType?: SignalType;
 }
 
 interface CHSecureConfigProperties {

--- a/src/views/CHConfigEditor.test.tsx
+++ b/src/views/CHConfigEditor.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { ConfigEditor } from './CHConfigEditor';
 import { mockConfigEditorProps } from '__mocks__/ConfigEditor';
 import '@testing-library/jest-dom';
@@ -130,5 +130,82 @@ describe('ConfigEditor', () => {
     expect(screen.getByDisplayValue(jsonDataOverrides.customSettings[0].value)).toBeInTheDocument();
     expect(screen.getByText(labels.enableRowLimit.label)).toBeInTheDocument();
     expect(screen.getByTestId(labels.enableRowLimit.testid)).toBeChecked();
+  });
+
+  it('renders single-table logs configuration', () => {
+    render(
+      <ConfigEditor
+        {...mockConfigEditorProps({
+          configMode: 'single-table',
+          signalType: 'logs',
+          logs: {
+            defaultDatabase: 'otel_v2',
+            defaultTable: 'otel_logs',
+            otelEnabled: true,
+            otelVersion: '1.29.0',
+          },
+        })}
+      />
+    );
+
+    expect(screen.getByText('Configuration Mode')).toBeInTheDocument();
+    expect(screen.getByText('Signal type')).toBeInTheDocument();
+    expect(screen.getByText('Logs Table & Schema')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('otel_v2')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('otel_logs')).toBeInTheDocument();
+    expect(screen.getByText(allLabels.components.OtelVersionSelect.label)).toBeInTheDocument();
+    expect(screen.getByText(allLabels.components.Config.LogsConfig.traceIdCorrelation.title)).toBeInTheDocument();
+    expect(
+      screen.getByText(allLabels.components.Config.LogsConfig.traceIdCorrelation.showLogLinks.label)
+    ).toBeInTheDocument();
+  });
+
+  it('defaults to logs when switching to single-table mode', () => {
+    const props = mockConfigEditorProps({ configMode: 'classic' });
+    render(<ConfigEditor {...props} />);
+
+    (props.onOptionsChange as jest.Mock).mockClear();
+    fireEvent.click(screen.getByText('Single table'));
+
+    expect(props.onOptionsChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        jsonData: expect.objectContaining({
+          configMode: 'single-table',
+          signalType: 'logs',
+        }),
+      })
+    );
+  });
+
+  it('persists the single-table logs trace correlation setting', () => {
+    const props = mockConfigEditorProps({
+      configMode: 'single-table',
+      signalType: 'logs',
+      logs: {
+        defaultTable: 'otel_logs',
+        otelVersion: '1.29.0',
+        showLogLinks: true,
+      },
+    });
+    render(<ConfigEditor {...props} />);
+
+    (props.onOptionsChange as jest.Mock).mockClear();
+    const showLogLinksLabel = screen.getByText(
+      allLabels.components.Config.LogsConfig.traceIdCorrelation.showLogLinks.label
+    );
+    const showLogLinksInput = showLogLinksLabel.closest('.gf-form')?.querySelector('input');
+
+    expect(showLogLinksInput).toBeChecked();
+    fireEvent.click(showLogLinksInput!);
+
+    expect(props.onOptionsChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        jsonData: expect.objectContaining({
+          logs: expect.objectContaining({
+            showLogLinks: false,
+          }),
+        }),
+      })
+    );
   });
 });

--- a/src/views/CHConfigEditor.tsx
+++ b/src/views/CHConfigEditor.tsx
@@ -14,6 +14,8 @@ import {
   Protocol,
   CHTracesConfig,
   AliasTableEntry,
+  ConfigMode,
+  SignalType,
 } from 'types/config';
 import { isVersionGtOrEq as versionGte } from 'utils/version';
 import { ConfigSection, ConfigSubSection, DataSourceDescription } from 'components/experimental/ConfigSection';
@@ -243,6 +245,9 @@ export const ConfigEditor: React.FC<ConfigEditorProps> = (props) => {
     options.jsonData.logs ||
     options.jsonData.traces
   );
+  const configMode = jsonData.configMode || (jsonData.signalType ? 'single-table' : 'classic');
+  const isSingleTableMode = configMode === 'single-table';
+  const selectedSignalType = isSingleTableMode ? jsonData.signalType || 'logs' : undefined;
 
   const defaultPort = jsonData.secure
     ? jsonData.protocol === Protocol.Native
@@ -469,295 +474,425 @@ export const ConfigEditor: React.FC<ConfigEditorProps> = (props) => {
 
       <Divider />
       <ConfigSection
-        title="Additional settings"
-        description="Additional settings are optional settings that can be configured for more control over your data source. This includes the default database, dial and query timeouts, SQL validation, and custom ClickHouse settings."
-        isCollapsible
-        isInitiallyOpen={hasAdditionalSettings}
+        title="Configuration Mode"
+        description="Choose how this datasource is used. 'Single table' provides a focused, compact query editor for one table. 'All databases' gives full access to explore any database and table."
       >
-        <Divider />
-        <DefaultDatabaseTableConfig
-          defaultDatabase={jsonData.defaultDatabase}
-          defaultTable={jsonData.defaultTable}
-          onDefaultDatabaseChange={(e) => {
-            trackingV1.trackClickhouseConfigV1DefaultDbInput();
-            onUpdateDatasourceJsonDataOption(props, 'defaultDatabase')(e);
-          }}
-          onDefaultTableChange={(e) => {
-            trackingV1.trackClickhouseConfigV1DefaultTableInput();
-            onUpdateDatasourceJsonDataOption(props, 'defaultTable')(e);
-          }}
-        />
-
-        <Divider />
-        <QuerySettingsConfig
-          connMaxLifetime={jsonData.connMaxLifetime}
-          dialTimeout={jsonData.dialTimeout}
-          maxIdleConns={jsonData.maxIdleConns}
-          maxOpenConns={jsonData.maxOpenConns}
-          queryTimeout={jsonData.queryTimeout}
-          validateSql={jsonData.validateSql}
-          onDialTimeoutChange={(e) => {
-            trackingV1.trackClickhouseConfigV1QuerySettings({ dialTimeout: Number(e.currentTarget.value) });
-            onUpdateDatasourceJsonDataOption(props, 'dialTimeout')(e);
-          }}
-          onQueryTimeoutChange={(e) => {
-            trackingV1.trackClickhouseConfigV1QuerySettings({ queryTimeout: Number(e.currentTarget.value) });
-            onUpdateDatasourceJsonDataOption(props, 'queryTimeout')(e);
-          }}
-          onConnMaxLifetimeChange={(e) => {
-            trackingV1.trackClickhouseConfigV1QuerySettings({ connMaxLifetime: Number(e.currentTarget.value) });
-            onUpdateDatasourceJsonDataOption(props, 'connMaxLifetime')(e);
-          }}
-          onConnMaxIdleConnsChange={(e) => {
-            trackingV1.trackClickhouseConfigV1QuerySettings({ maxIdleConns: Number(e.currentTarget.value) });
-            onUpdateDatasourceJsonDataOption(props, 'maxIdleConns')(e);
-          }}
-          onConnMaxOpenConnsChange={(e) => {
-            trackingV1.trackClickhouseConfigV1QuerySettings({ maxOpenConns: Number(e.currentTarget.value) });
-            onUpdateDatasourceJsonDataOption(props, 'maxOpenConns')(e);
-          }}
-          onValidateSqlChange={(e) => {
-            trackingV1.trackClickhouseConfigV1QuerySettings({ validateSql: e.currentTarget.checked });
-            onSwitchToggle('validateSql', e.currentTarget.checked);
-          }}
-        />
-
-        <Divider />
-        <LogsConfig
-          logsConfig={jsonData.logs}
-          onDefaultDatabaseChange={(db) => {
-            trackingV1.trackClickhouseConfigV1LogsConfig({ defaultDatabase: db });
-            onLogsConfigChange('defaultDatabase', db);
-          }}
-          onDefaultTableChange={(table) => {
-            trackingV1.trackClickhouseConfigV1LogsConfig({ defaultTable: table });
-            onLogsConfigChange('defaultTable', table);
-          }}
-          onOtelEnabledChange={(v) => {
-            trackingV1.trackClickhouseConfigV1LogsConfig({ otelEnabled: v });
-            onLogsConfigChange('otelEnabled', v);
-          }}
-          onOtelVersionChange={(v) => {
-            trackingV1.trackClickhouseConfigV1LogsConfig({ version: v });
-            onLogsConfigChange('otelVersion', v);
-          }}
-          onFilterTimeColumnChange={(c) => {
-            trackingV1.trackClickhouseConfigV1LogsConfig({ filterTimeColumn: c });
-            onLogsConfigChange('filterTimeColumn', c);
-          }}
-          onTimeColumnChange={(c) => {
-            trackingV1.trackClickhouseConfigV1LogsConfig({ timeColumn: c });
-            onLogsConfigChange('timeColumn', c);
-          }}
-          onLevelColumnChange={(c) => {
-            trackingV1.trackClickhouseConfigV1LogsConfig({ levelColumn: c });
-            onLogsConfigChange('levelColumn', c);
-          }}
-          onMessageColumnChange={(c) => {
-            trackingV1.trackClickhouseConfigV1LogsConfig({ messageColumn: c });
-            onLogsConfigChange('messageColumn', c);
-          }}
-          onSelectContextColumnsChange={(c) => {
-            trackingV1.trackClickhouseConfigV1LogsConfig({ selectContextColumns: c });
-            onLogsConfigChange('selectContextColumns', c);
-          }}
-          onContextColumnsChange={(c) => {
-            trackingV1.trackClickhouseConfigV1LogsConfig({ contextColumns: c });
-            onLogsConfigChange('contextColumns', c);
-          }}
-          onShowLogLinksChange={(v) => {
-            onLogsConfigChange('showLogLinks', v);
-          }}
-        />
-
-        <Divider />
-        <TracesConfig
-          tracesConfig={jsonData.traces}
-          onDefaultDatabaseChange={(db) => {
-            trackingV1.trackClickhouseConfigV1TracesConfig({ defaultDatabase: db });
-            onTracesConfigChange('defaultDatabase', db);
-          }}
-          onDefaultTableChange={(table) => {
-            trackingV1.trackClickhouseConfigV1TracesConfig({ defaultTable: table });
-            onTracesConfigChange('defaultTable', table);
-          }}
-          onOtelEnabledChange={(v) => {
-            trackingV1.trackClickhouseConfigV1TracesConfig({ otelEnabled: v });
-            onTracesConfigChange('otelEnabled', v);
-          }}
-          onOtelVersionChange={(v) => {
-            trackingV1.trackClickhouseConfigV1TracesConfig({ version: v });
-            onTracesConfigChange('otelVersion', v);
-          }}
-          onTraceIdColumnChange={(c) => {
-            trackingV1.trackClickhouseConfigV1TracesConfig({ traceIdColumn: c });
-            onTracesConfigChange('traceIdColumn', c);
-          }}
-          onSpanIdColumnChange={(c) => {
-            trackingV1.trackClickhouseConfigV1TracesConfig({ spanIdColumn: c });
-            onTracesConfigChange('spanIdColumn', c);
-          }}
-          onOperationNameColumnChange={(c) => {
-            trackingV1.trackClickhouseConfigV1TracesConfig({ operationNameColumn: c });
-            onTracesConfigChange('operationNameColumn', c);
-          }}
-          onParentSpanIdColumnChange={(c) => {
-            trackingV1.trackClickhouseConfigV1TracesConfig({ parentSpanIdColumn: c });
-            onTracesConfigChange('parentSpanIdColumn', c);
-          }}
-          onServiceNameColumnChange={(c) => {
-            trackingV1.trackClickhouseConfigV1TracesConfig({ serviceNameColumn: c });
-            onTracesConfigChange('serviceNameColumn', c);
-          }}
-          onDurationColumnChange={(c) => {
-            trackingV1.trackClickhouseConfigV1TracesConfig({ durationColumn: c });
-            onTracesConfigChange('durationColumn', c);
-          }}
-          onDurationUnitChange={(c) => {
-            trackingV1.trackClickhouseConfigV1TracesConfig({ durationUnit: c });
-            onTracesConfigChange('durationUnit', c);
-          }}
-          onStartTimeColumnChange={(c) => {
-            trackingV1.trackClickhouseConfigV1TracesConfig({ startTimeColumn: c });
-            onTracesConfigChange('startTimeColumn', c);
-          }}
-          onTagsColumnChange={(c) => {
-            trackingV1.trackClickhouseConfigV1TracesConfig({ tagsColumn: c });
-            onTracesConfigChange('tagsColumn', c);
-          }}
-          onServiceTagsColumnChange={(c) => {
-            trackingV1.trackClickhouseConfigV1TracesConfig({ serviceTagsColumn: c });
-            onTracesConfigChange('serviceTagsColumn', c);
-          }}
-          onKindColumnChange={(c) => {
-            trackingV1.trackClickhouseConfigV1TracesConfig({ kindColumn: c });
-            onTracesConfigChange('kindColumn', c);
-          }}
-          onStatusCodeColumnChange={(c) => {
-            trackingV1.trackClickhouseConfigV1TracesConfig({ statusCodeColumn: c });
-            onTracesConfigChange('statusCodeColumn', c);
-          }}
-          onStatusMessageColumnChange={(c) => {
-            trackingV1.trackClickhouseConfigV1TracesConfig({ statusMessageColumn: c });
-            onTracesConfigChange('statusMessageColumn', c);
-          }}
-          onStateColumnChange={(c) => {
-            trackingV1.trackClickhouseConfigV1TracesConfig({ stateColumn: c });
-            onTracesConfigChange('stateColumn', c);
-          }}
-          onInstrumentationLibraryNameColumnChange={(c) => {
-            trackingV1.trackClickhouseConfigV1TracesConfig({ instrumentationLibraryNameColumn: c });
-            onTracesConfigChange('instrumentationLibraryNameColumn', c);
-          }}
-          onInstrumentationLibraryVersionColumnChange={(c) => {
-            trackingV1.trackClickhouseConfigV1TracesConfig({ instrumentationLibraryVersionColumn: c });
-            onTracesConfigChange('instrumentationLibraryVersionColumn', c);
-          }}
-          onFlattenNestedChange={(c) => {
-            trackingV1.trackClickhouseConfigV1TracesConfig({ flattenNested: c });
-            onTracesConfigChange('flattenNested', c);
-          }}
-          onEventsColumnPrefixChange={(c) => {
-            trackingV1.trackClickhouseConfigV1TracesConfig({ traceEventsColumnPrefix: c });
-            onTracesConfigChange('traceEventsColumnPrefix', c);
-          }}
-          onLinksColumnPrefixChange={(c) => {
-            trackingV1.trackClickhouseConfigV1TracesConfig({ traceLinksColumnPrefix: c });
-            onTracesConfigChange('traceLinksColumnPrefix', c);
-          }}
-          onShowTraceLinksChange={(v) => {
-            onTracesConfigChange('showTraceLinks', v);
-          }}
-          onTraceTimestampTableSuffixChange={(c) => {
-            trackingV1.trackClickhouseConfigV1TracesConfig({ traceTimestampTableSuffix: c });
-            onTracesConfigChange('traceTimestampTableSuffix', c);
-          }}
-        />
-
-        <Divider />
-        <AliasTableConfig aliasTables={jsonData.aliasTables} onAliasTablesChange={onAliasTableConfigChange} />
-        <Divider />
-        <Field label={labels.enableRowLimit.label} description={labels.enableRowLimit.tooltip}>
-          <Switch
-            className="gf-form"
-            value={jsonData.enableRowLimit || false}
-            data-testid={labels.enableRowLimit.testid}
-            onChange={(e) => {
-              trackingV1.trackClickhouseConfigV1EnableRowLimitToggle({ rowLimitEnabled: e.currentTarget.checked });
-              onSwitchToggle('enableRowLimit', e.currentTarget.checked);
+        <Field label="Mode">
+          <RadioButtonGroup<ConfigMode>
+            options={[
+              { label: 'All databases', value: 'classic' },
+              { label: 'Single table', value: 'single-table' },
+            ]}
+            value={configMode}
+            onChange={(v) => {
+              const newJsonData = { ...options.jsonData, configMode: v };
+              if (v === 'classic') {
+                newJsonData.signalType = undefined;
+              } else if (!newJsonData.signalType) {
+                newJsonData.signalType = 'logs';
+              }
+              onOptionsChange({ ...options, jsonData: newJsonData });
             }}
           />
         </Field>
-        <Field
-          label={labels.hideTableNameInAdhocFilters.label}
-          description={labels.hideTableNameInAdhocFilters.tooltip}
-        >
-          <Switch
-            className="gf-form"
-            value={jsonData.hideTableNameInAdhocFilters || false}
-            data-testid={labels.hideTableNameInAdhocFilters.testid}
-            onChange={(e) => {
-              onSwitchToggle('hideTableNameInAdhocFilters', e.currentTarget.checked);
-            }}
-          />
-        </Field>
-        {config.secureSocksDSProxyEnabled && versionGte(config.buildInfo.version, '10.0.0') && (
-          <Field label={labels.secureSocksProxy.label} description={labels.secureSocksProxy.tooltip}>
-            <Switch
-              className="gf-form"
-              value={jsonData.enableSecureSocksProxy || false}
-              onChange={(e) => onSwitchToggle('enableSecureSocksProxy', e.currentTarget.checked)}
+        {isSingleTableMode && (
+          <Field label="Signal type" description="What kind of data does this table contain?">
+            <RadioButtonGroup<SignalType>
+              options={[
+                { label: 'Logs', value: 'logs', description: 'Log search with severity, message, and attributes' },
+                { label: 'Traces', value: 'traces', description: 'Distributed tracing with spans and service maps' },
+              ]}
+              value={selectedSignalType}
+              onChange={(v) => {
+                onOptionsChange({
+                  ...options,
+                  jsonData: {
+                    ...options.jsonData,
+                    configMode: 'single-table',
+                    signalType: v,
+                  },
+                });
+              }}
             />
           </Field>
         )}
-        <ConfigSubSection title="Custom Settings">
-          {customSettings.map(({ setting, value }, i) => {
-            return (
-              <Stack key={i} direction="row">
-                <Field label={`Setting`} aria-label={`Setting`}>
-                  <Input
-                    value={setting}
-                    placeholder={'Setting'}
-                    onChange={(changeEvent: ChangeEvent<HTMLInputElement>) => {
-                      let newSettings = customSettings.concat();
-                      newSettings[i] = { setting: changeEvent.target.value, value };
-                      setCustomSettings(newSettings);
-                    }}
-                    onBlur={() => {
-                      trackingV1.trackClickhouseConfigV1CustomSettingAdded();
-                      onCustomSettingsChange(customSettings);
-                    }}
-                  ></Input>
-                </Field>
-                <Field label={'Value'} aria-label={`Value`}>
-                  <Input
-                    value={value}
-                    placeholder={'Value'}
-                    onChange={(changeEvent: ChangeEvent<HTMLInputElement>) => {
-                      let newSettings = customSettings.concat();
-                      newSettings[i] = { setting, value: changeEvent.target.value };
-                      setCustomSettings(newSettings);
-                    }}
-                    onBlur={() => {
-                      onCustomSettingsChange(customSettings);
-                    }}
-                  ></Input>
-                </Field>
-              </Stack>
-            );
-          })}
-          <Button
-            variant="secondary"
-            icon="plus"
-            type="button"
-            onClick={() => {
-              setCustomSettings([...customSettings, { setting: '', value: '' }]);
-            }}
-          >
-            Add custom setting
-          </Button>
-        </ConfigSubSection>
       </ConfigSection>
+
+      {isSingleTableMode && selectedSignalType && (
+        <>
+          {selectedSignalType === 'logs' && (
+            <>
+              <Divider />
+              <LogsConfig
+                variant="single-table"
+                logsConfig={jsonData.logs}
+                onDefaultDatabaseChange={(db) => onLogsConfigChange('defaultDatabase', db)}
+                onDefaultTableChange={(table) => onLogsConfigChange('defaultTable', table)}
+                onOtelEnabledChange={(v) => onLogsConfigChange('otelEnabled', v)}
+                onOtelVersionChange={(v) => onLogsConfigChange('otelVersion', v)}
+                onFilterTimeColumnChange={(c) => onLogsConfigChange('filterTimeColumn', c)}
+                onTimeColumnChange={(c) => onLogsConfigChange('timeColumn', c)}
+                onLevelColumnChange={(c) => onLogsConfigChange('levelColumn', c)}
+                onMessageColumnChange={(c) => onLogsConfigChange('messageColumn', c)}
+                onSelectContextColumnsChange={(c) => onLogsConfigChange('selectContextColumns', c)}
+                onContextColumnsChange={(c) => onLogsConfigChange('contextColumns', c)}
+                onShowLogLinksChange={(v) => onLogsConfigChange('showLogLinks', v)}
+              />
+            </>
+          )}
+          {selectedSignalType === 'traces' && (
+            <>
+              <Divider />
+              <TracesConfig
+                variant="single-table"
+                tracesConfig={jsonData.traces}
+                onDefaultDatabaseChange={(db) => onTracesConfigChange('defaultDatabase', db)}
+                onDefaultTableChange={(table) => onTracesConfigChange('defaultTable', table)}
+                onOtelEnabledChange={(v) => onTracesConfigChange('otelEnabled', v)}
+                onOtelVersionChange={(v) => onTracesConfigChange('otelVersion', v)}
+                onTraceIdColumnChange={(c) => onTracesConfigChange('traceIdColumn', c)}
+                onSpanIdColumnChange={(c) => onTracesConfigChange('spanIdColumn', c)}
+                onOperationNameColumnChange={(c) => onTracesConfigChange('operationNameColumn', c)}
+                onParentSpanIdColumnChange={(c) => onTracesConfigChange('parentSpanIdColumn', c)}
+                onServiceNameColumnChange={(c) => onTracesConfigChange('serviceNameColumn', c)}
+                onDurationColumnChange={(c) => onTracesConfigChange('durationColumn', c)}
+                onDurationUnitChange={(c) => onTracesConfigChange('durationUnit', c)}
+                onStartTimeColumnChange={(c) => onTracesConfigChange('startTimeColumn', c)}
+                onTagsColumnChange={(c) => onTracesConfigChange('tagsColumn', c)}
+                onServiceTagsColumnChange={(c) => onTracesConfigChange('serviceTagsColumn', c)}
+                onKindColumnChange={(c) => onTracesConfigChange('kindColumn', c)}
+                onStatusCodeColumnChange={(c) => onTracesConfigChange('statusCodeColumn', c)}
+                onStatusMessageColumnChange={(c) => onTracesConfigChange('statusMessageColumn', c)}
+                onStateColumnChange={(c) => onTracesConfigChange('stateColumn', c)}
+                onInstrumentationLibraryNameColumnChange={(c) =>
+                  onTracesConfigChange('instrumentationLibraryNameColumn', c)
+                }
+                onInstrumentationLibraryVersionColumnChange={(c) =>
+                  onTracesConfigChange('instrumentationLibraryVersionColumn', c)
+                }
+                onFlattenNestedChange={(c) => onTracesConfigChange('flattenNested', c)}
+                onEventsColumnPrefixChange={(c) => onTracesConfigChange('traceEventsColumnPrefix', c)}
+                onLinksColumnPrefixChange={(c) => onTracesConfigChange('traceLinksColumnPrefix', c)}
+                onShowTraceLinksChange={(v) => onTracesConfigChange('showTraceLinks', v)}
+                onTraceTimestampTableSuffixChange={(v) => onTracesConfigChange('traceTimestampTableSuffix', v)}
+              />
+            </>
+          )}
+          <Divider />
+          <ConfigSection title="Query settings" isCollapsible isInitiallyOpen={false}>
+            <QuerySettingsConfig
+              dialTimeout={jsonData.dialTimeout}
+              queryTimeout={jsonData.queryTimeout}
+              connMaxLifetime={jsonData.connMaxLifetime}
+              maxIdleConns={jsonData.maxIdleConns}
+              maxOpenConns={jsonData.maxOpenConns}
+              validateSql={jsonData.validateSql}
+              onDialTimeoutChange={(e) => onUpdateDatasourceJsonDataOption(props, 'dialTimeout')(e)}
+              onQueryTimeoutChange={(e) => onUpdateDatasourceJsonDataOption(props, 'queryTimeout')(e)}
+              onConnMaxLifetimeChange={(e) => onUpdateDatasourceJsonDataOption(props, 'connMaxLifetime')(e)}
+              onConnMaxIdleConnsChange={(e) => onUpdateDatasourceJsonDataOption(props, 'maxIdleConns')(e)}
+              onConnMaxOpenConnsChange={(e) => onUpdateDatasourceJsonDataOption(props, 'maxOpenConns')(e)}
+              onValidateSqlChange={(e) => onSwitchToggle('validateSql', e.currentTarget.checked)}
+            />
+          </ConfigSection>
+        </>
+      )}
+
+      {!isSingleTableMode && (
+        <>
+          <Divider />
+          <ConfigSection
+            title="Additional settings"
+            description="Additional settings are optional settings that can be configured for more control over your data source. This includes the default database, dial and query timeouts, SQL validation, and custom ClickHouse settings."
+            isCollapsible
+            isInitiallyOpen={hasAdditionalSettings}
+          >
+            <Divider />
+            <DefaultDatabaseTableConfig
+              defaultDatabase={jsonData.defaultDatabase}
+              defaultTable={jsonData.defaultTable}
+              onDefaultDatabaseChange={(e) => {
+                trackingV1.trackClickhouseConfigV1DefaultDbInput();
+                onUpdateDatasourceJsonDataOption(props, 'defaultDatabase')(e);
+              }}
+              onDefaultTableChange={(e) => {
+                trackingV1.trackClickhouseConfigV1DefaultTableInput();
+                onUpdateDatasourceJsonDataOption(props, 'defaultTable')(e);
+              }}
+            />
+
+            <Divider />
+            <QuerySettingsConfig
+              connMaxLifetime={jsonData.connMaxLifetime}
+              dialTimeout={jsonData.dialTimeout}
+              maxIdleConns={jsonData.maxIdleConns}
+              maxOpenConns={jsonData.maxOpenConns}
+              queryTimeout={jsonData.queryTimeout}
+              validateSql={jsonData.validateSql}
+              onDialTimeoutChange={(e) => {
+                trackingV1.trackClickhouseConfigV1QuerySettings({ dialTimeout: Number(e.currentTarget.value) });
+                onUpdateDatasourceJsonDataOption(props, 'dialTimeout')(e);
+              }}
+              onQueryTimeoutChange={(e) => {
+                trackingV1.trackClickhouseConfigV1QuerySettings({ queryTimeout: Number(e.currentTarget.value) });
+                onUpdateDatasourceJsonDataOption(props, 'queryTimeout')(e);
+              }}
+              onConnMaxLifetimeChange={(e) => {
+                trackingV1.trackClickhouseConfigV1QuerySettings({ connMaxLifetime: Number(e.currentTarget.value) });
+                onUpdateDatasourceJsonDataOption(props, 'connMaxLifetime')(e);
+              }}
+              onConnMaxIdleConnsChange={(e) => {
+                trackingV1.trackClickhouseConfigV1QuerySettings({ maxIdleConns: Number(e.currentTarget.value) });
+                onUpdateDatasourceJsonDataOption(props, 'maxIdleConns')(e);
+              }}
+              onConnMaxOpenConnsChange={(e) => {
+                trackingV1.trackClickhouseConfigV1QuerySettings({ maxOpenConns: Number(e.currentTarget.value) });
+                onUpdateDatasourceJsonDataOption(props, 'maxOpenConns')(e);
+              }}
+              onValidateSqlChange={(e) => {
+                trackingV1.trackClickhouseConfigV1QuerySettings({ validateSql: e.currentTarget.checked });
+                onSwitchToggle('validateSql', e.currentTarget.checked);
+              }}
+            />
+
+            <Divider />
+            <LogsConfig
+              logsConfig={jsonData.logs}
+              onDefaultDatabaseChange={(db) => {
+                trackingV1.trackClickhouseConfigV1LogsConfig({ defaultDatabase: db });
+                onLogsConfigChange('defaultDatabase', db);
+              }}
+              onDefaultTableChange={(table) => {
+                trackingV1.trackClickhouseConfigV1LogsConfig({ defaultTable: table });
+                onLogsConfigChange('defaultTable', table);
+              }}
+              onOtelEnabledChange={(v) => {
+                trackingV1.trackClickhouseConfigV1LogsConfig({ otelEnabled: v });
+                onLogsConfigChange('otelEnabled', v);
+              }}
+              onOtelVersionChange={(v) => {
+                trackingV1.trackClickhouseConfigV1LogsConfig({ version: v });
+                onLogsConfigChange('otelVersion', v);
+              }}
+              onFilterTimeColumnChange={(c) => {
+                trackingV1.trackClickhouseConfigV1LogsConfig({ filterTimeColumn: c });
+                onLogsConfigChange('filterTimeColumn', c);
+              }}
+              onTimeColumnChange={(c) => {
+                trackingV1.trackClickhouseConfigV1LogsConfig({ timeColumn: c });
+                onLogsConfigChange('timeColumn', c);
+              }}
+              onLevelColumnChange={(c) => {
+                trackingV1.trackClickhouseConfigV1LogsConfig({ levelColumn: c });
+                onLogsConfigChange('levelColumn', c);
+              }}
+              onMessageColumnChange={(c) => {
+                trackingV1.trackClickhouseConfigV1LogsConfig({ messageColumn: c });
+                onLogsConfigChange('messageColumn', c);
+              }}
+              onSelectContextColumnsChange={(c) => {
+                trackingV1.trackClickhouseConfigV1LogsConfig({ selectContextColumns: c });
+                onLogsConfigChange('selectContextColumns', c);
+              }}
+              onContextColumnsChange={(c) => {
+                trackingV1.trackClickhouseConfigV1LogsConfig({ contextColumns: c });
+                onLogsConfigChange('contextColumns', c);
+              }}
+              onShowLogLinksChange={(v) => {
+                onLogsConfigChange('showLogLinks', v);
+              }}
+            />
+
+            <Divider />
+            <TracesConfig
+              tracesConfig={jsonData.traces}
+              onDefaultDatabaseChange={(db) => {
+                trackingV1.trackClickhouseConfigV1TracesConfig({ defaultDatabase: db });
+                onTracesConfigChange('defaultDatabase', db);
+              }}
+              onDefaultTableChange={(table) => {
+                trackingV1.trackClickhouseConfigV1TracesConfig({ defaultTable: table });
+                onTracesConfigChange('defaultTable', table);
+              }}
+              onOtelEnabledChange={(v) => {
+                trackingV1.trackClickhouseConfigV1TracesConfig({ otelEnabled: v });
+                onTracesConfigChange('otelEnabled', v);
+              }}
+              onOtelVersionChange={(v) => {
+                trackingV1.trackClickhouseConfigV1TracesConfig({ version: v });
+                onTracesConfigChange('otelVersion', v);
+              }}
+              onTraceIdColumnChange={(c) => {
+                trackingV1.trackClickhouseConfigV1TracesConfig({ traceIdColumn: c });
+                onTracesConfigChange('traceIdColumn', c);
+              }}
+              onSpanIdColumnChange={(c) => {
+                trackingV1.trackClickhouseConfigV1TracesConfig({ spanIdColumn: c });
+                onTracesConfigChange('spanIdColumn', c);
+              }}
+              onOperationNameColumnChange={(c) => {
+                trackingV1.trackClickhouseConfigV1TracesConfig({ operationNameColumn: c });
+                onTracesConfigChange('operationNameColumn', c);
+              }}
+              onParentSpanIdColumnChange={(c) => {
+                trackingV1.trackClickhouseConfigV1TracesConfig({ parentSpanIdColumn: c });
+                onTracesConfigChange('parentSpanIdColumn', c);
+              }}
+              onServiceNameColumnChange={(c) => {
+                trackingV1.trackClickhouseConfigV1TracesConfig({ serviceNameColumn: c });
+                onTracesConfigChange('serviceNameColumn', c);
+              }}
+              onDurationColumnChange={(c) => {
+                trackingV1.trackClickhouseConfigV1TracesConfig({ durationColumn: c });
+                onTracesConfigChange('durationColumn', c);
+              }}
+              onDurationUnitChange={(c) => {
+                trackingV1.trackClickhouseConfigV1TracesConfig({ durationUnit: c });
+                onTracesConfigChange('durationUnit', c);
+              }}
+              onStartTimeColumnChange={(c) => {
+                trackingV1.trackClickhouseConfigV1TracesConfig({ startTimeColumn: c });
+                onTracesConfigChange('startTimeColumn', c);
+              }}
+              onTagsColumnChange={(c) => {
+                trackingV1.trackClickhouseConfigV1TracesConfig({ tagsColumn: c });
+                onTracesConfigChange('tagsColumn', c);
+              }}
+              onServiceTagsColumnChange={(c) => {
+                trackingV1.trackClickhouseConfigV1TracesConfig({ serviceTagsColumn: c });
+                onTracesConfigChange('serviceTagsColumn', c);
+              }}
+              onKindColumnChange={(c) => {
+                trackingV1.trackClickhouseConfigV1TracesConfig({ kindColumn: c });
+                onTracesConfigChange('kindColumn', c);
+              }}
+              onStatusCodeColumnChange={(c) => {
+                trackingV1.trackClickhouseConfigV1TracesConfig({ statusCodeColumn: c });
+                onTracesConfigChange('statusCodeColumn', c);
+              }}
+              onStatusMessageColumnChange={(c) => {
+                trackingV1.trackClickhouseConfigV1TracesConfig({ statusMessageColumn: c });
+                onTracesConfigChange('statusMessageColumn', c);
+              }}
+              onStateColumnChange={(c) => {
+                trackingV1.trackClickhouseConfigV1TracesConfig({ stateColumn: c });
+                onTracesConfigChange('stateColumn', c);
+              }}
+              onInstrumentationLibraryNameColumnChange={(c) => {
+                trackingV1.trackClickhouseConfigV1TracesConfig({ instrumentationLibraryNameColumn: c });
+                onTracesConfigChange('instrumentationLibraryNameColumn', c);
+              }}
+              onInstrumentationLibraryVersionColumnChange={(c) => {
+                trackingV1.trackClickhouseConfigV1TracesConfig({ instrumentationLibraryVersionColumn: c });
+                onTracesConfigChange('instrumentationLibraryVersionColumn', c);
+              }}
+              onFlattenNestedChange={(c) => {
+                trackingV1.trackClickhouseConfigV1TracesConfig({ flattenNested: c });
+                onTracesConfigChange('flattenNested', c);
+              }}
+              onEventsColumnPrefixChange={(c) => {
+                trackingV1.trackClickhouseConfigV1TracesConfig({ traceEventsColumnPrefix: c });
+                onTracesConfigChange('traceEventsColumnPrefix', c);
+              }}
+              onLinksColumnPrefixChange={(c) => {
+                trackingV1.trackClickhouseConfigV1TracesConfig({ traceLinksColumnPrefix: c });
+                onTracesConfigChange('traceLinksColumnPrefix', c);
+              }}
+              onShowTraceLinksChange={(v) => {
+                onTracesConfigChange('showTraceLinks', v);
+              }}
+              onTraceTimestampTableSuffixChange={(c) => {
+                trackingV1.trackClickhouseConfigV1TracesConfig({ traceTimestampTableSuffix: c });
+                onTracesConfigChange('traceTimestampTableSuffix', c);
+              }}
+            />
+
+            <Divider />
+            <AliasTableConfig aliasTables={jsonData.aliasTables} onAliasTablesChange={onAliasTableConfigChange} />
+            <Divider />
+            <Field label={labels.enableRowLimit.label} description={labels.enableRowLimit.tooltip}>
+              <Switch
+                className="gf-form"
+                value={jsonData.enableRowLimit || false}
+                data-testid={labels.enableRowLimit.testid}
+                onChange={(e) => {
+                  trackingV1.trackClickhouseConfigV1EnableRowLimitToggle({ rowLimitEnabled: e.currentTarget.checked });
+                  onSwitchToggle('enableRowLimit', e.currentTarget.checked);
+                }}
+              />
+            </Field>
+            <Field
+              label={labels.hideTableNameInAdhocFilters.label}
+              description={labels.hideTableNameInAdhocFilters.tooltip}
+            >
+              <Switch
+                className="gf-form"
+                value={jsonData.hideTableNameInAdhocFilters || false}
+                data-testid={labels.hideTableNameInAdhocFilters.testid}
+                onChange={(e) => {
+                  onSwitchToggle('hideTableNameInAdhocFilters', e.currentTarget.checked);
+                }}
+              />
+            </Field>
+            {config.secureSocksDSProxyEnabled && versionGte(config.buildInfo.version, '10.0.0') && (
+              <Field label={labels.secureSocksProxy.label} description={labels.secureSocksProxy.tooltip}>
+                <Switch
+                  className="gf-form"
+                  value={jsonData.enableSecureSocksProxy || false}
+                  onChange={(e) => onSwitchToggle('enableSecureSocksProxy', e.currentTarget.checked)}
+                />
+              </Field>
+            )}
+            <ConfigSubSection title="Custom Settings">
+              {customSettings.map(({ setting, value }, i) => {
+                return (
+                  <Stack key={i} direction="row">
+                    <Field label={`Setting`} aria-label={`Setting`}>
+                      <Input
+                        value={setting}
+                        placeholder={'Setting'}
+                        onChange={(changeEvent: ChangeEvent<HTMLInputElement>) => {
+                          let newSettings = customSettings.concat();
+                          newSettings[i] = { setting: changeEvent.target.value, value };
+                          setCustomSettings(newSettings);
+                        }}
+                        onBlur={() => {
+                          trackingV1.trackClickhouseConfigV1CustomSettingAdded();
+                          onCustomSettingsChange(customSettings);
+                        }}
+                      ></Input>
+                    </Field>
+                    <Field label={'Value'} aria-label={`Value`}>
+                      <Input
+                        value={value}
+                        placeholder={'Value'}
+                        onChange={(changeEvent: ChangeEvent<HTMLInputElement>) => {
+                          let newSettings = customSettings.concat();
+                          newSettings[i] = { setting, value: changeEvent.target.value };
+                          setCustomSettings(newSettings);
+                        }}
+                        onBlur={() => {
+                          onCustomSettingsChange(customSettings);
+                        }}
+                      ></Input>
+                    </Field>
+                  </Stack>
+                );
+              })}
+              <Button
+                variant="secondary"
+                icon="plus"
+                type="button"
+                onClick={() => {
+                  setCustomSettings([...customSettings, { setting: '', value: '' }]);
+                }}
+              >
+                Add custom setting
+              </Button>
+            </ConfigSubSection>
+          </ConfigSection>
+        </>
+      )}
     </>
   );
 };

--- a/src/views/config-v2/AdditionalSettingsSection.tsx
+++ b/src/views/config-v2/AdditionalSettingsSection.tsx
@@ -57,6 +57,8 @@ export const AdditionalSettingsSection = (props: Props) => {
   const { jsonData } = options;
   const labels = allLabels.components.Config.ConfigEditor;
   const styles = useStyles2(getStyles);
+  const isSingleTableMode =
+    (jsonData.configMode || (jsonData.signalType ? 'single-table' : 'classic')) === 'single-table';
 
   useConfigDefaults(options, onOptionsChange);
 
@@ -119,28 +121,33 @@ export const AdditionalSettingsSection = (props: Props) => {
     });
   };
   const shouldBeOpen = useMemo(() => {
-    const defaultLogs = defaultCHAdditionalSettingsConfig.logs;
-    const defaultTraces = defaultCHAdditionalSettingsConfig.traces;
-    const logs = jsonData.logs ?? defaultLogs;
-    const traces = jsonData.traces ?? defaultTraces;
-
     return (
-      !!jsonData.defaultDatabase ||
-      !!jsonData.defaultTable ||
-      !!jsonData.connMaxLifetime ||
-      !!jsonData.dialTimeout ||
-      !!jsonData.maxIdleConns ||
-      !!jsonData.maxOpenConns ||
-      !!jsonData.queryTimeout ||
-      !!jsonData.validateSql ||
-      !isEqual(logs, defaultLogs) ||
-      !isEqual(traces, defaultTraces) ||
+      (!isSingleTableMode &&
+        (() => {
+          const defaultLogs = defaultCHAdditionalSettingsConfig.logs;
+          const defaultTraces = defaultCHAdditionalSettingsConfig.traces;
+          const logs = jsonData.logs ?? defaultLogs;
+          const traces = jsonData.traces ?? defaultTraces;
+
+          return (
+            !!jsonData.defaultDatabase ||
+            !!jsonData.defaultTable ||
+            !!jsonData.connMaxLifetime ||
+            !!jsonData.dialTimeout ||
+            !!jsonData.maxIdleConns ||
+            !!jsonData.maxOpenConns ||
+            !!jsonData.queryTimeout ||
+            !!jsonData.validateSql ||
+            !isEqual(logs, defaultLogs) ||
+            !isEqual(traces, defaultTraces)
+          );
+        })()) ||
       (jsonData.aliasTables?.length ?? 0) > 0 ||
       !!jsonData.enableRowLimit ||
       !!jsonData.enableSecureSocksProxy ||
       customSettings.length > 0
     );
-  }, [jsonData, customSettings]);
+  }, [jsonData, isSingleTableMode, customSettings]);
 
   return (
     <Box
@@ -148,111 +155,117 @@ export const AdditionalSettingsSection = (props: Props) => {
       borderColor="weak"
       padding={2}
       marginBottom={4}
-      id={`${CONFIG_SECTION_HEADERS[3].id}`}
+      id={`${CONFIG_SECTION_HEADERS[4].id}`}
       minWidth={CONTAINER_MIN_WIDTH}
     >
       <CollapsableSection
         label={
           <>
-            <Text variant="h3">{CONFIG_SECTION_HEADERS[3].label}</Text>
+            <Text variant="h3">{CONFIG_SECTION_HEADERS[4].label}</Text>
             <Badge text="optional" color="darkgrey" className={styles.badge} />
           </>
         }
         isOpen={!!shouldBeOpen}
       >
-        <DefaultDatabaseTableConfig
-          defaultDatabase={jsonData.defaultDatabase}
-          defaultTable={jsonData.defaultTable}
-          onDefaultDatabaseChange={(e) => {
-            trackClickhouseConfigV2DefaultDbInput();
-            onUpdateDatasourceJsonDataOption(props, 'defaultDatabase')(e);
-          }}
-          onDefaultTableChange={(e) => {
-            trackClickhouseConfigV2DefaultTableInput();
-            onUpdateDatasourceJsonDataOption(props, 'defaultTable')(e);
-          }}
-        />
-        <Divider />
-        <QuerySettingsConfig
-          connMaxLifetime={jsonData.connMaxLifetime}
-          dialTimeout={jsonData.dialTimeout}
-          maxIdleConns={jsonData.maxIdleConns}
-          maxOpenConns={jsonData.maxOpenConns}
-          queryTimeout={jsonData.queryTimeout}
-          validateSql={jsonData.validateSql}
-          onDialTimeoutChange={(e) => {
-            trackClickhouseConfigV2QuerySettings({ dialTimeout: Number(e.currentTarget.value) });
-            onUpdateDatasourceJsonDataOption(props, 'dialTimeout')(e);
-          }}
-          onQueryTimeoutChange={(e) => {
-            trackClickhouseConfigV2QuerySettings({ queryTimeout: Number(e.currentTarget.value) });
-            onUpdateDatasourceJsonDataOption(props, 'queryTimeout')(e);
-          }}
-          onConnMaxLifetimeChange={(e) => {
-            trackClickhouseConfigV2QuerySettings({ connMaxLifetime: Number(e.currentTarget.value) });
-            onUpdateDatasourceJsonDataOption(props, 'connMaxLifetime')(e);
-          }}
-          onConnMaxIdleConnsChange={(e) => {
-            trackClickhouseConfigV2QuerySettings({ maxIdleConns: Number(e.currentTarget.value) });
-            onUpdateDatasourceJsonDataOption(props, 'maxIdleConns')(e);
-          }}
-          onConnMaxOpenConnsChange={(e) => {
-            trackClickhouseConfigV2QuerySettings({ maxOpenConns: Number(e.currentTarget.value) });
-            onUpdateDatasourceJsonDataOption(props, 'maxOpenConns')(e);
-          }}
-          onValidateSqlChange={(e) => {
-            trackClickhouseConfigV2QuerySettings({ validateSql: e.currentTarget.checked });
-            onUpdateDatasourceJsonDataOptionChecked(props, 'validateSql')(e);
-          }}
-        />
-        <Divider />
-        <LogsConfig
-          logsConfig={jsonData.logs}
-          onDefaultDatabaseChange={(db) => onUpdateLogsConfig('defaultDatabase', db)}
-          onDefaultTableChange={(table) => onUpdateLogsConfig('defaultTable', table)}
-          onOtelEnabledChange={(v) => onUpdateLogsConfig('otelEnabled', v)}
-          onOtelVersionChange={(v) => onUpdateLogsConfig('otelVersion', v)}
-          onFilterTimeColumnChange={(c) => onUpdateLogsConfig('filterTimeColumn', c)}
-          onTimeColumnChange={(c) => onUpdateLogsConfig('timeColumn', c)}
-          onLevelColumnChange={(c) => onUpdateLogsConfig('levelColumn', c)}
-          onMessageColumnChange={(c) => onUpdateLogsConfig('messageColumn', c)}
-          onSelectContextColumnsChange={(c) => onUpdateLogsConfig('selectContextColumns', c)}
-          onContextColumnsChange={(c) => onUpdateLogsConfig('contextColumns', c)}
-          onShowLogLinksChange={(v) => onUpdateLogsConfig('showLogLinks', v)}
-        />
+        {!isSingleTableMode && (
+          <>
+            <DefaultDatabaseTableConfig
+              defaultDatabase={jsonData.defaultDatabase}
+              defaultTable={jsonData.defaultTable}
+              onDefaultDatabaseChange={(e) => {
+                trackClickhouseConfigV2DefaultDbInput();
+                onUpdateDatasourceJsonDataOption(props, 'defaultDatabase')(e);
+              }}
+              onDefaultTableChange={(e) => {
+                trackClickhouseConfigV2DefaultTableInput();
+                onUpdateDatasourceJsonDataOption(props, 'defaultTable')(e);
+              }}
+            />
+            <Divider />
+            <QuerySettingsConfig
+              connMaxLifetime={jsonData.connMaxLifetime}
+              dialTimeout={jsonData.dialTimeout}
+              maxIdleConns={jsonData.maxIdleConns}
+              maxOpenConns={jsonData.maxOpenConns}
+              queryTimeout={jsonData.queryTimeout}
+              validateSql={jsonData.validateSql}
+              onDialTimeoutChange={(e) => {
+                trackClickhouseConfigV2QuerySettings({ dialTimeout: Number(e.currentTarget.value) });
+                onUpdateDatasourceJsonDataOption(props, 'dialTimeout')(e);
+              }}
+              onQueryTimeoutChange={(e) => {
+                trackClickhouseConfigV2QuerySettings({ queryTimeout: Number(e.currentTarget.value) });
+                onUpdateDatasourceJsonDataOption(props, 'queryTimeout')(e);
+              }}
+              onConnMaxLifetimeChange={(e) => {
+                trackClickhouseConfigV2QuerySettings({ connMaxLifetime: Number(e.currentTarget.value) });
+                onUpdateDatasourceJsonDataOption(props, 'connMaxLifetime')(e);
+              }}
+              onConnMaxIdleConnsChange={(e) => {
+                trackClickhouseConfigV2QuerySettings({ maxIdleConns: Number(e.currentTarget.value) });
+                onUpdateDatasourceJsonDataOption(props, 'maxIdleConns')(e);
+              }}
+              onConnMaxOpenConnsChange={(e) => {
+                trackClickhouseConfigV2QuerySettings({ maxOpenConns: Number(e.currentTarget.value) });
+                onUpdateDatasourceJsonDataOption(props, 'maxOpenConns')(e);
+              }}
+              onValidateSqlChange={(e) => {
+                trackClickhouseConfigV2QuerySettings({ validateSql: e.currentTarget.checked });
+                onUpdateDatasourceJsonDataOptionChecked(props, 'validateSql')(e);
+              }}
+            />
+            <Divider />
+            <LogsConfig
+              logsConfig={jsonData.logs}
+              onDefaultDatabaseChange={(db) => onUpdateLogsConfig('defaultDatabase', db)}
+              onDefaultTableChange={(table) => onUpdateLogsConfig('defaultTable', table)}
+              onOtelEnabledChange={(v) => onUpdateLogsConfig('otelEnabled', v)}
+              onOtelVersionChange={(v) => onUpdateLogsConfig('otelVersion', v)}
+              onFilterTimeColumnChange={(c) => onUpdateLogsConfig('filterTimeColumn', c)}
+              onTimeColumnChange={(c) => onUpdateLogsConfig('timeColumn', c)}
+              onLevelColumnChange={(c) => onUpdateLogsConfig('levelColumn', c)}
+              onMessageColumnChange={(c) => onUpdateLogsConfig('messageColumn', c)}
+              onSelectContextColumnsChange={(c) => onUpdateLogsConfig('selectContextColumns', c)}
+              onContextColumnsChange={(c) => onUpdateLogsConfig('contextColumns', c)}
+              onShowLogLinksChange={(v) => onUpdateLogsConfig('showLogLinks', v)}
+            />
 
-        <Divider />
-        <TracesConfig
-          tracesConfig={jsonData.traces}
-          onDefaultDatabaseChange={(db) => onUpdateTracesConfig('defaultDatabase', db)}
-          onDefaultTableChange={(table) => onUpdateTracesConfig('defaultTable', table)}
-          onOtelEnabledChange={(v) => onUpdateTracesConfig('otelEnabled', v)}
-          onOtelVersionChange={(v) => onUpdateTracesConfig('otelVersion', v)}
-          onTraceIdColumnChange={(c) => onUpdateTracesConfig('traceIdColumn', c)}
-          onSpanIdColumnChange={(c) => onUpdateTracesConfig('spanIdColumn', c)}
-          onOperationNameColumnChange={(c) => onUpdateTracesConfig('operationNameColumn', c)}
-          onParentSpanIdColumnChange={(c) => onUpdateTracesConfig('parentSpanIdColumn', c)}
-          onServiceNameColumnChange={(c) => onUpdateTracesConfig('serviceNameColumn', c)}
-          onDurationColumnChange={(c) => onUpdateTracesConfig('durationColumn', c)}
-          onDurationUnitChange={(c) => onUpdateTracesConfig('durationUnit', c)}
-          onStartTimeColumnChange={(c) => onUpdateTracesConfig('startTimeColumn', c)}
-          onTagsColumnChange={(c) => onUpdateTracesConfig('tagsColumn', c)}
-          onServiceTagsColumnChange={(c) => onUpdateTracesConfig('serviceTagsColumn', c)}
-          onKindColumnChange={(c) => onUpdateTracesConfig('kindColumn', c)}
-          onStatusCodeColumnChange={(c) => onUpdateTracesConfig('statusCodeColumn', c)}
-          onStatusMessageColumnChange={(c) => onUpdateTracesConfig('statusMessageColumn', c)}
-          onStateColumnChange={(c) => onUpdateTracesConfig('stateColumn', c)}
-          onInstrumentationLibraryNameColumnChange={(c) => onUpdateTracesConfig('instrumentationLibraryNameColumn', c)}
-          onInstrumentationLibraryVersionColumnChange={(c) =>
-            onUpdateTracesConfig('instrumentationLibraryVersionColumn', c)
-          }
-          onFlattenNestedChange={(c) => onUpdateTracesConfig('flattenNested', c)}
-          onEventsColumnPrefixChange={(c) => onUpdateTracesConfig('traceEventsColumnPrefix', c)}
-          onLinksColumnPrefixChange={(c) => onUpdateTracesConfig('traceLinksColumnPrefix', c)}
-          onShowTraceLinksChange={(v) => onUpdateTracesConfig('showTraceLinks', v)}
-          onTraceTimestampTableSuffixChange={(c) => onUpdateTracesConfig('traceTimestampTableSuffix', c)}
-        />
-        <Divider />
+            <Divider />
+            <TracesConfig
+              tracesConfig={jsonData.traces}
+              onDefaultDatabaseChange={(db) => onUpdateTracesConfig('defaultDatabase', db)}
+              onDefaultTableChange={(table) => onUpdateTracesConfig('defaultTable', table)}
+              onOtelEnabledChange={(v) => onUpdateTracesConfig('otelEnabled', v)}
+              onOtelVersionChange={(v) => onUpdateTracesConfig('otelVersion', v)}
+              onTraceIdColumnChange={(c) => onUpdateTracesConfig('traceIdColumn', c)}
+              onSpanIdColumnChange={(c) => onUpdateTracesConfig('spanIdColumn', c)}
+              onOperationNameColumnChange={(c) => onUpdateTracesConfig('operationNameColumn', c)}
+              onParentSpanIdColumnChange={(c) => onUpdateTracesConfig('parentSpanIdColumn', c)}
+              onServiceNameColumnChange={(c) => onUpdateTracesConfig('serviceNameColumn', c)}
+              onDurationColumnChange={(c) => onUpdateTracesConfig('durationColumn', c)}
+              onDurationUnitChange={(c) => onUpdateTracesConfig('durationUnit', c)}
+              onStartTimeColumnChange={(c) => onUpdateTracesConfig('startTimeColumn', c)}
+              onTagsColumnChange={(c) => onUpdateTracesConfig('tagsColumn', c)}
+              onServiceTagsColumnChange={(c) => onUpdateTracesConfig('serviceTagsColumn', c)}
+              onKindColumnChange={(c) => onUpdateTracesConfig('kindColumn', c)}
+              onStatusCodeColumnChange={(c) => onUpdateTracesConfig('statusCodeColumn', c)}
+              onStatusMessageColumnChange={(c) => onUpdateTracesConfig('statusMessageColumn', c)}
+              onStateColumnChange={(c) => onUpdateTracesConfig('stateColumn', c)}
+              onInstrumentationLibraryNameColumnChange={(c) =>
+                onUpdateTracesConfig('instrumentationLibraryNameColumn', c)
+              }
+              onInstrumentationLibraryVersionColumnChange={(c) =>
+                onUpdateTracesConfig('instrumentationLibraryVersionColumn', c)
+              }
+              onFlattenNestedChange={(c) => onUpdateTracesConfig('flattenNested', c)}
+              onEventsColumnPrefixChange={(c) => onUpdateTracesConfig('traceEventsColumnPrefix', c)}
+              onLinksColumnPrefixChange={(c) => onUpdateTracesConfig('traceLinksColumnPrefix', c)}
+              onShowTraceLinksChange={(v) => onUpdateTracesConfig('showTraceLinks', v)}
+              onTraceTimestampTableSuffixChange={(c) => onUpdateTracesConfig('traceTimestampTableSuffix', c)}
+            />
+            <Divider />
+          </>
+        )}
         <AliasTableConfig aliasTables={jsonData.aliasTables} onAliasTablesChange={onAliasTableConfigChange} />
         <Divider />
         <Field label={labels.enableRowLimit.label} description={labels.enableRowLimit.tooltip}>

--- a/src/views/config-v2/CHConfigEditor.tsx
+++ b/src/views/config-v2/CHConfigEditor.tsx
@@ -12,6 +12,7 @@ import { AdditionalSettingsSection } from './AdditionalSettingsSection';
 import { DatabaseCredentialsSection } from './DatabaseCredentialsSection';
 import { TLSSSLSettingsSection } from './TLSSSLSettingsSection';
 import { createValidationAPI } from '../CHConfigEditorHooks';
+import { ConfigurationModeSection } from './ConfigurationModeSection';
 
 export interface ConfigEditorProps extends DataSourcePluginOptionsEditorProps<CHConfig, CHSecureConfig> {}
 
@@ -59,6 +60,7 @@ export const ConfigEditor: React.FC<ConfigEditorProps> = (props) => {
         <ServerAndEncryptionSection onOptionsChange={onOptionsChange} options={options} validation={validation} />
         <DatabaseCredentialsSection onOptionsChange={onOptionsChange} options={options} validation={validation} />
         <TLSSSLSettingsSection onOptionsChange={onOptionsChange} options={options} />
+        <ConfigurationModeSection onOptionsChange={onOptionsChange} options={options} />
         <AdditionalSettingsSection onOptionsChange={onOptionsChange} options={options} />
       </Box>
       <Box width="20%" flex="0 0 20%">

--- a/src/views/config-v2/ConfigurationModeSection.test.tsx
+++ b/src/views/config-v2/ConfigurationModeSection.test.tsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ConfigurationModeSection } from './ConfigurationModeSection';
+import { createTestProps } from './helpers';
+
+describe('ConfigurationModeSection', () => {
+  const onOptionsChangeMock = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('defaults to logs when switching to single source mode', () => {
+    const props = createTestProps({
+      options: {
+        jsonData: {
+          configMode: 'classic',
+        },
+      },
+      mocks: {
+        onOptionsChange: onOptionsChangeMock,
+      },
+    });
+
+    render(<ConfigurationModeSection {...props} />);
+    fireEvent.click(screen.getByText('Single source'));
+
+    expect(onOptionsChangeMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        jsonData: expect.objectContaining({
+          configMode: 'single-table',
+          signalType: 'logs',
+        }),
+      })
+    );
+  });
+
+  it('renders focused logs configuration in single source mode', () => {
+    const props = createTestProps({
+      options: {
+        jsonData: {
+          configMode: 'single-table',
+          signalType: 'logs',
+          logs: {
+            defaultDatabase: 'otel_v2',
+            defaultTable: 'otel_logs',
+          },
+        },
+      },
+      mocks: {
+        onOptionsChange: onOptionsChangeMock,
+      },
+    });
+
+    render(<ConfigurationModeSection {...props} />);
+
+    expect(screen.getByText('Signal type')).toBeInTheDocument();
+    expect(screen.getByText('Logs Table & Schema')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('otel_v2')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('otel_logs')).toBeInTheDocument();
+    expect(screen.queryByText('Traces Table & Schema')).not.toBeInTheDocument();
+  });
+
+  it('updates the selected signal type', () => {
+    const props = createTestProps({
+      options: {
+        jsonData: {
+          configMode: 'single-table',
+          signalType: 'logs',
+        },
+      },
+      mocks: {
+        onOptionsChange: onOptionsChangeMock,
+      },
+    });
+
+    render(<ConfigurationModeSection {...props} />);
+    fireEvent.click(screen.getByText('Traces'));
+
+    expect(onOptionsChangeMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        jsonData: expect.objectContaining({
+          configMode: 'single-table',
+          signalType: 'traces',
+        }),
+      })
+    );
+  });
+
+  it('does not render the focused source configuration in classic mode', () => {
+    const props = createTestProps({
+      options: {
+        jsonData: {
+          configMode: 'classic',
+        },
+      },
+      mocks: {
+        onOptionsChange: onOptionsChangeMock,
+      },
+    });
+
+    render(<ConfigurationModeSection {...props} />);
+
+    expect(screen.queryByText('Signal type')).not.toBeInTheDocument();
+    expect(screen.queryByText('Logs Table & Schema')).not.toBeInTheDocument();
+    expect(screen.queryByText('Traces Table & Schema')).not.toBeInTheDocument();
+  });
+});

--- a/src/views/config-v2/ConfigurationModeSection.tsx
+++ b/src/views/config-v2/ConfigurationModeSection.tsx
@@ -1,0 +1,223 @@
+import React from 'react';
+import {
+  DataSourcePluginOptionsEditorProps,
+  onUpdateDatasourceJsonDataOption,
+  onUpdateDatasourceJsonDataOptionChecked,
+} from '@grafana/data';
+import { Box, CollapsableSection, Divider, Field, RadioButtonGroup, Text } from '@grafana/ui';
+import { LogsConfig } from 'components/configEditor/LogsConfig';
+import { QuerySettingsConfig } from 'components/configEditor/QuerySettingsConfig';
+import { TracesConfig } from 'components/configEditor/TracesConfig';
+import { CHConfig, CHLogsConfig, CHSecureConfig, CHTracesConfig, ConfigMode, SignalType } from 'types/config';
+import { TimeUnit } from 'types/queryBuilder';
+import { CONFIG_SECTION_HEADERS, CONTAINER_MIN_WIDTH } from './constants';
+import {
+  trackClickhouseConfigV2LogsConfig,
+  trackClickhouseConfigV2QuerySettings,
+  trackClickhouseConfigV2TracesConfig,
+} from './tracking';
+
+export interface Props extends DataSourcePluginOptionsEditorProps<CHConfig, CHSecureConfig> {}
+
+export const ConfigurationModeSection = (props: Props) => {
+  const { options, onOptionsChange } = props;
+  const { jsonData } = options;
+  const configMode = jsonData.configMode || (jsonData.signalType ? 'single-table' : 'classic');
+  const isSingleTableMode = configMode === 'single-table';
+  const selectedSignalType = isSingleTableMode ? jsonData.signalType || 'logs' : undefined;
+
+  const onLogsConfigChange = (key: keyof CHLogsConfig, value: string | boolean | string[]) => {
+    onOptionsChange({
+      ...options,
+      jsonData: {
+        ...options.jsonData,
+        logs: {
+          ...(options.jsonData.logs || {}),
+          [key]: value,
+        },
+      },
+    });
+  };
+
+  const onUpdateLogsConfig = (key: keyof CHLogsConfig, value: string | boolean | string[]) => {
+    trackClickhouseConfigV2LogsConfig({ [key]: value });
+    onLogsConfigChange(key, value);
+  };
+
+  const onTracesConfigChange = (key: keyof CHTracesConfig, value: string | boolean | TimeUnit) => {
+    onOptionsChange({
+      ...options,
+      jsonData: {
+        ...options.jsonData,
+        traces: {
+          ...options.jsonData.traces,
+          durationUnit: options.jsonData.traces?.durationUnit || TimeUnit.Nanoseconds,
+          [key]: value,
+        },
+      },
+    });
+  };
+
+  const onUpdateTracesConfig = (key: keyof CHTracesConfig, value: string | boolean | TimeUnit) => {
+    trackClickhouseConfigV2TracesConfig({ [key]: value });
+    onTracesConfigChange(key, value);
+  };
+
+  return (
+    <Box
+      borderStyle="solid"
+      borderColor="weak"
+      padding={2}
+      marginBottom={4}
+      id={`${CONFIG_SECTION_HEADERS[3].id}`}
+      minWidth={CONTAINER_MIN_WIDTH}
+    >
+      <CollapsableSection
+        label={<Text variant="h3">{CONFIG_SECTION_HEADERS[3].label}</Text>}
+        isOpen={!!CONFIG_SECTION_HEADERS[3].isOpen}
+      >
+        <Text variant="body" color="secondary">
+          Choose how this data source is used. Single source provides a focused query editor for one table. All
+          databases gives full access to explore any database and table.
+        </Text>
+        <Field label="Mode">
+          <RadioButtonGroup<ConfigMode>
+            options={[
+              { label: 'All databases', value: 'classic' },
+              { label: 'Single source', value: 'single-table' },
+            ]}
+            value={configMode}
+            onChange={(v) => {
+              const newJsonData = { ...options.jsonData, configMode: v };
+              if (v === 'classic') {
+                newJsonData.signalType = undefined;
+              } else if (!newJsonData.signalType) {
+                newJsonData.signalType = 'logs';
+              }
+              onOptionsChange({ ...options, jsonData: newJsonData });
+            }}
+          />
+        </Field>
+        {isSingleTableMode && (
+          <Field label="Signal type" description="What kind of data does this table contain????">
+            <RadioButtonGroup<SignalType>
+              options={[
+                { label: 'Logs', value: 'logs', description: 'Log search with severity, message, and attributes' },
+                { label: 'Traces', value: 'traces', description: 'Distributed tracing with spans and service maps' },
+              ]}
+              value={selectedSignalType}
+              onChange={(v) => {
+                onOptionsChange({
+                  ...options,
+                  jsonData: {
+                    ...options.jsonData,
+                    configMode: 'single-table',
+                    signalType: v,
+                  },
+                });
+              }}
+            />
+          </Field>
+        )}
+
+        {selectedSignalType === 'logs' && (
+          <>
+            <Divider />
+            <LogsConfig
+              variant="single-table"
+              logsConfig={jsonData.logs}
+              onDefaultDatabaseChange={(db) => onUpdateLogsConfig('defaultDatabase', db)}
+              onDefaultTableChange={(table) => onUpdateLogsConfig('defaultTable', table)}
+              onOtelEnabledChange={(v) => onUpdateLogsConfig('otelEnabled', v)}
+              onOtelVersionChange={(v) => onUpdateLogsConfig('otelVersion', v)}
+              onFilterTimeColumnChange={(c) => onUpdateLogsConfig('filterTimeColumn', c)}
+              onTimeColumnChange={(c) => onUpdateLogsConfig('timeColumn', c)}
+              onLevelColumnChange={(c) => onUpdateLogsConfig('levelColumn', c)}
+              onMessageColumnChange={(c) => onUpdateLogsConfig('messageColumn', c)}
+              onSelectContextColumnsChange={(c) => onUpdateLogsConfig('selectContextColumns', c)}
+              onContextColumnsChange={(c) => onUpdateLogsConfig('contextColumns', c)}
+              onShowLogLinksChange={(v) => onUpdateLogsConfig('showLogLinks', v)}
+            />
+          </>
+        )}
+
+        {selectedSignalType === 'traces' && (
+          <>
+            <Divider />
+            <TracesConfig
+              variant="single-table"
+              tracesConfig={jsonData.traces}
+              onDefaultDatabaseChange={(db) => onUpdateTracesConfig('defaultDatabase', db)}
+              onDefaultTableChange={(table) => onUpdateTracesConfig('defaultTable', table)}
+              onOtelEnabledChange={(v) => onUpdateTracesConfig('otelEnabled', v)}
+              onOtelVersionChange={(v) => onUpdateTracesConfig('otelVersion', v)}
+              onTraceIdColumnChange={(c) => onUpdateTracesConfig('traceIdColumn', c)}
+              onSpanIdColumnChange={(c) => onUpdateTracesConfig('spanIdColumn', c)}
+              onOperationNameColumnChange={(c) => onUpdateTracesConfig('operationNameColumn', c)}
+              onParentSpanIdColumnChange={(c) => onUpdateTracesConfig('parentSpanIdColumn', c)}
+              onServiceNameColumnChange={(c) => onUpdateTracesConfig('serviceNameColumn', c)}
+              onDurationColumnChange={(c) => onUpdateTracesConfig('durationColumn', c)}
+              onDurationUnitChange={(c) => onUpdateTracesConfig('durationUnit', c)}
+              onStartTimeColumnChange={(c) => onUpdateTracesConfig('startTimeColumn', c)}
+              onTagsColumnChange={(c) => onUpdateTracesConfig('tagsColumn', c)}
+              onServiceTagsColumnChange={(c) => onUpdateTracesConfig('serviceTagsColumn', c)}
+              onKindColumnChange={(c) => onUpdateTracesConfig('kindColumn', c)}
+              onStatusCodeColumnChange={(c) => onUpdateTracesConfig('statusCodeColumn', c)}
+              onStatusMessageColumnChange={(c) => onUpdateTracesConfig('statusMessageColumn', c)}
+              onStateColumnChange={(c) => onUpdateTracesConfig('stateColumn', c)}
+              onInstrumentationLibraryNameColumnChange={(c) =>
+                onUpdateTracesConfig('instrumentationLibraryNameColumn', c)
+              }
+              onInstrumentationLibraryVersionColumnChange={(c) =>
+                onUpdateTracesConfig('instrumentationLibraryVersionColumn', c)
+              }
+              onFlattenNestedChange={(c) => onUpdateTracesConfig('flattenNested', c)}
+              onEventsColumnPrefixChange={(c) => onUpdateTracesConfig('traceEventsColumnPrefix', c)}
+              onLinksColumnPrefixChange={(c) => onUpdateTracesConfig('traceLinksColumnPrefix', c)}
+              onShowTraceLinksChange={(v) => onUpdateTracesConfig('showTraceLinks', v)}
+              onTraceTimestampTableSuffixChange={(v) => onUpdateTracesConfig('traceTimestampTableSuffix', v)}
+            />
+          </>
+        )}
+
+        {isSingleTableMode && (
+          <>
+            <Divider />
+            <QuerySettingsConfig
+              dialTimeout={jsonData.dialTimeout}
+              queryTimeout={jsonData.queryTimeout}
+              connMaxLifetime={jsonData.connMaxLifetime}
+              maxIdleConns={jsonData.maxIdleConns}
+              maxOpenConns={jsonData.maxOpenConns}
+              validateSql={jsonData.validateSql}
+              onDialTimeoutChange={(e) => {
+                trackClickhouseConfigV2QuerySettings({ dialTimeout: Number(e.currentTarget.value) });
+                onUpdateDatasourceJsonDataOption(props, 'dialTimeout')(e);
+              }}
+              onQueryTimeoutChange={(e) => {
+                trackClickhouseConfigV2QuerySettings({ queryTimeout: Number(e.currentTarget.value) });
+                onUpdateDatasourceJsonDataOption(props, 'queryTimeout')(e);
+              }}
+              onConnMaxLifetimeChange={(e) => {
+                trackClickhouseConfigV2QuerySettings({ connMaxLifetime: Number(e.currentTarget.value) });
+                onUpdateDatasourceJsonDataOption(props, 'connMaxLifetime')(e);
+              }}
+              onConnMaxIdleConnsChange={(e) => {
+                trackClickhouseConfigV2QuerySettings({ maxIdleConns: Number(e.currentTarget.value) });
+                onUpdateDatasourceJsonDataOption(props, 'maxIdleConns')(e);
+              }}
+              onConnMaxOpenConnsChange={(e) => {
+                trackClickhouseConfigV2QuerySettings({ maxOpenConns: Number(e.currentTarget.value) });
+                onUpdateDatasourceJsonDataOption(props, 'maxOpenConns')(e);
+              }}
+              onValidateSqlChange={(e) => {
+                trackClickhouseConfigV2QuerySettings({ validateSql: e.currentTarget.checked });
+                onUpdateDatasourceJsonDataOptionChecked(props, 'validateSql')(e);
+              }}
+            />
+          </>
+        )}
+      </CollapsableSection>
+    </Box>
+  );
+};

--- a/src/views/config-v2/constants.ts
+++ b/src/views/config-v2/constants.ts
@@ -6,6 +6,7 @@ export const CONFIG_SECTION_HEADERS = [
   { label: 'Server and encryption', id: 'server', isOpen: true, isOptional: false },
   { label: 'Database credentials', id: 'credentials', isOpen: true, isOptional: false },
   { label: 'TLS/SSL settings', id: 'tls', isOpen: false, isOptional: true },
+  { label: 'Configuration mode', id: 'configuration-mode', isOpen: true, isOptional: false },
   { label: 'Additional settings', id: 'additional', isOpen: false, isOptional: true },
   { label: 'Save & test', id: `${selectors.pages.DataSource.saveAndTest}`, isOpen: undefined, isOptional: null },
 ];
@@ -14,6 +15,7 @@ export const CONFIG_SECTION_HEADERS_WITH_PDC = [
   { label: 'Server and encryption', id: 'server', isOpen: true, isOptional: false },
   { label: 'Database credentials', id: 'credentials', isOpen: true, isOptional: false },
   { label: 'TLS/SSL settings', id: 'tls', isOpen: false, isOptional: true },
+  { label: 'Configuration mode', id: 'configuration-mode', isOpen: true, isOptional: false },
   { label: 'Additional settings', id: 'additional', isOpen: false, isOptional: true },
   { label: 'Private data source connect', id: 'pdc', isOpen: false, isOptional: true },
   { label: 'Save & test', id: `${selectors.pages.DataSource.saveAndTest}`, isOpen: undefined, isOptional: null },


### PR DESCRIPTION
## Type of Change

- [x] 🚀 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧹 Refactor / Chore

---

## Feature

### What is this feature?

Adds a single-source configuration mode for ClickHouse data sources. Users can choose whether the data source should target all databases or focus on one logs or traces table, then configure the signal type and table schema for that focused setup.

### Why is this feature needed?

Some ClickHouse data sources are created for a specific logs or traces table. A focused mode reduces setup friction for those users and lets the query experience be tailored to the selected signal source.

### Who is this feature for?

Users configuring ClickHouse data sources for a known logs or traces table, especially OpenTelemetry-style datasets where the database, table, and schema mappings are known up front.

### How to test this feature

1. Open a ClickHouse data source configuration page.
2. Select `Single source` in the configuration mode section.
3. Choose `Logs` or `Traces`, configure the database/table and schema fields, then save and test the data source.
4. Reopen the configuration page and verify the selected mode, signal type, and schema settings are preserved.
5. Switch back to `All databases` and verify the full logs and traces configuration remains available.

---

## Screenshots / Videos

| | Before | After |
|-|------ | ----- |
|Config v1|    <img width="1236" height="1678" alt="CleanShot 2026-05-12 at 16 22 34@2x" src="https://github.com/user-attachments/assets/2afc2377-9991-4c5e-a7ae-434298f1d600" />   |   <img width="1064" height="1682" alt="CleanShot 2026-05-12 at 16 20 42@2x" src="https://github.com/user-attachments/assets/0c20ce8d-e8cf-4aa0-86a9-27de29ac7ebf" />    |
|Config v2| <img width="1854" height="1642" alt="CleanShot 2026-05-15 at 15 13 35@2x" src="https://github.com/user-attachments/assets/28426851-1ffb-4090-8207-1db197fcd139" /> | <img width="2022" height="1624" alt="CleanShot 2026-05-15 at 15 11 29@2x" src="https://github.com/user-attachments/assets/7c437a08-3cba-43dc-8f88-9f4a96f3bb21" /> |

---

## Please check that:

- [x] Tests for this change have been added/updated.
- [x] Documentation has been added/updated (where applicable).

## Special notes for your reviewer

No special notes.