### PR TITLE
refactor(queryBuilder): migrate VerticalGroup / HorizontalGroup to Stack

### DIFF
--- a/src/components/queryBuilder/AggregateEditor.tsx
+++ b/src/components/queryBuilder/AggregateEditor.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { SelectableValue } from '@grafana/data';
-import { InlineFormLabel, Select, Button, Input, HorizontalGroup } from '@grafana/ui';
+import { InlineFormLabel, Select, Button, Input, Stack } from '@grafana/ui';
 import { AggregateColumn, AggregateType, TableColumn } from 'types/queryBuilder';
 import labels from 'labels';
 import { selectors } from 'selectors';
@@ -43,7 +43,7 @@ const Aggregate = (props: AggregateProps) => {
   }
 
   return (
-    <HorizontalGroup wrap align="flex-start" justify="flex-start">
+    <Stack direction="row" wrap="wrap" alignItems="flex-start" justifyContent="flex-start">
       <Select
         width={20}
         className={styles.Common.inlineSelect}
@@ -84,7 +84,7 @@ const Aggregate = (props: AggregateProps) => {
         onClick={() => removeAggregate(index)}
         aria-label="aggregate-remove-item"
       />
-    </HorizontalGroup>
+    </Stack>
   );
 };
 

--- a/src/components/queryBuilder/FilterEditor.tsx
+++ b/src/components/queryBuilder/FilterEditor.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { SelectableValue } from '@grafana/data';
-import { Button, HorizontalGroup, InlineFormLabel, Input, MultiSelect, RadioButtonGroup, Select } from '@grafana/ui';
+import { Button, InlineFormLabel, Input, MultiSelect, RadioButtonGroup, Select, Stack } from '@grafana/ui';
 import { Filter, FilterOperator, TableColumn, NullFilter } from 'types/queryBuilder';
 import * as utils from 'components/queryBuilder/utils';
 import labels from 'labels';
@@ -392,7 +392,7 @@ export const FilterEditor = (props: {
   };
 
   return (
-    <HorizontalGroup wrap align="flex-start" justify="flex-start">
+    <Stack direction="row" wrap="wrap" alignItems="flex-start" justifyContent="flex-start">
       {index !== 0 && (
         <RadioButtonGroup options={conditions} value={filter.condition} onChange={(e) => onFilterConditionChange(e!)} />
       )}
@@ -444,7 +444,7 @@ export const FilterEditor = (props: {
         onClick={() => removeFilter(index)}
         aria-label="query-builder-filters-remove-button"
       />
-    </HorizontalGroup>
+    </Stack>
   );
 };
 

--- a/src/components/queryBuilder/QueryBuilder.tsx
+++ b/src/components/queryBuilder/QueryBuilder.tsx
@@ -18,7 +18,7 @@ import {
   setTable,
 } from 'hooks/useBuilderOptionsState';
 import TraceIdInput from './TraceIdInput';
-import { Alert, Button, VerticalGroup } from '@grafana/ui';
+import { Alert, Button, Stack } from '@grafana/ui';
 import { Components as allSelectors } from 'selectors';
 import allLabels from 'labels';
 
@@ -142,7 +142,7 @@ const MinimizedQueryViewer = (props: MinimizedQueryBuilder) => {
     <div data-testid="query-editor-minimized-viewer">
       {showConfigWarning && (
         <Alert title="" severity="warning">
-          <VerticalGroup>
+          <Stack direction="column">
             <div>
               {`To enable data linking, enter your default ${configQueryType} configuration in your `}
               <a
@@ -152,14 +152,14 @@ const MinimizedQueryViewer = (props: MinimizedQueryBuilder) => {
                 ClickHouse Data Source settings
               </a>
             </div>
-          </VerticalGroup>
+          </Stack>
         </Alert>
       )}
       {!traceId && (
         <Alert title="" severity="warning">
-          <VerticalGroup>
+          <Stack direction="column">
             <div>Trace ID is empty</div>
-          </VerticalGroup>
+          </Stack>
         </Alert>
       )}
 

--- a/src/components/queryBuilder/views/LogsQueryBuilder.tsx
+++ b/src/components/queryBuilder/views/LogsQueryBuilder.tsx
@@ -12,7 +12,7 @@ import { getColumnByHint } from 'data/sqlGenerator';
 import { columnFilterDateTime, columnFilterString } from 'data/columnFilters';
 import { Datasource } from 'data/CHDatasource';
 import { useBuilderOptionChanges } from 'hooks/useBuilderOptionChanges';
-import { Alert, Button, InlineFormLabel, Input, VerticalGroup } from '@grafana/ui';
+import { Alert, Button, InlineFormLabel, Input, Stack } from '@grafana/ui';
 import useColumns from 'hooks/useColumns';
 import { BuilderOptionsReducerAction, setOptions, setOtelEnabled, setOtelVersion } from 'hooks/useBuilderOptionsState';
 import useIsNewQuery from 'hooks/useIsNewQuery';
@@ -122,7 +122,7 @@ export const LogsQueryBuilder = (props: LogsQueryBuilderProps) => {
 
   const configWarning = showConfigWarning && (
     <Alert title="" severity="warning" buttonContent="Close" onRemove={() => setConfigWarningOpen(false)}>
-      <VerticalGroup>
+      <Stack direction="column">
         <div>
           {'To speed up your query building, enter your default logs configuration in your '}
           <a
@@ -132,7 +132,7 @@ export const LogsQueryBuilder = (props: LogsQueryBuilderProps) => {
             ClickHouse Data Source settings
           </a>
         </div>
-      </VerticalGroup>
+      </Stack>
     </Alert>
   );
 


### PR DESCRIPTION
## Summary

Migrates the remaining `VerticalGroup` / `HorizontalGroup` usages in the query builder layer to `Stack`. The two legacy layout components are deprecated in `@grafana/ui` v12 (the rule already fires four warnings on `main`) and remain in v13 only as wrapping shims; `Stack` is already the canonical layout primitive elsewhere in this repo (`src/views/config-v2/`, `src/components/LogsContextPanel.tsx`, `src/components/QueryToolbox.tsx`).

This is the second small PR in a Grafana 13 readiness chain. The first was [#1861](https://github.com/grafana/clickhouse-datasource/pull/1861) (mechanical removals: `ConfirmModal icon`, `Collapse collapsible`, `Field.values.get`). The two PRs touch disjoint sets of files and can land in either order.

## Why

Two motivations:

1. `Stack` is the only layout primitive that survives in `@grafana/ui` v13 with its current API. Both `VerticalGroup` and `HorizontalGroup` are tagged `@deprecated use Stack component instead` in the Grafana source. Migrating now removes four `@typescript-eslint/no-deprecated` warnings from `main`.
2. The migration is a prop-for-prop rename with verifiable behavioral equivalence (see "Visual parity" below).

## Changes

Five sites across four files. Net diff: 4 files, +14 / -14 lines.

| File | Change | Sites |
|---|---|---|
| `src/components/queryBuilder/views/LogsQueryBuilder.tsx` | Import swap; `<VerticalGroup>` to `<Stack direction="column">` | 1 |
| `src/components/queryBuilder/QueryBuilder.tsx` | Import swap; two `<VerticalGroup>` to `<Stack direction="column">` (minimized viewer config-warning Alert and Trace-ID-empty Alert bodies) | 2 |
| `src/components/queryBuilder/AggregateEditor.tsx` | Import swap; `<HorizontalGroup wrap align="flex-start" justify="flex-start">` to `<Stack direction="row" wrap="wrap" alignItems="flex-start" justifyContent="flex-start">` (aggregate row controls) | 1 |
| `src/components/queryBuilder/FilterEditor.tsx` | Import swap; same `HorizontalGroup` to `Stack` migration (filter row controls) | 1 |

Prop mapping applied at every site:

| `Layout` (HorizontalGroup / VerticalGroup) | `Stack` |
|---|---|
| `<VerticalGroup>` | `<Stack direction="column">` |
| `<HorizontalGroup>` | `<Stack direction="row">` |
| `wrap` (boolean) | `wrap="wrap"` |
| `align="flex-start"` | `alignItems="flex-start"` |
| `justify="flex-start"` | `justifyContent="flex-start"` |

None of the in-scope sites pass a `spacing` prop, so no `gap` translation is needed (see equivalence below).

## Visual parity

The default gap is identical:

- `HorizontalGroup` / `VerticalGroup` default `spacing='sm'`, which maps to `theme.spacing(1)` = 8px.
- `Stack` defaults `gap=1`, which also maps to `theme.spacing(1)` = 8px.

The wrap semantics are identical:

- Legacy `wrap={true}` sets `flex-wrap: wrap` on the container.
- `Stack wrap="wrap"` sets `flex-wrap: wrap` on the container.

The alignment and justification props pass through to `align-items` and `justify-content` unchanged.

The one implementation difference is internal: `Layout` wraps each child in a per-item `<div>` with margins and a `marginBottom` compensation row, while `Stack` uses CSS `gap` directly on the flex container. The visible behavior is the same for the cases this PR touches:

- Three of the five sites (`LogsQueryBuilder`, both in `QueryBuilder`) are single-child wrappers inside an `Alert` body. The gap is invisible there.
- The two `HorizontalGroup wrap` sites (`AggregateEditor`, `FilterEditor`) are sibling-control rows where `flex-wrap` is the behavior that matters; both implementations apply the same `flex-wrap: wrap` rule with the same 8px gap.

## Test plan

- [x] `npm run lint` is green. Four `@typescript-eslint/no-deprecated` warnings for `VerticalGroup` / `HorizontalGroup` go away. Pre-existing `Select` / `MultiSelect` to `Combobox` warnings remain (out of scope; broader migration).
- [x] `npm run typecheck` is green on `@grafana/* @ 12.4.2` (the pinned versions on `main`).
- [x] `npm run typecheck` is green on a transient bump to `@grafana/* @ ^13.0.0`. Verified locally with the two `ConfirmModal icon` errors from #1861 also patched out (so the v13 check exercises Stack on top of PR-A's changes); reverted both verification patches before pushing.
- [x] `npx jest --maxWorkers 2` passes 64 suites / 699 tests on both `@grafana/* @ 12.4.2` and `@grafana/* @ ^13.0.0`. No tests reference `VerticalGroup` or `HorizontalGroup`, so nothing needed updating.
- [ ] Side-by-side Explore pass on Grafana 12.4.2 and Grafana 13.0.1+security-01 with this branch built against the official 4.17.0 plugin. Narrow-viewport screenshots for `AggregateEditor` and `FilterEditor` row-wrap behavior to be added as a comment before merge; happy to capture earlier if a reviewer wants them up front.

Please add the `changelog` label so this surfaces in the next release notes.
