### PR TITLE
feat: compact query mode for single table data sources

### DIFF
--- a/docs/sources/configure.md
+++ b/docs/sources/configure.md
@@ -174,7 +174,7 @@ Use **Configuration mode** to choose how the data source is used by the query bu
 | **All databases** | Allows queries against any database and table the ClickHouse user can read. Use this mode for general exploration and dashboards that query multiple tables. |
 | **Single source** | Focuses the data source on one logs or traces table. Choose a **Signal type**, then configure the database, table, and column mappings for that source. |
 
-Use **Single source** when the data source is dedicated to one logs or traces table, such as an OpenTelemetry table. This keeps the logs or traces schema settings with the selected source and avoids reconfiguring column mappings in each query.
+Use **Single source** when the data source is dedicated to one logs or traces table, such as an OpenTelemetry table. This keeps the logs or traces schema settings with the selected source and avoids reconfiguring column mappings in each query. Single source data sources use the [compact query mode](/docs/plugins/grafana-clickhouse-datasource/<CLICKHOUSE_PLUGIN_VERSION>/query-editor/#compact-query-mode) in the query editor.
 
 ### Additional settings
 

--- a/docs/sources/query-editor.md
+++ b/docs/sources/query-editor.md
@@ -58,7 +58,7 @@ Compact filters use Grafana's selected time range automatically. The configured 
 
 Filter operators are tailored to the selected field type. Numeric fields offer comparison operators such as `>`, `<`, `>=`, `<=`, `=`, and `!=`. String fields offer text matching and equality operators such as **contains**, **does not contain**, `=`, and `!=`.
 
-The compact editor also includes a generated SQL preview. Use **Copy** to copy the generated query, or **Edit as SQL** to switch to the SQL editor for manual customization.
+The compact editor also includes a generated SQL preview. Use **Copy** to copy the generated query, or **Open in SQL editor** to switch to the SQL editor for manual customization.
 
 ## Build queries
 

--- a/docs/sources/query-editor.md
+++ b/docs/sources/query-editor.md
@@ -48,6 +48,18 @@ The query editor appears in [Explore](https://grafana.com/docs/grafana/latest/vi
 
 If the data source is configured in **Single source** mode, the query builder uses the configured logs or traces source as its default database, table, and column mapping.
 
+### Compact query mode
+
+When a data source is configured in **Single source** mode for logs or traces, the query builder uses a compact editor focused on the configured source. The compact editor omits database, table, and query type controls because those values come from the data source configuration.
+
+For logs, use the search field to filter log message text. Use **Add filter** to add column filters, and use the advanced options to adjust sorting and the result limit.
+
+Compact filters use Grafana's selected time range automatically. The configured time fields are not shown in the filter field list because the query builder manages the time range filter for you.
+
+Filter operators are tailored to the selected field type. Numeric fields offer comparison operators such as `>`, `<`, `>=`, `<=`, `=`, and `!=`. String fields offer text matching and equality operators such as **contains**, **does not contain**, `=`, and `!=`.
+
+The compact editor also includes a generated SQL preview. Use **Copy** to copy the generated query, or **Edit as SQL** to switch to the SQL editor for manual customization.
+
 ## Build queries
 
 You can build queries using the **SQL editor** (raw SQL) or the **Query builder**. Queries can include macros for dynamic parts such as time range filters.

--- a/jest-setup.js
+++ b/jest-setup.js
@@ -14,3 +14,11 @@ const mockIntersectionObserver = jest.fn().mockImplementation((arg) => ({
 }));
 
 global.IntersectionObserver = mockIntersectionObserver;
+
+Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', {
+  configurable: true,
+  writable: true,
+  value: jest.fn(() => ({
+    measureText: (text = '') => ({ width: String(text).length * 8 }),
+  })),
+});

--- a/provisioning/datasources/clickhouse.yml
+++ b/provisioning/datasources/clickhouse.yml
@@ -5,6 +5,10 @@ apiVersion: 1
 deleteDatasources:
   - name: ClickHouse
     orgId: 1
+  - name: ClickHouse Single Logs
+    orgId: 1
+  - name: ClickHouse Single Traces
+    orgId: 1
 
 datasources:
   - name: ClickHouse
@@ -15,13 +19,75 @@ datasources:
     orgId: 1
     jsonData:
       host: clickhouse-server
-      database: "test"
-      username: "default"
+      database: 'test'
+      username: 'default'
       port: 9000
       protocol: native
       # Enables the Monaco SQL validator in the query editor. Turned on in the
       # E2E datasource so tests/e2e/sqlValidation.spec.ts can regression-guard
       # against false positives on ClickHouse-specific syntax.
       validateSql: true
+    secureJsonData:
+      # password: ""
+  - name: ClickHouse Single Logs
+    uid: clickhouse-e2e-single-logs
+    type: grafana-clickhouse-datasource
+    access: proxy
+    url: clickhouse-server
+    orgId: 1
+    jsonData:
+      host: clickhouse-server
+      database: 'e2e_test'
+      username: 'default'
+      port: 9000
+      protocol: native
+      configMode: single-table
+      signalType: logs
+      logs:
+        defaultDatabase: 'e2e_test'
+        defaultTable: 'events'
+        filterTimeColumn: 'timestamp'
+        timeColumn: 'timestamp'
+        levelColumn: 'level'
+        messageColumn: 'message'
+        otelEnabled: false
+    secureJsonData:
+      # password: ""
+  - name: ClickHouse Single Traces
+    uid: clickhouse-e2e-single-traces
+    type: grafana-clickhouse-datasource
+    access: proxy
+    url: clickhouse-server
+    orgId: 1
+    jsonData:
+      host: clickhouse-server
+      database: 'e2e_test'
+      username: 'default'
+      port: 9000
+      protocol: native
+      configMode: single-table
+      signalType: traces
+      traces:
+        defaultDatabase: 'e2e_test'
+        defaultTable: 'trace_spans'
+        traceIdColumn: 'TraceId'
+        spanIdColumn: 'SpanId'
+        operationNameColumn: 'SpanName'
+        parentSpanIdColumn: 'ParentSpanId'
+        serviceNameColumn: 'ServiceName'
+        durationColumn: 'Duration'
+        durationUnit: 'nanoseconds'
+        startTimeColumn: 'Timestamp'
+        tagsColumn: 'SpanAttributes'
+        serviceTagsColumn: 'ResourceAttributes'
+        kindColumn: 'SpanKind'
+        statusCodeColumn: 'StatusCode'
+        statusMessageColumn: 'StatusMessage'
+        stateColumn: 'TraceState'
+        flattenNested: false
+        traceEventsColumnPrefix: 'Events'
+        traceLinksColumnPrefix: 'Links'
+        traceTimestampTableSuffix: '_trace_id_ts'
+        otelEnabled: false
     secureJsonData:
       # password: ""

--- a/src/components/queryBuilder/CompactAdvanced.tsx
+++ b/src/components/queryBuilder/CompactAdvanced.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import { css } from '@emotion/css';
+import { GrafanaTheme2, SelectableValue } from '@grafana/data';
+import { Input, Select, useStyles2 } from '@grafana/ui';
+import { OrderBy, OrderByDirection, QueryBuilderOptions, TableColumn } from 'types/queryBuilder';
+
+interface CompactAdvancedProps {
+  builderOptions: QueryBuilderOptions;
+  allColumns: readonly TableColumn[];
+  onOrderByChange: (orderBy: OrderBy[]) => void;
+  onLimitChange: (limit: number) => void;
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  row: css`
+    display: flex;
+    align-items: center;
+    gap: ${theme.spacing(1)};
+    padding: ${theme.spacing(0.5)} 0;
+    flex-wrap: wrap;
+  `,
+  item: css`
+    display: flex;
+    align-items: center;
+    gap: ${theme.spacing(0.5)};
+  `,
+  label: css`
+    font-size: ${theme.typography.bodySmall.fontSize};
+    color: ${theme.colors.text.secondary};
+    font-weight: ${theme.typography.fontWeightMedium};
+    white-space: nowrap;
+  `,
+});
+
+export const CompactAdvanced = (props: CompactAdvancedProps) => {
+  const { builderOptions, allColumns, onOrderByChange, onLimitChange } = props;
+  const styles = useStyles2(getStyles);
+  const orderBy = builderOptions.orderBy || [];
+  const limit = builderOptions.limit || 1000;
+  const columnOptions: Array<SelectableValue<string>> = allColumns.map((column) => ({
+    label: column.label || column.name,
+    value: column.name,
+  }));
+  const directionOptions: Array<SelectableValue<OrderByDirection>> = [
+    { label: 'ASC', value: OrderByDirection.ASC },
+    { label: 'DESC', value: OrderByDirection.DESC },
+  ];
+  const currentOrderCol = orderBy.length > 0 ? orderBy[0].name : undefined;
+  const currentOrderDir = orderBy.length > 0 ? orderBy[0].dir : OrderByDirection.DESC;
+
+  return (
+    <div className={styles.row} data-testid="compact-advanced">
+      <div className={styles.item}>
+        <span className={styles.label}>Order by</span>
+        <Select
+          options={columnOptions}
+          value={currentOrderCol}
+          onChange={(option) => {
+            if (option.value) {
+              onOrderByChange([{ name: option.value, dir: currentOrderDir }]);
+            }
+          }}
+          width={20}
+          placeholder="Column..."
+          isClearable
+          menuPlacement="bottom"
+        />
+        <Select
+          options={directionOptions}
+          value={currentOrderDir}
+          onChange={(option) => {
+            if (currentOrderCol && option.value) {
+              onOrderByChange([{ name: currentOrderCol, dir: option.value }]);
+            }
+          }}
+          width={10}
+          menuPlacement="bottom"
+        />
+      </div>
+
+      <div className={styles.item}>
+        <span className={styles.label}>Limit</span>
+        <Input
+          type="number"
+          value={limit}
+          width={10}
+          onChange={(event) => {
+            const value = parseInt(event.currentTarget.value, 10);
+            if (!isNaN(value) && value > 0) {
+              onLimitChange(value);
+            }
+          }}
+        />
+      </div>
+    </div>
+  );
+};

--- a/src/components/queryBuilder/CompactAdvanced.tsx
+++ b/src/components/queryBuilder/CompactAdvanced.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { css } from '@emotion/css';
-import { GrafanaTheme2, SelectableValue } from '@grafana/data';
-import { Input, Select, useStyles2 } from '@grafana/ui';
+import { GrafanaTheme2 } from '@grafana/data';
+import { Combobox, ComboboxOption, Input, useStyles2 } from '@grafana/ui';
 import { OrderBy, OrderByDirection, QueryBuilderOptions, TableColumn } from 'types/queryBuilder';
 
 interface CompactAdvancedProps {
@@ -37,11 +37,11 @@ export const CompactAdvanced = (props: CompactAdvancedProps) => {
   const styles = useStyles2(getStyles);
   const orderBy = builderOptions.orderBy || [];
   const limit = builderOptions.limit || 1000;
-  const columnOptions: Array<SelectableValue<string>> = allColumns.map((column) => ({
+  const columnOptions: Array<ComboboxOption<string>> = allColumns.map((column) => ({
     label: column.label || column.name,
     value: column.name,
   }));
-  const directionOptions: Array<SelectableValue<OrderByDirection>> = [
+  const directionOptions: Array<ComboboxOption<OrderByDirection>> = [
     { label: 'ASC', value: OrderByDirection.ASC },
     { label: 'DESC', value: OrderByDirection.DESC },
   ];
@@ -52,29 +52,29 @@ export const CompactAdvanced = (props: CompactAdvancedProps) => {
     <div className={styles.row} data-testid="compact-advanced">
       <div className={styles.item}>
         <span className={styles.label}>Order by</span>
-        <Select
+        <Combobox
           options={columnOptions}
-          value={currentOrderCol}
+          value={currentOrderCol || null}
           onChange={(option) => {
-            if (option.value) {
+            if (option) {
               onOrderByChange([{ name: option.value, dir: currentOrderDir }]);
+            } else {
+              onOrderByChange([]);
             }
           }}
           width={20}
           placeholder="Column..."
           isClearable
-          menuPlacement="bottom"
         />
-        <Select
+        <Combobox
           options={directionOptions}
           value={currentOrderDir}
           onChange={(option) => {
-            if (currentOrderCol && option.value) {
+            if (currentOrderCol) {
               onOrderByChange([{ name: currentOrderCol, dir: option.value }]);
             }
           }}
           width={10}
-          menuPlacement="bottom"
         />
       </div>
 

--- a/src/components/queryBuilder/CompactFilterBar.tsx
+++ b/src/components/queryBuilder/CompactFilterBar.tsx
@@ -64,34 +64,20 @@ export const CompactFilterBar = (props: CompactFilterBarProps) => {
           <Button icon="plus" variant="secondary" size="sm" fill="text" onClick={() => setShowPopover(!showPopover)}>
             Add filter
           </Button>
-        </div>
-
-        <div className={styles.actions}>
           {onToggleAdvanced && (
-            <Tooltip content={advancedOpen ? 'Hide advanced options' : 'Show advanced options'}>
+            <Tooltip content={advancedOpen ? 'Hide order and limit options' : 'Show order and limit options'}>
               <Button
-                icon="cog"
-                aria-label={advancedOpen ? 'Hide advanced options' : 'Show advanced options'}
+                icon="plus"
+                aria-label={advancedOpen ? 'Hide order by' : 'Order by'}
                 variant="secondary"
                 size="sm"
                 fill={advancedOpen ? 'solid' : 'text'}
                 onClick={onToggleAdvanced}
-              />
+              >
+                Order by
+              </Button>
             </Tooltip>
           )}
-          <Tooltip content="Open query history (Ctrl+H in Explore)">
-            <Button
-              icon="history"
-              aria-label="Open query history"
-              variant="secondary"
-              size="sm"
-              fill="text"
-              onClick={() => {
-                const event = new KeyboardEvent('keydown', { key: 'h', ctrlKey: true, bubbles: true });
-                document.dispatchEvent(event);
-              }}
-            />
-          </Tooltip>
         </div>
       </div>
       {showPopover && (

--- a/src/components/queryBuilder/CompactFilterBar.tsx
+++ b/src/components/queryBuilder/CompactFilterBar.tsx
@@ -1,0 +1,109 @@
+import React, { useState } from 'react';
+import { css } from '@emotion/css';
+import { GrafanaTheme2 } from '@grafana/data';
+import { Button, Tooltip, useStyles2 } from '@grafana/ui';
+import { Datasource } from 'data/CHDatasource';
+import { Filter, TableColumn } from 'types/queryBuilder';
+import { FilterPopover } from './FilterPopover';
+import { FilterTagBar } from './FilterTagBar';
+
+interface CompactFilterBarProps {
+  datasource: Datasource;
+  database: string;
+  table: string;
+  filters: Filter[];
+  allColumns: readonly TableColumn[];
+  onFiltersChange: (filters: Filter[]) => void;
+  onToggleAdvanced?: () => void;
+  advancedOpen?: boolean;
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  row: css`
+    display: flex;
+    align-items: center;
+    gap: ${theme.spacing(0.5)};
+    padding: ${theme.spacing(0.25)} 0;
+    min-height: 32px;
+  `,
+  filters: css`
+    display: flex;
+    align-items: center;
+    gap: ${theme.spacing(0.5)};
+    flex-wrap: wrap;
+    flex: 1;
+    min-width: 0;
+  `,
+  actions: css`
+    display: flex;
+    align-items: center;
+    gap: ${theme.spacing(0.5)};
+    flex-shrink: 0;
+    margin-left: auto;
+  `,
+});
+
+export const CompactFilterBar = (props: CompactFilterBarProps) => {
+  const { datasource, database, table, filters, allColumns, onFiltersChange, onToggleAdvanced, advancedOpen } = props;
+  const styles = useStyles2(getStyles);
+  const [showPopover, setShowPopover] = useState(false);
+
+  const onRemoveFilter = (index: number) => {
+    onFiltersChange(filters.filter((_, filterIndex) => filterIndex !== index));
+  };
+
+  const onAddFilter = (filter: Filter) => {
+    onFiltersChange([...filters, filter]);
+  };
+
+  return (
+    <div data-testid="compact-filter-bar">
+      <div className={styles.row}>
+        <div className={styles.filters}>
+          <FilterTagBar filters={filters} onRemoveFilter={onRemoveFilter} />
+          <Button icon="plus" variant="secondary" size="sm" fill="text" onClick={() => setShowPopover(!showPopover)}>
+            Add filter
+          </Button>
+        </div>
+
+        <div className={styles.actions}>
+          {onToggleAdvanced && (
+            <Tooltip content={advancedOpen ? 'Hide advanced options' : 'Show advanced options'}>
+              <Button
+                icon="cog"
+                aria-label={advancedOpen ? 'Hide advanced options' : 'Show advanced options'}
+                variant="secondary"
+                size="sm"
+                fill={advancedOpen ? 'solid' : 'text'}
+                onClick={onToggleAdvanced}
+              />
+            </Tooltip>
+          )}
+          <Tooltip content="Open query history (Ctrl+H in Explore)">
+            <Button
+              icon="history"
+              aria-label="Open query history"
+              variant="secondary"
+              size="sm"
+              fill="text"
+              onClick={() => {
+                const event = new KeyboardEvent('keydown', { key: 'h', ctrlKey: true, bubbles: true });
+                document.dispatchEvent(event);
+              }}
+            />
+          </Tooltip>
+        </div>
+      </div>
+      {showPopover && (
+        <FilterPopover
+          datasource={datasource}
+          database={database}
+          table={table}
+          allColumns={allColumns}
+          onAddFilter={onAddFilter}
+          onClose={() => setShowPopover(false)}
+        />
+      )}
+    </div>
+  );
+};

--- a/src/components/queryBuilder/CompactModeBar.tsx
+++ b/src/components/queryBuilder/CompactModeBar.tsx
@@ -1,0 +1,110 @@
+import React, { useEffect, useState } from 'react';
+import { css } from '@emotion/css';
+import { GrafanaTheme2 } from '@grafana/data';
+import { Icon, Input, Select, useStyles2 } from '@grafana/ui';
+import { Datasource } from 'data/CHDatasource';
+import { SignalType } from 'types/config';
+
+export type CompactMode = 'otel-logs' | 'otel-traces' | 'raw-sql';
+
+interface CompactModeBarProps {
+  datasource: Datasource;
+  signalType: SignalType | undefined;
+  mode: CompactMode | undefined;
+  onModeChange: (mode: CompactMode) => void;
+  searchText: string;
+  onSearchChange: (text: string) => void;
+  onSearchSubmit: () => void;
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  bar: css`
+    display: flex;
+    align-items: center;
+    gap: ${theme.spacing(0.75)};
+    padding: ${theme.spacing(0.5)} 0;
+  `,
+  searchWrapper: css`
+    flex: 1;
+    min-width: 200px;
+  `,
+});
+
+export function getDefaultCompactMode(signalType: SignalType | undefined): CompactMode | undefined {
+  if (signalType === 'logs') {
+    return 'otel-logs';
+  }
+  if (signalType === 'traces') {
+    return 'otel-traces';
+  }
+  return undefined;
+}
+
+export function getModeOptions(
+  signalType: SignalType | undefined,
+  datasource: Datasource
+): Array<{ label: string; value: CompactMode; description?: string }> {
+  const hasOtelLogs = Boolean(datasource.getLogsOtelVersion() && datasource.getDefaultLogsTable());
+  const hasOtelTraces = Boolean(datasource.getTraceOtelVersion() && datasource.getDefaultTraceTable());
+  const options: Array<{ label: string; value: CompactMode; description?: string }> = [];
+
+  if (signalType === 'logs' || (!signalType && hasOtelLogs)) {
+    options.push({ label: 'OTEL Logs', value: 'otel-logs' });
+  }
+  if (signalType === 'traces' || (!signalType && hasOtelTraces)) {
+    options.push({ label: 'OTEL Traces', value: 'otel-traces' });
+  }
+  if (!signalType) {
+    options.push({ label: 'Raw SQL', value: 'raw-sql' });
+  }
+  return options;
+}
+
+export const CompactModeBar = (props: CompactModeBarProps) => {
+  const { datasource, signalType, mode, onModeChange, searchText, onSearchChange, onSearchSubmit } = props;
+  const styles = useStyles2(getStyles);
+  const [localSearch, setLocalSearch] = useState(searchText);
+  const modeOptions = getModeOptions(signalType, datasource);
+  const showModeDropdown = !signalType && modeOptions.length > 1;
+  const isLogs = mode === 'otel-logs';
+
+  useEffect(() => {
+    setLocalSearch(searchText);
+  }, [searchText]);
+
+  if (!showModeDropdown && !isLogs) {
+    return null;
+  }
+
+  return (
+    <div className={styles.bar} data-testid="compact-mode-bar">
+      {showModeDropdown && (
+        <Select
+          options={modeOptions}
+          value={mode}
+          onChange={(v) => v.value && onModeChange(v.value)}
+          width={16}
+          placeholder="Select mode..."
+        />
+      )}
+
+      {isLogs && (
+        <div className={styles.searchWrapper}>
+          <Input
+            value={localSearch}
+            onChange={(e) => setLocalSearch(e.currentTarget.value)}
+            onBlur={() => onSearchChange(localSearch)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                onSearchChange(localSearch);
+                onSearchSubmit();
+              }
+            }}
+            placeholder="Search log body text..."
+            prefix={<Icon name="search" />}
+          />
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/queryBuilder/CompactModeBar.tsx
+++ b/src/components/queryBuilder/CompactModeBar.tsx
@@ -1,20 +1,15 @@
 import React, { useEffect, useState } from 'react';
 import { css } from '@emotion/css';
 import { GrafanaTheme2 } from '@grafana/data';
-import { Icon, Input, Select, useStyles2 } from '@grafana/ui';
-import { Datasource } from 'data/CHDatasource';
+import { Icon, Input, useStyles2 } from '@grafana/ui';
 import { SignalType } from 'types/config';
 
-export type CompactMode = 'otel-logs' | 'otel-traces' | 'raw-sql';
+export type CompactMode = 'otel-logs' | 'otel-traces';
 
 interface CompactModeBarProps {
-  datasource: Datasource;
-  signalType: SignalType | undefined;
-  mode: CompactMode | undefined;
-  onModeChange: (mode: CompactMode) => void;
+  mode: CompactMode;
   searchText: string;
   onSearchChange: (text: string) => void;
-  onSearchSubmit: () => void;
 }
 
 const getStyles = (theme: GrafanaTheme2) => ({
@@ -30,81 +25,39 @@ const getStyles = (theme: GrafanaTheme2) => ({
   `,
 });
 
-export function getDefaultCompactMode(signalType: SignalType | undefined): CompactMode | undefined {
-  if (signalType === 'logs') {
-    return 'otel-logs';
-  }
-  if (signalType === 'traces') {
-    return 'otel-traces';
-  }
-  return undefined;
-}
-
-export function getModeOptions(
-  signalType: SignalType | undefined,
-  datasource: Datasource
-): Array<{ label: string; value: CompactMode; description?: string }> {
-  const hasOtelLogs = Boolean(datasource.getLogsOtelVersion() && datasource.getDefaultLogsTable());
-  const hasOtelTraces = Boolean(datasource.getTraceOtelVersion() && datasource.getDefaultTraceTable());
-  const options: Array<{ label: string; value: CompactMode; description?: string }> = [];
-
-  if (signalType === 'logs' || (!signalType && hasOtelLogs)) {
-    options.push({ label: 'OTEL Logs', value: 'otel-logs' });
-  }
-  if (signalType === 'traces' || (!signalType && hasOtelTraces)) {
-    options.push({ label: 'OTEL Traces', value: 'otel-traces' });
-  }
-  if (!signalType) {
-    options.push({ label: 'Raw SQL', value: 'raw-sql' });
-  }
-  return options;
+export function getDefaultCompactMode(signalType: SignalType): CompactMode {
+  return signalType === 'traces' ? 'otel-traces' : 'otel-logs';
 }
 
 export const CompactModeBar = (props: CompactModeBarProps) => {
-  const { datasource, signalType, mode, onModeChange, searchText, onSearchChange, onSearchSubmit } = props;
+  const { mode, searchText, onSearchChange } = props;
   const styles = useStyles2(getStyles);
   const [localSearch, setLocalSearch] = useState(searchText);
-  const modeOptions = getModeOptions(signalType, datasource);
-  const showModeDropdown = !signalType && modeOptions.length > 1;
-  const isLogs = mode === 'otel-logs';
 
   useEffect(() => {
     setLocalSearch(searchText);
   }, [searchText]);
 
-  if (!showModeDropdown && !isLogs) {
+  if (mode === 'otel-traces') {
     return null;
   }
 
   return (
     <div className={styles.bar} data-testid="compact-mode-bar">
-      {showModeDropdown && (
-        <Select
-          options={modeOptions}
-          value={mode}
-          onChange={(v) => v.value && onModeChange(v.value)}
-          width={16}
-          placeholder="Select mode..."
+      <div className={styles.searchWrapper}>
+        <Input
+          value={localSearch}
+          onChange={(e) => setLocalSearch(e.currentTarget.value)}
+          onBlur={() => onSearchChange(localSearch)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              onSearchChange(localSearch);
+            }
+          }}
+          placeholder="Search log body text..."
+          prefix={<Icon name="search" />}
         />
-      )}
-
-      {isLogs && (
-        <div className={styles.searchWrapper}>
-          <Input
-            value={localSearch}
-            onChange={(e) => setLocalSearch(e.currentTarget.value)}
-            onBlur={() => onSearchChange(localSearch)}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') {
-                onSearchChange(localSearch);
-                onSearchSubmit();
-              }
-            }}
-            placeholder="Search log body text..."
-            prefix={<Icon name="search" />}
-          />
-        </div>
-      )}
+      </div>
     </div>
   );
 };

--- a/src/components/queryBuilder/FilterEditor.test.tsx
+++ b/src/components/queryBuilder/FilterEditor.test.tsx
@@ -135,7 +135,8 @@ describe('FilterEditor', () => {
       );
       expect(result.container.firstChild).not.toBeNull();
     });
-    it('should have all provided fields in the select', async () => {
+    it('should select a provided field from the combobox', async () => {
+      const onFilterChange = jest.fn();
       const result = render(
         <FilterEditor
           allColumns={[
@@ -151,7 +152,7 @@ describe('FilterEditor', () => {
             filterType: 'custom',
           }}
           index={0}
-          onFilterChange={() => {}}
+          onFilterChange={onFilterChange}
           removeFilter={() => {}}
           datasource={mockDatasource}
           database=""
@@ -159,12 +160,16 @@ describe('FilterEditor', () => {
         />
       );
 
-      // expand the `fieldName` select box
-      await userEvent.type(result.getAllByRole('combobox')[0], '{ArrowDown}');
+      await userEvent.type(result.getAllByRole('combobox')[0], 'col2');
+      await userEvent.keyboard('{ArrowDown}{Enter}');
 
-      expect(result.getByText('col1')).toBeInTheDocument();
-      expect(result.getByText('col2')).toBeInTheDocument();
-      expect(result.getByText('col3')).toBeInTheDocument();
+      expect(onFilterChange).toHaveBeenCalledWith(0, {
+        condition: 'AND',
+        filterType: 'custom',
+        key: 'col2',
+        operator: FilterOperator.IsNotNull,
+        type: 'string',
+      });
     });
     it('should call onFilterChange when user adds correct custom filter for the field with Map type', async () => {
       const onFilterChange = jest.fn();
@@ -187,13 +192,13 @@ describe('FilterEditor', () => {
         />
       );
 
-      // type into the `fieldName` select box
-      await userEvent.type(result!.getAllByRole('combobox')[0], `colName[['keyName']`);
-      await userEvent.keyboard('{Enter}');
+      // select the Map field from the `fieldName` combobox
+      await userEvent.type(result!.getAllByRole('combobox')[0], 'colName');
+      await userEvent.keyboard('{ArrowDown}{Enter}');
 
       const expectedFilter: Filter = {
-        key: `colName['keyName']`,
-        type: 'String',
+        key: 'colName',
+        type: 'Map(String, String)',
         operator: FilterOperator.IsNotNull,
         condition: 'AND',
         filterType: 'custom',
@@ -363,7 +368,7 @@ describe('FilterEditor', () => {
       const result = render(<FilterValueEditor allColumns={[]} filter={filter} onFilterChange={onFilterChange} />);
       expect(result.container.firstChild).not.toBeNull();
       expect(result.getByTestId('query-builder-filters-date-value-container')).toBeInTheDocument();
-      expect(result.getByText('NOW')).toBeInTheDocument();
+      expect(result.getByDisplayValue('NOW')).toBeInTheDocument();
     });
     it('should render select filter for single value picklist', () => {
       const filter: StringFilter = {
@@ -394,7 +399,7 @@ describe('FilterEditor', () => {
       );
       expect(result.container.firstChild).not.toBeNull();
       expect(result.getByTestId('query-builder-filters-single-picklist-value-container')).toBeInTheDocument();
-      expect(result.getByText('Deal Won')).toBeInTheDocument();
+      expect(result.getByDisplayValue('Deal Won')).toBeInTheDocument();
       expect(result.queryByText('Discovery')).not.toBeInTheDocument();
     });
     it('should render select filter for multi value picklist', () => {
@@ -427,7 +432,7 @@ describe('FilterEditor', () => {
       expect(result.container.firstChild).not.toBeNull();
       expect(result.getByTestId('query-builder-filters-multi-picklist-value-container')).toBeInTheDocument();
       expect(result.getByText('Deal Won')).toBeInTheDocument();
-      expect(result.getByText('Deal Lost')).toBeInTheDocument();
+      expect(result.getByText('1')).toBeInTheDocument();
       expect(result.queryByText('Discovery')).not.toBeInTheDocument();
     });
     it('should render input filter for single value string', async () => {

--- a/src/components/queryBuilder/FilterEditor.tsx
+++ b/src/components/queryBuilder/FilterEditor.tsx
@@ -8,6 +8,7 @@ import { styles } from 'styles';
 import { Datasource } from 'data/CHDatasource';
 import useUniqueMapKeys from 'hooks/useUniqueMapKeys';
 import useUniqueJSONPaths from 'hooks/useUniqueJSONPaths';
+import { getFilterOperatorsByType } from './filterOperatorOptions';
 
 const boolValues: Array<SelectableValue<boolean>> = [
   { value: true, label: 'True' },
@@ -16,27 +17,6 @@ const boolValues: Array<SelectableValue<boolean>> = [
 const conditions: Array<SelectableValue<'AND' | 'OR'>> = [
   { value: 'AND', label: 'AND' },
   { value: 'OR', label: 'OR' },
-];
-const filterOperators: Array<SelectableValue<FilterOperator>> = [
-  { value: FilterOperator.WithInGrafanaTimeRange, label: 'Within dashboard time range' },
-  { value: FilterOperator.OutsideGrafanaTimeRange, label: 'Outside dashboard time range' },
-  { value: FilterOperator.IsAnything, label: 'IS ANYTHING' },
-  { value: FilterOperator.Equals, label: '=' },
-  { value: FilterOperator.NotEquals, label: '!=' },
-  { value: FilterOperator.LessThan, label: '<' },
-  { value: FilterOperator.LessThanOrEqual, label: '<=' },
-  { value: FilterOperator.GreaterThan, label: '>' },
-  { value: FilterOperator.GreaterThanOrEqual, label: '>=' },
-  { value: FilterOperator.Like, label: 'LIKE' },
-  { value: FilterOperator.NotLike, label: 'NOT LIKE' },
-  { value: FilterOperator.ILike, label: 'ILIKE' },
-  { value: FilterOperator.NotILike, label: 'NOT ILIKE' },
-  { value: FilterOperator.IsEmpty, label: 'IS EMPTY' },
-  { value: FilterOperator.IsNotEmpty, label: 'IS NOT EMPTY' },
-  { value: FilterOperator.In, label: 'IN' },
-  { value: FilterOperator.NotIn, label: 'NOT IN' },
-  { value: FilterOperator.IsNull, label: 'IS NULL' },
-  { value: FilterOperator.IsNotNull, label: 'IS NOT NULL' },
 ];
 const standardTimeOptions: Array<SelectableValue<string>> = [
   { value: 'today()', label: 'TODAY' },
@@ -240,80 +220,6 @@ export const FilterEditor = (props: {
     }
     return values;
   };
-  const getFilterOperatorsByType = (type = 'string'): Array<SelectableValue<FilterOperator>> => {
-    if (utils.isBooleanType(type)) {
-      return filterOperators.filter((f) => [FilterOperator.Equals, FilterOperator.NotEquals].includes(f.value!));
-    } else if (utils.isNumberType(type)) {
-      return filterOperators.filter((f) =>
-        [
-          FilterOperator.IsAnything,
-          FilterOperator.IsNull,
-          FilterOperator.IsNotNull,
-          FilterOperator.Equals,
-          FilterOperator.NotEquals,
-          FilterOperator.LessThan,
-          FilterOperator.LessThanOrEqual,
-          FilterOperator.GreaterThan,
-          FilterOperator.GreaterThanOrEqual,
-        ].includes(f.value!)
-      );
-    } else if (utils.isDateType(type)) {
-      return filterOperators.filter((f) =>
-        [
-          FilterOperator.IsAnything,
-          FilterOperator.IsNull,
-          FilterOperator.IsNotNull,
-          FilterOperator.Equals,
-          FilterOperator.NotEquals,
-          FilterOperator.LessThan,
-          FilterOperator.LessThanOrEqual,
-          FilterOperator.GreaterThan,
-          FilterOperator.GreaterThanOrEqual,
-          FilterOperator.WithInGrafanaTimeRange,
-          FilterOperator.OutsideGrafanaTimeRange,
-        ].includes(f.value!)
-      );
-    } else if (isJSONType) {
-      // JSON sub-column values are strings; exclude IsEmpty/IsNotEmpty which are unreliable on JSON paths
-      return filterOperators.filter((f) =>
-        [
-          FilterOperator.IsAnything,
-          FilterOperator.Equals,
-          FilterOperator.NotEquals,
-          FilterOperator.Like,
-          FilterOperator.NotLike,
-          FilterOperator.ILike,
-          FilterOperator.NotILike,
-          FilterOperator.In,
-          FilterOperator.NotIn,
-          FilterOperator.IsNull,
-          FilterOperator.IsNotNull,
-        ].includes(f.value!)
-      );
-    } else {
-      return filterOperators.filter((f) =>
-        [
-          FilterOperator.IsAnything,
-          FilterOperator.Like,
-          FilterOperator.NotLike,
-          FilterOperator.ILike,
-          FilterOperator.NotILike,
-          FilterOperator.In,
-          FilterOperator.NotIn,
-          FilterOperator.IsNull,
-          FilterOperator.IsNotNull,
-          FilterOperator.Equals,
-          FilterOperator.NotEquals,
-          FilterOperator.IsEmpty,
-          FilterOperator.IsNotEmpty,
-          FilterOperator.LessThan,
-          FilterOperator.LessThanOrEqual,
-          FilterOperator.GreaterThan,
-          FilterOperator.GreaterThanOrEqual,
-        ].includes(f.value!)
-      );
-    }
-  };
   const onFilterNameChange = (fieldName: string) => {
     setIsOpen(false);
     const matchingField = fieldsList.find((f) => f.name === fieldName);
@@ -430,7 +336,7 @@ export const FilterEditor = (props: {
         value={filter.operator}
         width={40}
         className={styles.Common.inlineSelect}
-        options={getFilterOperatorsByType(filter.type)}
+        options={getFilterOperatorsByType(filter.type, isJSONType)}
         onChange={(e) => onFilterOperatorChange(e.value!)}
         menuPlacement={'bottom'}
       />

--- a/src/components/queryBuilder/FilterEditor.tsx
+++ b/src/components/queryBuilder/FilterEditor.tsx
@@ -1,6 +1,15 @@
 import React, { useState } from 'react';
 import { SelectableValue } from '@grafana/data';
-import { Button, InlineFormLabel, Input, MultiSelect, RadioButtonGroup, Select, Stack } from '@grafana/ui';
+import {
+  Button,
+  Combobox,
+  ComboboxOption,
+  InlineFormLabel,
+  Input,
+  MultiCombobox,
+  RadioButtonGroup,
+  Stack,
+} from '@grafana/ui';
 import { Filter, FilterOperator, TableColumn, NullFilter } from 'types/queryBuilder';
 import * as utils from 'components/queryBuilder/utils';
 import labels from 'labels';
@@ -35,6 +44,17 @@ export const defaultNewFilter: NullFilter = {
 export interface PredefinedFilter {
   restrictToFields?: readonly TableColumn[];
 }
+
+const toComboboxOptions = <T extends string | number>(
+  options: Array<{ label?: unknown; value?: T }>
+): Array<ComboboxOption<T>> => {
+  return options
+    .filter((option): option is { label?: unknown; value: T } => option.value !== undefined)
+    .map((option) => ({
+      label: String(option.label || option.value),
+      value: option.value,
+    }));
+};
 
 const FilterValueNumberItem = (props: { value: number; onChange: (value: number) => void }) => {
   const [value, setValue] = useState(props.value || 0);
@@ -120,12 +140,12 @@ export const FilterValueEditor = (props: {
 
     return (
       <div data-testid="query-builder-filters-date-value-container">
-        <Select
+        <Combobox
           value={filter.value || 'TODAY'}
-          onChange={(e) => onDateFilterValueChange(e.value!)}
-          options={dateOptions}
+          onChange={(option) => onDateFilterValueChange(option.value)}
+          options={toComboboxOptions(dateOptions)}
           width={40}
-          allowCustomValue
+          createCustomValue
         />
       </div>
     );
@@ -139,7 +159,11 @@ export const FilterValueEditor = (props: {
     ) {
       return (
         <div data-testid="query-builder-filters-single-picklist-value-container">
-          <Select value={filter.value} onChange={(e) => onStringFilterValueChange(e.value!)} options={getOptions()} />
+          <Combobox
+            value={filter.value}
+            onChange={(option) => onStringFilterValueChange(option.value)}
+            options={toComboboxOptions(getOptions())}
+          />
         </div>
       );
     }
@@ -159,10 +183,10 @@ export const FilterValueEditor = (props: {
     if (filter.type === 'picklist') {
       return (
         <div data-testid="query-builder-filters-multi-picklist-value-container">
-          <MultiSelect
+          <MultiCombobox
             value={filter.value}
-            options={getOptions()}
-            onChange={(e) => onMultiFilterValueChange(e.map((v) => v.value!))}
+            options={toComboboxOptions(getOptions())}
+            onChange={(options) => onMultiFilterValueChange(options.map((option) => option.value))}
           />
         </div>
       );
@@ -184,7 +208,6 @@ export const FilterEditor = (props: {
   table: string;
 }) => {
   const { index, filter, allColumns: fieldsList, onFilterChange, removeFilter } = props;
-  const [isOpen, setIsOpen] = useState(false);
   const isMapType = filter.type.startsWith('Map');
   const isJSONType = filter.type.startsWith('JSON');
   const mapKeys = useUniqueMapKeys(props.datasource, isMapType ? filter.key : '', props.database, props.table);
@@ -221,7 +244,6 @@ export const FilterEditor = (props: {
     return values;
   };
   const onFilterNameChange = (fieldName: string) => {
-    setIsOpen(false);
     const matchingField = fieldsList.find((f) => f.name === fieldName);
     const filterData = {
       key: matchingField?.name || fieldName,
@@ -302,22 +324,17 @@ export const FilterEditor = (props: {
       {index !== 0 && (
         <RadioButtonGroup options={conditions} value={filter.condition} onChange={(e) => onFilterConditionChange(e!)} />
       )}
-      <Select
+      <Combobox
         disabled={Boolean(filter.hint)}
         placeholder={filter.hint ? labels.types.ColumnHint[filter.hint] : undefined}
         value={filter.key}
         width={40}
-        className={styles.Common.inlineSelect}
-        options={getFields()}
-        isOpen={isOpen}
-        onOpenMenu={() => setIsOpen(true)}
-        onCloseMenu={() => setIsOpen(false)}
-        onChange={(e) => onFilterNameChange(e.value!)}
-        allowCustomValue
-        menuPlacement={'bottom'}
+        options={toComboboxOptions(getFields())}
+        onChange={(option) => option && onFilterNameChange(option.value)}
+        createCustomValue
       />
       {(isMapType || isJSONType) && (
-        <Select
+        <Combobox
           value={filter.mapKey}
           placeholder={
             isJSONType
@@ -325,20 +342,16 @@ export const FilterEditor = (props: {
               : labels.components.FilterEditor.mapKeyPlaceholder
           }
           width={40}
-          className={styles.Common.inlineSelect}
-          options={subKeyOptions}
-          onChange={(e) => onFilterMapKeyChange(e.value!)}
-          allowCustomValue
-          menuPlacement={'bottom'}
+          options={toComboboxOptions(subKeyOptions)}
+          onChange={(option) => option && onFilterMapKeyChange(option.value)}
+          createCustomValue
         />
       )}
-      <Select
+      <Combobox
         value={filter.operator}
         width={40}
-        className={styles.Common.inlineSelect}
-        options={getFilterOperatorsByType(filter.type, isJSONType)}
-        onChange={(e) => onFilterOperatorChange(e.value!)}
-        menuPlacement={'bottom'}
+        options={toComboboxOptions(getFilterOperatorsByType(filter.type, isJSONType))}
+        onChange={(option) => option && onFilterOperatorChange(option.value)}
       />
       <FilterValueEditor filter={filter} onFilterChange={onFilterValueChange} allColumns={fieldsList} />
       <Button

--- a/src/components/queryBuilder/FilterPopover.test.tsx
+++ b/src/components/queryBuilder/FilterPopover.test.tsx
@@ -1,0 +1,39 @@
+import { FilterOperator } from 'types/queryBuilder';
+import { getFilterValueKind, getOperatorOptions } from './FilterPopover';
+
+describe('FilterPopover', () => {
+  it('infers number filter kind from ClickHouse numeric types', () => {
+    expect(getFilterValueKind('UInt64')).toBe('number');
+    expect(getFilterValueKind('Nullable(Float64)')).toBe('number');
+    expect(getFilterValueKind('Decimal(18, 2)')).toBe('number');
+    expect(getFilterValueKind('Map(String, UInt32)')).toBe('number');
+  });
+
+  it('treats non-numeric types as string filters', () => {
+    expect(getFilterValueKind('String')).toBe('string');
+    expect(getFilterValueKind('LowCardinality(String)')).toBe('string');
+    expect(getFilterValueKind('DateTime64(9)')).toBe('string');
+    expect(getFilterValueKind('Map(String, String)')).toBe('string');
+  });
+
+  it('returns type-specific operator options', () => {
+    expect(getOperatorOptions('number').map((option) => option.value)).toEqual([
+      FilterOperator.GreaterThan,
+      FilterOperator.LessThan,
+      FilterOperator.GreaterThanOrEqual,
+      FilterOperator.LessThanOrEqual,
+      FilterOperator.Equals,
+      FilterOperator.NotEquals,
+      FilterOperator.IsNull,
+      FilterOperator.IsNotNull,
+    ]);
+    expect(getOperatorOptions('string').map((option) => option.value)).toEqual([
+      FilterOperator.Like,
+      FilterOperator.NotLike,
+      FilterOperator.Equals,
+      FilterOperator.NotEquals,
+      FilterOperator.IsNull,
+      FilterOperator.IsNotNull,
+    ]);
+  });
+});

--- a/src/components/queryBuilder/FilterPopover.test.tsx
+++ b/src/components/queryBuilder/FilterPopover.test.tsx
@@ -1,5 +1,5 @@
 import { FilterOperator } from 'types/queryBuilder';
-import { getFilterValueKind, getOperatorOptions } from './FilterPopover';
+import { getFilterValueKind, getOperatorOptions, toFilterValueOption } from './FilterPopover';
 
 describe('FilterPopover', () => {
   it('infers number filter kind from ClickHouse numeric types', () => {
@@ -34,6 +34,14 @@ describe('FilterPopover', () => {
       FilterOperator.NotEquals,
       FilterOperator.IsNull,
       FilterOperator.IsNotNull,
+    ]);
+  });
+
+  it('converts distinct values to selectable string values', () => {
+    expect([1, 'error', true].map(toFilterValueOption)).toEqual([
+      { label: '1', value: '1' },
+      { label: 'error', value: 'error' },
+      { label: 'true', value: 'true' },
     ]);
   });
 });

--- a/src/components/queryBuilder/FilterPopover.tsx
+++ b/src/components/queryBuilder/FilterPopover.tsx
@@ -1,0 +1,256 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { css } from '@emotion/css';
+import { GrafanaTheme2, SelectableValue } from '@grafana/data';
+import { AsyncSelect, Button, Select, useStyles2 } from '@grafana/ui';
+import { Datasource } from 'data/CHDatasource';
+import { Filter, FilterOperator, NumberFilter, StringFilter, TableColumn } from 'types/queryBuilder';
+
+interface FilterPopoverProps {
+  datasource: Datasource;
+  database: string;
+  table: string;
+  allColumns: readonly TableColumn[];
+  onAddFilter: (filter: Filter) => void;
+  onClose: () => void;
+}
+
+type FilterValueKind = 'number' | 'string';
+
+const numberOperatorOptions: Array<SelectableValue<FilterOperator>> = [
+  { label: '>', value: FilterOperator.GreaterThan },
+  { label: '<', value: FilterOperator.LessThan },
+  { label: '>=', value: FilterOperator.GreaterThanOrEqual },
+  { label: '<=', value: FilterOperator.LessThanOrEqual },
+  { label: '=', value: FilterOperator.Equals },
+  { label: '!=', value: FilterOperator.NotEquals },
+  { label: 'IS NULL', value: FilterOperator.IsNull },
+  { label: 'IS NOT NULL', value: FilterOperator.IsNotNull },
+];
+
+const stringOperatorOptions: Array<SelectableValue<FilterOperator>> = [
+  { label: 'contains', value: FilterOperator.Like },
+  { label: 'does not contain', value: FilterOperator.NotLike },
+  { label: '=', value: FilterOperator.Equals },
+  { label: '!=', value: FilterOperator.NotEquals },
+  { label: 'IS NULL', value: FilterOperator.IsNull },
+  { label: 'IS NOT NULL', value: FilterOperator.IsNotNull },
+];
+
+const defaultOperatorByKind: Record<FilterValueKind, FilterOperator> = {
+  number: FilterOperator.GreaterThan,
+  string: FilterOperator.Like,
+};
+
+const getMapValueType = (type: string): string => {
+  return type.match(/Map\(\s*.+\s*,\s*(.+)\s*\)/)?.[1]?.trim() || type;
+};
+
+export const getFilterValueKind = (type = ''): FilterValueKind => {
+  const normalizedType = getMapValueType(type)
+    .toLowerCase()
+    .replace(/\(/g, '')
+    .replace(/\)/g, '')
+    .replace(/nullable/g, '')
+    .replace(/lowcardinality/g, '');
+
+  return ['int', 'float', 'decimal'].some((numberType) => normalizedType.includes(numberType)) ? 'number' : 'string';
+};
+
+export const getOperatorOptions = (kind: FilterValueKind): Array<SelectableValue<FilterOperator>> => {
+  return kind === 'number' ? numberOperatorOptions : stringOperatorOptions;
+};
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  popover: css`
+    display: flex;
+    align-items: flex-end;
+    gap: ${theme.spacing(0.75)};
+    padding: ${theme.spacing(0.75)} 0;
+    flex-wrap: wrap;
+  `,
+  field: css`
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  `,
+  fieldLabel: css`
+    font-size: 11px;
+    color: ${theme.colors.text.secondary};
+    font-weight: ${theme.typography.fontWeightMedium};
+  `,
+  actions: css`
+    display: flex;
+    gap: ${theme.spacing(0.5)};
+  `,
+});
+
+export const FilterPopover = (props: FilterPopoverProps) => {
+  const { datasource, database, table, allColumns, onAddFilter, onClose } = props;
+  const styles = useStyles2(getStyles);
+
+  const [selectedColumn, setSelectedColumn] = useState('');
+  const [selectedMapKey, setSelectedMapKey] = useState('');
+  const [operator, setOperator] = useState<FilterOperator>(FilterOperator.Equals);
+  const [value, setValue] = useState('');
+  const [mapKeys, setMapKeys] = useState<string[]>([]);
+
+  const selectedColDef = allColumns.find((column) => column.name === selectedColumn);
+  const isMapColumn = selectedColDef?.type?.startsWith('Map(') || false;
+  const filterKind = getFilterValueKind(selectedColDef?.type);
+  const currentOperatorOptions = useMemo(() => getOperatorOptions(filterKind), [filterKind]);
+
+  useEffect(() => {
+    if (isMapColumn && selectedColumn && database && table) {
+      datasource
+        .fetchUniqueMapKeys(selectedColumn, database, table)
+        .then(setMapKeys)
+        .catch(() => setMapKeys([]));
+    } else {
+      setMapKeys([]);
+      setSelectedMapKey('');
+    }
+  }, [datasource, database, table, selectedColumn, isMapColumn]);
+
+  const columnOptions: Array<SelectableValue<string>> = allColumns.map((column) => ({
+    label: column.label || column.name,
+    value: column.name,
+    description: column.type,
+  }));
+
+  const loadValueOptions = useCallback(
+    async (inputValue: string): Promise<Array<SelectableValue<string>>> => {
+      if (!selectedColumn || !database || !table) {
+        return [];
+      }
+      try {
+        const values =
+          isMapColumn && selectedMapKey
+            ? await datasource.fetchDistinctMapValues(selectedColumn, selectedMapKey, database, table)
+            : !isMapColumn
+              ? await datasource.fetchDistinctValues(selectedColumn, database, table)
+              : [];
+
+        return values
+          .filter((nextValue) => !inputValue || nextValue.toLowerCase().includes(inputValue.toLowerCase()))
+          .map((nextValue) => ({ label: nextValue, value: nextValue }));
+      } catch (err) {
+        console.error('FilterPopover: failed to load values for column', selectedColumn, err);
+        return [];
+      }
+    },
+    [datasource, database, table, selectedColumn, isMapColumn, selectedMapKey]
+  );
+
+  const noValueNeeded = operator === FilterOperator.IsNull || operator === FilterOperator.IsNotNull;
+  const numericValue = Number(value);
+  const isNumberValueInvalid =
+    filterKind === 'number' && !noValueNeeded && (value.trim() === '' || isNaN(numericValue));
+
+  const handleAdd = () => {
+    if (!selectedColumn || isNumberValueInvalid) {
+      return;
+    }
+
+    const commonFilter = {
+      filterType: 'custom',
+      key: selectedColumn,
+      type: selectedColDef?.type || 'string',
+      operator: operator as any,
+      condition: 'AND',
+      ...(isMapColumn && selectedMapKey ? { mapKey: selectedMapKey } : {}),
+    };
+
+    const filter: StringFilter | NumberFilter =
+      filterKind === 'number'
+        ? ({
+            ...commonFilter,
+            value: noValueNeeded ? 0 : numericValue,
+          } as NumberFilter)
+        : ({
+            ...commonFilter,
+            value: noValueNeeded ? '' : value,
+          } as StringFilter);
+
+    onAddFilter(filter as Filter);
+    onClose();
+  };
+
+  return (
+    <div className={styles.popover} data-testid="filter-popover">
+      <div className={styles.field}>
+        <span className={styles.fieldLabel}>Column</span>
+        <Select
+          options={columnOptions}
+          value={selectedColumn}
+          onChange={(option) => {
+            const nextColumn = option.value || '';
+            const nextColumnDef = allColumns.find((column) => column.name === nextColumn);
+            const nextKind = getFilterValueKind(nextColumnDef?.type);
+            setSelectedColumn(nextColumn);
+            setSelectedMapKey('');
+            setOperator(defaultOperatorByKind[nextKind]);
+            setValue('');
+          }}
+          width={24}
+          placeholder="Select column..."
+          menuPlacement="bottom"
+        />
+      </div>
+
+      {isMapColumn && (
+        <div className={styles.field}>
+          <span className={styles.fieldLabel}>Map key</span>
+          <Select
+            options={mapKeys.map((key) => ({ label: key, value: key }))}
+            value={selectedMapKey}
+            onChange={(option) => {
+              setSelectedMapKey(option.value || '');
+              setValue('');
+            }}
+            width={20}
+            placeholder="Select key..."
+            menuPlacement="bottom"
+          />
+        </div>
+      )}
+
+      <div className={styles.field}>
+        <span className={styles.fieldLabel}>Operator</span>
+        <Select
+          options={currentOperatorOptions}
+          value={operator}
+          onChange={(option) => setOperator(option.value || defaultOperatorByKind[filterKind])}
+          width={14}
+          menuPlacement="bottom"
+        />
+      </div>
+
+      {!noValueNeeded && (
+        <div className={styles.field}>
+          <span className={styles.fieldLabel}>Value</span>
+          <AsyncSelect
+            key={`${selectedColumn}-${selectedMapKey}`}
+            loadOptions={loadValueOptions}
+            defaultOptions={Boolean(selectedColumn)}
+            value={value ? { label: value, value } : undefined}
+            onChange={(option) => setValue(option?.value || '')}
+            allowCustomValue
+            onCreateOption={(nextValue) => setValue(nextValue)}
+            width={24}
+            placeholder="Type or select..."
+            menuPlacement="bottom"
+          />
+        </div>
+      )}
+
+      <div className={styles.actions}>
+        <Button size="sm" onClick={handleAdd} disabled={!selectedColumn || isNumberValueInvalid}>
+          Add
+        </Button>
+        <Button size="sm" variant="secondary" onClick={onClose}>
+          Cancel
+        </Button>
+      </div>
+    </div>
+  );
+};

--- a/src/components/queryBuilder/FilterPopover.tsx
+++ b/src/components/queryBuilder/FilterPopover.tsx
@@ -60,6 +60,13 @@ export const getOperatorOptions = (kind: FilterValueKind): Array<SelectableValue
   return kind === 'number' ? numberOperatorOptions : stringOperatorOptions;
 };
 
+export const toFilterValueOption = (
+  nextValue: string | number | boolean
+): SelectableValue<string> & { label: string; value: string } => {
+  const value = String(nextValue);
+  return { label: value, value };
+};
+
 const getStyles = (theme: GrafanaTheme2) => ({
   popover: css`
     display: flex;
@@ -130,9 +137,10 @@ export const FilterPopover = (props: FilterPopoverProps) => {
               ? await datasource.fetchDistinctValues(selectedColumn, database, table)
               : [];
 
+        const normalizedInput = inputValue.toLowerCase();
         return values
-          .filter((nextValue) => !inputValue || nextValue.toLowerCase().includes(inputValue.toLowerCase()))
-          .map((nextValue) => ({ label: nextValue, value: nextValue }));
+          .map(toFilterValueOption)
+          .filter((option) => !normalizedInput || option.value.toLowerCase().includes(normalizedInput));
       } catch (err) {
         console.error('FilterPopover: failed to load values for column', selectedColumn, err);
         return [];

--- a/src/components/queryBuilder/FilterPopover.tsx
+++ b/src/components/queryBuilder/FilterPopover.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { css } from '@emotion/css';
-import { GrafanaTheme2, SelectableValue } from '@grafana/data';
-import { AsyncSelect, Button, Select, useStyles2 } from '@grafana/ui';
+import { GrafanaTheme2 } from '@grafana/data';
+import { Button, Combobox, ComboboxOption, useStyles2 } from '@grafana/ui';
 import { Datasource } from 'data/CHDatasource';
 import { Filter, FilterOperator, NumberFilter, StringFilter, TableColumn } from 'types/queryBuilder';
 import { getFilterOperatorOptions } from './filterOperatorOptions';
@@ -58,13 +58,18 @@ export const getFilterValueKind = (type = ''): FilterValueKind => {
   return utils.isNumberType(valueType) ? 'number' : 'string';
 };
 
-export const getOperatorOptions = (kind: FilterValueKind): Array<SelectableValue<FilterOperator>> => {
-  return getFilterOperatorOptions(kind === 'number' ? numberOperators : stringOperators, compactOperatorLabels);
+export const getOperatorOptions = (kind: FilterValueKind): Array<ComboboxOption<FilterOperator>> => {
+  return getFilterOperatorOptions(kind === 'number' ? numberOperators : stringOperators, compactOperatorLabels).map(
+    (option) => ({
+      label: String(option.label || option.value),
+      value: option.value!,
+    })
+  );
 };
 
 export const toFilterValueOption = (
   nextValue: string | number | boolean
-): SelectableValue<string> & { label: string; value: string } => {
+): ComboboxOption<string> & { label: string; value: string } => {
   const value = String(nextValue);
   return { label: value, value };
 };
@@ -120,14 +125,14 @@ export const FilterPopover = (props: FilterPopoverProps) => {
     }
   }, [datasource, database, table, selectedColumn, isMapColumn]);
 
-  const columnOptions: Array<SelectableValue<string>> = allColumns.map((column) => ({
+  const columnOptions: Array<ComboboxOption<string>> = allColumns.map((column) => ({
     label: column.label || column.name,
     value: column.name,
     description: column.type,
   }));
 
   const loadValueOptions = useCallback(
-    async (inputValue: string): Promise<Array<SelectableValue<string>>> => {
+    async (inputValue: string): Promise<Array<ComboboxOption<string>>> => {
       if (!selectedColumn || !database || !table) {
         return [];
       }
@@ -189,10 +194,13 @@ export const FilterPopover = (props: FilterPopoverProps) => {
     <div className={styles.popover} data-testid="filter-popover">
       <div className={styles.field}>
         <span className={styles.fieldLabel}>Column</span>
-        <Select
+        <Combobox
           options={columnOptions}
-          value={selectedColumn}
+          value={selectedColumn || null}
           onChange={(option) => {
+            if (!option) {
+              return;
+            }
             const nextColumn = option.value || '';
             const nextColumnDef = allColumns.find((column) => column.name === nextColumn);
             const nextKind = getFilterValueKind(nextColumnDef?.type);
@@ -203,52 +211,49 @@ export const FilterPopover = (props: FilterPopoverProps) => {
           }}
           width={24}
           placeholder="Select column..."
-          menuPlacement="bottom"
         />
       </div>
 
       {isMapColumn && (
         <div className={styles.field}>
           <span className={styles.fieldLabel}>Map key</span>
-          <Select
+          <Combobox
             options={mapKeys.map((key) => ({ label: key, value: key }))}
-            value={selectedMapKey}
+            value={selectedMapKey || null}
             onChange={(option) => {
+              if (!option) {
+                return;
+              }
               setSelectedMapKey(option.value || '');
               setValue('');
             }}
             width={20}
             placeholder="Select key..."
-            menuPlacement="bottom"
           />
         </div>
       )}
 
       <div className={styles.field}>
         <span className={styles.fieldLabel}>Operator</span>
-        <Select
+        <Combobox
           options={currentOperatorOptions}
           value={operator}
-          onChange={(option) => setOperator(option.value || defaultOperatorByKind[filterKind])}
+          onChange={(option) => option && setOperator(option.value || defaultOperatorByKind[filterKind])}
           width={14}
-          menuPlacement="bottom"
         />
       </div>
 
       {!noValueNeeded && (
         <div className={styles.field}>
           <span className={styles.fieldLabel}>Value</span>
-          <AsyncSelect
+          <Combobox
             key={`${selectedColumn}-${selectedMapKey}`}
-            loadOptions={loadValueOptions}
-            defaultOptions={Boolean(selectedColumn)}
+            options={loadValueOptions}
             value={value ? { label: value, value } : undefined}
-            onChange={(option) => setValue(option?.value || '')}
-            allowCustomValue
-            onCreateOption={(nextValue) => setValue(nextValue)}
+            onChange={(option) => option && setValue(option.value || '')}
+            createCustomValue
             width={24}
             placeholder="Type or select..."
-            menuPlacement="bottom"
           />
         </div>
       )}

--- a/src/components/queryBuilder/FilterPopover.tsx
+++ b/src/components/queryBuilder/FilterPopover.tsx
@@ -4,6 +4,8 @@ import { GrafanaTheme2, SelectableValue } from '@grafana/data';
 import { AsyncSelect, Button, Select, useStyles2 } from '@grafana/ui';
 import { Datasource } from 'data/CHDatasource';
 import { Filter, FilterOperator, NumberFilter, StringFilter, TableColumn } from 'types/queryBuilder';
+import { getFilterOperatorOptions } from './filterOperatorOptions';
+import * as utils from './utils';
 
 interface FilterPopoverProps {
   datasource: Datasource;
@@ -16,25 +18,30 @@ interface FilterPopoverProps {
 
 type FilterValueKind = 'number' | 'string';
 
-const numberOperatorOptions: Array<SelectableValue<FilterOperator>> = [
-  { label: '>', value: FilterOperator.GreaterThan },
-  { label: '<', value: FilterOperator.LessThan },
-  { label: '>=', value: FilterOperator.GreaterThanOrEqual },
-  { label: '<=', value: FilterOperator.LessThanOrEqual },
-  { label: '=', value: FilterOperator.Equals },
-  { label: '!=', value: FilterOperator.NotEquals },
-  { label: 'IS NULL', value: FilterOperator.IsNull },
-  { label: 'IS NOT NULL', value: FilterOperator.IsNotNull },
+const numberOperators = [
+  FilterOperator.GreaterThan,
+  FilterOperator.LessThan,
+  FilterOperator.GreaterThanOrEqual,
+  FilterOperator.LessThanOrEqual,
+  FilterOperator.Equals,
+  FilterOperator.NotEquals,
+  FilterOperator.IsNull,
+  FilterOperator.IsNotNull,
 ];
 
-const stringOperatorOptions: Array<SelectableValue<FilterOperator>> = [
-  { label: 'contains', value: FilterOperator.Like },
-  { label: 'does not contain', value: FilterOperator.NotLike },
-  { label: '=', value: FilterOperator.Equals },
-  { label: '!=', value: FilterOperator.NotEquals },
-  { label: 'IS NULL', value: FilterOperator.IsNull },
-  { label: 'IS NOT NULL', value: FilterOperator.IsNotNull },
+const stringOperators = [
+  FilterOperator.Like,
+  FilterOperator.NotLike,
+  FilterOperator.Equals,
+  FilterOperator.NotEquals,
+  FilterOperator.IsNull,
+  FilterOperator.IsNotNull,
 ];
+
+const compactOperatorLabels: Partial<Record<FilterOperator, string>> = {
+  [FilterOperator.Like]: 'contains',
+  [FilterOperator.NotLike]: 'does not contain',
+};
 
 const defaultOperatorByKind: Record<FilterValueKind, FilterOperator> = {
   number: FilterOperator.GreaterThan,
@@ -46,18 +53,13 @@ const getMapValueType = (type: string): string => {
 };
 
 export const getFilterValueKind = (type = ''): FilterValueKind => {
-  const normalizedType = getMapValueType(type)
-    .toLowerCase()
-    .replace(/\(/g, '')
-    .replace(/\)/g, '')
-    .replace(/nullable/g, '')
-    .replace(/lowcardinality/g, '');
+  const valueType = getMapValueType(type);
 
-  return ['int', 'float', 'decimal'].some((numberType) => normalizedType.includes(numberType)) ? 'number' : 'string';
+  return utils.isNumberType(valueType) ? 'number' : 'string';
 };
 
 export const getOperatorOptions = (kind: FilterValueKind): Array<SelectableValue<FilterOperator>> => {
-  return kind === 'number' ? numberOperatorOptions : stringOperatorOptions;
+  return getFilterOperatorOptions(kind === 'number' ? numberOperators : stringOperators, compactOperatorLabels);
 };
 
 export const toFilterValueOption = (

--- a/src/components/queryBuilder/FilterTagBar.tsx
+++ b/src/components/queryBuilder/FilterTagBar.tsx
@@ -1,0 +1,169 @@
+import React from 'react';
+import { css } from '@emotion/css';
+import { GrafanaTheme2 } from '@grafana/data';
+import { Icon, Tooltip, useStyles2 } from '@grafana/ui';
+import { Filter, FilterOperator } from 'types/queryBuilder';
+
+interface FilterTagBarProps {
+  filters: Filter[];
+  onRemoveFilter: (index: number) => void;
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  bar: css`
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: ${theme.spacing(0.5)};
+    padding: ${theme.spacing(0.5)} 0;
+    min-height: 28px;
+  `,
+  tag: css`
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 2px 6px 2px 8px;
+    border-radius: ${theme.shape.radius.pill};
+    background: ${theme.colors.background.secondary};
+    border: 1px solid ${theme.colors.border.medium};
+    font-size: ${theme.typography.bodySmall.fontSize};
+    font-family: ${theme.typography.fontFamilyMonospace};
+    color: ${theme.colors.text.primary};
+    max-width: 400px;
+    white-space: nowrap;
+  `,
+  tagContent: css`
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    min-width: 0;
+  `,
+  tagKey: css`
+    color: ${theme.colors.primary.text};
+    font-weight: ${theme.typography.fontWeightMedium};
+  `,
+  tagOperator: css`
+    color: ${theme.colors.text.secondary};
+  `,
+  tagValue: css`
+    color: ${theme.colors.text.primary};
+  `,
+  removeBtn: css`
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    color: ${theme.colors.text.secondary};
+    border-radius: 50%;
+    padding: 1px;
+    flex-shrink: 0;
+    &:hover {
+      color: ${theme.colors.text.primary};
+      background: ${theme.colors.action.hover};
+    }
+  `,
+  label: css`
+    font-size: ${theme.typography.bodySmall.fontSize};
+    color: ${theme.colors.text.secondary};
+    margin-right: ${theme.spacing(0.5)};
+    font-weight: ${theme.typography.fontWeightMedium};
+  `,
+});
+
+const getFilterDisplayName = (filter: Filter): string => {
+  const key = filter.key || (filter.hint ? filter.hint.replace(/_/g, ' ') : '?');
+  const mapSuffix = 'mapKey' in filter && filter.mapKey ? `.${filter.mapKey}` : '';
+  return `${key}${mapSuffix}`;
+};
+
+const getFilterDisplayValue = (filter: Filter): string => {
+  if (filter.operator === FilterOperator.IsAnything) {
+    return '';
+  }
+  if (filter.operator === FilterOperator.IsNull || filter.operator === FilterOperator.IsNotNull) {
+    return '';
+  }
+  if (filter.operator === FilterOperator.IsEmpty || filter.operator === FilterOperator.IsNotEmpty) {
+    return '';
+  }
+  if (filter.operator === FilterOperator.WithInGrafanaTimeRange) {
+    return 'dashboard time';
+  }
+  if (filter.operator === FilterOperator.OutsideGrafanaTimeRange) {
+    return 'outside dashboard time';
+  }
+  if ('value' in filter && filter.value !== undefined) {
+    const value = String(filter.value);
+    return value.length > 30 ? value.substring(0, 27) + '...' : value;
+  }
+  return '';
+};
+
+const getOperatorDisplay = (operator: FilterOperator): string => {
+  switch (operator) {
+    case FilterOperator.IsAnything:
+      return 'is anything';
+    case FilterOperator.IsNull:
+      return 'is null';
+    case FilterOperator.IsNotNull:
+      return 'is not null';
+    case FilterOperator.IsEmpty:
+      return 'is empty';
+    case FilterOperator.IsNotEmpty:
+      return 'is not empty';
+    default:
+      return operator;
+  }
+};
+
+export const FilterTagBar = (props: FilterTagBarProps) => {
+  const { filters, onRemoveFilter } = props;
+  const styles = useStyles2(getStyles);
+
+  const activeFilters = filters.filter(
+    (filter) =>
+      (filter.operator !== FilterOperator.IsAnything || filter.key !== '') &&
+      filter.operator !== FilterOperator.WithInGrafanaTimeRange &&
+      filter.operator !== FilterOperator.OutsideGrafanaTimeRange
+  );
+
+  if (activeFilters.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className={styles.bar} data-testid="filter-tag-bar">
+      <span className={styles.label}>Filters:</span>
+      {filters.map((filter, index) => {
+        if (filter.operator === FilterOperator.IsAnything && !filter.key) {
+          return null;
+        }
+        if (
+          filter.operator === FilterOperator.WithInGrafanaTimeRange ||
+          filter.operator === FilterOperator.OutsideGrafanaTimeRange
+        ) {
+          return null;
+        }
+
+        const name = getFilterDisplayName(filter);
+        const operator = getOperatorDisplay(filter.operator);
+        const value = getFilterDisplayValue(filter);
+
+        return (
+          <Tooltip key={index} content={`${name} ${operator} ${value}`.trim()} placement="top">
+            <span className={styles.tag}>
+              <span className={styles.tagContent}>
+                <span className={styles.tagKey}>{name}</span>
+                <span className={styles.tagOperator}> {operator} </span>
+                {value && <span className={styles.tagValue}>{value}</span>}
+              </span>
+              <span className={styles.removeBtn} onClick={() => onRemoveFilter(index)} role="button" tabIndex={0}>
+                <Icon name="times" size="sm" />
+              </span>
+            </span>
+          </Tooltip>
+        );
+      })}
+    </div>
+  );
+};

--- a/src/components/queryBuilder/QueryBuilder.test.tsx
+++ b/src/components/queryBuilder/QueryBuilder.test.tsx
@@ -1,27 +1,34 @@
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
-import { QueryBuilder } from './QueryBuilder';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { getCompactFilterColumns, QueryBuilder } from './QueryBuilder';
 import { Datasource } from 'data/CHDatasource';
-import { BuilderMode, QueryType, TimeUnit } from 'types/queryBuilder';
+import { BuilderMode, ColumnHint, QueryType, TimeUnit } from 'types/queryBuilder';
 import { CoreApp } from '@grafana/data';
 
 jest.mock('./views/TableQueryBuilder', () => ({
   TableQueryBuilder: () => <div data-testid="table-component" />,
 }));
 jest.mock('./views/LogsQueryBuilder', () => ({
-  LogsQueryBuilder: () => <div data-testid="logs-component" />,
+  LogsQueryBuilder: ({ builderOptions }: any) => (
+    <div data-testid="logs-component" data-database={builderOptions.database} data-table={builderOptions.table} />
+  ),
 }));
 jest.mock('./views/TimeSeriesQueryBuilder', () => ({
   TimeSeriesQueryBuilder: () => <div data-testid="time-series-component" />,
 }));
 jest.mock('./views/TraceQueryBuilder', () => ({
-  TraceQueryBuilder: () => <div data-testid="trace-component" />,
+  TraceQueryBuilder: ({ builderOptions }: any) => (
+    <div data-testid="trace-component" data-database={builderOptions.database} data-table={builderOptions.table} />
+  ),
 }));
 
 describe('QueryBuilder', () => {
   const setState = jest.fn();
   const mockDs = { settings: { jsonData: {} } } as Datasource;
 
+  mockDs.getSignalType = jest.fn(() => undefined);
+  mockDs.getConfigMode = jest.fn(() => 'classic');
+  mockDs.isSingleTableMode = jest.fn(() => false);
   mockDs.fetchDatabases = jest.fn(() => Promise.resolve([]));
   mockDs.fetchTables = jest.fn((_db?: string) => Promise.resolve([]));
   mockDs.getDefaultLogsColumns = jest.fn((_db?: string) => new Map());
@@ -39,9 +46,34 @@ describe('QueryBuilder', () => {
   mockDs.getDefaultTraceFlattenNested = jest.fn((_db?: string) => false);
   mockDs.getDefaultTraceEventsColumnPrefix = jest.fn((_db?: string) => '');
   mockDs.getDefaultTraceLinksColumnPrefix = jest.fn((_db?: string) => '');
+  mockDs.getTraceTimestampTableSuffix = jest.fn((_db?: string) => '_trace_id_ts');
+  mockDs.getLogContextColumnNames = jest.fn(() => []);
   mockDs.fetchColumns = jest.fn(() => {
     setState();
     return Promise.resolve([]);
+  });
+
+  it('omits compact time columns from filter column options', () => {
+    const filterColumns = getCompactFilterColumns(
+      [
+        { name: 'TimestampTime', type: 'DateTime', picklistValues: [] },
+        { name: 'Timestamp', type: 'DateTime64(9)', picklistValues: [] },
+        { name: 'Body', type: 'String', picklistValues: [] },
+        { name: 'ingested_at', type: 'DateTime', picklistValues: [] },
+      ],
+      {
+        database: 'otel_v2',
+        table: 'otel_logs',
+        queryType: QueryType.Logs,
+        columns: [
+          { name: 'TimestampTime', hint: ColumnHint.FilterTime },
+          { name: 'Timestamp', hint: ColumnHint.Time },
+          { name: 'Body', hint: ColumnHint.LogMessage },
+        ],
+      }
+    );
+
+    expect(filterColumns.map((column) => column.name)).toEqual(['Body', 'ingested_at']);
   });
 
   it('renders correctly', async () => {
@@ -150,5 +182,133 @@ describe('QueryBuilder', () => {
     await waitFor(() => {
       expect(screen.getByTestId('trace-component')).toBeInTheDocument();
     });
+  });
+
+  it('renders logs compact mode without database/table or query type selectors', async () => {
+    const compactDs = {
+      ...mockDs,
+      getSignalType: jest.fn(() => 'logs'),
+      getConfigMode: jest.fn(() => 'single-table'),
+      isSingleTableMode: jest.fn(() => true),
+      getDefaultLogsDatabase: jest.fn(() => 'otel_v2'),
+      getDefaultLogsTable: jest.fn(() => 'otel_logs'),
+      getDefaultLogsColumns: jest.fn(
+        () =>
+          new Map([
+            ['filter_time', 'TimestampTime'],
+            ['time', 'Timestamp'],
+            ['log_message', 'Body'],
+          ])
+      ),
+      getLogsOtelVersion: jest.fn(() => '1.29.0'),
+      shouldSelectLogContextColumns: jest.fn(() => false),
+      getLogContextColumnNames: jest.fn(() => []),
+    } as unknown as Datasource;
+    const builderOptionsDispatch = jest.fn();
+    const onQueryChange = jest.fn();
+    const onEditAsSql = jest.fn();
+
+    render(
+      <QueryBuilder
+        app={CoreApp.PanelEditor}
+        builderOptions={{
+          queryType: QueryType.Table,
+          mode: BuilderMode.List,
+          database: '',
+          table: '',
+          columns: [],
+          filters: [],
+        }}
+        builderOptionsDispatch={builderOptionsDispatch}
+        datasource={compactDs}
+        generatedSql=""
+        onQueryChange={onQueryChange}
+        onEditAsSql={onEditAsSql}
+      />
+    );
+
+    expect(screen.getByTestId('compact-mode-bar')).toBeInTheDocument();
+    expect(screen.getByTestId('compact-filter-bar')).toBeInTheDocument();
+    expect(screen.queryByText('Database')).not.toBeInTheDocument();
+    expect(screen.queryByText('Query Type')).not.toBeInTheDocument();
+    fireEvent.change(screen.getByPlaceholderText('Search log body text...'), { target: { value: 'error' } });
+    fireEvent.blur(screen.getByPlaceholderText('Search log body text...'));
+    expect(screen.getByRole('button', { name: 'Add filter' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Show advanced options' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Open query history' })).toBeInTheDocument();
+    await waitFor(() =>
+      expect(builderOptionsDispatch).toHaveBeenCalledWith(expect.objectContaining({ type: 'set_all_options' }))
+    );
+    expect(onQueryChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        database: 'otel_v2',
+        table: 'otel_logs',
+        queryType: QueryType.Logs,
+      })
+    );
+    expect(onQueryChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        meta: expect.objectContaining({ logMessageLike: 'error' }),
+      })
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Edit as SQL' }));
+    expect(onEditAsSql).toHaveBeenCalledWith(
+      expect.objectContaining({
+        database: 'otel_v2',
+        table: 'otel_logs',
+        queryType: QueryType.Logs,
+      })
+    );
+  });
+
+  it('renders traces compact mode without database/table or query type selectors', async () => {
+    const compactDs = {
+      ...mockDs,
+      getSignalType: jest.fn(() => 'traces'),
+      getConfigMode: jest.fn(() => 'single-table'),
+      isSingleTableMode: jest.fn(() => true),
+      getDefaultTraceDatabase: jest.fn(() => 'otel_v2'),
+      getDefaultTraceTable: jest.fn(() => 'otel_traces'),
+      getDefaultTraceColumns: jest.fn(
+        () =>
+          new Map([
+            ['time', 'Timestamp'],
+            ['trace_id', 'TraceId'],
+            ['trace_span_id', 'SpanId'],
+          ])
+      ),
+      getTraceOtelVersion: jest.fn(() => '1.29.0'),
+      getDefaultTraceDurationUnit: jest.fn(() => TimeUnit.Nanoseconds),
+      getDefaultTraceFlattenNested: jest.fn(() => false),
+      getDefaultTraceEventsColumnPrefix: jest.fn(() => 'Events'),
+      getDefaultTraceLinksColumnPrefix: jest.fn(() => 'Links'),
+      getTraceTimestampTableSuffix: jest.fn(() => '_trace_id_ts'),
+    } as unknown as Datasource;
+    const builderOptionsDispatch = jest.fn();
+
+    render(
+      <QueryBuilder
+        app={CoreApp.PanelEditor}
+        builderOptions={{
+          queryType: QueryType.Logs,
+          mode: BuilderMode.List,
+          database: 'logs_db',
+          table: 'logs_table',
+          columns: [],
+          filters: [],
+        }}
+        builderOptionsDispatch={builderOptionsDispatch}
+        datasource={compactDs}
+        generatedSql=""
+      />
+    );
+
+    expect(screen.queryByTestId('compact-mode-bar')).not.toBeInTheDocument();
+    expect(screen.getByTestId('compact-filter-bar')).toBeInTheDocument();
+    expect(screen.queryByText('Database')).not.toBeInTheDocument();
+    expect(screen.queryByText('Query Type')).not.toBeInTheDocument();
+    await waitFor(() =>
+      expect(builderOptionsDispatch).toHaveBeenCalledWith(expect.objectContaining({ type: 'set_all_options' }))
+    );
   });
 });

--- a/src/components/queryBuilder/QueryBuilder.test.tsx
+++ b/src/components/queryBuilder/QueryBuilder.test.tsx
@@ -207,6 +207,7 @@ describe('QueryBuilder', () => {
     const builderOptionsDispatch = jest.fn();
     const onQueryChange = jest.fn();
     const onEditAsSql = jest.fn();
+    const onRunQuery = jest.fn();
 
     render(
       <QueryBuilder
@@ -224,6 +225,7 @@ describe('QueryBuilder', () => {
         generatedSql=""
         onQueryChange={onQueryChange}
         onEditAsSql={onEditAsSql}
+        onRunQuery={onRunQuery}
       />
     );
 
@@ -234,8 +236,8 @@ describe('QueryBuilder', () => {
     fireEvent.change(screen.getByPlaceholderText('Search log body text...'), { target: { value: 'error' } });
     fireEvent.blur(screen.getByPlaceholderText('Search log body text...'));
     expect(screen.getByRole('button', { name: 'Add filter' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Show advanced options' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Open query history' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Order by' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Open query history' })).not.toBeInTheDocument();
     await waitFor(() =>
       expect(builderOptionsDispatch).toHaveBeenCalledWith(expect.objectContaining({ type: 'set_all_options' }))
     );
@@ -251,7 +253,8 @@ describe('QueryBuilder', () => {
         meta: expect.objectContaining({ logMessageLike: 'error' }),
       })
     );
-    fireEvent.click(screen.getByRole('button', { name: 'Edit as SQL' }));
+    expect(onRunQuery).toHaveBeenCalled();
+    fireEvent.click(screen.getByRole('button', { name: 'Open in SQL editor' }));
     expect(onEditAsSql).toHaveBeenCalledWith(
       expect.objectContaining({
         database: 'otel_v2',

--- a/src/components/queryBuilder/QueryBuilder.test.tsx
+++ b/src/components/queryBuilder/QueryBuilder.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { getCompactFilterColumns, QueryBuilder } from './QueryBuilder';
+import { getDefaultCompactMode } from './CompactModeBar';
 import { Datasource } from 'data/CHDatasource';
 import { BuilderMode, ColumnHint, QueryType, TimeUnit } from 'types/queryBuilder';
 import { CoreApp } from '@grafana/data';
@@ -74,6 +75,11 @@ describe('QueryBuilder', () => {
     );
 
     expect(filterColumns.map((column) => column.name)).toEqual(['Body', 'ingested_at']);
+  });
+
+  it('maps configured signal types to compact modes', () => {
+    expect(getDefaultCompactMode('logs')).toBe('otel-logs');
+    expect(getDefaultCompactMode('traces')).toBe('otel-traces');
   });
 
   it('renders correctly', async () => {

--- a/src/components/queryBuilder/QueryBuilder.tsx
+++ b/src/components/queryBuilder/QueryBuilder.tsx
@@ -45,10 +45,12 @@ interface QueryBuilderProps {
   generatedSql: string;
   onQueryChange?: (builderOptions: QueryBuilderOptions) => void;
   onEditAsSql?: (builderOptions: QueryBuilderOptions) => void;
+  onRunQuery?: () => void;
 }
 
 export const QueryBuilder = (props: QueryBuilderProps) => {
-  const { datasource, builderOptions, builderOptionsDispatch, generatedSql, onQueryChange, onEditAsSql } = props;
+  const { datasource, builderOptions, builderOptionsDispatch, generatedSql, onQueryChange, onEditAsSql, onRunQuery } =
+    props;
   const signalType = datasource.getSignalType();
   const singleTableMode = datasource.isSingleTableMode();
 
@@ -76,6 +78,7 @@ export const QueryBuilder = (props: QueryBuilderProps) => {
         signalType={signalType}
         onQueryChange={onQueryChange}
         onEditAsSql={onEditAsSql}
+        onRunQuery={onRunQuery}
       />
     );
   }
@@ -150,11 +153,20 @@ interface CompactQueryEditorProps {
   signalType: SignalType;
   onQueryChange?: (builderOptions: QueryBuilderOptions) => void;
   onEditAsSql?: (builderOptions: QueryBuilderOptions) => void;
+  onRunQuery?: () => void;
 }
 
 const CompactQueryEditor = (props: CompactQueryEditorProps) => {
-  const { datasource, builderOptions, builderOptionsDispatch, generatedSql, signalType, onQueryChange, onEditAsSql } =
-    props;
+  const {
+    datasource,
+    builderOptions,
+    builderOptionsDispatch,
+    generatedSql,
+    signalType,
+    onQueryChange,
+    onEditAsSql,
+    onRunQuery,
+  } = props;
   const needsInitialization = isDefaultOrMismatchedCompactQuery(builderOptions, signalType);
   const [advancedOpen, setAdvancedOpen] = useState(false);
   const lastInitializationKey = useRef<string>();
@@ -186,20 +198,26 @@ const CompactQueryEditor = (props: CompactQueryEditorProps) => {
   const allColumns = useColumns(datasource, activeOptions.database, activeOptions.table);
   const filterColumns = useMemo(() => getCompactFilterColumns(allColumns, activeOptions), [allColumns, activeOptions]);
 
-  const onActiveOptionsChange = (nextOptions: QueryBuilderOptions) => {
+  const onActiveOptionsChange = (nextOptions: QueryBuilderOptions, shouldRunQuery = false) => {
     builderOptionsDispatch(setAllOptions(nextOptions));
     onQueryChange?.(nextOptions);
+    if (shouldRunQuery) {
+      onRunQuery?.();
+    }
   };
 
-  const mergeActiveOptions = (nextOptions: Partial<QueryBuilderOptions>) => {
-    onActiveOptionsChange({
-      ...activeOptions,
-      ...nextOptions,
-      meta: {
-        ...activeOptions.meta,
-        ...nextOptions.meta,
+  const mergeActiveOptions = (nextOptions: Partial<QueryBuilderOptions>, shouldRunQuery = false) => {
+    onActiveOptionsChange(
+      {
+        ...activeOptions,
+        ...nextOptions,
+        meta: {
+          ...activeOptions.meta,
+          ...nextOptions.meta,
+        },
       },
-    });
+      shouldRunQuery
+    );
   };
 
   return (
@@ -210,7 +228,7 @@ const CompactQueryEditor = (props: CompactQueryEditorProps) => {
         mode={signalType === 'logs' ? 'otel-logs' : 'otel-traces'}
         onModeChange={() => {}}
         searchText={activeOptions.meta?.logMessageLike || ''}
-        onSearchChange={(logMessageLike) => mergeActiveOptions({ meta: { logMessageLike } })}
+        onSearchChange={(logMessageLike) => mergeActiveOptions({ meta: { logMessageLike } }, true)}
         onSearchSubmit={() => {}}
       />
       <CompactFilterBar
@@ -219,7 +237,7 @@ const CompactQueryEditor = (props: CompactQueryEditorProps) => {
         table={activeOptions.table}
         filters={activeOptions.filters || []}
         allColumns={filterColumns}
-        onFiltersChange={(filters: Filter[]) => mergeActiveOptions({ filters })}
+        onFiltersChange={(filters: Filter[]) => mergeActiveOptions({ filters }, true)}
         onToggleAdvanced={() => setAdvancedOpen(!advancedOpen)}
         advancedOpen={advancedOpen}
       />
@@ -227,8 +245,8 @@ const CompactQueryEditor = (props: CompactQueryEditorProps) => {
         <CompactAdvanced
           builderOptions={activeOptions}
           allColumns={allColumns}
-          onOrderByChange={(orderBy: OrderBy[]) => mergeActiveOptions({ orderBy })}
-          onLimitChange={(limit: number) => mergeActiveOptions({ limit })}
+          onOrderByChange={(orderBy: OrderBy[]) => mergeActiveOptions({ orderBy }, true)}
+          onLimitChange={(limit: number) => mergeActiveOptions({ limit }, true)}
         />
       )}
 

--- a/src/components/queryBuilder/QueryBuilder.tsx
+++ b/src/components/queryBuilder/QueryBuilder.tsx
@@ -1,6 +1,14 @@
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { Datasource } from 'data/CHDatasource';
-import { QueryType, QueryBuilderOptions, ColumnHint, StringFilter } from 'types/queryBuilder';
+import {
+  Filter,
+  OrderBy,
+  QueryType,
+  QueryBuilderOptions,
+  ColumnHint,
+  StringFilter,
+  TableColumn,
+} from 'types/queryBuilder';
 import { CoreApp } from '@grafana/data';
 import { LogsQueryBuilder } from './views/LogsQueryBuilder';
 import { TimeSeriesQueryBuilder } from './views/TimeSeriesQueryBuilder';
@@ -12,6 +20,7 @@ import { styles } from 'styles';
 import { TraceQueryBuilder } from './views/TraceQueryBuilder';
 import {
   BuilderOptionsReducerAction,
+  setAllOptions,
   setBuilderMinimized,
   setDatabase,
   setQueryType,
@@ -21,6 +30,12 @@ import TraceIdInput from './TraceIdInput';
 import { Alert, Button, Stack } from '@grafana/ui';
 import { Components as allSelectors } from 'selectors';
 import allLabels from 'labels';
+import { buildCompactQueryDefaults, isDefaultOrMismatchedCompactQuery } from './compactQueryDefaults';
+import { SignalType } from 'types/config';
+import useColumns from 'hooks/useColumns';
+import { CompactModeBar } from './CompactModeBar';
+import { CompactFilterBar } from './CompactFilterBar';
+import { CompactAdvanced } from './CompactAdvanced';
 
 interface QueryBuilderProps {
   app: CoreApp | undefined;
@@ -28,10 +43,14 @@ interface QueryBuilderProps {
   builderOptionsDispatch: React.Dispatch<BuilderOptionsReducerAction>;
   datasource: Datasource;
   generatedSql: string;
+  onQueryChange?: (builderOptions: QueryBuilderOptions) => void;
+  onEditAsSql?: (builderOptions: QueryBuilderOptions) => void;
 }
 
 export const QueryBuilder = (props: QueryBuilderProps) => {
-  const { datasource, builderOptions, builderOptionsDispatch, generatedSql } = props;
+  const { datasource, builderOptions, builderOptionsDispatch, generatedSql, onQueryChange, onEditAsSql } = props;
+  const signalType = datasource.getSignalType();
+  const singleTableMode = datasource.isSingleTableMode();
 
   const onDatabaseChange = (database: string) => builderOptionsDispatch(setDatabase(database));
   const onTableChange = (table: string) => builderOptionsDispatch(setTable(table));
@@ -43,6 +62,20 @@ export const QueryBuilder = (props: QueryBuilderProps) => {
         builderOptions={builderOptions}
         builderOptionsDispatch={builderOptionsDispatch}
         datasource={datasource}
+      />
+    );
+  }
+
+  if (singleTableMode && signalType) {
+    return (
+      <CompactQueryEditor
+        datasource={datasource}
+        builderOptions={builderOptions}
+        builderOptionsDispatch={builderOptionsDispatch}
+        generatedSql={generatedSql}
+        signalType={signalType}
+        onQueryChange={onQueryChange}
+        onEditAsSql={onEditAsSql}
       />
     );
   }
@@ -92,6 +125,114 @@ export const QueryBuilder = (props: QueryBuilderProps) => {
       )}
 
       <SqlPreview sql={generatedSql} />
+    </div>
+  );
+};
+
+export const getCompactFilterColumns = (
+  allColumns: readonly TableColumn[],
+  builderOptions: QueryBuilderOptions
+): readonly TableColumn[] => {
+  const timeColumnNames = new Set(
+    (builderOptions.columns || [])
+      .filter((column) => column.hint === ColumnHint.Time || column.hint === ColumnHint.FilterTime)
+      .map((column) => column.name)
+  );
+
+  return allColumns.filter((column) => !timeColumnNames.has(column.name));
+};
+
+interface CompactQueryEditorProps {
+  datasource: Datasource;
+  builderOptions: QueryBuilderOptions;
+  builderOptionsDispatch: React.Dispatch<BuilderOptionsReducerAction>;
+  generatedSql: string;
+  signalType: SignalType;
+  onQueryChange?: (builderOptions: QueryBuilderOptions) => void;
+  onEditAsSql?: (builderOptions: QueryBuilderOptions) => void;
+}
+
+const CompactQueryEditor = (props: CompactQueryEditorProps) => {
+  const { datasource, builderOptions, builderOptionsDispatch, generatedSql, signalType, onQueryChange, onEditAsSql } =
+    props;
+  const needsInitialization = isDefaultOrMismatchedCompactQuery(builderOptions, signalType);
+  const [advancedOpen, setAdvancedOpen] = useState(false);
+  const lastInitializationKey = useRef<string>();
+  const onQueryChangeRef = useRef(onQueryChange);
+
+  useEffect(() => {
+    onQueryChangeRef.current = onQueryChange;
+  }, [onQueryChange]);
+
+  useEffect(() => {
+    if (!needsInitialization) {
+      return;
+    }
+
+    const initializationKey = `${datasource.uid}:${signalType}:${builderOptions.table}`;
+    if (lastInitializationKey.current === initializationKey) {
+      return;
+    }
+    lastInitializationKey.current = initializationKey;
+
+    const nextOptions = buildCompactQueryDefaults(datasource, signalType, builderOptions.table);
+    builderOptionsDispatch(setAllOptions(nextOptions));
+    onQueryChangeRef.current?.(nextOptions);
+  }, [builderOptions.table, builderOptionsDispatch, datasource, needsInitialization, signalType]);
+
+  const activeOptions = needsInitialization
+    ? buildCompactQueryDefaults(datasource, signalType, builderOptions.table)
+    : builderOptions;
+  const allColumns = useColumns(datasource, activeOptions.database, activeOptions.table);
+  const filterColumns = useMemo(() => getCompactFilterColumns(allColumns, activeOptions), [allColumns, activeOptions]);
+
+  const onActiveOptionsChange = (nextOptions: QueryBuilderOptions) => {
+    builderOptionsDispatch(setAllOptions(nextOptions));
+    onQueryChange?.(nextOptions);
+  };
+
+  const mergeActiveOptions = (nextOptions: Partial<QueryBuilderOptions>) => {
+    onActiveOptionsChange({
+      ...activeOptions,
+      ...nextOptions,
+      meta: {
+        ...activeOptions.meta,
+        ...nextOptions.meta,
+      },
+    });
+  };
+
+  return (
+    <div data-testid="query-editor-section-builder">
+      <CompactModeBar
+        datasource={datasource}
+        signalType={signalType}
+        mode={signalType === 'logs' ? 'otel-logs' : 'otel-traces'}
+        onModeChange={() => {}}
+        searchText={activeOptions.meta?.logMessageLike || ''}
+        onSearchChange={(logMessageLike) => mergeActiveOptions({ meta: { logMessageLike } })}
+        onSearchSubmit={() => {}}
+      />
+      <CompactFilterBar
+        datasource={datasource}
+        database={activeOptions.database}
+        table={activeOptions.table}
+        filters={activeOptions.filters || []}
+        allColumns={filterColumns}
+        onFiltersChange={(filters: Filter[]) => mergeActiveOptions({ filters })}
+        onToggleAdvanced={() => setAdvancedOpen(!advancedOpen)}
+        advancedOpen={advancedOpen}
+      />
+      {advancedOpen && (
+        <CompactAdvanced
+          builderOptions={activeOptions}
+          allColumns={allColumns}
+          onOrderByChange={(orderBy: OrderBy[]) => mergeActiveOptions({ orderBy })}
+          onLimitChange={(limit: number) => mergeActiveOptions({ limit })}
+        />
+      )}
+
+      <SqlPreview sql={generatedSql} compact onEditAsSql={() => onEditAsSql?.(activeOptions)} />
     </div>
   );
 };

--- a/src/components/queryBuilder/QueryBuilder.tsx
+++ b/src/components/queryBuilder/QueryBuilder.tsx
@@ -36,6 +36,7 @@ import useColumns from 'hooks/useColumns';
 import { CompactModeBar } from './CompactModeBar';
 import { CompactFilterBar } from './CompactFilterBar';
 import { CompactAdvanced } from './CompactAdvanced';
+import { isEqual } from 'lodash';
 
 interface QueryBuilderProps {
   app: CoreApp | undefined;
@@ -188,9 +189,11 @@ const CompactQueryEditor = (props: CompactQueryEditorProps) => {
     lastInitializationKey.current = initializationKey;
 
     const nextOptions = buildCompactQueryDefaults(datasource, signalType, builderOptions.table);
-    builderOptionsDispatch(setAllOptions(nextOptions));
-    onQueryChangeRef.current?.(nextOptions);
-  }, [builderOptions.table, builderOptionsDispatch, datasource, needsInitialization, signalType]);
+    if (!isEqual(builderOptions, nextOptions)) {
+      builderOptionsDispatch(setAllOptions(nextOptions));
+      onQueryChangeRef.current?.(nextOptions);
+    }
+  }, [builderOptions, builderOptionsDispatch, datasource, needsInitialization, signalType]);
 
   const activeOptions = needsInitialization
     ? buildCompactQueryDefaults(datasource, signalType, builderOptions.table)

--- a/src/components/queryBuilder/QueryBuilder.tsx
+++ b/src/components/queryBuilder/QueryBuilder.tsx
@@ -33,7 +33,7 @@ import allLabels from 'labels';
 import { buildCompactQueryDefaults, isDefaultOrMismatchedCompactQuery } from './compactQueryDefaults';
 import { SignalType } from 'types/config';
 import useColumns from 'hooks/useColumns';
-import { CompactModeBar } from './CompactModeBar';
+import { CompactModeBar, getDefaultCompactMode } from './CompactModeBar';
 import { CompactFilterBar } from './CompactFilterBar';
 import { CompactAdvanced } from './CompactAdvanced';
 import { isEqual } from 'lodash';
@@ -226,13 +226,9 @@ const CompactQueryEditor = (props: CompactQueryEditorProps) => {
   return (
     <div data-testid="query-editor-section-builder">
       <CompactModeBar
-        datasource={datasource}
-        signalType={signalType}
-        mode={signalType === 'logs' ? 'otel-logs' : 'otel-traces'}
-        onModeChange={() => {}}
+        mode={getDefaultCompactMode(signalType)}
         searchText={activeOptions.meta?.logMessageLike || ''}
         onSearchChange={(logMessageLike) => mergeActiveOptions({ meta: { logMessageLike } }, true)}
-        onSearchSubmit={() => {}}
       />
       <CompactFilterBar
         datasource={datasource}

--- a/src/components/queryBuilder/SqlPreview.test.tsx
+++ b/src/components/queryBuilder/SqlPreview.test.tsx
@@ -1,10 +1,33 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { SqlPreview } from './SqlPreview';
 
 describe('SqlPreview', () => {
   it('renders correctly', () => {
     const result = render(<SqlPreview sql="" />);
     expect(result.container.firstChild).not.toBeNull();
+  });
+
+  it('renders compact actions', () => {
+    const writeText = jest.fn();
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    });
+    const onEditAsSql = jest.fn();
+
+    render(<SqlPreview sql="SELECT 1" compact onEditAsSql={onEditAsSql} />);
+
+    expect(screen.queryByText('SELECT 1')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'SQL' }));
+    expect(screen.getByText('SELECT 1')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Copy' }));
+    expect(writeText).toHaveBeenCalledWith('SELECT 1');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit as SQL' }));
+    expect(onEditAsSql).toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'SQL' }));
+    expect(screen.queryByText('SELECT 1')).not.toBeInTheDocument();
   });
 });

--- a/src/components/queryBuilder/SqlPreview.test.tsx
+++ b/src/components/queryBuilder/SqlPreview.test.tsx
@@ -24,7 +24,7 @@ describe('SqlPreview', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Copy' }));
     expect(writeText).toHaveBeenCalledWith('SELECT 1');
 
-    fireEvent.click(screen.getByRole('button', { name: 'Edit as SQL' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Open in SQL editor' }));
     expect(onEditAsSql).toHaveBeenCalled();
 
     fireEvent.click(screen.getByRole('button', { name: 'SQL' }));

--- a/src/components/queryBuilder/SqlPreview.tsx
+++ b/src/components/queryBuilder/SqlPreview.tsx
@@ -1,14 +1,91 @@
 import React from 'react';
-import { InlineFormLabel } from '@grafana/ui';
+import { css } from '@emotion/css';
+import { GrafanaTheme2 } from '@grafana/data';
+import { Button, Icon, InlineFormLabel, useStyles2 } from '@grafana/ui';
 import labels from 'labels';
 
 interface SqlPreviewProps {
   sql: string;
+  compact?: boolean;
+  onEditAsSql?: () => void;
 }
 
+const getStyles = (theme: GrafanaTheme2) => ({
+  compactWrapper: css`
+    border: 1px solid ${theme.colors.border.medium};
+    border-radius: ${theme.shape.radius.default};
+    margin-top: ${theme.spacing(0.75)};
+    overflow: hidden;
+  `,
+  compactHeader: css`
+    align-items: center;
+    background: ${theme.colors.background.secondary};
+    display: flex;
+    justify-content: space-between;
+    min-height: 32px;
+    padding: 0 ${theme.spacing(1)};
+  `,
+  compactTitle: css`
+    align-items: center;
+    background: transparent;
+    border: 0;
+    color: ${theme.colors.text.primary};
+    cursor: pointer;
+    display: flex;
+    font-weight: ${theme.typography.fontWeightMedium};
+    gap: ${theme.spacing(0.5)};
+    padding: 0;
+  `,
+  compactActions: css`
+    align-items: center;
+    display: flex;
+    gap: ${theme.spacing(0.5)};
+  `,
+  compactSql: css`
+    border-top: 1px solid ${theme.colors.border.weak};
+    font-family: ${theme.typography.fontFamilyMonospace};
+    margin: 0;
+    max-height: 96px;
+    overflow: auto;
+    padding: ${theme.spacing(1)};
+    white-space: pre-wrap;
+    word-break: break-word;
+  `,
+});
+
 export const SqlPreview = (props: SqlPreviewProps) => {
-  const { sql } = props;
+  const { sql, compact, onEditAsSql } = props;
   const { label, tooltip } = labels.components.SqlPreview;
+  const styles = useStyles2(getStyles);
+  const [isOpen, setIsOpen] = React.useState(!compact);
+
+  const copySql = () => {
+    void navigator.clipboard?.writeText(sql);
+  };
+
+  if (compact) {
+    return (
+      <div className={styles.compactWrapper}>
+        <div className={styles.compactHeader}>
+          <button className={styles.compactTitle} type="button" onClick={() => setIsOpen(!isOpen)}>
+            <Icon name={isOpen ? 'angle-down' : 'angle-right'} />
+            SQL
+          </button>
+          <div className={styles.compactActions}>
+            <Button icon="copy" variant="secondary" size="sm" fill="text" onClick={copySql}>
+              Copy
+            </Button>
+            {onEditAsSql && (
+              <Button icon="pen" variant="secondary" size="sm" fill="text" onClick={onEditAsSql}>
+                Edit as SQL
+              </Button>
+            )}
+          </div>
+        </div>
+        {isOpen && <pre className={styles.compactSql}>{sql}</pre>}
+      </div>
+    );
+  }
 
   return (
     <div className="gf-form">

--- a/src/components/queryBuilder/SqlPreview.tsx
+++ b/src/components/queryBuilder/SqlPreview.tsx
@@ -77,7 +77,7 @@ export const SqlPreview = (props: SqlPreviewProps) => {
             </Button>
             {onEditAsSql && (
               <Button icon="pen" variant="secondary" size="sm" fill="text" onClick={onEditAsSql}>
-                Edit as SQL
+                Open in SQL editor
               </Button>
             )}
           </div>

--- a/src/components/queryBuilder/compactQueryDefaults.ts
+++ b/src/components/queryBuilder/compactQueryDefaults.ts
@@ -1,0 +1,189 @@
+import { Datasource } from 'data/CHDatasource';
+import {
+  BuilderMode,
+  ColumnHint,
+  DateFilterWithoutValue,
+  Filter,
+  FilterOperator,
+  NumberFilter,
+  OrderBy,
+  OrderByDirection,
+  QueryBuilderOptions,
+  QueryType,
+  SelectedColumn,
+  StringFilter,
+} from 'types/queryBuilder';
+import { SignalType } from 'types/config';
+
+export const getCompactQueryType = (signalType: SignalType): QueryType => {
+  return signalType === 'logs' ? QueryType.Logs : QueryType.Traces;
+};
+
+export const isDefaultOrMismatchedCompactQuery = (
+  builderOptions: QueryBuilderOptions,
+  signalType: SignalType
+): boolean => {
+  const expectedQueryType = getCompactQueryType(signalType);
+  const isDefaultState =
+    builderOptions.queryType === QueryType.Table &&
+    !builderOptions.database &&
+    !builderOptions.table &&
+    (!builderOptions.columns || builderOptions.columns.length === 0) &&
+    (!builderOptions.filters || builderOptions.filters.length === 0) &&
+    (!builderOptions.aggregates || builderOptions.aggregates.length === 0);
+
+  return isDefaultState || builderOptions.queryType !== expectedQueryType;
+};
+
+export function buildCompactQueryDefaults(
+  datasource: Datasource,
+  signalType: SignalType,
+  fallbackTable = ''
+): QueryBuilderOptions {
+  return signalType === 'logs'
+    ? buildCompactLogsDefaults(datasource, fallbackTable)
+    : buildCompactTracesDefaults(datasource, fallbackTable);
+}
+
+const buildCompactLogsDefaults = (datasource: Datasource, fallbackTable: string): QueryBuilderOptions => {
+  const defaultDb = datasource.getDefaultLogsDatabase() || datasource.getDefaultDatabase();
+  const defaultTable = datasource.getDefaultLogsTable() || datasource.getDefaultTable() || fallbackTable;
+  const otelVersion = datasource.getLogsOtelVersion();
+  const columns = getLogsDefaultColumns(datasource);
+
+  return {
+    database: defaultDb,
+    table: defaultTable || '',
+    queryType: QueryType.Logs,
+    mode: BuilderMode.List,
+    columns,
+    filters: getLogsDefaultFilters(),
+    orderBy: getLogsDefaultOrderBy(),
+    limit: 1000,
+    meta: {
+      otelEnabled: Boolean(otelVersion),
+      otelVersion,
+    },
+  };
+};
+
+const buildCompactTracesDefaults = (datasource: Datasource, fallbackTable: string): QueryBuilderOptions => {
+  const defaultDb = datasource.getDefaultTraceDatabase() || datasource.getDefaultDatabase();
+  const defaultTable = datasource.getDefaultTraceTable() || datasource.getDefaultTable() || fallbackTable;
+  const otelVersion = datasource.getTraceOtelVersion();
+
+  return {
+    database: defaultDb,
+    table: defaultTable || '',
+    queryType: QueryType.Traces,
+    columns: getDefaultColumns(datasource.getDefaultTraceColumns()),
+    filters: getTracesDefaultFilters(),
+    orderBy: getTracesDefaultOrderBy(),
+    limit: 1000,
+    meta: {
+      otelEnabled: Boolean(otelVersion),
+      otelVersion,
+      traceDurationUnit: datasource.getDefaultTraceDurationUnit(),
+      flattenNested: datasource.getDefaultTraceFlattenNested(),
+      traceEventsColumnPrefix: datasource.getDefaultTraceEventsColumnPrefix(),
+      traceLinksColumnPrefix: datasource.getDefaultTraceLinksColumnPrefix(),
+      traceTimestampTableSuffix: datasource.getTraceTimestampTableSuffix(),
+    },
+  };
+};
+
+const getLogsDefaultColumns = (datasource: Datasource): SelectedColumn[] => {
+  const nextColumns = getDefaultColumns(datasource.getDefaultLogsColumns());
+  const includedColumns = new Set(nextColumns.map((c) => c.name));
+
+  if (datasource.shouldSelectLogContextColumns()) {
+    const contextColumnNames = datasource.getLogContextColumnNames();
+
+    for (let columnName of contextColumnNames) {
+      if (includedColumns.has(columnName) || includedColumns.has(columnName.split('[')[0])) {
+        continue;
+      }
+
+      nextColumns.push({ name: columnName });
+      includedColumns.add(columnName);
+    }
+  }
+
+  return nextColumns;
+};
+
+const getDefaultColumns = (columns: Map<ColumnHint, string>): SelectedColumn[] => {
+  const nextColumns: SelectedColumn[] = [];
+  for (let [hint, name] of columns) {
+    nextColumns.push({ name, hint });
+  }
+  return nextColumns;
+};
+
+const getLogsDefaultFilters = (): Filter[] => [
+  {
+    type: 'datetime',
+    operator: FilterOperator.WithInGrafanaTimeRange,
+    filterType: 'custom',
+    key: '',
+    hint: ColumnHint.FilterTime,
+    condition: 'AND',
+  } as DateFilterWithoutValue,
+  {
+    type: 'string',
+    operator: FilterOperator.IsAnything,
+    filterType: 'custom',
+    key: '',
+    hint: ColumnHint.LogLevel,
+    condition: 'AND',
+    value: '',
+  } as StringFilter,
+];
+
+const getLogsDefaultOrderBy = (): OrderBy[] => [
+  { name: '', hint: ColumnHint.FilterTime, dir: OrderByDirection.DESC, default: true },
+  { name: '', hint: ColumnHint.Time, dir: OrderByDirection.DESC, default: true },
+];
+
+const getTracesDefaultFilters = (): Filter[] => [
+  {
+    type: 'datetime',
+    operator: FilterOperator.WithInGrafanaTimeRange,
+    filterType: 'custom',
+    key: '',
+    hint: ColumnHint.Time,
+    condition: 'AND',
+  } as DateFilterWithoutValue,
+  {
+    type: 'string',
+    operator: FilterOperator.IsEmpty,
+    filterType: 'custom',
+    key: '',
+    hint: ColumnHint.TraceParentSpanId,
+    condition: 'AND',
+    value: '',
+  } as StringFilter,
+  {
+    type: 'UInt64',
+    operator: FilterOperator.GreaterThan,
+    filterType: 'custom',
+    key: '',
+    hint: ColumnHint.TraceDurationTime,
+    condition: 'AND',
+    value: 0,
+  } as NumberFilter,
+  {
+    type: 'string',
+    operator: FilterOperator.IsAnything,
+    filterType: 'custom',
+    key: '',
+    hint: ColumnHint.TraceServiceName,
+    condition: 'AND',
+    value: '',
+  } as StringFilter,
+];
+
+const getTracesDefaultOrderBy = (): OrderBy[] => [
+  { name: '', hint: ColumnHint.Time, dir: OrderByDirection.DESC, default: true },
+  { name: '', hint: ColumnHint.TraceDurationTime, dir: OrderByDirection.DESC, default: true },
+];

--- a/src/components/queryBuilder/compactQueryDefaults.ts
+++ b/src/components/queryBuilder/compactQueryDefaults.ts
@@ -1,19 +1,12 @@
 import { Datasource } from 'data/CHDatasource';
-import {
-  BuilderMode,
-  ColumnHint,
-  DateFilterWithoutValue,
-  Filter,
-  FilterOperator,
-  NumberFilter,
-  OrderBy,
-  OrderByDirection,
-  QueryBuilderOptions,
-  QueryType,
-  SelectedColumn,
-  StringFilter,
-} from 'types/queryBuilder';
+import { BuilderMode, ColumnHint, QueryBuilderOptions, QueryType, SelectedColumn } from 'types/queryBuilder';
 import { SignalType } from 'types/config';
+import {
+  getDefaultLogsFilters,
+  getDefaultLogsOrderBy,
+  getDefaultTraceFilters,
+  getDefaultTraceOrderBy,
+} from './defaultQueryOptions';
 
 export const getCompactQueryType = (signalType: SignalType): QueryType => {
   return signalType === 'logs' ? QueryType.Logs : QueryType.Traces;
@@ -57,8 +50,8 @@ const buildCompactLogsDefaults = (datasource: Datasource, fallbackTable: string)
     queryType: QueryType.Logs,
     mode: BuilderMode.List,
     columns,
-    filters: getLogsDefaultFilters(),
-    orderBy: getLogsDefaultOrderBy(),
+    filters: getDefaultLogsFilters(),
+    orderBy: getDefaultLogsOrderBy(),
     limit: 1000,
     meta: {
       otelEnabled: Boolean(otelVersion),
@@ -77,8 +70,8 @@ const buildCompactTracesDefaults = (datasource: Datasource, fallbackTable: strin
     table: defaultTable || '',
     queryType: QueryType.Traces,
     columns: getDefaultColumns(datasource.getDefaultTraceColumns()),
-    filters: getTracesDefaultFilters(),
-    orderBy: getTracesDefaultOrderBy(),
+    filters: getDefaultTraceFilters(),
+    orderBy: getDefaultTraceOrderBy(),
     limit: 1000,
     meta: {
       otelEnabled: Boolean(otelVersion),
@@ -119,71 +112,3 @@ const getDefaultColumns = (columns: Map<ColumnHint, string>): SelectedColumn[] =
   }
   return nextColumns;
 };
-
-const getLogsDefaultFilters = (): Filter[] => [
-  {
-    type: 'datetime',
-    operator: FilterOperator.WithInGrafanaTimeRange,
-    filterType: 'custom',
-    key: '',
-    hint: ColumnHint.FilterTime,
-    condition: 'AND',
-  } as DateFilterWithoutValue,
-  {
-    type: 'string',
-    operator: FilterOperator.IsAnything,
-    filterType: 'custom',
-    key: '',
-    hint: ColumnHint.LogLevel,
-    condition: 'AND',
-    value: '',
-  } as StringFilter,
-];
-
-const getLogsDefaultOrderBy = (): OrderBy[] => [
-  { name: '', hint: ColumnHint.FilterTime, dir: OrderByDirection.DESC, default: true },
-  { name: '', hint: ColumnHint.Time, dir: OrderByDirection.DESC, default: true },
-];
-
-const getTracesDefaultFilters = (): Filter[] => [
-  {
-    type: 'datetime',
-    operator: FilterOperator.WithInGrafanaTimeRange,
-    filterType: 'custom',
-    key: '',
-    hint: ColumnHint.Time,
-    condition: 'AND',
-  } as DateFilterWithoutValue,
-  {
-    type: 'string',
-    operator: FilterOperator.IsEmpty,
-    filterType: 'custom',
-    key: '',
-    hint: ColumnHint.TraceParentSpanId,
-    condition: 'AND',
-    value: '',
-  } as StringFilter,
-  {
-    type: 'UInt64',
-    operator: FilterOperator.GreaterThan,
-    filterType: 'custom',
-    key: '',
-    hint: ColumnHint.TraceDurationTime,
-    condition: 'AND',
-    value: 0,
-  } as NumberFilter,
-  {
-    type: 'string',
-    operator: FilterOperator.IsAnything,
-    filterType: 'custom',
-    key: '',
-    hint: ColumnHint.TraceServiceName,
-    condition: 'AND',
-    value: '',
-  } as StringFilter,
-];
-
-const getTracesDefaultOrderBy = (): OrderBy[] => [
-  { name: '', hint: ColumnHint.Time, dir: OrderByDirection.DESC, default: true },
-  { name: '', hint: ColumnHint.TraceDurationTime, dir: OrderByDirection.DESC, default: true },
-];

--- a/src/components/queryBuilder/defaultQueryOptions.test.ts
+++ b/src/components/queryBuilder/defaultQueryOptions.test.ts
@@ -1,0 +1,38 @@
+import { ColumnHint, FilterOperator, OrderByDirection } from 'types/queryBuilder';
+import {
+  getDefaultLogsFilters,
+  getDefaultLogsOrderBy,
+  getDefaultTraceFilters,
+  getDefaultTraceOrderBy,
+} from './defaultQueryOptions';
+
+describe('defaultQueryOptions', () => {
+  it('returns logs filters and order by defaults', () => {
+    expect(getDefaultLogsFilters()).toMatchObject([
+      { hint: ColumnHint.FilterTime, operator: FilterOperator.WithInGrafanaTimeRange },
+      { hint: ColumnHint.LogLevel, operator: FilterOperator.IsAnything },
+    ]);
+    expect(getDefaultLogsOrderBy()).toEqual([
+      { name: '', hint: ColumnHint.FilterTime, dir: OrderByDirection.DESC, default: true },
+      { name: '', hint: ColumnHint.Time, dir: OrderByDirection.DESC, default: true },
+    ]);
+  });
+
+  it('returns trace filters and order by defaults', () => {
+    expect(getDefaultTraceFilters()).toMatchObject([
+      { hint: ColumnHint.Time, operator: FilterOperator.WithInGrafanaTimeRange },
+      { hint: ColumnHint.TraceParentSpanId, operator: FilterOperator.IsEmpty },
+      { hint: ColumnHint.TraceDurationTime, operator: FilterOperator.GreaterThan },
+      { hint: ColumnHint.TraceServiceName, operator: FilterOperator.IsAnything },
+    ]);
+    expect(getDefaultTraceOrderBy()).toEqual([
+      { name: '', hint: ColumnHint.Time, dir: OrderByDirection.DESC, default: true },
+      { name: '', hint: ColumnHint.TraceDurationTime, dir: OrderByDirection.DESC, default: true },
+    ]);
+  });
+
+  it('returns fresh arrays for each call', () => {
+    expect(getDefaultLogsFilters()).not.toBe(getDefaultLogsFilters());
+    expect(getDefaultTraceOrderBy()).not.toBe(getDefaultTraceOrderBy());
+  });
+});

--- a/src/components/queryBuilder/defaultQueryOptions.ts
+++ b/src/components/queryBuilder/defaultQueryOptions.ts
@@ -1,0 +1,78 @@
+import {
+  ColumnHint,
+  DateFilterWithoutValue,
+  Filter,
+  FilterOperator,
+  NumberFilter,
+  OrderBy,
+  OrderByDirection,
+  StringFilter,
+} from 'types/queryBuilder';
+
+export const getDefaultLogsFilters = (): Filter[] => [
+  {
+    type: 'datetime',
+    operator: FilterOperator.WithInGrafanaTimeRange,
+    filterType: 'custom',
+    key: '',
+    hint: ColumnHint.FilterTime,
+    condition: 'AND',
+  } as DateFilterWithoutValue,
+  {
+    type: 'string',
+    operator: FilterOperator.IsAnything,
+    filterType: 'custom',
+    key: '',
+    hint: ColumnHint.LogLevel,
+    condition: 'AND',
+    value: '',
+  } as StringFilter,
+];
+
+export const getDefaultLogsOrderBy = (): OrderBy[] => [
+  { name: '', hint: ColumnHint.FilterTime, dir: OrderByDirection.DESC, default: true },
+  { name: '', hint: ColumnHint.Time, dir: OrderByDirection.DESC, default: true },
+];
+
+export const getDefaultTraceFilters = (): Filter[] => [
+  {
+    type: 'datetime',
+    operator: FilterOperator.WithInGrafanaTimeRange,
+    filterType: 'custom',
+    key: '',
+    hint: ColumnHint.Time,
+    condition: 'AND',
+  } as DateFilterWithoutValue,
+  {
+    type: 'string',
+    operator: FilterOperator.IsEmpty,
+    filterType: 'custom',
+    key: '',
+    hint: ColumnHint.TraceParentSpanId,
+    condition: 'AND',
+    value: '',
+  } as StringFilter,
+  {
+    type: 'UInt64',
+    operator: FilterOperator.GreaterThan,
+    filterType: 'custom',
+    key: '',
+    hint: ColumnHint.TraceDurationTime,
+    condition: 'AND',
+    value: 0,
+  } as NumberFilter,
+  {
+    type: 'string',
+    operator: FilterOperator.IsAnything,
+    filterType: 'custom',
+    key: '',
+    hint: ColumnHint.TraceServiceName,
+    condition: 'AND',
+    value: '',
+  } as StringFilter,
+];
+
+export const getDefaultTraceOrderBy = (): OrderBy[] => [
+  { name: '', hint: ColumnHint.Time, dir: OrderByDirection.DESC, default: true },
+  { name: '', hint: ColumnHint.TraceDurationTime, dir: OrderByDirection.DESC, default: true },
+];

--- a/src/components/queryBuilder/filterOperatorOptions.ts
+++ b/src/components/queryBuilder/filterOperatorOptions.ts
@@ -1,0 +1,104 @@
+import { SelectableValue } from '@grafana/data';
+import { FilterOperator } from 'types/queryBuilder';
+import * as utils from 'components/queryBuilder/utils';
+
+export const filterOperatorOptions: Array<SelectableValue<FilterOperator>> = [
+  { value: FilterOperator.WithInGrafanaTimeRange, label: 'Within dashboard time range' },
+  { value: FilterOperator.OutsideGrafanaTimeRange, label: 'Outside dashboard time range' },
+  { value: FilterOperator.IsAnything, label: 'IS ANYTHING' },
+  { value: FilterOperator.Equals, label: '=' },
+  { value: FilterOperator.NotEquals, label: '!=' },
+  { value: FilterOperator.LessThan, label: '<' },
+  { value: FilterOperator.LessThanOrEqual, label: '<=' },
+  { value: FilterOperator.GreaterThan, label: '>' },
+  { value: FilterOperator.GreaterThanOrEqual, label: '>=' },
+  { value: FilterOperator.Like, label: 'LIKE' },
+  { value: FilterOperator.NotLike, label: 'NOT LIKE' },
+  { value: FilterOperator.ILike, label: 'ILIKE' },
+  { value: FilterOperator.NotILike, label: 'NOT ILIKE' },
+  { value: FilterOperator.IsEmpty, label: 'IS EMPTY' },
+  { value: FilterOperator.IsNotEmpty, label: 'IS NOT EMPTY' },
+  { value: FilterOperator.In, label: 'IN' },
+  { value: FilterOperator.NotIn, label: 'NOT IN' },
+  { value: FilterOperator.IsNull, label: 'IS NULL' },
+  { value: FilterOperator.IsNotNull, label: 'IS NOT NULL' },
+];
+
+const booleanOperators = [FilterOperator.Equals, FilterOperator.NotEquals];
+const comparableOperators = [
+  FilterOperator.IsAnything,
+  FilterOperator.IsNull,
+  FilterOperator.IsNotNull,
+  FilterOperator.Equals,
+  FilterOperator.NotEquals,
+  FilterOperator.LessThan,
+  FilterOperator.LessThanOrEqual,
+  FilterOperator.GreaterThan,
+  FilterOperator.GreaterThanOrEqual,
+];
+const dateOperators = [
+  ...comparableOperators,
+  FilterOperator.WithInGrafanaTimeRange,
+  FilterOperator.OutsideGrafanaTimeRange,
+];
+const jsonStringOperators = [
+  FilterOperator.IsAnything,
+  FilterOperator.Equals,
+  FilterOperator.NotEquals,
+  FilterOperator.Like,
+  FilterOperator.NotLike,
+  FilterOperator.ILike,
+  FilterOperator.NotILike,
+  FilterOperator.In,
+  FilterOperator.NotIn,
+  FilterOperator.IsNull,
+  FilterOperator.IsNotNull,
+];
+const stringOperators = [
+  ...jsonStringOperators,
+  FilterOperator.IsEmpty,
+  FilterOperator.IsNotEmpty,
+  FilterOperator.LessThan,
+  FilterOperator.LessThanOrEqual,
+  FilterOperator.GreaterThan,
+  FilterOperator.GreaterThanOrEqual,
+];
+
+const filterBySourceOrder = (operators: FilterOperator[]): Array<SelectableValue<FilterOperator>> => {
+  return filterOperatorOptions.filter((option) => operators.includes(option.value!));
+};
+
+const filterByRequestedOrder = (operators: FilterOperator[]): Array<SelectableValue<FilterOperator>> => {
+  return operators
+    .map((operator) => filterOperatorOptions.find((option) => option.value === operator))
+    .filter((option): option is SelectableValue<FilterOperator> => Boolean(option));
+};
+
+export const getFilterOperatorsByType = (
+  type = 'string',
+  isJSONType = false
+): Array<SelectableValue<FilterOperator>> => {
+  if (utils.isBooleanType(type)) {
+    return filterBySourceOrder(booleanOperators);
+  }
+  if (utils.isNumberType(type)) {
+    return filterBySourceOrder(comparableOperators);
+  }
+  if (utils.isDateType(type)) {
+    return filterBySourceOrder(dateOperators);
+  }
+  if (isJSONType) {
+    return filterBySourceOrder(jsonStringOperators);
+  }
+  return filterBySourceOrder(stringOperators);
+};
+
+export const getFilterOperatorOptions = (
+  operators: FilterOperator[],
+  labels?: Partial<Record<FilterOperator, string>>
+): Array<SelectableValue<FilterOperator>> => {
+  return filterByRequestedOrder(operators).map((option) => ({
+    ...option,
+    label: labels?.[option.value!] || option.label,
+  }));
+};

--- a/src/components/queryBuilder/views/logsQueryBuilderHooks.ts
+++ b/src/components/queryBuilder/views/logsQueryBuilderHooks.ts
@@ -1,20 +1,10 @@
 import { Datasource } from 'data/CHDatasource';
 import { BuilderOptionsReducerAction, setColumnByHint, setOptions } from 'hooks/useBuilderOptionsState';
 import { useEffect, useMemo, useRef } from 'react';
-import {
-  ColumnHint,
-  DateFilterWithoutValue,
-  Filter,
-  FilterOperator,
-  OrderBy,
-  OrderByDirection,
-  QueryBuilderOptions,
-  SelectedColumn,
-  StringFilter,
-  TableColumn,
-} from 'types/queryBuilder';
+import { ColumnHint, QueryBuilderOptions, SelectedColumn, TableColumn } from 'types/queryBuilder';
 import otel from 'otel';
 import { findColumnByNameHeuristic, isDateTimeColumn, isStringLikeColumn } from './columnNameHeuristics';
+import { getDefaultLogsFilters, getDefaultLogsOrderBy } from '../defaultQueryOptions';
 
 /**
  * Loads the default configuration for new queries. (Only runs on new queries)
@@ -248,36 +238,12 @@ export const useDefaultFilters = (
       return;
     }
 
-    const defaultFilters: Filter[] = [
-      {
-        type: 'datetime',
-        operator: FilterOperator.WithInGrafanaTimeRange,
-        filterType: 'custom',
-        key: '',
-        hint: ColumnHint.FilterTime,
-        condition: 'AND',
-      } as DateFilterWithoutValue,
-      {
-        type: 'string',
-        operator: FilterOperator.IsAnything,
-        filterType: 'custom',
-        key: '',
-        hint: ColumnHint.LogLevel,
-        condition: 'AND',
-      } as StringFilter,
-    ];
-
-    const defaultOrderBy: OrderBy[] = [
-      { name: '', hint: ColumnHint.FilterTime, dir: OrderByDirection.DESC, default: true },
-      { name: '', hint: ColumnHint.Time, dir: OrderByDirection.DESC, default: true },
-    ];
-
     lastTable.current = table;
     appliedDefaultFilters.current = true;
     builderOptionsDispatch(
       setOptions({
-        filters: defaultFilters,
-        orderBy: defaultOrderBy,
+        filters: getDefaultLogsFilters(),
+        orderBy: getDefaultLogsOrderBy(),
       })
     );
   }, [table, builderOptionsDispatch]);

--- a/src/components/queryBuilder/views/traceQueryBuilderHooks.ts
+++ b/src/components/queryBuilder/views/traceQueryBuilderHooks.ts
@@ -1,19 +1,7 @@
 import React, { useEffect, useRef } from 'react';
 import { Datasource } from 'data/CHDatasource';
 import otel from 'otel';
-import {
-  ColumnHint,
-  DateFilterWithoutValue,
-  Filter,
-  FilterOperator,
-  NumberFilter,
-  OrderBy,
-  OrderByDirection,
-  QueryBuilderOptions,
-  SelectedColumn,
-  StringFilter,
-  TableColumn,
-} from 'types/queryBuilder';
+import { ColumnHint, QueryBuilderOptions, SelectedColumn, TableColumn } from 'types/queryBuilder';
 import { BuilderOptionsReducerAction, setColumnByHint, setOptions } from 'hooks/useBuilderOptionsState';
 import {
   findColumnByNameHeuristic,
@@ -21,6 +9,7 @@ import {
   isNumericColumn,
   isStringLikeColumn,
 } from './columnNameHeuristics';
+import { getDefaultTraceFilters, getDefaultTraceOrderBy } from '../defaultQueryOptions';
 
 /**
  * Loads the default configuration for new queries. (Only runs on new queries)
@@ -288,55 +277,12 @@ export const useDefaultFilters = (
       return;
     }
 
-    const defaultFilters: Filter[] = [
-      {
-        type: 'datetime',
-        operator: FilterOperator.WithInGrafanaTimeRange,
-        filterType: 'custom',
-        key: '',
-        hint: ColumnHint.Time,
-        condition: 'AND',
-      } as DateFilterWithoutValue, // Filter to dashboard time range
-      {
-        type: 'string',
-        operator: FilterOperator.IsEmpty,
-        filterType: 'custom',
-        key: '',
-        hint: ColumnHint.TraceParentSpanId,
-        condition: 'AND',
-        value: '',
-      } as StringFilter, // Only show top level spans
-      {
-        type: 'UInt64',
-        operator: FilterOperator.GreaterThan,
-        filterType: 'custom',
-        key: '',
-        hint: ColumnHint.TraceDurationTime,
-        condition: 'AND',
-        value: 0,
-      } as NumberFilter, // Only show spans where duration > 0
-      {
-        type: 'string',
-        operator: FilterOperator.IsAnything,
-        filterType: 'custom',
-        key: '',
-        hint: ColumnHint.TraceServiceName,
-        condition: 'AND',
-        value: '',
-      } as StringFilter, // Placeholder service name filter for convenience
-    ];
-
-    const defaultOrderBy: OrderBy[] = [
-      { name: '', hint: ColumnHint.Time, dir: OrderByDirection.DESC, default: true },
-      { name: '', hint: ColumnHint.TraceDurationTime, dir: OrderByDirection.DESC, default: true },
-    ];
-
     lastTable.current = table;
     appliedDefaultFilters.current = true;
     builderOptionsDispatch(
       setOptions({
-        filters: defaultFilters,
-        orderBy: defaultOrderBy,
+        filters: getDefaultTraceFilters(),
+        orderBy: getDefaultTraceOrderBy(),
       })
     );
   }, [table, isTraceIdMode, builderOptionsDispatch]);

--- a/src/data/CHDatasource.test.ts
+++ b/src/data/CHDatasource.test.ts
@@ -52,6 +52,43 @@ const createInstance = ({ queryResponse }: Partial<InstanceConfig> = {}) => {
 };
 
 describe('ClickHouseDatasource', () => {
+  describe('single-table configuration mode', () => {
+    it('defaults to classic mode when configMode and signalType are unset', () => {
+      const ds = createInstance({});
+
+      expect(ds.getSignalType()).toBeUndefined();
+      expect(ds.getConfigMode()).toBe('classic');
+      expect(ds.isSingleTableMode()).toBe(false);
+    });
+
+    it('uses explicit configMode and signalType', () => {
+      const ds = createInstance({});
+      ds.settings.jsonData.configMode = 'single-table';
+      ds.settings.jsonData.signalType = 'logs';
+
+      expect(ds.getSignalType()).toBe('logs');
+      expect(ds.getConfigMode()).toBe('single-table');
+      expect(ds.isSingleTableMode()).toBe(true);
+    });
+
+    it('infers single-table mode from legacy signalType', () => {
+      const ds = createInstance({});
+      ds.settings.jsonData.signalType = 'traces';
+
+      expect(ds.getSignalType()).toBe('traces');
+      expect(ds.getConfigMode()).toBe('single-table');
+      expect(ds.isSingleTableMode()).toBe(true);
+    });
+
+    it('does not enter single-table mode without a signal type', () => {
+      const ds = createInstance({});
+      ds.settings.jsonData.configMode = 'single-table';
+
+      expect(ds.getConfigMode()).toBe('single-table');
+      expect(ds.isSingleTableMode()).toBe(false);
+    });
+  });
+
   describe('metricFindQuery', () => {
     it('fetches values', async () => {
       const mockedValues = [1, 100];

--- a/src/data/CHDatasource.test.ts
+++ b/src/data/CHDatasource.test.ts
@@ -975,6 +975,34 @@ describe('ClickHouseDatasource', () => {
     });
   });
 
+  describe('distinct value suggestions', () => {
+    it('escapes identifiers for distinct column values', async () => {
+      const ds = cloneDeep(mockDatasource);
+      const frame = arrayToDataFrame([{ value: 1 }, { value: 2 }]);
+      const spy = jest.spyOn(ds, 'query').mockImplementation(() => of({ data: [frame] }));
+
+      const result = await ds.fetchDistinctValues('some"col', 'db"name', 'events');
+
+      expect(result).toEqual([1, 2]);
+      const sql = spy.mock.calls[0][0].targets[0].rawSql!;
+      expect(sql).toBe('SELECT DISTINCT "some""col" FROM "db""name"."events" WHERE "some""col" IS NOT NULL LIMIT 1000');
+    });
+
+    it('escapes map identifiers and map key literals for distinct map values', async () => {
+      const ds = cloneDeep(mockDatasource);
+      const frame = arrayToDataFrame([{ value: 'alice' }]);
+      const spy = jest.spyOn(ds, 'query').mockImplementation(() => of({ data: [frame] }));
+
+      const result = await ds.fetchDistinctMapValues('labels"map', "user's key", 'db', 'events');
+
+      expect(result).toEqual(['alice']);
+      const sql = spy.mock.calls[0][0].targets[0].rawSql!;
+      expect(sql).toBe(
+        'SELECT DISTINCT "labels""map"[\'user\\\'s key\'] FROM "db"."events" WHERE mapContains("labels""map", \'user\\\'s key\') LIMIT 1000'
+      );
+    });
+  });
+
   describe('Conditional All', () => {
     it('should replace $__conditionalAll with 1=1 when all is selected', async () => {
       const rawSql = 'select stuff from table where $__conditionalAll(fieldVal in ($fieldVal), $fieldVal);';

--- a/src/data/CHDatasource.test.ts
+++ b/src/data/CHDatasource.test.ts
@@ -1980,6 +1980,29 @@ describe('ClickHouseDatasource', () => {
         });
       });
 
+      it('splits legacy LogAttributes key even when the column is not selected', () => {
+        const queryWithoutLogAttributes: CHBuilderQuery = {
+          ...query,
+          builderOptions: {
+            ...query.builderOptions,
+            columns: [{ name: 'Body', hint: ColumnHint.LogMessage }],
+          },
+        };
+
+        const result = datasource.modifyQuery(queryWithoutLogAttributes, {
+          type: 'ADD_FILTER',
+          options: { key: 'LogAttributes.foo.bar', value: 'baz' },
+        } as any) as CHBuilderQuery;
+
+        expect(result.builderOptions.filters![0]).toMatchObject({
+          key: 'LogAttributes',
+          mapKey: 'foo.bar',
+          type: 'JSON',
+          operator: FilterOperator.Equals,
+          value: 'baz',
+        });
+      });
+
       it('resolves normalized log attribute field names through column hints', () => {
         const queryWithLogAttributes: CHBuilderQuery = {
           ...query,
@@ -1998,11 +2021,10 @@ describe('ClickHouseDatasource', () => {
           key: '',
           hint: ColumnHint.LogAttributes,
           mapKey: 'log.file.path',
-          type: 'Map(String, String)',
+          type: 'JSON',
           operator: FilterOperator.Equals,
           value: '/var/log/pod.log',
         });
-        expect(result.rawSql).toContain("LogAttributes['log.file.path'] = '/var/log/pod.log'");
       });
     });
 

--- a/src/data/CHDatasource.test.ts
+++ b/src/data/CHDatasource.test.ts
@@ -1951,6 +1951,31 @@ describe('ClickHouseDatasource', () => {
           value: 'abc123',
         });
       });
+
+      it('resolves normalized log attribute field names through column hints', () => {
+        const queryWithLogAttributes: CHBuilderQuery = {
+          ...query,
+          builderOptions: {
+            ...query.builderOptions,
+            columns: [{ name: 'LogAttributes', hint: ColumnHint.LogAttributes }],
+          },
+        };
+
+        const result = datasource.modifyQuery(queryWithLogAttributes, {
+          type: 'ADD_FILTER',
+          options: { key: 'log_attributes.log.file.path', value: '/var/log/pod.log' },
+        } as any) as CHBuilderQuery;
+
+        expect(result.builderOptions.filters![0]).toMatchObject({
+          key: '',
+          hint: ColumnHint.LogAttributes,
+          mapKey: 'log.file.path',
+          type: 'Map(String, String)',
+          operator: FilterOperator.Equals,
+          value: '/var/log/pod.log',
+        });
+        expect(result.rawSql).toContain("LogAttributes['log.file.path'] = '/var/log/pod.log'");
+      });
     });
 
     describe('ADD_STRING_FILTER with LogMessage column alias', () => {

--- a/src/data/CHDatasource.ts
+++ b/src/data/CHDatasource.ts
@@ -78,6 +78,7 @@ const attributeColumnHints = new Set([
   ColumnHint.ScopeAttributes,
   ColumnHint.LogAttributes,
 ]);
+const legacyAttributeColumns = new Set(['ResourceAttributes', 'ScopeAttributes', 'LogAttributes']);
 
 function getAttributeColumnByDisplayPrefix(
   builderOptions: QueryBuilderOptions,
@@ -110,6 +111,9 @@ function resolveFilterColumn(builderOptions: QueryBuilderOptions, key: string): 
     if (attributeColumn) {
       mapKey = columnName.substring(prefixIndex + 1);
       columnName = attributeColumn.alias || attributeColumn.name;
+    } else if (legacyAttributeColumns.has(columnPrefix)) {
+      mapKey = columnName.substring(prefixIndex + 1);
+      columnName = columnPrefix;
     }
   }
 
@@ -137,7 +141,7 @@ function buildFilter(resolved: ResolvedColumn, operator: StringFilter['operator'
     key: resolved.column?.hint ? '' : resolved.columnName,
     hint: resolved.column?.hint || undefined,
     mapKey: resolved.hasMapKey ? resolved.mapKey : undefined,
-    type: resolved.hasMapKey ? (resolved.columnType.startsWith('JSON') ? 'JSON' : 'Map(String, String)') : 'string',
+    type: resolved.hasMapKey ? (resolved.columnType.startsWith('Map') ? 'Map(String, String)' : 'JSON') : 'string',
     filterType: 'custom',
     operator,
     value,

--- a/src/data/CHDatasource.ts
+++ b/src/data/CHDatasource.ts
@@ -1097,13 +1097,21 @@ export class Datasource
     return this.fetchData(rawSql);
   }
 
-  async fetchDistinctValues(column: string, db: string, table: string): Promise<string[]> {
-    const rawSql = `SELECT DISTINCT "${column}" FROM "${db}"."${table}" WHERE "${column}" IS NOT NULL LIMIT 1000`;
+  async fetchDistinctValues(column: string, db: string, table: string): Promise<Array<string | number | boolean>> {
+    const escapedColumn = escapeIdentifier(column);
+    const rawSql = `SELECT DISTINCT ${escapedColumn} FROM ${escapeIdentifier(db)}.${escapeIdentifier(table)} WHERE ${escapedColumn} IS NOT NULL LIMIT 1000`;
     return this.fetchData(rawSql);
   }
 
-  async fetchDistinctMapValues(mapColumn: string, mapKey: string, db: string, table: string): Promise<string[]> {
-    const rawSql = `SELECT DISTINCT ${mapColumn}['${mapKey}'] FROM "${db}"."${table}" WHERE mapContains(${mapColumn}, '${mapKey}') LIMIT 1000`;
+  async fetchDistinctMapValues(
+    mapColumn: string,
+    mapKey: string,
+    db: string,
+    table: string
+  ): Promise<Array<string | number | boolean>> {
+    const escapedMapColumn = escapeIdentifier(mapColumn);
+    const escapedMapKey = `'${escapeCHStringLiteral(mapKey)}'`;
+    const rawSql = `SELECT DISTINCT ${escapedMapColumn}[${escapedMapKey}] FROM ${escapeIdentifier(db)}.${escapeIdentifier(table)} WHERE mapContains(${escapedMapColumn}, ${escapedMapKey}) LIMIT 1000`;
     return this.fetchData(rawSql);
   }
 

--- a/src/data/CHDatasource.ts
+++ b/src/data/CHDatasource.ts
@@ -73,16 +73,44 @@ interface ResolvedColumn {
   hasMapKey: boolean;
 }
 
+const attributeColumnHints = new Set([
+  ColumnHint.ResourceAttributes,
+  ColumnHint.ScopeAttributes,
+  ColumnHint.LogAttributes,
+]);
+
+function getAttributeColumnByDisplayPrefix(
+  builderOptions: QueryBuilderOptions,
+  columnPrefix: string
+): SelectedColumn | undefined {
+  const normalizedPrefix = normalizeLogFieldName(columnPrefix);
+
+  return builderOptions.columns?.find((column) => {
+    const isAttributeHint = column.hint ? attributeColumnHints.has(column.hint) : false;
+    const isAttributeType = column.type?.startsWith('Map') || column.type?.startsWith('JSON');
+    if (!isAttributeHint && !isAttributeType) {
+      return false;
+    }
+
+    const candidates = isAttributeHint ? [column.name, column.alias, column.hint] : [column.name, column.alias];
+    return candidates.filter(isString).some((candidate) => normalizeLogFieldName(candidate) === normalizedPrefix);
+  });
+}
+
 /** Resolve a filter key to a column in the builder options, handling OTel map key splitting and alias/hint lookup. */
 function resolveFilterColumn(builderOptions: QueryBuilderOptions, key: string): ResolvedColumn {
   let columnName = key;
   let mapKey = '';
 
-  // Convert flattened/merged OTel attributes into column+path pair
-  if (['ResourceAttributes', 'ScopeAttributes', 'LogAttributes'].includes(columnName.split('.')[0])) {
-    const prefixIndex = columnName.indexOf('.');
-    mapKey = columnName.substring(prefixIndex + 1);
-    columnName = columnName.substring(0, prefixIndex);
+  // Convert flattened/merged OTel attributes into a column+path pair.
+  const prefixIndex = columnName.indexOf('.');
+  if (prefixIndex > -1) {
+    const columnPrefix = columnName.substring(0, prefixIndex);
+    const attributeColumn = getAttributeColumnByDisplayPrefix(builderOptions, columnPrefix);
+    if (attributeColumn) {
+      mapKey = columnName.substring(prefixIndex + 1);
+      columnName = attributeColumn.alias || attributeColumn.name;
+    }
   }
 
   // Find selected column by alias/name
@@ -109,7 +137,7 @@ function buildFilter(resolved: ResolvedColumn, operator: StringFilter['operator'
     key: resolved.column?.hint ? '' : resolved.columnName,
     hint: resolved.column?.hint || undefined,
     mapKey: resolved.hasMapKey ? resolved.mapKey : undefined,
-    type: resolved.hasMapKey ? (resolved.columnType.startsWith('Map') ? 'Map(String, String)' : 'JSON') : 'string',
+    type: resolved.hasMapKey ? (resolved.columnType.startsWith('JSON') ? 'JSON' : 'Map(String, String)') : 'string',
     filterType: 'custom',
     operator,
     value,
@@ -1976,6 +2004,8 @@ enum AdHocFilterStatus {
   enabled,
   disabled,
 }
+
+const normalizeLogFieldName = (fieldName: string): string => fieldName.toLowerCase().replace(/[^a-z0-9]/g, '');
 
 interface Tags {
   type?: TagType;

--- a/src/data/CHDatasource.ts
+++ b/src/data/CHDatasource.ts
@@ -32,7 +32,7 @@ import { cloneDeep, isEmpty, isString } from 'lodash';
 import otel from 'otel';
 import { createElement as createReactElement, ReactNode } from 'react';
 import { concatMap, firstValueFrom, Observable } from 'rxjs';
-import { CHConfig } from 'types/config';
+import { CHConfig, ConfigMode, SignalType } from 'types/config';
 import {
   AggregateColumn,
   AggregateType,
@@ -774,6 +774,22 @@ export class Datasource
     return this.settings.jsonData.defaultTable;
   }
 
+  getSignalType(): SignalType | undefined {
+    return this.settings.jsonData.signalType;
+  }
+
+  getConfigMode(): ConfigMode {
+    if (this.settings.jsonData.configMode) {
+      return this.settings.jsonData.configMode;
+    }
+
+    return this.getSignalType() ? 'single-table' : 'classic';
+  }
+
+  isSingleTableMode(): boolean {
+    return this.getConfigMode() === 'single-table' && Boolean(this.getSignalType());
+  }
+
   getDefaultLogsDatabase(): string | undefined {
     return this.settings.jsonData.logs?.defaultDatabase;
   }
@@ -1050,6 +1066,16 @@ export class Datasource
     const rawSql = keysColumn
       ? `SELECT DISTINCT arrayJoin(${escapeIdentifier(keysColumn)}) as path FROM ${escapeIdentifier(db)}.${escapeIdentifier(table)} LIMIT 1000`
       : `SELECT DISTINCT arrayJoin(JSONAllPaths(${escapeIdentifier(jsonColumn)})) as path FROM ${escapeIdentifier(db)}.${escapeIdentifier(table)} LIMIT 1000`;
+    return this.fetchData(rawSql);
+  }
+
+  async fetchDistinctValues(column: string, db: string, table: string): Promise<string[]> {
+    const rawSql = `SELECT DISTINCT "${column}" FROM "${db}"."${table}" WHERE "${column}" IS NOT NULL LIMIT 1000`;
+    return this.fetchData(rawSql);
+  }
+
+  async fetchDistinctMapValues(mapColumn: string, mapKey: string, db: string, table: string): Promise<string[]> {
+    const rawSql = `SELECT DISTINCT ${mapColumn}['${mapKey}'] FROM "${db}"."${table}" WHERE mapContains(${mapColumn}, '${mapKey}') LIMIT 1000`;
     return this.fetchData(rawSql);
   }
 

--- a/src/views/CHQueryEditor.test.tsx
+++ b/src/views/CHQueryEditor.test.tsx
@@ -5,7 +5,7 @@ import { CHQueryEditor } from './CHQueryEditor';
 import * as ui from '@grafana/ui';
 import { mockDatasource, newMockDatasource } from '__mocks__/datasource';
 import { EditorType } from 'types/sql';
-import { ColumnHint, QueryType } from 'types/queryBuilder';
+import { ColumnHint, FilterOperator, QueryType } from 'types/queryBuilder';
 import { pluginVersion } from 'utils/version';
 
 jest.mock('@grafana/ui', () => ({
@@ -254,5 +254,65 @@ describe('Query Editor', () => {
         queryType: QueryType.Traces,
       })
     );
+  });
+
+  it('syncs compact builder state when query filters change externally', () => {
+    const datasource = newMockDatasource();
+    datasource.settings.jsonData.configMode = 'single-table';
+    datasource.settings.jsonData.signalType = 'logs';
+    datasource.settings.jsonData.logs = {
+      defaultDatabase: 'otel_v2',
+      defaultTable: 'otel_logs',
+      otelEnabled: true,
+      otelVersion: '1.29.0',
+    };
+    datasource.fetchColumns = jest.fn(() => Promise.resolve([]));
+    const baseQuery = {
+      pluginVersion,
+      rawSql: 'SELECT 1',
+      refId: 'A',
+      editorType: EditorType.Builder,
+      builderOptions: {
+        database: 'otel_v2',
+        table: 'otel_logs',
+        queryType: QueryType.Logs,
+        columns: [{ name: 'SeverityText', hint: ColumnHint.LogLevel }],
+        filters: [],
+      },
+    };
+
+    const result = render(
+      <CHQueryEditor query={baseQuery} onChange={jest.fn()} onRunQuery={jest.fn()} datasource={datasource} />
+    );
+
+    expect(screen.queryByText('SeverityText')).not.toBeInTheDocument();
+
+    result.rerender(
+      <CHQueryEditor
+        query={{
+          ...baseQuery,
+          rawSql: 'SELECT 2',
+          builderOptions: {
+            ...baseQuery.builderOptions,
+            filters: [
+              {
+                condition: 'AND',
+                key: 'SeverityText',
+                type: 'string',
+                filterType: 'custom',
+                operator: FilterOperator.Equals,
+                value: 'error',
+              },
+            ],
+          },
+        }}
+        onChange={jest.fn()}
+        onRunQuery={jest.fn()}
+        datasource={datasource}
+      />
+    );
+
+    expect(screen.getByText('SeverityText')).toBeInTheDocument();
+    expect(screen.getByText('error')).toBeInTheDocument();
   });
 });

--- a/src/views/CHQueryEditor.test.tsx
+++ b/src/views/CHQueryEditor.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, act } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { CHQueryEditor } from './CHQueryEditor';
 import * as ui from '@grafana/ui';
@@ -150,5 +150,109 @@ describe('Query Editor', () => {
         expect(updated.rawSql).toContain('otel_traces_trace_id_ts');
       }
     }
+  });
+
+  it('renders compact SQL chrome for single-table datasources', () => {
+    const datasource = newMockDatasource();
+    datasource.settings.jsonData.configMode = 'single-table';
+    datasource.settings.jsonData.signalType = 'logs';
+    datasource.settings.jsonData.logs = {
+      defaultDatabase: 'otel_v2',
+      defaultTable: 'otel_logs',
+      otelEnabled: true,
+      otelVersion: '1.29.0',
+    };
+
+    render(
+      <CHQueryEditor
+        query={{ pluginVersion: '', rawSql: 'SELECT 1', refId: 'A', editorType: EditorType.SQL }}
+        onChange={jest.fn()}
+        onRunQuery={jest.fn()}
+        datasource={datasource}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: 'Query Builder' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Run Query' })).toBeInTheDocument();
+    expect(screen.queryByText('Editor Type')).not.toBeInTheDocument();
+    expect(screen.getByText('SELECT 1')).toBeInTheDocument();
+  });
+
+  it('switches from compact SQL back to a configured logs builder query', () => {
+    const datasource = newMockDatasource();
+    datasource.settings.jsonData.configMode = 'single-table';
+    datasource.settings.jsonData.signalType = 'logs';
+    datasource.settings.jsonData.logs = {
+      defaultDatabase: 'otel_v2',
+      defaultTable: 'otel_logs',
+      otelEnabled: true,
+      otelVersion: '1.29.0',
+    };
+    const onChange = jest.fn();
+
+    render(
+      <CHQueryEditor
+        query={{ pluginVersion: '', rawSql: 'SELECT 1', refId: 'A', editorType: EditorType.SQL }}
+        onChange={onChange}
+        onRunQuery={jest.fn()}
+        datasource={datasource}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Query Builder' }));
+
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        editorType: EditorType.Builder,
+        builderOptions: expect.objectContaining({
+          database: 'otel_v2',
+          table: 'otel_logs',
+          queryType: QueryType.Logs,
+        }),
+      })
+    );
+  });
+
+  it('switches compact trace builder to SQL with traces query type', async () => {
+    const datasource = newMockDatasource();
+    datasource.settings.jsonData.configMode = 'single-table';
+    datasource.settings.jsonData.signalType = 'traces';
+    datasource.settings.jsonData.traces = {
+      defaultDatabase: 'otel_v2',
+      defaultTable: 'otel_traces',
+      otelEnabled: true,
+      otelVersion: '1.29.0',
+    };
+    datasource.fetchColumns = jest.fn(() => Promise.resolve([]));
+    const onChange = jest.fn();
+
+    render(
+      <CHQueryEditor
+        query={{
+          pluginVersion,
+          rawSql: 'SELECT 1',
+          refId: 'A',
+          editorType: EditorType.Builder,
+          builderOptions: {
+            database: 'otel_v2',
+            table: 'otel_traces',
+            queryType: QueryType.Traces,
+          },
+        }}
+        onChange={onChange}
+        onRunQuery={jest.fn()}
+        datasource={datasource}
+      />
+    );
+    await act(async () => {});
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit as SQL' }));
+
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        editorType: EditorType.SQL,
+        queryType: QueryType.Traces,
+      })
+    );
   });
 });

--- a/src/views/CHQueryEditor.test.tsx
+++ b/src/views/CHQueryEditor.test.tsx
@@ -172,7 +172,7 @@ describe('Query Editor', () => {
       />
     );
 
-    expect(screen.getByRole('button', { name: 'Query Builder' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Switch to compact view' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Run Query' })).toBeInTheDocument();
     expect(screen.queryByText('Editor Type')).not.toBeInTheDocument();
     expect(screen.getByText('SELECT 1')).toBeInTheDocument();
@@ -199,7 +199,7 @@ describe('Query Editor', () => {
       />
     );
 
-    fireEvent.click(screen.getByRole('button', { name: 'Query Builder' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Switch to compact view' }));
 
     expect(onChange).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -246,7 +246,7 @@ describe('Query Editor', () => {
     );
     await act(async () => {});
 
-    fireEvent.click(screen.getByRole('button', { name: 'Edit as SQL' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Open in SQL editor' }));
 
     expect(onChange).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/src/views/CHQueryEditor.test.tsx
+++ b/src/views/CHQueryEditor.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { act, fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { CHQueryEditor } from './CHQueryEditor';
 import * as ui from '@grafana/ui';
@@ -256,7 +256,52 @@ describe('Query Editor', () => {
     );
   });
 
-  it('syncs compact builder state when query filters change externally', () => {
+  it('does not resync compact builder state for fresh equal builder options', async () => {
+    const datasource = newMockDatasource();
+    datasource.settings.jsonData.configMode = 'single-table';
+    datasource.settings.jsonData.signalType = 'logs';
+    datasource.settings.jsonData.logs = {
+      defaultDatabase: 'otel_v2',
+      defaultTable: 'otel_logs',
+      otelEnabled: true,
+      otelVersion: '1.29.0',
+    };
+    datasource.fetchColumns = jest.fn(() => Promise.resolve([]));
+    const builderOptions = {
+      database: 'otel_v2',
+      table: 'otel_logs',
+      queryType: QueryType.Logs,
+      columns: [{ name: 'SeverityText', hint: ColumnHint.LogLevel }],
+      filters: [],
+    };
+    const query = {
+      pluginVersion,
+      rawSql: 'SELECT 1',
+      refId: 'A',
+      editorType: EditorType.Builder,
+      builderOptions,
+    };
+    const onChange = jest.fn();
+
+    const result = render(
+      <CHQueryEditor query={query} onChange={onChange} onRunQuery={jest.fn()} datasource={datasource} />
+    );
+
+    await waitFor(() => expect(onChange).toHaveBeenCalledTimes(1));
+
+    result.rerender(
+      <CHQueryEditor
+        query={{ ...query, builderOptions: { ...builderOptions, filters: [] } }}
+        onChange={onChange}
+        onRunQuery={jest.fn()}
+        datasource={datasource}
+      />
+    );
+
+    await waitFor(() => expect(onChange).toHaveBeenCalledTimes(1));
+  });
+
+  it('syncs compact builder state when query filters change externally', async () => {
     const datasource = newMockDatasource();
     datasource.settings.jsonData.configMode = 'single-table';
     datasource.settings.jsonData.signalType = 'logs';
@@ -312,7 +357,7 @@ describe('Query Editor', () => {
       />
     );
 
-    expect(screen.getByText('SeverityText')).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByText('SeverityText')).toBeInTheDocument());
     expect(screen.getByText('error')).toBeInTheDocument();
   });
 });

--- a/src/views/CHQueryEditor.test.tsx
+++ b/src/views/CHQueryEditor.test.tsx
@@ -172,6 +172,7 @@ describe('Query Editor', () => {
       />
     );
 
+    expect(screen.getByTestId('compact-sql-toolbar')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Switch to compact view' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Run Query' })).toBeInTheDocument();
     expect(screen.queryByText('Editor Type')).not.toBeInTheDocument();
@@ -179,6 +180,41 @@ describe('Query Editor', () => {
   });
 
   it('switches from compact SQL back to a configured logs builder query', () => {
+    const datasource = newMockDatasource();
+    datasource.settings.jsonData.configMode = 'single-table';
+    datasource.settings.jsonData.signalType = 'logs';
+    datasource.settings.jsonData.logs = {
+      defaultDatabase: 'otel_v2',
+      defaultTable: 'otel_logs',
+      otelEnabled: true,
+      otelVersion: '1.29.0',
+    };
+    const onChange = jest.fn();
+
+    render(
+      <CHQueryEditor
+        query={{ pluginVersion: '', rawSql: '', refId: 'A', editorType: EditorType.SQL }}
+        onChange={onChange}
+        onRunQuery={jest.fn()}
+        datasource={datasource}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Switch to compact view' }));
+
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        editorType: EditorType.Builder,
+        builderOptions: expect.objectContaining({
+          database: 'otel_v2',
+          table: 'otel_logs',
+          queryType: QueryType.Logs,
+        }),
+      })
+    );
+  });
+
+  it('confirms before replacing hand-written SQL with compact defaults', async () => {
     const datasource = newMockDatasource();
     datasource.settings.jsonData.configMode = 'single-table';
     datasource.settings.jsonData.signalType = 'logs';
@@ -201,15 +237,22 @@ describe('Query Editor', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Switch to compact view' }));
 
-    expect(onChange).toHaveBeenCalledWith(
-      expect.objectContaining({
-        editorType: EditorType.Builder,
-        builderOptions: expect.objectContaining({
-          database: 'otel_v2',
-          table: 'otel_logs',
-          queryType: QueryType.Logs,
-        }),
-      })
+    expect(onChange).not.toHaveBeenCalled();
+    expect(screen.getByText('Discard SQL changes?')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Discard SQL and switch' }));
+
+    await waitFor(() =>
+      expect(onChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          editorType: EditorType.Builder,
+          builderOptions: expect.objectContaining({
+            database: 'otel_v2',
+            table: 'otel_logs',
+            queryType: QueryType.Logs,
+          }),
+        })
+      )
     );
   });
 

--- a/src/views/CHQueryEditor.tsx
+++ b/src/views/CHQueryEditor.tsx
@@ -73,6 +73,16 @@ const CHEditorByType = (props: CHQueryEditorProps) => {
   }
   lastEditorType.current = query.editorType;
 
+  const propBuilderOptions =
+    query.editorType === EditorType.Builder ? (query as CHBuilderQuery).builderOptions : undefined;
+  const lastPropBuilderOptions = useRef<QueryBuilderOptions | undefined>(propBuilderOptions);
+  if (propBuilderOptions && propBuilderOptions !== lastPropBuilderOptions.current) {
+    lastPropBuilderOptions.current = propBuilderOptions;
+    if (propBuilderOptions !== builderOptions) {
+      builderOptionsDispatch(setAllOptions(propBuilderOptions));
+    }
+  }
+
   // Prevent trying to run empty query on load, or stale query after datasource/signal switches.
   const shouldSkipChanges = useRef<boolean>(true);
   if (isBuilderOptionsRunnable(builderOptions)) {

--- a/src/views/CHQueryEditor.tsx
+++ b/src/views/CHQueryEditor.tsx
@@ -1,9 +1,9 @@
-import React, { useCallback, useEffect, useRef } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { QueryEditorProps } from '@grafana/data';
 import { Datasource } from 'data/CHDatasource';
 import { EditorTypeSwitcher } from 'components/queryBuilder/EditorTypeSwitcher';
 import { styles } from 'styles';
-import { Button } from '@grafana/ui';
+import { Button, ConfirmModal, Stack } from '@grafana/ui';
 import { CHBuilderQuery, CHQuery, EditorType } from 'types/sql';
 import { CHConfig } from 'types/config';
 import { QueryBuilder } from 'components/queryBuilder/QueryBuilder';
@@ -224,18 +224,25 @@ const CHEditorByType = (props: CHQueryEditorProps) => {
 const CompactSqlMode = (props: CHQueryEditorProps) => {
   const { datasource, query, onChange, onRunQuery } = props;
   const signalType = datasource.getSignalType();
+  const [confirmSwitchOpen, setConfirmSwitchOpen] = useState(false);
 
-  const onSwitchToBuilder = () => {
+  const switchToBuilder = (confirmed = false) => {
     if (!signalType) {
       return;
     }
 
     const builderOptions = buildCompactQueryDefaults(datasource, signalType);
+    const compactSql = generateSql(builderOptions);
+    if (!confirmed && query.rawSql.trim() && query.rawSql.trim() !== compactSql.trim()) {
+      setConfirmSwitchOpen(true);
+      return;
+    }
+
     onChange({
       ...query,
       pluginVersion,
       editorType: EditorType.Builder,
-      rawSql: generateSql(builderOptions),
+      rawSql: compactSql,
       builderOptions,
       format: mapQueryBuilderOptionsToGrafanaFormat(builderOptions),
     });
@@ -243,12 +250,24 @@ const CompactSqlMode = (props: CHQueryEditorProps) => {
 
   return (
     <>
-      <div className={'gf-form ' + styles.QueryEditor.queryType}>
-        <Button variant="secondary" onClick={onSwitchToBuilder}>
+      <Stack gap={1} alignItems="center" data-testid="compact-sql-toolbar">
+        <Button variant="secondary" onClick={() => switchToBuilder()}>
           Switch to compact view
         </Button>
         <Button onClick={() => onRunQuery()}>Run Query</Button>
-      </div>
+      </Stack>
+      <ConfirmModal
+        isOpen={confirmSwitchOpen}
+        title="Discard SQL changes?"
+        body="Switching to compact view replaces the current SQL with generated compact query defaults."
+        confirmText="Discard SQL and switch"
+        dismissText="Cancel"
+        onConfirm={() => {
+          setConfirmSwitchOpen(false);
+          switchToBuilder(true);
+        }}
+        onDismiss={() => setConfirmSwitchOpen(false)}
+      />
       <div data-testid="query-editor-section-sql">
         <SqlEditor {...props} />
       </div>

--- a/src/views/CHQueryEditor.tsx
+++ b/src/views/CHQueryEditor.tsx
@@ -16,6 +16,7 @@ import { pluginVersion } from 'utils/version';
 import { migrateCHQuery } from 'data/migration';
 import useHasTraceTimestampTable from 'hooks/useHasTraceTimestampTable';
 import { buildCompactQueryDefaults, getCompactQueryType } from 'components/queryBuilder/compactQueryDefaults';
+import { isEqual } from 'lodash';
 
 export type CHQueryEditorProps = QueryEditorProps<Datasource, CHQuery, CHConfig>;
 
@@ -76,12 +77,21 @@ const CHEditorByType = (props: CHQueryEditorProps) => {
   const propBuilderOptions =
     query.editorType === EditorType.Builder ? (query as CHBuilderQuery).builderOptions : undefined;
   const lastPropBuilderOptions = useRef<QueryBuilderOptions | undefined>(propBuilderOptions);
-  if (propBuilderOptions && propBuilderOptions !== lastPropBuilderOptions.current) {
+  useEffect(() => {
+    if (!propBuilderOptions) {
+      lastPropBuilderOptions.current = undefined;
+      return;
+    }
+
+    if (isEqual(propBuilderOptions, lastPropBuilderOptions.current)) {
+      return;
+    }
+
     lastPropBuilderOptions.current = propBuilderOptions;
-    if (propBuilderOptions !== builderOptions) {
+    if (!isEqual(propBuilderOptions, builderOptions)) {
       builderOptionsDispatch(setAllOptions(propBuilderOptions));
     }
-  }
+  }, [builderOptions, builderOptionsDispatch, propBuilderOptions]);
 
   // Prevent trying to run empty query on load, or stale query after datasource/signal switches.
   const shouldSkipChanges = useRef<boolean>(true);

--- a/src/views/CHQueryEditor.tsx
+++ b/src/views/CHQueryEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useCallback, useEffect, useRef } from 'react';
 import { QueryEditorProps } from '@grafana/data';
 import { Datasource } from 'data/CHDatasource';
 import { EditorTypeSwitcher } from 'components/queryBuilder/EditorTypeSwitcher';
@@ -11,9 +11,11 @@ import { generateSql } from 'data/sqlGenerator';
 import { SqlEditor } from 'components/SqlEditor';
 import { isBuilderOptionsRunnable, mapQueryBuilderOptionsToGrafanaFormat } from 'data/utils';
 import { setAllOptions, setOptions, useBuilderOptionsState } from 'hooks/useBuilderOptionsState';
+import { QueryBuilderOptions } from 'types/queryBuilder';
 import { pluginVersion } from 'utils/version';
 import { migrateCHQuery } from 'data/migration';
 import useHasTraceTimestampTable from 'hooks/useHasTraceTimestampTable';
+import { buildCompactQueryDefaults, getCompactQueryType } from 'components/queryBuilder/compactQueryDefaults';
 
 export type CHQueryEditorProps = QueryEditorProps<Datasource, CHQuery, CHConfig>;
 
@@ -23,6 +25,15 @@ export type CHQueryEditorProps = QueryEditorProps<Datasource, CHQuery, CHConfig>
 export const CHQueryEditor = (props: CHQueryEditorProps) => {
   const { datasource, query: savedQuery, onRunQuery } = props;
   const query = migrateCHQuery(savedQuery);
+  const singleTableMode = datasource.isSingleTableMode();
+
+  if (singleTableMode && query.editorType === EditorType.SQL) {
+    return <CompactSqlMode {...props} query={query} />;
+  }
+
+  if (singleTableMode) {
+    return <CHEditorByType {...props} query={query} />;
+  }
 
   return (
     <>
@@ -38,6 +49,8 @@ export const CHQueryEditor = (props: CHQueryEditorProps) => {
 const CHEditorByType = (props: CHQueryEditorProps) => {
   const { query, onChange, app } = props;
   const [builderOptions, builderOptionsDispatch] = useBuilderOptionsState((query as CHBuilderQuery).builderOptions);
+  const singleTableMode = props.datasource.isSingleTableMode();
+  const signalType = props.datasource.getSignalType();
 
   /**
    * Grafana will sometimes replace the builder options directly, so we need to sync in both directions.
@@ -60,10 +73,14 @@ const CHEditorByType = (props: CHQueryEditorProps) => {
   }
   lastEditorType.current = query.editorType;
 
-  // Prevent trying to run empty query on load
+  // Prevent trying to run empty query on load, or stale query after datasource/signal switches.
   const shouldSkipChanges = useRef<boolean>(true);
   if (isBuilderOptionsRunnable(builderOptions)) {
-    shouldSkipChanges.current = false;
+    if (singleTableMode && signalType) {
+      shouldSkipChanges.current = builderOptions.queryType !== getCompactQueryType(signalType);
+    } else {
+      shouldSkipChanges.current = false;
+    }
   }
 
   // Resolve hasTraceTimestampTable for any trace ID query — not only OTel ones.
@@ -122,6 +139,46 @@ const CHEditorByType = (props: CHQueryEditorProps) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [builderOptions]);
 
+  const onQueryChange = useCallback(
+    (newOptions: QueryBuilderOptions) => {
+      onChange({
+        ...query,
+        pluginVersion,
+        editorType: EditorType.Builder,
+        rawSql: generateSql(newOptions),
+        builderOptions: newOptions,
+        format: mapQueryBuilderOptionsToGrafanaFormat(newOptions),
+      });
+    },
+    [onChange, query]
+  );
+
+  const onEditAsSql = useCallback(
+    (newOptions: QueryBuilderOptions) => {
+      const {
+        builderOptions: discardedBuilderOptions,
+        queryType: discardedQueryType,
+        ...baseQuery
+      } = query as CHBuilderQuery;
+      void discardedBuilderOptions;
+      void discardedQueryType;
+
+      onChange({
+        ...baseQuery,
+        pluginVersion,
+        editorType: EditorType.SQL,
+        rawSql: generateSql(newOptions),
+        queryType: newOptions.queryType,
+        meta: {
+          ...baseQuery.meta,
+          builderOptions: newOptions,
+        },
+        format: mapQueryBuilderOptionsToGrafanaFormat(newOptions),
+      });
+    },
+    [onChange, query]
+  );
+
   if (query.editorType === EditorType.SQL) {
     return (
       <div data-testid="query-editor-section-sql">
@@ -137,6 +194,43 @@ const CHEditorByType = (props: CHQueryEditorProps) => {
       builderOptionsDispatch={builderOptionsDispatch}
       generatedSql={query.rawSql}
       app={app}
+      onQueryChange={onQueryChange}
+      onEditAsSql={onEditAsSql}
     />
+  );
+};
+
+const CompactSqlMode = (props: CHQueryEditorProps) => {
+  const { datasource, query, onChange, onRunQuery } = props;
+  const signalType = datasource.getSignalType();
+
+  const onSwitchToBuilder = () => {
+    if (!signalType) {
+      return;
+    }
+
+    const builderOptions = buildCompactQueryDefaults(datasource, signalType);
+    onChange({
+      ...query,
+      pluginVersion,
+      editorType: EditorType.Builder,
+      rawSql: generateSql(builderOptions),
+      builderOptions,
+      format: mapQueryBuilderOptionsToGrafanaFormat(builderOptions),
+    });
+  };
+
+  return (
+    <>
+      <div className={'gf-form ' + styles.QueryEditor.queryType}>
+        <Button variant="secondary" onClick={onSwitchToBuilder}>
+          Query Builder
+        </Button>
+        <Button onClick={() => onRunQuery()}>Run Query</Button>
+      </div>
+      <div data-testid="query-editor-section-sql">
+        <SqlEditor {...props} />
+      </div>
+    </>
   );
 };

--- a/src/views/CHQueryEditor.tsx
+++ b/src/views/CHQueryEditor.tsx
@@ -47,7 +47,7 @@ export const CHQueryEditor = (props: CHQueryEditorProps) => {
 };
 
 const CHEditorByType = (props: CHQueryEditorProps) => {
-  const { query, onChange, app } = props;
+  const { query, onChange, onRunQuery, app } = props;
   const [builderOptions, builderOptionsDispatch] = useBuilderOptionsState((query as CHBuilderQuery).builderOptions);
   const singleTableMode = props.datasource.isSingleTableMode();
   const signalType = props.datasource.getSignalType();
@@ -196,6 +196,7 @@ const CHEditorByType = (props: CHQueryEditorProps) => {
       app={app}
       onQueryChange={onQueryChange}
       onEditAsSql={onEditAsSql}
+      onRunQuery={onRunQuery}
     />
   );
 };
@@ -224,7 +225,7 @@ const CompactSqlMode = (props: CHQueryEditorProps) => {
     <>
       <div className={'gf-form ' + styles.QueryEditor.queryType}>
         <Button variant="secondary" onClick={onSwitchToBuilder}>
-          Query Builder
+          Switch to compact view
         </Button>
         <Button onClick={() => onRunQuery()}>Run Query</Button>
       </div>

--- a/src/views/config-v2/ConfigurationModeSection.tsx
+++ b/src/views/config-v2/ConfigurationModeSection.tsx
@@ -99,7 +99,7 @@ export const ConfigurationModeSection = (props: Props) => {
           />
         </Field>
         {isSingleTableMode && (
-          <Field label="Signal type" description="What kind of data does this table contain????">
+          <Field label="Signal type" description="What kind of data does this table contain?">
             <RadioButtonGroup<SignalType>
               options={[
                 { label: 'Logs', value: 'logs', description: 'Log search with severity, message, and attributes' },

--- a/tests/e2e/queryEditor.spec.ts
+++ b/tests/e2e/queryEditor.spec.ts
@@ -18,6 +18,8 @@ const isCloudRun = !!process.env.GRAFANA_URL;
 const CLOUD_DEFAULT_UID = 'clickhouse-native-ds-m';
 const LOCAL_DEFAULT_UID = 'clickhouse-e2e';
 const DATASOURCE_UID = process.env.DS_E2E_UID || (isCloudRun ? CLOUD_DEFAULT_UID : LOCAL_DEFAULT_UID);
+const LOCAL_SINGLE_LOGS_UID = 'clickhouse-e2e-single-logs';
+const LOCAL_SINGLE_TRACES_UID = 'clickhouse-e2e-single-traces';
 
 // Time range that fully covers the seed fixture data in tests/e2e/fixtures/seed.sql
 const FIXTURE_FROM_ISO = '2024-03-15T09:45:00.000Z';
@@ -26,6 +28,7 @@ const FIXTURE_TO_ISO = '2024-03-15T10:15:00.000Z';
 interface ExploreUrlOpts {
   queryType?: QueryType;
   editorType?: EditorType;
+  datasourceUid?: string;
   from?: string;
   to?: string;
 }
@@ -37,11 +40,11 @@ interface ExploreUrlOpts {
  * queryType IS restored via the query's top-level queryType field (used by SQL mode).
  */
 function exploreUrl(opts: ExploreUrlOpts = {}): string {
-  const { from = 'now-1h', to = 'now' } = opts;
+  const { datasourceUid = DATASOURCE_UID, from = 'now-1h', to = 'now' } = opts;
 
   const query: Record<string, unknown> = {
     refId: 'A',
-    datasource: { type: PLUGIN_TYPE, uid: DATASOURCE_UID },
+    datasource: { type: PLUGIN_TYPE, uid: datasourceUid },
     editorType: 'sql',
     pluginVersion: '',
     rawSql: '',
@@ -49,7 +52,7 @@ function exploreUrl(opts: ExploreUrlOpts = {}): string {
 
   const panes = JSON.stringify({
     explore: {
-      datasource: DATASOURCE_UID,
+      datasource: datasourceUid,
       queries: [query],
       range: { from, to },
     },
@@ -163,6 +166,75 @@ test.describe('Query editor', () => {
       await expect(page.getByText('Builder Mode')).toBeVisible();
       await expect(page.getByRole('radio', { name: 'Simple' })).toBeVisible();
       await expect(page.getByRole('radio', { name: 'Aggregate' })).toBeVisible();
+    });
+  });
+
+  test.describe('Compact query mode', () => {
+    test.beforeEach(() => {
+      test.skip(
+        isCloudRun,
+        'Compact mode E2E uses local provisioned single-source datasources and seeded ClickHouse fixture tables.'
+      );
+    });
+
+    test('renders compact logs editor for single-source datasource', async ({ page, explorePage }) => {
+      await page.goto(
+        exploreUrl({
+          datasourceUid: LOCAL_SINGLE_LOGS_UID,
+          from: FIXTURE_FROM_ISO,
+          to: FIXTURE_TO_ISO,
+        })
+      );
+
+      await page.getByRole('button', { name: 'Switch to compact view' }).click();
+
+      const queryEditor = page.locator('[data-testid="query-editor-section-builder"]');
+      await expect(queryEditor.locator('[data-testid="compact-filter-bar"]')).toBeVisible();
+      await expect(page.getByPlaceholder('Search log body text...')).toBeVisible();
+      await expect(page.getByRole('button', { name: 'Add filter' })).toBeVisible();
+      await expect(page.getByRole('button', { name: 'Order by' })).toBeVisible();
+      await expect(queryEditor.getByRole('button', { name: 'SQL', exact: true })).toBeVisible();
+
+      const databaseLabel = page.locator('.query-editor-row').locator('label.query-keyword', { hasText: 'Database' });
+      await expect(databaseLabel).toHaveCount(0);
+      await expect(page.getByRole('radio', { name: 'Table' })).toHaveCount(0);
+      await expect(queryEditor.locator('pre')).toHaveCount(0);
+      await expect(
+        page.getByText(/React error #185|Maximum update depth exceeded|An unexpected error occurred/i)
+      ).toHaveCount(0);
+
+      const { responsePromise, getBody } = await waitForQueryDataResponseWithBody(explorePage);
+      await page.getByPlaceholder('Search log body text...').fill('error');
+      await page.keyboard.press('Enter');
+      await responsePromise;
+      expect((getBody() as any)?.results?.A?.frames?.length).toBeGreaterThan(0);
+    });
+
+    test('renders compact traces editor for single-source datasource', async ({ page }) => {
+      await page.goto(
+        exploreUrl({
+          datasourceUid: LOCAL_SINGLE_TRACES_UID,
+          from: FIXTURE_FROM_ISO,
+          to: FIXTURE_TO_ISO,
+        })
+      );
+
+      await page.getByRole('button', { name: 'Switch to compact view' }).click();
+
+      const queryEditor = page.locator('[data-testid="query-editor-section-builder"]');
+      await expect(queryEditor.locator('[data-testid="compact-filter-bar"]')).toBeVisible();
+      await expect(page.getByPlaceholder('Search log body text...')).toHaveCount(0);
+      await expect(page.getByRole('button', { name: 'Add filter' })).toBeVisible();
+      await expect(page.getByRole('button', { name: 'Order by' })).toBeVisible();
+      await expect(queryEditor.getByRole('button', { name: 'SQL', exact: true })).toBeVisible();
+
+      const databaseLabel = page.locator('.query-editor-row').locator('label.query-keyword', { hasText: 'Database' });
+      await expect(databaseLabel).toHaveCount(0);
+      await expect(page.getByRole('radio', { name: 'Table' })).toHaveCount(0);
+      await expect(queryEditor.locator('pre')).toHaveCount(0);
+      await expect(
+        page.getByText(/React error #185|Maximum update depth exceeded|An unexpected error occurred/i)
+      ).toHaveCount(0);
     });
   });
 


### PR DESCRIPTION
## Type of Change

- [x] 🚀 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧹 Refactor / Chore

---

## Feature

### What is this feature?

Adds a compact query editor for single-table logs and traces datasources. The compact editor provides a focused logs/traces workflow with search, filter controls, advanced options, query history access, and a generated SQL preview with copy and edit-as-SQL actions.

The compact filter controls also hide builder-owned timestamp columns and tailor available operators based on inferred field type: numeric fields get comparison operators, while string fields get contains/equality operators.

### Why is this feature needed?

Single-table logs and traces datasources do not need the full database/table/query-type builder surface. A compact editor keeps common Explore workflows faster and reduces confusing filter options, while preserving access to the generated SQL when users need to inspect or customize it.

### Who is this feature for?

Users querying logs or traces from a datasource configured for a focused single-table setup.

### How to test this feature

1. Configure a datasource in single-table mode for logs or traces.
2. Open Explore and confirm the compact query editor renders instead of the full database/table/query-type builder.
3. For logs, use the search input and add filters from the compact filter bar.
4. Confirm configured time columns are not offered in the Add filter column list.
5. Confirm numeric fields show numeric comparison operators and string fields show contains/equality operators.
6. Open the SQL preview, copy the generated SQL, and use Edit as SQL to switch to the SQL editor.

---

## Screenshots / Videos

|Case | Screenshot |
| ------ | ----- |
| Compact logs view  |    <img width="3024" height="1782" alt="CleanShot 2026-05-28 at 17 16 26@2x" src="https://github.com/user-attachments/assets/ecf80c30-03a7-4676-829b-7ecf12fc53ec" /> |
| Compact traces view | <img width="3024" height="1776" alt="CleanShot 2026-05-28 at 17 17 17@2x" src="https://github.com/user-attachments/assets/a529b5e1-8310-4433-a3e8-bf3ee7e66d3c" /> |


---

## Please check that:

- [x] Tests for this change have been added/updated.
- [x] Documentation has been added/updated (where applicable).
