### PR TITLE
fix: scope variables support with the datasource

### DIFF
--- a/src/data/CHDatasource.test.ts
+++ b/src/data/CHDatasource.test.ts
@@ -69,6 +69,21 @@ describe('ClickHouseDatasource', () => {
       const values = await createInstance({ queryResponse }).metricFindQuery('mock', {});
       expect(values).toEqual(expectedValues);
     });
+
+    it('forwards scopedVars from options to the query request', async () => {
+      const queryResponse = {
+        fields: [{ name: 'field', type: 'string', values: ['val1'] }],
+      };
+      const instance = createInstance({ queryResponse });
+      const querySpy = jest.spyOn(instance, 'query');
+      const scopedVars = { namespace: { text: 'prod', value: 'prod' } };
+
+      await instance.metricFindQuery('SELECT 1', { scopedVars });
+
+      expect(querySpy).toHaveBeenCalledWith(
+        expect.objectContaining({ scopedVars })
+      );
+    });
   });
 
   describe('applyTemplateVariables', () => {

--- a/src/data/CHDatasource.ts
+++ b/src/data/CHDatasource.ts
@@ -988,6 +988,7 @@ export class Datasource
       const req = {
         targets: [{ ...request, refId: String(Math.random()) }],
         range: options ? options.range : (getTemplateSrv() as any).timeRange,
+        scopedVars: options?.scopedVars,
       } as DataQueryRequest<CHQuery>;
       this.query(req).subscribe((res: DataQueryResponse) => {
         resolve(res.data[0] || { fields: [] });


### PR DESCRIPTION
<!-- Please take time to fill out the below template appropriately, deleting sections where necessary. -->
<!-- Doing so will aid our reviewers in providing timely feedback and allow us to reach an outcome faster. Thanks! -->
<!-- Please delete all sections that do not apply. -->
<!-- To surface this PR in the changelog add the label: changelog -->
<!-- If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way: -->
<!-- Bad: fix state bug in hooks -->
<!-- Good: Fix crash when switching from Query Builder -->

## Type of Change

_Please check the relevant option._

- [ ] 🚀 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧹 Refactor / Chore

---

## Bug Fix

### What is the bug?

Referencing Section vars in query doesn't work, the bug is explained here: [#12253](https://github.com/grafana/grafana/issues/122553)

### How to reproduce

1. Create a dashboard with the new dashboardSectionVariables enabled
2. Create a query variable that references a scope variable 
3. The query returns full without the filtering

### Related Issues

Closes https://github.com/grafana/grafana/issues/122553

## Please check that:

- [x] Tests for this change have been added/updated.
- [x] Documentation has been added/updated (where applicable).
