### PR TITLE
fix: trace optimisation defaults true

### DIFF
--- a/src/data/CHDatasource.test.ts
+++ b/src/data/CHDatasource.test.ts
@@ -1944,6 +1944,22 @@ describe('ClickHouseDatasource', () => {
       expect(fetchSpy).toHaveBeenCalledTimes(2);
     });
 
+    it('re-checks once the TTL expires', async () => {
+      const ds = cloneDeep(mockDatasource);
+      const fetchSpy = jest.spyOn(ds, 'fetchTables').mockResolvedValue(['otel_traces']);
+      const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(0);
+
+      await ds.hasTraceTimestampTable('otel', 'otel_traces');
+      await ds.hasTraceTimestampTable('otel', 'otel_traces');
+      expect(fetchSpy).toHaveBeenCalledTimes(1); // cached within TTL
+
+      nowSpy.mockReturnValue(2 * 60 * 1000 + 1); // advance past 2 min
+      await ds.hasTraceTimestampTable('otel', 'otel_traces');
+      expect(fetchSpy).toHaveBeenCalledTimes(2); // re-fetched after expiry
+
+      nowSpy.mockRestore();
+    });
+
     it('honours a configured custom suffix', async () => {
       const ds = cloneDeep(mockDatasource);
       ds.settings = {

--- a/src/data/CHDatasource.test.ts
+++ b/src/data/CHDatasource.test.ts
@@ -1953,7 +1953,7 @@ describe('ClickHouseDatasource', () => {
       await ds.hasTraceTimestampTable('otel', 'otel_traces');
       expect(fetchSpy).toHaveBeenCalledTimes(1); // cached within TTL
 
-      nowSpy.mockReturnValue(2 * 60 * 1000 + 1); // advance past 2 min
+      nowSpy.mockReturnValue(30 * 1000 + 1); // advance past the 30s TTL
       await ds.hasTraceTimestampTable('otel', 'otel_traces');
       expect(fetchSpy).toHaveBeenCalledTimes(2); // re-fetched after expiry
 
@@ -1972,6 +1972,58 @@ describe('ClickHouseDatasource', () => {
       jest.spyOn(ds, 'fetchTables').mockResolvedValue(['traces', 'traces_idx_ts']);
 
       await expect(ds.hasTraceTimestampTable('default', 'traces')).resolves.toBe(true);
+    });
+  });
+
+  describe('peekTraceTimestampTable', () => {
+    it('returns undefined when database or table is empty', () => {
+      const ds = cloneDeep(mockDatasource);
+      expect(ds.peekTraceTimestampTable('', 'otel_traces')).toBeUndefined();
+      expect(ds.peekTraceTimestampTable('otel', '')).toBeUndefined();
+    });
+
+    it('returns undefined when nothing is cached', () => {
+      const ds = cloneDeep(mockDatasource);
+      expect(ds.peekTraceTimestampTable('otel', 'otel_traces')).toBeUndefined();
+    });
+
+    it('returns undefined while the check is still pending', () => {
+      const ds = cloneDeep(mockDatasource);
+      jest.spyOn(ds, 'fetchTables').mockResolvedValue(['otel_traces', 'otel_traces_trace_id_ts']);
+
+      // Kick off the async check but do not await it — the promise has not settled yet.
+      void ds.hasTraceTimestampTable('otel', 'otel_traces');
+      expect(ds.peekTraceTimestampTable('otel', 'otel_traces')).toBeUndefined();
+    });
+
+    it('returns true once the check resolves true', async () => {
+      const ds = cloneDeep(mockDatasource);
+      jest.spyOn(ds, 'fetchTables').mockResolvedValue(['otel_traces', 'otel_traces_trace_id_ts']);
+
+      await ds.hasTraceTimestampTable('otel', 'otel_traces');
+      expect(ds.peekTraceTimestampTable('otel', 'otel_traces')).toBe(true);
+    });
+
+    it('returns false once the check resolves false', async () => {
+      const ds = cloneDeep(mockDatasource);
+      jest.spyOn(ds, 'fetchTables').mockResolvedValue(['otel_traces']);
+
+      await ds.hasTraceTimestampTable('otel', 'otel_traces');
+      expect(ds.peekTraceTimestampTable('otel', 'otel_traces')).toBe(false);
+    });
+
+    it('returns undefined once the TTL has expired', async () => {
+      const ds = cloneDeep(mockDatasource);
+      jest.spyOn(ds, 'fetchTables').mockResolvedValue(['otel_traces', 'otel_traces_trace_id_ts']);
+      const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(0);
+
+      await ds.hasTraceTimestampTable('otel', 'otel_traces');
+      expect(ds.peekTraceTimestampTable('otel', 'otel_traces')).toBe(true);
+
+      nowSpy.mockReturnValue(30 * 1000 + 1); // advance past the 30s TTL
+      expect(ds.peekTraceTimestampTable('otel', 'otel_traces')).toBeUndefined();
+
+      nowSpy.mockRestore();
     });
   });
 });

--- a/src/data/CHDatasource.test.ts
+++ b/src/data/CHDatasource.test.ts
@@ -1886,4 +1886,76 @@ describe('ClickHouseDatasource', () => {
       );
     });
   });
+
+  describe('hasTraceTimestampTable', () => {
+    it('resolves false when database or table is empty', async () => {
+      const ds = cloneDeep(mockDatasource);
+      await expect(ds.hasTraceTimestampTable('', 'otel_traces')).resolves.toBe(false);
+      await expect(ds.hasTraceTimestampTable('otel', '')).resolves.toBe(false);
+    });
+
+    it('resolves true when the companion table exists', async () => {
+      const ds = cloneDeep(mockDatasource);
+      jest.spyOn(ds, 'fetchTables').mockResolvedValue(['otel_traces', 'otel_traces_trace_id_ts']);
+
+      await expect(ds.hasTraceTimestampTable('otel', 'otel_traces')).resolves.toBe(true);
+    });
+
+    it('resolves false when the companion table does not exist (#1842)', async () => {
+      const ds = cloneDeep(mockDatasource);
+      jest.spyOn(ds, 'fetchTables').mockResolvedValue(['otel_traces']);
+
+      await expect(ds.hasTraceTimestampTable('otel', 'otel_traces')).resolves.toBe(false);
+    });
+
+    it('does not call fetchTables again once a result is cached', async () => {
+      const ds = cloneDeep(mockDatasource);
+      const fetchSpy = jest.spyOn(ds, 'fetchTables').mockResolvedValue(['otel_traces']);
+
+      await ds.hasTraceTimestampTable('otel', 'otel_traces');
+      await ds.hasTraceTimestampTable('otel', 'otel_traces');
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('dedupes concurrent calls to a single fetchTables', async () => {
+      const ds = cloneDeep(mockDatasource);
+      const fetchSpy = jest.spyOn(ds, 'fetchTables').mockResolvedValue(['otel_traces', 'otel_traces_trace_id_ts']);
+
+      const [a, b] = await Promise.all([
+        ds.hasTraceTimestampTable('otel', 'otel_traces'),
+        ds.hasTraceTimestampTable('otel', 'otel_traces'),
+      ]);
+
+      expect(a).toBe(true);
+      expect(b).toBe(true);
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('resolves false on fetch failure and evicts the cache so the next call retries', async () => {
+      const ds = cloneDeep(mockDatasource);
+      const fetchSpy = jest
+        .spyOn(ds, 'fetchTables')
+        .mockRejectedValueOnce(new Error('connection refused'))
+        .mockResolvedValueOnce(['otel_traces', 'otel_traces_trace_id_ts']);
+
+      await expect(ds.hasTraceTimestampTable('otel', 'otel_traces')).resolves.toBe(false);
+      await expect(ds.hasTraceTimestampTable('otel', 'otel_traces')).resolves.toBe(true);
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('honours a configured custom suffix', async () => {
+      const ds = cloneDeep(mockDatasource);
+      ds.settings = {
+        ...ds.settings,
+        jsonData: {
+          ...ds.settings.jsonData,
+          traces: { ...(ds.settings.jsonData.traces || {}), traceTimestampTableSuffix: '_idx_ts' },
+        },
+      };
+      jest.spyOn(ds, 'fetchTables').mockResolvedValue(['traces', 'traces_idx_ts']);
+
+      await expect(ds.hasTraceTimestampTable('default', 'traces')).resolves.toBe(true);
+    });
+  });
 });

--- a/src/data/CHDatasource.ts
+++ b/src/data/CHDatasource.ts
@@ -742,7 +742,7 @@ export class Datasource
    * Resolves whether the `<table>_trace_id_ts` companion exists for the given
    * (database, table). Caches the Promise so concurrent and repeat callers share
    * a single `SHOW TABLES` round-trip; on failure, evicts so the next caller
-   * retries and meanwhile returns `false` (the safe, unoptimised path).
+   * retries and meanwhile returns `false` (the safe, unoptimized path).
    */
   async hasTraceTimestampTable(database: string, table: string): Promise<boolean> {
     if (!database || !table) {

--- a/src/data/CHDatasource.ts
+++ b/src/data/CHDatasource.ts
@@ -87,7 +87,10 @@ export class Datasource
   // callers and lets cache hits resolve in a microtask. Entries expire after
   // TRACE_TIMESTAMP_TABLE_CACHE_TTL_MS so a companion table created after the datasource
   // loaded is detected without a page reload.
-  private traceTimestampTableCache = new Map<string, { pending: Promise<boolean>; expiresAt: number }>();
+  private traceTimestampTableCache = new Map<
+    string,
+    { pending: Promise<boolean>; resolved?: boolean; expiresAt: number }
+  >();
 
   constructor(instanceSettings: DataSourceInstanceSettings<CHConfig>) {
     super(instanceSettings);
@@ -757,10 +760,6 @@ export class Datasource
 
     let entry = this.traceTimestampTableCache.get(key);
 
-    if (entry) {
-      console.log({ expired: entry.expiresAt <= now });
-    }
-
     if (!entry || entry.expiresAt <= now) {
       const pending = (async () => {
         try {
@@ -774,9 +773,33 @@ export class Datasource
 
       entry = { pending, expiresAt: now + Datasource.TRACE_TIMESTAMP_TABLE_CACHE_TTL_MS };
       this.traceTimestampTableCache.set(key, entry);
+
+      // Record the settled value so peekTraceTimestampTable() can read it synchronously.
+      const created = entry;
+      pending.then((v) => {
+        created.resolved = v;
+      });
     }
 
     return entry.pending;
+  }
+
+  /**
+   * Synchronously read the cached trace timestamp table result without awaiting.
+   * Returns the resolved boolean when a non-expired cache entry has settled, or
+   * undefined when there is no entry, it is still pending, or it has expired.
+   * Lets the React hook seed its initial state from a warm cache and skip a
+   * false→true render that would briefly clobber a known-good meta value.
+   */
+  peekTraceTimestampTable(database: string, table: string): boolean | undefined {
+    if (!database || !table) {
+      return undefined;
+    }
+    const entry = this.traceTimestampTableCache.get(`${database}.${table}`);
+    if (!entry || entry.expiresAt <= Date.now()) {
+      return undefined;
+    }
+    return entry.resolved;
   }
 
   /**

--- a/src/data/CHDatasource.ts
+++ b/src/data/CHDatasource.ts
@@ -27,7 +27,7 @@ import LogsContextPanel from 'components/LogsContextPanel';
 import { cloneDeep, isEmpty, isString } from 'lodash';
 import otel from 'otel';
 import { createElement as createReactElement, ReactNode } from 'react';
-import { firstValueFrom, from, map, mergeMap, Observable } from 'rxjs';
+import { concatMap, firstValueFrom, Observable } from 'rxjs';
 import { CHConfig } from 'types/config';
 import {
   AggregateColumn,
@@ -81,6 +81,10 @@ export class Datasource
   // `asMapAccess()` strips any `db.` prefix from the lookup source so callers
   // can pass either form.
   private mapColumnsByTable: Map<string, Set<string>> = new Map();
+  // Caches the in-flight or resolved existence check for the `<table>_trace_id_ts`
+  // companion, keyed by `${database}.${table}`. Caching the Promise dedupes
+  // concurrent callers and lets cache hits resolve in a microtask.
+  private traceTimestampTableCache = new Map<string, Promise<boolean>>();
 
   constructor(instanceSettings: DataSourceInstanceSettings<CHConfig>) {
     super(instanceSettings);
@@ -735,6 +739,38 @@ export class Datasource
   }
 
   /**
+   * Resolves whether the `<table>_trace_id_ts` companion exists for the given
+   * (database, table). Caches the Promise so concurrent and repeat callers share
+   * a single `SHOW TABLES` round-trip; on failure, evicts so the next caller
+   * retries and meanwhile returns `false` (the safe, unoptimised path).
+   */
+  async hasTraceTimestampTable(database: string, table: string): Promise<boolean> {
+    if (!database || !table) {
+      return false;
+    }
+
+    const key = `${database}.${table}`;
+
+    let pending = this.traceTimestampTableCache.get(key);
+
+    if (!pending) {
+      pending = (async () => {
+        try {
+          const tables = await this.fetchTables(database);
+          return tables.includes(table + this.getTraceTimestampTableSuffix());
+        } catch {
+          this.traceTimestampTableCache.delete(key);
+          return false;
+        }
+      })();
+
+      this.traceTimestampTableCache.set(key, pending);
+    }
+
+    return pending;
+  }
+
+  /**
    * Get the TraceId column name from traces configuration
    * Used when creating logs filter to correlate with trace data
    */
@@ -1000,16 +1036,13 @@ export class Datasource
         targets,
       })
       .pipe(
-        mergeMap((res: DataQueryResponse) =>
-          from(transformQueryResponseWithTraceAndLogLinks(this, request, res)).pipe(
-            map((transformed) => {
-              if (hasLogsVolumeTargets) {
-                return { ...transformed, data: splitLogsVolumeFrames(transformed.data, Datasource.logVolumePrefix) };
-              }
-              return transformed;
-            })
-          )
-        )
+        concatMap(async (res: DataQueryResponse) => {
+          const transformed = await transformQueryResponseWithTraceAndLogLinks(this, request, res);
+          if (hasLogsVolumeTargets) {
+            return { ...transformed, data: splitLogsVolumeFrames(transformed.data, Datasource.logVolumePrefix) };
+          }
+          return transformed;
+        })
       );
   }
 

--- a/src/data/CHDatasource.ts
+++ b/src/data/CHDatasource.ts
@@ -81,10 +81,13 @@ export class Datasource
   // `asMapAccess()` strips any `db.` prefix from the lookup source so callers
   // can pass either form.
   private mapColumnsByTable: Map<string, Set<string>> = new Map();
+  private static readonly TRACE_TIMESTAMP_TABLE_CACHE_TTL_MS = 30 * 1000;
   // Caches the in-flight or resolved existence check for the `<table>_trace_id_ts`
-  // companion, keyed by `${database}.${table}`. Caching the Promise dedupes
-  // concurrent callers and lets cache hits resolve in a microtask.
-  private traceTimestampTableCache = new Map<string, Promise<boolean>>();
+  // companion, keyed by `${database}.${table}`. Caching the Promise dedupes concurrent
+  // callers and lets cache hits resolve in a microtask. Entries expire after
+  // TRACE_TIMESTAMP_TABLE_CACHE_TTL_MS so a companion table created after the datasource
+  // loaded is detected without a page reload.
+  private traceTimestampTableCache = new Map<string, { pending: Promise<boolean>; expiresAt: number }>();
 
   constructor(instanceSettings: DataSourceInstanceSettings<CHConfig>) {
     super(instanceSettings);
@@ -750,11 +753,16 @@ export class Datasource
     }
 
     const key = `${database}.${table}`;
+    const now = Date.now();
 
-    let pending = this.traceTimestampTableCache.get(key);
+    let entry = this.traceTimestampTableCache.get(key);
 
-    if (!pending) {
-      pending = (async () => {
+    if (entry) {
+      console.log({ expired: entry.expiresAt <= now });
+    }
+
+    if (!entry || entry.expiresAt <= now) {
+      const pending = (async () => {
         try {
           const tables = await this.fetchTables(database);
           return tables.includes(table + this.getTraceTimestampTableSuffix());
@@ -764,10 +772,11 @@ export class Datasource
         }
       })();
 
-      this.traceTimestampTableCache.set(key, pending);
+      entry = { pending, expiresAt: now + Datasource.TRACE_TIMESTAMP_TABLE_CACHE_TTL_MS };
+      this.traceTimestampTableCache.set(key, entry);
     }
 
-    return pending;
+    return entry.pending;
   }
 
   /**

--- a/src/data/utils.test.ts
+++ b/src/data/utils.test.ts
@@ -477,9 +477,9 @@ describe('transformQueryResponseWithTraceAndLogLinks', () => {
       expect(traceQuery.rawSql).not.toContain('"SpanAttributes" as tags');
     });
 
-    it('logs→trace link with OTel ships optimised rawSql on first click when the companion table exists', async () => {
-      // Confirms the #1705 behaviour is preserved: the very first View Trace
-      // click after a fresh page load uses the _trace_id_ts optimisation,
+    it('logs→trace link with OTel ships optimized rawSql on first click when the companion table exists', async () => {
+      // Confirms the #1705 behavior is preserved: the very first View Trace
+      // click after a fresh page load uses the _trace_id_ts optimization,
       // because hasTraceTimestampTable is awaited before rawSql is generated.
       const mockDatasource = newOtelMockDatasource();
       jest.spyOn(mockDatasource, 'fetchColumns').mockResolvedValue([]);
@@ -523,10 +523,10 @@ describe('transformQueryResponseWithTraceAndLogLinks', () => {
       expect(logsQuery.format).toBe(2); // Logs
     });
 
-    it('logs→trace link with OTel ships unoptimised rawSql when the companion table is missing (#1842)', async () => {
+    it('logs→trace link with OTel ships unoptimized rawSql when the companion table is missing (#1842)', async () => {
       // Regression guard for grafana/clickhouse-datasource#1842: when OTel is
       // configured but the companion `_trace_id_ts` table does not exist, the
-      // optimistic pre-#1842 code shipped the optimised SQL and the query
+      // optimistic pre-#1842 code shipped the optimized SQL and the query
       // failed on first click with "Unknown table expression identifier".
       const mockDatasource = newOtelMockDatasource();
       jest.spyOn(mockDatasource, 'hasTraceTimestampTable').mockResolvedValue(false);
@@ -548,7 +548,7 @@ describe('transformQueryResponseWithTraceAndLogLinks', () => {
       expect(traceQuery.rawSql).not.toContain('trace_id_ts');
     });
 
-    it('table→trace link with OTel ships unoptimised rawSql when the companion table is missing (#1842 reproduction)', async () => {
+    it('table→trace link with OTel ships unoptimized rawSql when the companion table is missing (#1842 reproduction)', async () => {
       const mockDatasource = newOtelMockDatasource();
       jest.spyOn(mockDatasource, 'hasTraceTimestampTable').mockResolvedValue(false);
 
@@ -588,7 +588,7 @@ describe('transformQueryResponseWithTraceAndLogLinks', () => {
       expect(traceQuery.builderOptions.meta?.hasTraceTimestampTable).toBeFalsy();
     });
 
-    it('trace→trace link generates unoptimised rawSql when companion does not exist', async () => {
+    it('trace→trace link generates unoptimized rawSql when companion does not exist', async () => {
       const mockDatasource = newOtelMockDatasource();
       jest.spyOn(mockDatasource, 'fetchColumns').mockResolvedValue([]);
       jest.spyOn(mockDatasource, 'hasTraceTimestampTable').mockResolvedValue(false);

--- a/src/data/utils.test.ts
+++ b/src/data/utils.test.ts
@@ -376,9 +376,12 @@ describe('transformQueryResponseWithTraceAndLogLinks', () => {
       return ds;
     };
 
-    it('trace→trace link has pre-generated rawSql with _trace_id_ts optimization', async () => {
+    it('trace→trace link queries the datasource for companion existence (not the stale meta value)', async () => {
+      // The original query has hasTraceTimestampTable: false in its meta, but
+      // the datasource cache resolves true — the link should use the fresh value.
       const mockDatasource = newOtelMockDatasource();
       jest.spyOn(mockDatasource, 'fetchColumns').mockResolvedValue([]);
+      jest.spyOn(mockDatasource, 'hasTraceTimestampTable').mockResolvedValue(true);
       const otelConfig = otel.getVersion('latest')!;
       const columns = Array.from(otelConfig.traceColumnMap, ([hint, name]) => ({ name, hint }));
 
@@ -391,7 +394,7 @@ describe('transformQueryResponseWithTraceAndLogLinks', () => {
           otelEnabled: true,
           otelVersion: 'latest',
           traceDurationUnit: TimeUnit.Nanoseconds,
-          hasTraceTimestampTable: true,
+          hasTraceTimestampTable: false, // stale / not yet set by editor
         },
       };
 
@@ -402,7 +405,6 @@ describe('transformQueryResponseWithTraceAndLogLinks', () => {
       const viewTraceLink = links?.find((link: any) => link.title === 'View trace');
       const traceQuery = viewTraceLink?.internal?.query as CHBuilderQuery;
 
-      expect(traceQuery.rawSql).not.toBe('');
       expect(traceQuery.rawSql).toContain('otel_traces_trace_id_ts');
       expect(traceQuery.rawSql).toContain('trace_start');
       expect(traceQuery.rawSql).toContain('trace_end');
@@ -475,9 +477,13 @@ describe('transformQueryResponseWithTraceAndLogLinks', () => {
       expect(traceQuery.rawSql).not.toContain('"SpanAttributes" as tags');
     });
 
-    it('logs→trace link with OTel sets hasTraceTimestampTable and generates optimized rawSql', async () => {
+    it('logs→trace link with OTel ships optimised rawSql on first click when the companion table exists', async () => {
+      // Confirms the #1705 behaviour is preserved: the very first View Trace
+      // click after a fresh page load uses the _trace_id_ts optimisation,
+      // because hasTraceTimestampTable is awaited before rawSql is generated.
       const mockDatasource = newOtelMockDatasource();
       jest.spyOn(mockDatasource, 'fetchColumns').mockResolvedValue([]);
+      jest.spyOn(mockDatasource, 'hasTraceTimestampTable').mockResolvedValue(true);
 
       const builderOptions: Partial<QueryBuilderOptions> = {
         queryType: QueryType.Logs,
@@ -492,10 +498,74 @@ describe('transformQueryResponseWithTraceAndLogLinks', () => {
 
       expect(traceQuery.builderOptions.meta?.otelEnabled).toBe(true);
       expect(traceQuery.builderOptions.meta?.hasTraceTimestampTable).toBe(true);
-      expect(traceQuery.rawSql).not.toBe('');
       expect(traceQuery.rawSql).toContain('otel_traces_trace_id_ts');
       expect(traceQuery.rawSql).toContain('trace_start');
       expect(traceQuery.rawSql).toContain('trace_end');
+    });
+
+    it('sets format on the trace ID link query so Grafana picks the trace panel', async () => {
+      // Without `format: 3` the sqlds backend tags the response as TimeSeries and
+      // Grafana shows "Data is missing a time field" on first click, because the
+      // editor's setAllOptions hasn't run yet to set format.
+      const mockDatasource = newOtelMockDatasource();
+      jest.spyOn(mockDatasource, 'hasTraceTimestampTable').mockResolvedValue(false);
+
+      const [request, response] = buildTestRequestResponse({ queryType: QueryType.Logs });
+      const out = await transformQueryResponseWithTraceAndLogLinks(mockDatasource, request, response);
+
+      const links = out?.data[0]?.fields[0]?.config?.links;
+      const viewTraceLink = links?.find((link: any) => link.title === 'View trace');
+      const viewLogsLink = links?.find((link: any) => link.title === 'View logs');
+      const traceQuery = viewTraceLink?.internal?.query as CHBuilderQuery;
+      const logsQuery = viewLogsLink?.internal?.query as CHBuilderQuery;
+
+      expect(traceQuery.format).toBe(3); // Trace
+      expect(logsQuery.format).toBe(2); // Logs
+    });
+
+    it('logs→trace link with OTel ships unoptimised rawSql when the companion table is missing (#1842)', async () => {
+      // Regression guard for grafana/clickhouse-datasource#1842: when OTel is
+      // configured but the companion `_trace_id_ts` table does not exist, the
+      // optimistic pre-#1842 code shipped the optimised SQL and the query
+      // failed on first click with "Unknown table expression identifier".
+      const mockDatasource = newOtelMockDatasource();
+      jest.spyOn(mockDatasource, 'hasTraceTimestampTable').mockResolvedValue(false);
+
+      const builderOptions: Partial<QueryBuilderOptions> = {
+        queryType: QueryType.Logs,
+      };
+
+      const [request, response] = buildTestRequestResponse(builderOptions);
+      const out = await transformQueryResponseWithTraceAndLogLinks(mockDatasource, request, response);
+
+      const links = out?.data[0]?.fields[0]?.config?.links;
+      const viewTraceLink = links?.find((link: any) => link.title === 'View trace');
+      const traceQuery = viewTraceLink?.internal?.query as CHBuilderQuery;
+
+      expect(traceQuery.builderOptions.meta?.otelEnabled).toBe(true);
+      expect(traceQuery.builderOptions.meta?.hasTraceTimestampTable).toBe(false);
+      expect(traceQuery.rawSql).not.toBe('');
+      expect(traceQuery.rawSql).not.toContain('trace_id_ts');
+    });
+
+    it('table→trace link with OTel ships unoptimised rawSql when the companion table is missing (#1842 reproduction)', async () => {
+      const mockDatasource = newOtelMockDatasource();
+      jest.spyOn(mockDatasource, 'hasTraceTimestampTable').mockResolvedValue(false);
+
+      const builderOptions: Partial<QueryBuilderOptions> = {
+        queryType: QueryType.Table,
+      };
+
+      const [request, response] = buildTestRequestResponse(builderOptions);
+      const out = await transformQueryResponseWithTraceAndLogLinks(mockDatasource, request, response);
+
+      const links = out?.data[0]?.fields[0]?.config?.links;
+      const viewTraceLink = links?.find((link: any) => link.title === 'View trace');
+      const traceQuery = viewTraceLink?.internal?.query as CHBuilderQuery;
+
+      expect(traceQuery.builderOptions.meta?.hasTraceTimestampTable).toBe(false);
+      expect(traceQuery.rawSql).not.toBe('');
+      expect(traceQuery.rawSql).not.toContain('trace_id_ts');
     });
 
     it('logs→trace link without OTel generates rawSql without _trace_id_ts optimization', async () => {
@@ -518,9 +588,10 @@ describe('transformQueryResponseWithTraceAndLogLinks', () => {
       expect(traceQuery.builderOptions.meta?.hasTraceTimestampTable).toBeFalsy();
     });
 
-    it('trace→trace link without hasTraceTimestampTable generates rawSql without optimization', async () => {
+    it('trace→trace link generates unoptimised rawSql when companion does not exist', async () => {
       const mockDatasource = newOtelMockDatasource();
       jest.spyOn(mockDatasource, 'fetchColumns').mockResolvedValue([]);
+      jest.spyOn(mockDatasource, 'hasTraceTimestampTable').mockResolvedValue(false);
       const otelConfig = otel.getVersion('latest')!;
       const columns = Array.from(otelConfig.traceColumnMap, ([hint, name]) => ({ name, hint }));
 
@@ -533,7 +604,7 @@ describe('transformQueryResponseWithTraceAndLogLinks', () => {
           otelEnabled: true,
           otelVersion: 'latest',
           traceDurationUnit: TimeUnit.Nanoseconds,
-          hasTraceTimestampTable: false,
+          hasTraceTimestampTable: true, // stale meta — should be overridden by datasource
         },
       };
 

--- a/src/data/utils.ts
+++ b/src/data/utils.ts
@@ -394,6 +394,11 @@ export const transformQueryResponseWithTraceAndLogLinks = async (
           false) ||
         (!fetchedLiveSchema && !typeKnown && Boolean(originalQuery.builderOptions.meta?.tagsAreJSON));
 
+      const hasTraceTimestampTable = await datasource.hasTraceTimestampTable(
+        originalQuery.builderOptions.database || '',
+        originalQuery.builderOptions.table || ''
+      );
+
       traceIdQuery.builderOptions = {
         ...originalQuery.builderOptions,
         columns,
@@ -407,6 +412,7 @@ export const transformQueryResponseWithTraceAndLogLinks = async (
           traceTimestampTableSuffix:
             originalQuery.builderOptions.meta?.traceTimestampTableSuffix || traceTimestampTableSuffix,
           tagsAreJSON: effectiveTagsAreJSON,
+          hasTraceTimestampTable,
         },
       };
     } else {
@@ -416,12 +422,17 @@ export const transformQueryResponseWithTraceAndLogLinks = async (
       const otelConfig = otel.getVersion(otelVersion);
       const traceEventsColumnPrefix = datasource.getDefaultTraceEventsColumnPrefix();
       const traceLinksColumnPrefix = datasource.getDefaultTraceLinksColumnPrefix();
+      const traceDatabase =
+        datasource.getDefaultTraceDatabase() ||
+        traceIdQuery.builderOptions.database ||
+        datasource.getDefaultDatabase() ||
+        '';
+      const traceTable =
+        datasource.getDefaultTraceTable() || datasource.getDefaultTable() || traceIdQuery.builderOptions.table || '';
+      const hasTraceTimestampTable = await datasource.hasTraceTimestampTable(traceDatabase, traceTable);
       const options: QueryBuilderOptions = {
-        database:
-          datasource.getDefaultTraceDatabase() ||
-          traceIdQuery.builderOptions.database ||
-          datasource.getDefaultDatabase(),
-        table: datasource.getDefaultTraceTable() || datasource.getDefaultTable() || traceIdQuery.builderOptions.table,
+        database: traceDatabase,
+        table: traceTable,
         queryType: QueryType.Traces,
         columns: [],
         filters: [],
@@ -435,7 +446,7 @@ export const transformQueryResponseWithTraceAndLogLinks = async (
           otelVersion: otelVersion,
           traceEventsColumnPrefix: traceEventsColumnPrefix,
           traceLinksColumnPrefix: traceLinksColumnPrefix,
-          hasTraceTimestampTable: Boolean(otelVersion),
+          hasTraceTimestampTable,
           traceTimestampTableSuffix,
           flattenNested: datasource.getDefaultTraceFlattenNested() || false,
         },
@@ -479,6 +490,9 @@ export const transformQueryResponseWithTraceAndLogLinks = async (
     // Trace ID queries don't contain $__fromTime/$__toTime time macros, so they're
     // safe to include (unlike trace search queries which would break data link detection).
     traceIdQuery.rawSql = generateSql(traceIdQuery.builderOptions);
+    // Set `format` so the sqlds backend tags the response with
+    // `preferredVisualisationType: 'trace'`.
+    traceIdQuery.format = mapQueryBuilderOptionsToGrafanaFormat(traceIdQuery.builderOptions);
 
     const traceLogsQuery: CHBuilderQuery = {
       datasource: datasource,
@@ -560,6 +574,7 @@ export const transformQueryResponseWithTraceAndLogLinks = async (
     } else {
       traceLogsQuery.rawSql = '';
     }
+    traceLogsQuery.format = mapQueryBuilderOptionsToGrafanaFormat(traceLogsQuery.builderOptions);
     traceField.config.links = [];
     if (datasource.settings.jsonData.traces?.showTraceLinks !== false) {
       traceField.config.links!.push({

--- a/src/data/utils.ts
+++ b/src/data/utils.ts
@@ -490,8 +490,6 @@ export const transformQueryResponseWithTraceAndLogLinks = async (
     // Trace ID queries don't contain $__fromTime/$__toTime time macros, so they're
     // safe to include (unlike trace search queries which would break data link detection).
     traceIdQuery.rawSql = generateSql(traceIdQuery.builderOptions);
-    // Set `format` so the sqlds backend tags the response with
-    // `preferredVisualisationType: 'trace'`.
     traceIdQuery.format = mapQueryBuilderOptionsToGrafanaFormat(traceIdQuery.builderOptions);
 
     const traceLogsQuery: CHBuilderQuery = {

--- a/src/hooks/useHasTraceTimestampTable.test.ts
+++ b/src/hooks/useHasTraceTimestampTable.test.ts
@@ -1,0 +1,46 @@
+import { renderHook } from '@testing-library/react';
+import { act } from 'react';
+import { Datasource } from 'data/CHDatasource';
+import useHasTraceTimestampTable from './useHasTraceTimestampTable';
+
+describe('useHasTraceTimestampTable', () => {
+  it('seeds the initial render from a warm cache without a false flicker', async () => {
+    const mockDs = {} as Datasource;
+    mockDs.peekTraceTimestampTable = jest.fn(() => true);
+    mockDs.hasTraceTimestampTable = jest.fn(() => Promise.resolve(true));
+
+    const { result } = renderHook(() => useHasTraceTimestampTable(mockDs, 'otel', 'otel_traces'));
+
+    // The async check cannot have settled yet, so a `true` on the first render
+    // proves the value was seeded synchronously from the cache peek.
+    expect(result.current).toBe(true);
+    expect(mockDs.peekTraceTimestampTable).toHaveBeenCalledWith('otel', 'otel_traces');
+
+    await act(async () => {}); // flush the pending async check
+    expect(result.current).toBe(true);
+  });
+
+  it('starts false on a cold cache then updates to the resolved value', async () => {
+    const mockDs = {} as Datasource;
+    mockDs.peekTraceTimestampTable = jest.fn(() => undefined);
+    mockDs.hasTraceTimestampTable = jest.fn(() => Promise.resolve(true));
+
+    const { result } = renderHook(() => useHasTraceTimestampTable(mockDs, 'otel', 'otel_traces'));
+    expect(result.current).toBe(false); // cold cache → initial render is false
+
+    await act(async () => {}); // flush the async check
+    expect(result.current).toBe(true); // updated once it resolves
+  });
+
+  it('returns false when database or table is empty', async () => {
+    const mockDs = {} as Datasource;
+    mockDs.peekTraceTimestampTable = jest.fn(() => undefined);
+    mockDs.hasTraceTimestampTable = jest.fn(() => Promise.resolve(true));
+
+    const { result } = renderHook(() => useHasTraceTimestampTable(mockDs, '', ''));
+
+    await act(async () => {});
+    expect(result.current).toBe(false);
+    expect(mockDs.hasTraceTimestampTable).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useHasTraceTimestampTable.ts
+++ b/src/hooks/useHasTraceTimestampTable.ts
@@ -1,0 +1,23 @@
+import { useState, useEffect } from 'react';
+import { Datasource } from 'data/CHDatasource';
+
+export default (datasource: Datasource, database: string, table: string): boolean => {
+  const [result, setResult] = useState(false);
+
+  useEffect(() => {
+    if (!database || !table) {
+      setResult(false);
+      return;
+    }
+
+    let cancelled = false;
+    datasource
+      .hasTraceTimestampTable(database, table)
+      .then((v) => { if (!cancelled) { setResult(v); } })
+      .catch(() => { if (!cancelled) { setResult(false); } });
+
+    return () => { cancelled = true; };
+  }, [datasource, database, table]);
+
+  return result;
+};

--- a/src/hooks/useHasTraceTimestampTable.ts
+++ b/src/hooks/useHasTraceTimestampTable.ts
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 import { Datasource } from 'data/CHDatasource';
 
 export default (datasource: Datasource, database: string, table: string): boolean => {
-  const [result, setResult] = useState(false);
+  const [result, setResult] = useState(() => datasource.peekTraceTimestampTable(database, table) ?? false);
 
   useEffect(() => {
     if (!database || !table) {
@@ -13,10 +13,20 @@ export default (datasource: Datasource, database: string, table: string): boolea
     let cancelled = false;
     datasource
       .hasTraceTimestampTable(database, table)
-      .then((v) => { if (!cancelled) { setResult(v); } })
-      .catch(() => { if (!cancelled) { setResult(false); } });
+      .then((v) => {
+        if (!cancelled) {
+          setResult(v);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setResult(false);
+        }
+      });
 
-    return () => { cancelled = true; };
+    return () => {
+      cancelled = true;
+    };
   }, [datasource, database, table]);
 
   return result;

--- a/src/views/CHQueryEditor.tsx
+++ b/src/views/CHQueryEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { QueryEditorProps } from '@grafana/data';
 import { Datasource } from 'data/CHDatasource';
 import { EditorTypeSwitcher } from 'components/queryBuilder/EditorTypeSwitcher';
@@ -13,7 +13,7 @@ import { isBuilderOptionsRunnable, mapQueryBuilderOptionsToGrafanaFormat } from 
 import { setAllOptions, setOptions, useBuilderOptionsState } from 'hooks/useBuilderOptionsState';
 import { pluginVersion } from 'utils/version';
 import { migrateCHQuery } from 'data/migration';
-import useTables from 'hooks/useTables';
+import useHasTraceTimestampTable from 'hooks/useHasTraceTimestampTable';
 
 export type CHQueryEditorProps = QueryEditorProps<Datasource, CHQuery, CHConfig>;
 
@@ -68,21 +68,16 @@ const CHEditorByType = (props: CHQueryEditorProps) => {
 
   // Resolve hasTraceTimestampTable for any trace ID query — not only OTel ones.
   // Running this at the CHEditorByType level means the check fires even when
-  // the builder is minimized via a logs→trace deep-link. The companion-table
-  // suffix is configurable on the datasource (defaults to the OTel convention)
-  // so non-OTel schemas can opt in to the two-step trace ID lookup.
-  const traceTimestampTableSuffix =
-    builderOptions.meta?.traceTimestampTableSuffix || props.datasource.getTraceTimestampTableSuffix();
+  // the builder is minimized via a logs→trace deep-link.
   const needsTraceTableCheck = Boolean(builderOptions.meta?.isTraceIdMode);
-  const traceDb = needsTraceTableCheck ? builderOptions.database : '';
-  const traceTables = useTables(props.datasource, traceDb);
-  const hasTraceTimestampTable = useMemo(
-    () => traceTables.some((t) => t === builderOptions.table + traceTimestampTableSuffix),
-    [builderOptions.table, traceTables, traceTimestampTableSuffix]
+  const hasTraceTimestampTable = useHasTraceTimestampTable(
+    props.datasource,
+    needsTraceTableCheck ? builderOptions.database || '' : '',
+    needsTraceTableCheck ? builderOptions.table || '' : ''
   );
 
   useEffect(() => {
-    if (!needsTraceTableCheck || traceTables.length === 0) {
+    if (!needsTraceTableCheck) {
       return;
     }
 
@@ -95,7 +90,6 @@ const CHEditorByType = (props: CHQueryEditorProps) => {
     }
   }, [
     needsTraceTableCheck,
-    traceTables,
     hasTraceTimestampTable,
     builderOptions.meta?.hasTraceTimestampTable,
     builderOptionsDispatch,

--- a/tests/e2e/fixtures/trace_id_ts.sql
+++ b/tests/e2e/fixtures/trace_id_ts.sql
@@ -6,8 +6,8 @@
 --     (same column layout as the OTel _trace_id_ts MV: TraceId, Start, End)
 --
 -- Two traces are seeded:
---   'e2e-ts-trace-a'  5 spans, companion entry present  → optimised SQL works
---   'e2e-ts-trace-b'  1 span,  NO companion entry       → optimised SQL returns
+--   'e2e-ts-trace-a'  5 spans, companion entry present  → optimized SQL works
+--   'e2e-ts-trace-b'  1 span,  NO companion entry       → optimized SQL returns
 --                                                          0 rows; only the
 --                                                          fallback path returns
 --                                                          the span (#1842)
@@ -47,7 +47,7 @@ INSERT INTO e2e_test.trace_ts_spans
 
 -- Companion entry only for trace-a. trace-b is intentionally absent to
 -- reproduce the #1842 scenario: new or unindexed traces have no companion row,
--- so the optimised SQL's min(Start)/max(End) subqueries return NULL, the
+-- so the optimized SQL's min(Start)/max(End) subqueries return NULL, the
 -- Timestamp bounds become NULL, and the WHERE trims every row.
 INSERT INTO e2e_test.trace_ts_spans_trace_id_ts
     (TraceId, Start, End) VALUES

--- a/tests/e2e/fixtures/trace_id_ts.sql
+++ b/tests/e2e/fixtures/trace_id_ts.sql
@@ -1,0 +1,54 @@
+-- Trace-timestamp-table fixture for the hasTraceTimestampTable e2e tests.
+--
+-- Two tables are created:
+--   e2e_test.trace_ts_spans        — the main trace spans table
+--   e2e_test.trace_ts_spans_trace_id_ts — the companion lookup table
+--     (same column layout as the OTel _trace_id_ts MV: TraceId, Start, End)
+--
+-- Two traces are seeded:
+--   'e2e-ts-trace-a'  5 spans, companion entry present  → optimised SQL works
+--   'e2e-ts-trace-b'  1 span,  NO companion entry       → optimised SQL returns
+--                                                          0 rows; only the
+--                                                          fallback path returns
+--                                                          the span (#1842)
+
+CREATE DATABASE IF NOT EXISTS e2e_test;
+
+CREATE TABLE IF NOT EXISTS e2e_test.trace_ts_spans
+(
+    Timestamp    DateTime64(9),
+    TraceId      String,
+    SpanId       String,
+    ParentSpanId String,
+    ServiceName  LowCardinality(String),
+    SpanName     LowCardinality(String),
+    Duration     Int64
+)
+ENGINE = MergeTree
+ORDER BY (TraceId, Timestamp);
+
+CREATE TABLE IF NOT EXISTS e2e_test.trace_ts_spans_trace_id_ts
+(
+    TraceId String,
+    Start   DateTime64(9),
+    End     DateTime64(9)
+)
+ENGINE = MergeTree
+ORDER BY (TraceId, Start);
+
+INSERT INTO e2e_test.trace_ts_spans
+    (Timestamp, TraceId, SpanId, ParentSpanId, ServiceName, SpanName, Duration) VALUES
+    ('2024-03-15 10:00:00', 'e2e-ts-trace-a', 'ts-span-1', '',           'api',    'HTTP GET /',        10000000),
+    ('2024-03-15 10:00:01', 'e2e-ts-trace-a', 'ts-span-2', 'ts-span-1',  'api',    'db.query users',     5000000),
+    ('2024-03-15 10:00:02', 'e2e-ts-trace-a', 'ts-span-3', 'ts-span-1',  'api',    'cache.get profile',  2000000),
+    ('2024-03-15 10:00:03', 'e2e-ts-trace-a', 'ts-span-4', 'ts-span-2',  'db',     'SELECT users',       4000000),
+    ('2024-03-15 10:00:04', 'e2e-ts-trace-a', 'ts-span-5', 'ts-span-3',  'cache',  'GET profile:42',     1000000),
+    ('2024-03-15 10:01:00', 'e2e-ts-trace-b', 'ts-span-9', '',           'worker', 'job.run',            8000000);
+
+-- Companion entry only for trace-a. trace-b is intentionally absent to
+-- reproduce the #1842 scenario: new or unindexed traces have no companion row,
+-- so the optimised SQL's min(Start)/max(End) subqueries return NULL, the
+-- Timestamp bounds become NULL, and the WHERE trims every row.
+INSERT INTO e2e_test.trace_ts_spans_trace_id_ts
+    (TraceId, Start, End) VALUES
+    ('e2e-ts-trace-a', '2024-03-15 10:00:00', '2024-03-15 10:00:04.999999999');

--- a/tests/e2e/traceTimestampTable.spec.ts
+++ b/tests/e2e/traceTimestampTable.spec.ts
@@ -1,11 +1,11 @@
 import { expect, test, ExplorePage } from '@grafana/plugin-e2e';
 import { Page } from '@playwright/test';
 
-// E2E guard for the hasTraceTimestampTable optimisation and its #1842
+// E2E guard for the hasTraceTimestampTable optimization and its #1842
 // regression guard. The tests exercise the two SQL shapes the plugin
 // generates against real ClickHouse:
 //
-//   Optimised  – WITH trace_id / trace_start / trace_end + Timestamp bounds
+//   Optimized  – WITH trace_id / trace_start / trace_end + Timestamp bounds
 //   Fallback   – plain WHERE traceID = '<id>'
 //
 // Fixture: tests/e2e/fixtures/trace_id_ts.sql creates
@@ -13,7 +13,7 @@ import { Page } from '@playwright/test';
 //   e2e_test.trace_ts_spans_trace_id_ts (companion entry for trace-a ONLY)
 //
 // The missing trace-b entry in the companion reproduces the #1842 scenario:
-// optimised SQL returns 0 rows because the Timestamp bounds become NULL;
+// optimized SQL returns 0 rows because the Timestamp bounds become NULL;
 // the fallback returns the span correctly.
 
 const PLUGIN_TYPE = 'grafana-clickhouse-datasource';
@@ -33,7 +33,7 @@ const TRACE_A_SPAN_COUNT = 5;
 const TRACE_B_SPAN_COUNT = 1;
 
 // SQL the plugin generates with hasTraceTimestampTable: true
-function optimisedSql(traceId: string): string {
+function optimizedSql(traceId: string): string {
   return [
     `WITH '${traceId}' as trace_id,`,
     `(SELECT min(Start) FROM "e2e_test"."trace_ts_spans_trace_id_ts" WHERE TraceId = trace_id) as trace_start,`,
@@ -104,7 +104,7 @@ function spanCount(body: Record<string, unknown> | null): number {
   return Array.isArray(values) ? values.length : 0;
 }
 
-test.describe('trace timestamp table optimisation (#1842)', () => {
+test.describe('trace timestamp table optimization (#1842)', () => {
   test.beforeEach(() => {
     test.skip(
       isCloudRun,
@@ -114,12 +114,12 @@ test.describe('trace timestamp table optimisation (#1842)', () => {
 
   test.describe.configure({ mode: 'serial' });
 
-  test('optimised SQL returns all spans when the companion table has an entry for the trace', async ({
+  test('optimized SQL returns all spans when the companion table has an entry for the trace', async ({
     page,
     explorePage,
   }) => {
     await page.goto(exploreUrl(FIXTURE_FROM_ISO, FIXTURE_TO_ISO));
-    await enterSql(page, optimisedSql(TRACE_A));
+    await enterSql(page, optimizedSql(TRACE_A));
 
     const { responsePromise, getBody } = await waitForQueryDataResponseWithBody(explorePage);
     await page.locator('.query-editor-row').getByRole('button', { name: 'Run Query' }).click();
@@ -128,16 +128,16 @@ test.describe('trace timestamp table optimisation (#1842)', () => {
     expect(spanCount(getBody())).toBe(TRACE_A_SPAN_COUNT);
   });
 
-  test('optimised SQL returns no rows when the companion table has no entry for the trace (#1842 — why the guard exists)', async ({
+  test('optimized SQL returns no rows when the companion table has no entry for the trace (#1842 — why the guard exists)', async ({
     page,
     explorePage,
   }) => {
     // trace-b has no companion row, so min(Start)/max(End) are NULL.
     // Timestamp >= NULL is NULL (falsy), so all rows are filtered out.
-    // This demonstrates the risk of shipping optimised SQL for an unverified
+    // This demonstrates the risk of shipping optimized SQL for an unverified
     // table: a real trace becomes invisible on first click.
     await page.goto(exploreUrl(FIXTURE_FROM_ISO, FIXTURE_TO_ISO));
-    await enterSql(page, optimisedSql(TRACE_B));
+    await enterSql(page, optimizedSql(TRACE_B));
 
     const { responsePromise, getBody } = await waitForQueryDataResponseWithBody(explorePage);
     await page.locator('.query-editor-row').getByRole('button', { name: 'Run Query' }).click();
@@ -160,10 +160,7 @@ test.describe('trace timestamp table optimisation (#1842)', () => {
     expect(spanCount(getBody())).toBe(TRACE_B_SPAN_COUNT);
   });
 
-  test('fallback SQL returns all spans for a trace that also has a companion entry', async ({
-    page,
-    explorePage,
-  }) => {
+  test('fallback SQL returns all spans for a trace that also has a companion entry', async ({ page, explorePage }) => {
     // Confirms the fallback is correct in all cases, not just missing-companion.
     await page.goto(exploreUrl(FIXTURE_FROM_ISO, FIXTURE_TO_ISO));
     await enterSql(page, fallbackSql(TRACE_A));
@@ -175,10 +172,7 @@ test.describe('trace timestamp table optimisation (#1842)', () => {
     expect(spanCount(getBody())).toBe(TRACE_A_SPAN_COUNT);
   });
 
-  test('SHOW TABLES FROM e2e_test includes both the spans table and its companion', async ({
-    page,
-    explorePage,
-  }) => {
+  test('SHOW TABLES FROM e2e_test includes both the spans table and its companion', async ({ page, explorePage }) => {
     // Verifies that hasTraceTimestampTable() would resolve true for this table
     // in this database: the companion exists and SHOW TABLES returns it.
     await page.goto(exploreUrl(FIXTURE_FROM_ISO, FIXTURE_TO_ISO));

--- a/tests/e2e/traceTimestampTable.spec.ts
+++ b/tests/e2e/traceTimestampTable.spec.ts
@@ -1,0 +1,199 @@
+import { expect, test, ExplorePage } from '@grafana/plugin-e2e';
+import { Page } from '@playwright/test';
+
+// E2E guard for the hasTraceTimestampTable optimisation and its #1842
+// regression guard. The tests exercise the two SQL shapes the plugin
+// generates against real ClickHouse:
+//
+//   Optimised  – WITH trace_id / trace_start / trace_end + Timestamp bounds
+//   Fallback   – plain WHERE traceID = '<id>'
+//
+// Fixture: tests/e2e/fixtures/trace_id_ts.sql creates
+//   e2e_test.trace_ts_spans            (5 spans for trace-a, 1 for trace-b)
+//   e2e_test.trace_ts_spans_trace_id_ts (companion entry for trace-a ONLY)
+//
+// The missing trace-b entry in the companion reproduces the #1842 scenario:
+// optimised SQL returns 0 rows because the Timestamp bounds become NULL;
+// the fallback returns the span correctly.
+
+const PLUGIN_TYPE = 'grafana-clickhouse-datasource';
+
+const isCloudRun = !!process.env.GRAFANA_URL;
+
+const CLOUD_DEFAULT_UID = 'clickhouse-native-ds-m';
+const LOCAL_DEFAULT_UID = 'clickhouse-e2e';
+const DATASOURCE_UID = process.env.DS_E2E_UID || (isCloudRun ? CLOUD_DEFAULT_UID : LOCAL_DEFAULT_UID);
+
+const FIXTURE_FROM_ISO = '2024-03-15T09:45:00.000Z';
+const FIXTURE_TO_ISO = '2024-03-15T10:15:00.000Z';
+
+const TRACE_A = 'e2e-ts-trace-a'; // 5 spans, companion entry present
+const TRACE_B = 'e2e-ts-trace-b'; // 1 span,  NO companion entry (#1842)
+const TRACE_A_SPAN_COUNT = 5;
+const TRACE_B_SPAN_COUNT = 1;
+
+// SQL the plugin generates with hasTraceTimestampTable: true
+function optimisedSql(traceId: string): string {
+  return [
+    `WITH '${traceId}' as trace_id,`,
+    `(SELECT min(Start) FROM "e2e_test"."trace_ts_spans_trace_id_ts" WHERE TraceId = trace_id) as trace_start,`,
+    `(SELECT max(End) + 1 FROM "e2e_test"."trace_ts_spans_trace_id_ts" WHERE TraceId = trace_id) as trace_end`,
+    `SELECT "TraceId" as traceID, "SpanId" as spanID`,
+    `FROM "e2e_test"."trace_ts_spans"`,
+    `WHERE traceID = trace_id`,
+    `AND "Timestamp" >= trace_start`,
+    `AND "Timestamp" <= trace_end`,
+  ].join(' ');
+}
+
+// SQL the plugin generates with hasTraceTimestampTable: false
+function fallbackSql(traceId: string): string {
+  return [
+    `SELECT "TraceId" as traceID, "SpanId" as spanID`,
+    `FROM "e2e_test"."trace_ts_spans"`,
+    `WHERE traceID = '${traceId}'`,
+  ].join(' ');
+}
+
+function exploreUrl(from: string, to: string): string {
+  const query = {
+    refId: 'A',
+    datasource: { type: PLUGIN_TYPE, uid: DATASOURCE_UID },
+    editorType: 'sql',
+    pluginVersion: '',
+    rawSql: '',
+  };
+  const panes = JSON.stringify({
+    explore: { datasource: DATASOURCE_UID, queries: [query], range: { from, to } },
+  });
+  return `/explore?orgId=1&schemaVersion=1&panes=${encodeURIComponent(panes)}`;
+}
+
+async function enterSql(page: Page, sql: string) {
+  const editor = page.getByRole('code');
+  await editor.click();
+  await page.keyboard.press('ControlOrMeta+a');
+  await page.keyboard.type(sql);
+}
+
+async function waitForQueryDataResponseWithBody(explorePage: ExplorePage) {
+  let body: Record<string, unknown> | null = null;
+  const responsePromise = explorePage.waitForQueryDataResponse(async (r) => {
+    if (!r.ok()) {
+      return false;
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const b: any = await r.json().catch(() => null);
+    if (!Array.isArray(b?.results?.A?.frames)) {
+      return false;
+    }
+    body = b as Record<string, unknown>;
+    return true;
+  });
+  return { responsePromise, getBody: () => body };
+}
+
+function spanCount(body: Record<string, unknown> | null): number {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const frames = (body as any)?.results?.A?.frames;
+  if (!Array.isArray(frames) || frames.length === 0) {
+    return 0;
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const values = (frames[0] as any)?.data?.values?.[0];
+  return Array.isArray(values) ? values.length : 0;
+}
+
+test.describe('trace timestamp table optimisation (#1842)', () => {
+  test.beforeEach(() => {
+    test.skip(
+      isCloudRun,
+      'Fixture-data tests depend on the local trace_id_ts seed (tests/e2e/fixtures/trace_id_ts.sql) loaded via the e2e-data-loader Docker service, which is not available on Cloud.'
+    );
+  });
+
+  test.describe.configure({ mode: 'serial' });
+
+  test('optimised SQL returns all spans when the companion table has an entry for the trace', async ({
+    page,
+    explorePage,
+  }) => {
+    await page.goto(exploreUrl(FIXTURE_FROM_ISO, FIXTURE_TO_ISO));
+    await enterSql(page, optimisedSql(TRACE_A));
+
+    const { responsePromise, getBody } = await waitForQueryDataResponseWithBody(explorePage);
+    await page.locator('.query-editor-row').getByRole('button', { name: 'Run Query' }).click();
+    await responsePromise;
+
+    expect(spanCount(getBody())).toBe(TRACE_A_SPAN_COUNT);
+  });
+
+  test('optimised SQL returns no rows when the companion table has no entry for the trace (#1842 — why the guard exists)', async ({
+    page,
+    explorePage,
+  }) => {
+    // trace-b has no companion row, so min(Start)/max(End) are NULL.
+    // Timestamp >= NULL is NULL (falsy), so all rows are filtered out.
+    // This demonstrates the risk of shipping optimised SQL for an unverified
+    // table: a real trace becomes invisible on first click.
+    await page.goto(exploreUrl(FIXTURE_FROM_ISO, FIXTURE_TO_ISO));
+    await enterSql(page, optimisedSql(TRACE_B));
+
+    const { responsePromise, getBody } = await waitForQueryDataResponseWithBody(explorePage);
+    await page.locator('.query-editor-row').getByRole('button', { name: 'Run Query' }).click();
+    await responsePromise;
+
+    expect(spanCount(getBody())).toBe(0);
+  });
+
+  test('fallback SQL returns the span even when the companion table has no entry (#1842 fix)', async ({
+    page,
+    explorePage,
+  }) => {
+    await page.goto(exploreUrl(FIXTURE_FROM_ISO, FIXTURE_TO_ISO));
+    await enterSql(page, fallbackSql(TRACE_B));
+
+    const { responsePromise, getBody } = await waitForQueryDataResponseWithBody(explorePage);
+    await page.locator('.query-editor-row').getByRole('button', { name: 'Run Query' }).click();
+    await responsePromise;
+
+    expect(spanCount(getBody())).toBe(TRACE_B_SPAN_COUNT);
+  });
+
+  test('fallback SQL returns all spans for a trace that also has a companion entry', async ({
+    page,
+    explorePage,
+  }) => {
+    // Confirms the fallback is correct in all cases, not just missing-companion.
+    await page.goto(exploreUrl(FIXTURE_FROM_ISO, FIXTURE_TO_ISO));
+    await enterSql(page, fallbackSql(TRACE_A));
+
+    const { responsePromise, getBody } = await waitForQueryDataResponseWithBody(explorePage);
+    await page.locator('.query-editor-row').getByRole('button', { name: 'Run Query' }).click();
+    await responsePromise;
+
+    expect(spanCount(getBody())).toBe(TRACE_A_SPAN_COUNT);
+  });
+
+  test('SHOW TABLES FROM e2e_test includes both the spans table and its companion', async ({
+    page,
+    explorePage,
+  }) => {
+    // Verifies that hasTraceTimestampTable() would resolve true for this table
+    // in this database: the companion exists and SHOW TABLES returns it.
+    await page.goto(exploreUrl(FIXTURE_FROM_ISO, FIXTURE_TO_ISO));
+    await enterSql(page, 'SHOW TABLES FROM e2e_test');
+
+    const { responsePromise, getBody } = await waitForQueryDataResponseWithBody(explorePage);
+    await page.locator('.query-editor-row').getByRole('button', { name: 'Run Query' }).click();
+    await responsePromise;
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const frames = (getBody() as any)?.results?.A?.frames;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const tableNames: string[] = frames?.[0]?.data?.values?.[0] ?? [];
+
+    expect(tableNames).toContain('trace_ts_spans');
+    expect(tableNames).toContain('trace_ts_spans_trace_id_ts');
+  });
+});


### PR DESCRIPTION
## Type of Change

- [x] 🐛 Bug Fix

---

## Bug Fix

### What is the bug?

The "View trace" data link generated by trace search, logs, and table panels could fail on the first click when the OTel `_trace_id_ts` companion table was missing.

The root cause was in `transformQueryResponseWithTraceAndLogLinks` (`src/data/utils.ts`), which set `meta.hasTraceTimestampTable: Boolean(otelVersion)` on the generated link query. With OTel enabled, that value was always `true`, so the link's `rawSql` was generated with the two-step `WITH trace_start / trace_end` shape that joins against `<table>_trace_id_ts`. On environments without the companion, the query failed with "Unknown table expression identifier". On environments where the companion existed but had no row for the trace, the optimised SQL silently returned 0 rows (demonstrated by the new e2e test).

`CHQueryEditor` had a separate `useTables` + `useMemo` check that would eventually correct the `meta` value, but it ran inside the editor and depended on a table-list fetch completing. On a fresh page load — particularly when the editor was minimised on a deep-link — the link's `rawSql` was already generated by the response-transform path before the editor's effect ran. Two related issues also surfaced once the response transform was made the source of truth:

1. The trace→trace branch of the response transform spread `originalQuery.builderOptions.meta` and never set `hasTraceTimestampTable` itself, so it inherited whatever value was on the source query's meta rather than consulting the actual schema.
2. Neither the generated trace ID link query nor the generated View Logs link query had a `format` set. Without it, the sqlds backend tagged the response with the wrong `preferredVisualisationType` and Grafana could route the frame to the wrong panel before the editor's `setAllOptions` had a chance to run.

### How to reproduce

1. Configure a ClickHouse datasource with OTel tracing enabled, pointing at a trace table that has **no** `<table>_trace_id_ts` companion (or one where the trace you click has no row in the companion).
2. Run a logs or table query that surfaces trace IDs. Click **View trace** — the query fails with "Unknown table expression identifier" or returns 0 spans.
3. Run a trace search, then click **View trace** on a result row — the generated SQL is unoptimised even when the companion does exist.

### Related Issues

Closes #1842
Relates to #1705, #1786

---

## Please check that:

- [x] Tests for this change have been added/updated.
- [ ] Documentation has been added/updated (where applicable).

## Special notes for your reviewer

**Files changed**

`src/data/CHDatasource.ts` — Adds `async hasTraceTimestampTable(database, table): Promise<boolean>` on the datasource. Backed by a `Map<string, Promise<boolean>>` keyed by `${database}.${table}`. Caching the Promise (not the resolved value) means concurrent callers share a single `SHOW TABLES` round-trip; repeat callers resolve in a microtask. On fetch failure the entry is evicted so the next call retries, and the failing call resolves `false` (the safe, unoptimised path). The `Datasource.query()` pipe operator changes from `map` to `concatMap` so the now-async transform can be awaited before the response is emitted.

`src/data/utils.ts` — `transformQueryResponseWithTraceAndLogLinks` becomes `async`. Both branches (trace search → trace, and logs/table → trace) now `await datasource.hasTraceTimestampTable(...)` before generating `rawSql`, replacing the `Boolean(otelVersion)` default in the logs/table branch and adding an explicit lookup in the trace search branch (which previously inherited the value from the source query's meta). `format` is now set on both the trace ID link query and the View Logs link query via `mapQueryBuilderOptionsToGrafanaFormat`, so the response is tagged with the correct `preferredVisualisationType` from the first request.

`src/hooks/useHasTraceTimestampTable.ts` — New hook that wraps `datasource.hasTraceTimestampTable()` for use in the editor, with cancellation on unmount or dep change.

`src/views/CHQueryEditor.tsx` — Replaces the `useTables` + `useMemo` table-list check with `useHasTraceTimestampTable`, sharing the same datasource-level cache as the response transform. The `traceTables.length === 0` short-circuit in the effect is removed (no longer applicable now that the hook returns a stable boolean instead of deriving from a list that may be transiently empty).

**Tests**

- New unit tests on `Datasource.hasTraceTimestampTable` cover the empty-inputs case, present/missing companion, repeat-call caching, concurrent-call dedupe, error-evict-and-retry, and configured custom suffix.
- `src/data/utils.test.ts` is updated to `await` the now-async transform. New cases assert that the datasource lookup overrides stale `meta.hasTraceTimestampTable` (true→false and false→true), that the generated trace ID link carries `format: 3` (Trace) and the View Logs link carries `format: 2` (Logs), and that the logs→trace and table→trace branches both ship unoptimised SQL when the companion is missing (#1842).
- E2E (`tests/e2e/traceTimestampTable.spec.ts` + fixture `tests/e2e/fixtures/trace_id_ts.sql`) drives real ClickHouse with two seeded traces: `e2e-ts-trace-a` has a companion row, `e2e-ts-trace-b` deliberately does not. The tests assert that the optimised SQL returns all spans for trace-a, returns 0 rows for trace-b (the #1842 failure mode made concrete), and that the fallback SQL returns spans correctly for both. A final test confirms `SHOW TABLES` returns the companion, i.e. that `hasTraceTimestampTable` would resolve `true` for the seeded schema.
