### PR TITLE
chore: update plugin-ci-workflows to v8.0.1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         environment: [dev, ops, prod]
     name: CD
-    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v7.3.1
+    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v8.0.1
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -27,7 +27,7 @@ jobs:
   ci:
     name: CI
 
-    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@ci-cd-workflows/v7.3.1
+    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@ci-cd-workflows/v8.0.1
 
     # Only run CI job for PRs / non-main refs.
     # Main publishing is handled by the CD workflow below.


### PR DESCRIPTION
## Summary
- Updates `grafana/plugin-ci-workflows` reusable workflows to the target version.
- This brings CI/CD pipelines in line with the latest plugin-ci-workflows release.

## Test plan
- [ ] Verify CI passes on this PR