### PR TITLE
chore: remove Grafana 13 hard-break call sites (ConfirmModal icon, Collapse collapsible, Vector to Array)

### DIFF
--- a/src/components/queryBuilder/EditorTypeSwitcher.tsx
+++ b/src/components/queryBuilder/EditorTypeSwitcher.tsx
@@ -96,7 +96,6 @@ export const EditorTypeSwitcher = (props: CHEditorTypeSwitcherProps) => {
         body={switcher.body}
         confirmText={switcher.confirmText}
         dismissText={switcher.dismissText}
-        icon="exclamation-triangle"
         onConfirm={onConfirmEditorTypeChange}
         onDismiss={() => setConfirmModalState(false)}
       />
@@ -104,7 +103,6 @@ export const EditorTypeSwitcher = (props: CHEditorTypeSwitcherProps) => {
         title={cannotConvert.title}
         body={`${errorMessage}\n${cannotConvert.message}`}
         isOpen={cannotConvertModalState}
-        icon="exclamation-triangle"
         onConfirm={onConfirmEditorTypeChange}
         confirmText={switcher.confirmText}
         onDismiss={() => setCannotConvertModalState(false)}

--- a/src/components/queryBuilder/views/TraceQueryBuilder.tsx
+++ b/src/components/queryBuilder/views/TraceQueryBuilder.tsx
@@ -192,7 +192,7 @@ export const TraceQueryBuilder = (props: TraceQueryBuilderProps) => {
         tooltip={labels.traceModeTooltip}
       />
 
-      <Collapse label={labels.columnsSection} collapsible isOpen={isColumnsOpen} onToggle={setColumnsOpen}>
+      <Collapse label={labels.columnsSection} isOpen={isColumnsOpen} onToggle={setColumnsOpen}>
         {configWarning}
         <ColumnRolesHelp
           text={labels.columnsHelp.text}
@@ -431,7 +431,7 @@ export const TraceQueryBuilder = (props: TraceQueryBuilderProps) => {
           />
         </div>
       </Collapse>
-      <Collapse label={labels.filtersSection} collapsible isOpen={isFiltersOpen} onToggle={setFiltersOpen}>
+      <Collapse label={labels.filtersSection} isOpen={isFiltersOpen} onToggle={setFiltersOpen}>
         <OrderByEditor
           orderByOptions={getOrderByOptions(builderOptions, allColumns)}
           orderBy={builderState.orderBy}

--- a/src/data/CHDatasource.ts
+++ b/src/data/CHDatasource.ts
@@ -317,7 +317,7 @@ export class Datasource
     }
     // convention - assume the first field is an id field
     const ids = frame?.fields[0]?.values;
-    return frame?.fields[1]?.values.map((text, i) => ({ text, value: ids.get(i) }));
+    return frame?.fields[1]?.values.map((text, i) => ({ text, value: ids[i] }));
   }
 
   applyTemplateVariables(query: CHQuery, scoped: ScopedVars, filters: AdHocVariableFilter[] = []): CHQuery {
@@ -1400,7 +1400,7 @@ export class Datasource
         continue;
       }
 
-      let value = field.values.get(row.rowIndex);
+      let value = field.values[row.rowIndex];
       if (value && field.type === 'other' && isMapKey) {
         // Extract merged Resource/Log Attributes from "labels"
         if (field.name === labelsFieldName) {

--- a/src/data/utils.test.ts
+++ b/src/data/utils.test.ts
@@ -734,21 +734,21 @@ describe('dataFrameHasLogLabelWithName', () => {
 
   it('should return false when log labels field is not present', () => {
     const frame: DataFrame = {
-      fields: [{ name: 'otherField', values: { get: jest.fn(), length: 1 } }],
+      fields: [{ name: 'otherField', values: [{}] }],
     } as any as DataFrame;
     expect(dataFrameHasLogLabelWithName(frame, 'testLabel')).toBe(false);
   });
 
   it('should return false when log labels field has no values', () => {
     const frame: DataFrame = {
-      fields: [{ name: labelsFieldName, values: { get: jest.fn(), length: 0 } }],
+      fields: [{ name: labelsFieldName, values: [] }],
     } as any as DataFrame;
     expect(dataFrameHasLogLabelWithName(frame, 'testLabel')).toBe(false);
   });
 
   it('should return false when log labels field value is null', () => {
     const frame: DataFrame = {
-      fields: [{ name: labelsFieldName, values: { get: () => null, length: 1 } }],
+      fields: [{ name: labelsFieldName, values: [null] }],
     } as any as DataFrame;
     expect(dataFrameHasLogLabelWithName(frame, 'testLabel')).toBe(false);
   });
@@ -758,7 +758,7 @@ describe('dataFrameHasLogLabelWithName', () => {
       fields: [
         {
           name: labelsFieldName,
-          values: { get: () => ({ testLabel: 'value', otherLabel: 'otherValue' }), length: 1 },
+          values: [{ testLabel: 'value', otherLabel: 'otherValue' }],
         },
       ],
     } as any as DataFrame;
@@ -770,7 +770,7 @@ describe('dataFrameHasLogLabelWithName', () => {
       fields: [
         {
           name: labelsFieldName,
-          values: { get: () => ({ otherLabel: 'value' }), length: 1 },
+          values: [{ otherLabel: 'value' }],
         },
       ],
     } as any as DataFrame;

--- a/src/data/utils.ts
+++ b/src/data/utils.ts
@@ -611,11 +611,11 @@ export const dataFrameHasLogLabelWithName = (frame: DataFrame | undefined, name:
   }
 
   const field = frame.fields.find((f) => f.name === labelsFieldName);
-  if (!field || !field.values || field.values.length < 1 || !field.values.get(0)) {
+  if (!field || !field.values || field.values.length < 1 || !field.values[0]) {
     return false;
   }
 
-  const labels = (field.values.get(0) || {}) as object;
+  const labels = (field.values[0] || {}) as object;
   const labelKeys = Object.keys(labels);
 
   return labelKeys.includes(name);


### PR DESCRIPTION
## Summary

Removes three `@grafana/ui` APIs that Grafana 13 removes outright. Each call site picks the documented G13 replacement; behavior on Grafana 11.6 / 12.x is unchanged.

- **`ConfirmModal`**: drop the `icon` prop on both call sites in `EditorTypeSwitcher.tsx` (convert-query and cannot-convert modals).
- **`Collapse`**: drop the `collapsible` prop on both call sites in `TraceQueryBuilder.tsx` (columns and filters sections). The `isOpen` / `onToggle` wiring is the source of truth and is unchanged.
- **`Field.values`**: migrate the four deprecated `.values.get(i)` reads to bracket access `.values[i]` (Vector to Array migration). Sites: `CHDatasource.ts` (metric-find query and log-context column resolution) and `utils.ts` (`dataFrameHasLogLabelWithName`, two sites).

This is the first in a small chain to clear the Grafana 13 path. The `VerticalGroup` / `HorizontalGroup` to `Stack` migration (another G13 hard break) ships separately because it touches a different set of files.

## Why

Renovate's `@grafana/* -> v13` bump
[#1817](https://github.com/grafana/clickhouse-datasource/pull/1817)
fails `tsc --noEmit` on these exact call sites. Once this lands, the
bump will go green automatically. The fix is mechanical and matches
the official
[Grafana 12 to 13 plugin migration guide](https://grafana.com/developers/plugin-tools/migration-guides/update-from-grafana-versions/migrate-12_x-to-13_x):
the removed props were already deprecated, and bracket access on
`Field.values` works on both v12 (`Vector`) and v13 (`Array`).

## Changes

- `src/components/queryBuilder/EditorTypeSwitcher.tsx`: remove `icon="exclamation-triangle"` from both `ConfirmModal` call sites.
- `src/components/queryBuilder/views/TraceQueryBuilder.tsx`: remove the boolean `collapsible` attribute from both `Collapse` call sites.
- `src/data/CHDatasource.ts`: replace `ids.get(i)` with `ids[i]` in the metric-find query path, and `field.values.get(row.rowIndex)` with `field.values[row.rowIndex]` in `getLogContextColumnsFromLogRow`.
- `src/data/utils.ts`: replace `field.values.get(0)` with `field.values[0]` at both sites in `dataFrameHasLogLabelWithName`.
- `src/data/utils.test.ts`: switch the `dataFrameHasLogLabelWithName` mocks from Vector shape (`{ get: () => ..., length: N }`) to Array shape (`[...]`) so they exercise the same access path the production code now uses.

Net diff: 5 files, +11 / -13 lines.

## Cosmetic delta

On Grafana 11.6 / 12.x the `icon` prop was the small leading exclamation-triangle on the `ConfirmModal` title. In practice on Grafana 12.4.2 the modal already renders without a visible icon, so removing the prop is a no-op visually on G12. The "Cannot convert" / "Convert query" copy and the Cancel / Continue buttons are unchanged.

## Local verification

Built the plugin from this branch and ran it side by side with the official 4.17.0 plugin on Grafana 12.4.2 AND Grafana 13.0.1+security-01.

### Convert-query modal: official vs PR build on Grafana 12.4.2 (dark)

| Official 4.17.0 | This PR (4.17.1) |
| --- | --- |
| ![](https://raw.githubusercontent.com/alex-fedotyev/clickhouse-datasource/chore/g13-unblock-screenshots/pr-screenshots/03-convert-modal-official-dark.png) | ![](https://raw.githubusercontent.com/alex-fedotyev/clickhouse-datasource/chore/g13-unblock-screenshots/pr-screenshots/04-convert-modal-custom-dark.png) |

### TraceQueryBuilder Collapse sections still toggle (Grafana 12.4.2)

| Default (Filters open) | After clicking Columns header |
| --- | --- |
| ![](https://raw.githubusercontent.com/alex-fedotyev/clickhouse-datasource/chore/g13-unblock-screenshots/pr-screenshots/06-trace-builder-custom-dark.png) | ![](https://raw.githubusercontent.com/alex-fedotyev/clickhouse-datasource/chore/g13-unblock-screenshots/pr-screenshots/09-trace-columns-toggled-custom.png) |

### Same plugin loads cleanly on Grafana 13.0.1+security-01

![](https://raw.githubusercontent.com/alex-fedotyev/clickhouse-datasource/chore/g13-unblock-screenshots/pr-screenshots/11-trace-builder-custom-g13.png)

## Test plan

- [x] `npm run typecheck` is green on `@grafana/* @ 12.4.2` (the pinned versions on `main`).
- [x] `npm run typecheck` is green on a transient bump to `@grafana/* @ ^13.0.0` (verified locally; lockfile reverted before commit so the actual bump can ship as a separate Renovate PR).
- [x] `npm run lint` is green; the previous deprecation warning for `Field.values.get` is gone.
- [x] `npx jest --maxWorkers 1` passes 64 suites / 699 tests.
- [x] Manual verification in Explore on Grafana 12.4.2 with the plugin built from this branch and the official 4.17.0 loaded side by side: convert-query modal, cannot-convert modal, TraceQueryBuilder Columns and Filters Collapse toggle.
- [x] Manual verification on Grafana 13.0.1+security-01: plugin loads, datasource detail page renders, query editor opens, query builder mode works, no console errors.

Please add the `changelog` label so this surfaces in the next release notes.
