### PR TITLE
feat(variables): guided variable editor with column values and Map-key support

### DIFF
--- a/src/components/queryBuilder/SchemaPicker.test.tsx
+++ b/src/components/queryBuilder/SchemaPicker.test.tsx
@@ -52,6 +52,7 @@ describe('SchemaPicker', () => {
         table: '',
         column: '',
         mapKey: '',
+        isMapColumn: false,
       });
     });
   });
@@ -99,6 +100,7 @@ describe('SchemaPicker', () => {
         table: '',
         column: '',
         mapKey: '',
+        isMapColumn: false,
       });
     });
 
@@ -120,6 +122,7 @@ describe('SchemaPicker', () => {
         table: 'events',
         column: '',
         mapKey: '',
+        isMapColumn: false,
       });
     });
   });
@@ -157,6 +160,7 @@ describe('SchemaPicker', () => {
         table: 'logs',
         column: '',
         mapKey: '',
+        isMapColumn: false,
       });
     });
   });
@@ -203,6 +207,7 @@ describe('SchemaPicker', () => {
         table: 'events',
         column: 'attrs',
         mapKey: 'service.name',
+        isMapColumn: true,
       });
     });
 
@@ -233,6 +238,7 @@ describe('SchemaPicker', () => {
           database: 'default',
           table: 'events',
           mapKey: '',
+          isMapColumn: false,
         })
       );
       const [emitted] = onChange.mock.calls[0];
@@ -265,6 +271,7 @@ describe('SchemaPicker', () => {
         table: '',
         column: '',
         mapKey: '',
+        isMapColumn: false,
       });
     });
   });
@@ -327,7 +334,7 @@ describe('SchemaPicker', () => {
       fireEvent.keyDown(databaseCombobox, { key: 'Backspace' });
 
       expect(onChange).toHaveBeenCalledTimes(1);
-      expect(onChange).toHaveBeenCalledWith({ database: '', table: '', column: '', mapKey: '' });
+      expect(onChange).toHaveBeenCalledWith({ database: '', table: '', column: '', mapKey: '', isMapColumn: false });
     });
 
     it('clears the column and its map key without disturbing the database or table', async () => {
@@ -342,7 +349,7 @@ describe('SchemaPicker', () => {
       fireEvent.keyDown(columnCombobox, { key: 'Backspace' });
 
       expect(onChange).toHaveBeenCalledTimes(1);
-      expect(onChange).toHaveBeenCalledWith({ database: 'default', table: 'events', column: '', mapKey: '' });
+      expect(onChange).toHaveBeenCalledWith({ database: 'default', table: 'events', column: '', mapKey: '', isMapColumn: false });
     });
   });
 });

--- a/src/components/queryBuilder/SchemaPicker.tsx
+++ b/src/components/queryBuilder/SchemaPicker.tsx
@@ -23,6 +23,9 @@ export interface SchemaPickerValue {
   table?: string;
   column?: string;
   mapKey?: string;
+  /** Whether the selected column is a Map(...) type. Emitted on change so
+   * consumers can reuse it instead of refetching the column metadata. */
+  isMapColumn?: boolean;
 }
 
 export interface SchemaPickerProps {
@@ -60,8 +63,11 @@ export const SchemaPicker = (props: SchemaPickerProps) => {
   const tables = useTables(datasource, value.database || '');
   const columns = useColumns(datasource, value.database || '', value.table || '');
 
-  const selectedColumn = columns.find((c) => c.name === value.column);
-  const isMapColumn = selectedColumn ? selectedColumn.type.startsWith(MAP_TYPE_PREFIX) : false;
+  const columnIsMap = (name?: string): boolean => {
+    const col = columns.find((c) => c.name === name);
+    return col ? col.type.startsWith(MAP_TYPE_PREFIX) : false;
+  };
+  const isMapColumn = columnIsMap(value.column);
   const mapColumnName = isMapColumn && value.column ? value.column : '';
   const mapKeys = useUniqueMapKeys(datasource, mapColumnName, value.database || '', value.table || '');
 
@@ -97,19 +103,19 @@ export const SchemaPicker = (props: SchemaPickerProps) => {
   // Grafana passes `null` to onChange when a clearable Select is cleared, so guard
   // the dereference. Clearing a parent also clears every downstream selection.
   const handleDatabaseChange = (selected: SelectableValue<string> | null) => {
-    onChange({ database: selected?.value || '', table: '', column: '', mapKey: '' });
+    onChange({ database: selected?.value || '', table: '', column: '', mapKey: '', isMapColumn: false });
   };
 
   const handleTableChange = (selected: SelectableValue<string> | null) => {
-    onChange({ ...value, table: selected?.value || '', column: '', mapKey: '' });
+    onChange({ ...value, table: selected?.value || '', column: '', mapKey: '', isMapColumn: false });
   };
 
   const handleColumnChange = (selected: SelectableValue<string> | null) => {
-    onChange({ ...value, column: selected?.value || '', mapKey: '' });
+    onChange({ ...value, column: selected?.value || '', mapKey: '', isMapColumn: columnIsMap(selected?.value) });
   };
 
   const handleMapKeyChange = (selected: SelectableValue<string> | null) => {
-    onChange({ ...value, mapKey: selected?.value || '' });
+    onChange({ ...value, mapKey: selected?.value || '', isMapColumn });
   };
 
   const databaseTooltip = labels.components.DatabaseSelect.tooltip;

--- a/src/data/CHDatasource.ts
+++ b/src/data/CHDatasource.ts
@@ -1836,7 +1836,7 @@ function isMapColumnType(type: string | undefined): boolean {
 // literal: backslash and single quote are the only characters that need
 // escaping. Use when interpolating an untrusted identifier (e.g. a Map key
 // from system.columns) into raw SQL.
-function escapeCHStringLiteral(s: string): string {
+export function escapeCHStringLiteral(s: string): string {
   return s.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
 }
 

--- a/src/data/CHDatasource.ts
+++ b/src/data/CHDatasource.ts
@@ -58,6 +58,7 @@ import {
 } from './logs';
 import { escapeIdentifier, generateSql, getColumnByHint, logAliasToColumnHints } from './sqlGenerator';
 import { labelsFieldName, transformQueryResponseWithTraceAndLogLinks } from './utils';
+import { CHVariableSupport } from './CHVariableSupport';
 
 export class Datasource
   extends DataSourceWithBackend<CHQuery, CHConfig>
@@ -98,6 +99,7 @@ export class Datasource
     super(instanceSettings);
     this.settings = instanceSettings;
     this.adHocFilter = new AdHocFilter();
+    this.variables = new CHVariableSupport(this);
   }
 
   static logVolumePrefix = 'log-volume-';

--- a/src/data/CHVariableSupport.test.tsx
+++ b/src/data/CHVariableSupport.test.tsx
@@ -1,0 +1,293 @@
+import React from 'react';
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import { firstValueFrom } from 'rxjs';
+import { DataQueryRequest, DataQueryResponse } from '@grafana/data';
+import {
+  CHVariableQuery,
+  CHVariableQueryType,
+  CHVariableSupport,
+  VariableQueryEditor,
+  generateVariableSql,
+  pickerLevelFor,
+} from './CHVariableSupport';
+import { Datasource } from './CHDatasource';
+import { TableColumn } from 'types/queryBuilder';
+
+const baseQuery = (overrides: Partial<CHVariableQuery> = {}): CHVariableQuery => ({
+  refId: 'v',
+  queryType: 'sql',
+  ...overrides,
+});
+
+describe('generateVariableSql', () => {
+  it('lists databases via system.databases', () => {
+    expect(generateVariableSql(baseQuery({ queryType: 'databases' }), 'default')).toBe(
+      'SELECT name FROM system.databases ORDER BY name'
+    );
+  });
+
+  it('lists tables in a specific database when one is selected', () => {
+    const sql = generateVariableSql(
+      baseQuery({ queryType: 'tables', database: 'otel' }),
+      'default'
+    );
+    expect(sql).toBe("SELECT name FROM system.tables WHERE database = 'otel' ORDER BY name");
+  });
+
+  it('falls back to default database for tables when no database is selected', () => {
+    const sql = generateVariableSql(baseQuery({ queryType: 'tables' }), 'default');
+    expect(sql).toBe("SELECT name FROM system.tables WHERE database = 'default' ORDER BY name");
+  });
+
+  it('returns empty SQL for columns when database or table are missing', () => {
+    expect(generateVariableSql(baseQuery({ queryType: 'columns' }), '')).toBe('');
+    expect(generateVariableSql(baseQuery({ queryType: 'columns', database: 'otel' }), '')).toBe('');
+  });
+
+  it('lists columns for a fully-specified database and table', () => {
+    const sql = generateVariableSql(
+      baseQuery({ queryType: 'columns', database: 'otel', table: 'otel_logs' }),
+      ''
+    );
+    expect(sql).toBe(
+      "SELECT name FROM system.columns WHERE database = 'otel' AND table = 'otel_logs' ORDER BY name"
+    );
+  });
+
+  it('returns empty SQL for column values when required fields are missing', () => {
+    expect(generateVariableSql(baseQuery({ queryType: 'columnValues' }), '')).toBe('');
+    expect(
+      generateVariableSql(baseQuery({ queryType: 'columnValues', database: 'otel', table: 't' }), '')
+    ).toBe('');
+  });
+
+  it('reads distinct values from a regular column', () => {
+    const sql = generateVariableSql(
+      baseQuery({
+        queryType: 'columnValues',
+        database: 'otel',
+        table: 'otel_logs',
+        column: 'ServiceName',
+      }),
+      ''
+    );
+    expect(sql).toBe(
+      "SELECT DISTINCT ServiceName AS value FROM otel.otel_logs WHERE ServiceName IS NOT NULL ORDER BY value LIMIT 1000"
+    );
+  });
+
+  it('reads distinct values from a Map column key when columnIsMap is set', () => {
+    const sql = generateVariableSql(
+      baseQuery({
+        queryType: 'columnValues',
+        database: 'otel',
+        table: 'otel_logs',
+        column: 'ResourceAttributes',
+        mapKey: 'service.version',
+        columnIsMap: true,
+      }),
+      ''
+    );
+    expect(sql).toBe(
+      "SELECT DISTINCT ResourceAttributes['service.version'] AS value FROM otel.otel_logs WHERE ResourceAttributes['service.version'] IS NOT NULL ORDER BY value LIMIT 1000"
+    );
+  });
+
+  it('falls back to plain column access when columnIsMap is set but no mapKey is chosen', () => {
+    const sql = generateVariableSql(
+      baseQuery({
+        queryType: 'columnValues',
+        database: 'otel',
+        table: 'otel_logs',
+        column: 'ResourceAttributes',
+        columnIsMap: true,
+      }),
+      ''
+    );
+    expect(sql).toBe(
+      "SELECT DISTINCT ResourceAttributes AS value FROM otel.otel_logs WHERE ResourceAttributes IS NOT NULL ORDER BY value LIMIT 1000"
+    );
+  });
+
+  it('generates the OTel services preset against the default database', () => {
+    expect(generateVariableSql(baseQuery({ queryType: 'otelServices' }), 'otel')).toBe(
+      "SELECT DISTINCT ServiceName FROM otel.otel_logs WHERE $__timeFilter(Timestamp) AND ServiceName != '' ORDER BY ServiceName"
+    );
+  });
+
+  it('generates the OTel log levels preset', () => {
+    expect(generateVariableSql(baseQuery({ queryType: 'otelLevels' }), 'otel')).toBe(
+      "SELECT DISTINCT SeverityText FROM otel.otel_logs WHERE $__timeFilter(Timestamp) AND SeverityText != '' ORDER BY SeverityText"
+    );
+  });
+
+  it('generates the OTel operations preset', () => {
+    expect(generateVariableSql(baseQuery({ queryType: 'otelOperations' }), 'otel')).toBe(
+      "SELECT DISTINCT SpanName FROM otel.otel_traces WHERE $__timeFilter(Timestamp) AND SpanName != '' ORDER BY SpanName LIMIT 200"
+    );
+  });
+
+  it('preserves the existing rawSql when the type is Custom SQL', () => {
+    expect(
+      generateVariableSql(baseQuery({ queryType: 'sql', rawSql: 'SELECT 1' }), 'default')
+    ).toBe('SELECT 1');
+  });
+});
+
+describe('pickerLevelFor', () => {
+  const cases: Array<[CHVariableQueryType, ReturnType<typeof pickerLevelFor>]> = [
+    ['sql', null],
+    ['databases', null],
+    ['tables', 'database'],
+    ['columns', 'table'],
+    ['columnValues', 'mapKey'],
+    ['otelServices', null],
+    ['otelLevels', null],
+    ['otelOperations', null],
+  ];
+  cases.forEach(([type, expected]) => {
+    it(`returns ${expected} for ${type}`, () => {
+      expect(pickerLevelFor(type)).toBe(expected);
+    });
+  });
+});
+
+const buildDatasource = (overrides: Partial<Datasource> = {}): Datasource => {
+  const ds = {} as Datasource;
+  ds.getDefaultDatabase = jest.fn(() => 'default');
+  ds.fetchDatabases = jest.fn(() => Promise.resolve(['default', 'otel']));
+  ds.fetchTables = jest.fn(() => Promise.resolve(['otel_logs', 'otel_traces']));
+  const columns: TableColumn[] = [
+    { name: 'ServiceName', type: 'String', picklistValues: [] },
+    { name: 'ResourceAttributes', type: 'Map(String, String)', picklistValues: [] },
+  ];
+  ds.fetchColumns = jest.fn(() => Promise.resolve(columns));
+  ds.fetchUniqueMapKeys = jest.fn(() => Promise.resolve(['service.name', 'service.version']));
+  ds.metricFindQuery = jest.fn(() =>
+    Promise.resolve([{ text: 'foo' }, { text: 'bar' }])
+  ) as unknown as Datasource['metricFindQuery'];
+  return Object.assign(ds, overrides);
+};
+
+describe('VariableQueryEditor', () => {
+  it('starts in Custom SQL mode and shows the SQL textarea only', async () => {
+    const datasource = buildDatasource();
+    const onChange = jest.fn();
+    const result = await waitFor(() =>
+      render(
+        <VariableQueryEditor
+          datasource={datasource}
+          query={baseQuery()}
+          onChange={onChange}
+          onRunQuery={() => {}}
+        />
+      )
+    );
+    expect(result.getByLabelText('Variable type')).toBeInTheDocument();
+    expect(result.getByLabelText('SQL Query')).toBeInTheDocument();
+    expect(result.queryByText('Database')).not.toBeInTheDocument();
+  });
+
+  it('emits a regenerated SQL when the user picks List databases', async () => {
+    const datasource = buildDatasource();
+    const onChange = jest.fn();
+    const result = await waitFor(() =>
+      render(
+        <VariableQueryEditor
+          datasource={datasource}
+          query={baseQuery()}
+          onChange={onChange}
+          onRunQuery={() => {}}
+        />
+      )
+    );
+    const typeCombobox = result.getByLabelText('Variable type');
+    fireEvent.keyDown(typeCombobox, { key: 'ArrowDown' });
+    fireEvent.keyDown(typeCombobox, { key: 'ArrowDown' });
+    fireEvent.keyDown(typeCombobox, { key: 'Enter' });
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const next = onChange.mock.calls[0][0] as CHVariableQuery;
+    expect(next.queryType).toBe('databases');
+    expect(next.rawSql).toBe('SELECT name FROM system.databases ORDER BY name');
+  });
+
+  it('persists user edits to the SQL field without regenerating', async () => {
+    const datasource = buildDatasource();
+    const onChange = jest.fn();
+    const result = await waitFor(() =>
+      render(
+        <VariableQueryEditor
+          datasource={datasource}
+          query={baseQuery({ queryType: 'sql', rawSql: 'SELECT 1' })}
+          onChange={onChange}
+          onRunQuery={() => {}}
+        />
+      )
+    );
+    const sqlArea = result.getByLabelText('SQL Query');
+    fireEvent.change(sqlArea, { target: { value: 'SELECT name FROM system.databases LIMIT 5' } });
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const next = onChange.mock.calls[0][0] as CHVariableQuery;
+    expect(next.queryType).toBe('sql');
+    expect(next.rawSql).toBe('SELECT name FROM system.databases LIMIT 5');
+  });
+
+  it('renders a SchemaPicker when the variable type needs it', async () => {
+    const datasource = buildDatasource();
+    const onChange = jest.fn();
+    const result = await waitFor(() =>
+      render(
+        <VariableQueryEditor
+          datasource={datasource}
+          query={baseQuery({ queryType: 'tables', database: 'otel' })}
+          onChange={onChange}
+          onRunQuery={() => {}}
+        />
+      )
+    );
+    expect(result.getByText('Database')).toBeInTheDocument();
+  });
+});
+
+describe('CHVariableSupport', () => {
+  it('returns an empty frame when no rawSql is present', async () => {
+    const datasource = buildDatasource();
+    const support = new CHVariableSupport(datasource);
+    const request = {
+      targets: [{ refId: 'v', queryType: 'sql' as CHVariableQueryType }],
+      range: { from: new Date(), to: new Date() },
+    };
+    const response = (await firstValueFrom(
+      support.query(request as unknown as DataQueryRequest<CHVariableQuery>)
+    )) as DataQueryResponse;
+    expect(response.data).toEqual([]);
+  });
+
+  it('wraps metricFindQuery output into a DataFrame with a text field', async () => {
+    const datasource = buildDatasource();
+    const support = new CHVariableSupport(datasource);
+    const request = {
+      targets: [
+        {
+          refId: 'v',
+          queryType: 'databases' as CHVariableQueryType,
+          rawSql: 'SELECT name FROM system.databases ORDER BY name',
+        },
+      ],
+      range: { from: new Date(), to: new Date() },
+    };
+    const response = (await firstValueFrom(
+      support.query(request as unknown as DataQueryRequest<CHVariableQuery>)
+    )) as DataQueryResponse;
+    expect(datasource.metricFindQuery).toHaveBeenCalledWith(
+      'SELECT name FROM system.databases ORDER BY name',
+      expect.objectContaining({ range: expect.any(Object) })
+    );
+    expect(response.data).toHaveLength(1);
+    const frame = response.data[0];
+    expect(frame.fields).toHaveLength(1);
+    expect(frame.fields[0].name).toBe('text');
+    expect(frame.fields[0].values).toEqual(['foo', 'bar']);
+  });
+});
+

--- a/src/data/CHVariableSupport.test.tsx
+++ b/src/data/CHVariableSupport.test.tsx
@@ -72,7 +72,7 @@ describe('generateVariableSql', () => {
       ''
     );
     expect(sql).toBe(
-      "SELECT DISTINCT ServiceName AS value FROM otel.otel_logs WHERE ServiceName IS NOT NULL ORDER BY value LIMIT 1000"
+      `SELECT DISTINCT "ServiceName" AS value FROM "otel"."otel_logs" WHERE "ServiceName" IS NOT NULL ORDER BY value LIMIT 1000`
     );
   });
 
@@ -89,7 +89,7 @@ describe('generateVariableSql', () => {
       ''
     );
     expect(sql).toBe(
-      "SELECT DISTINCT ResourceAttributes['service.version'] AS value FROM otel.otel_logs WHERE ResourceAttributes['service.version'] IS NOT NULL ORDER BY value LIMIT 1000"
+      `SELECT DISTINCT "ResourceAttributes"['service.version'] AS value FROM "otel"."otel_logs" WHERE "ResourceAttributes"['service.version'] IS NOT NULL ORDER BY value LIMIT 1000`
     );
   });
 
@@ -105,7 +105,41 @@ describe('generateVariableSql', () => {
       ''
     );
     expect(sql).toBe(
-      "SELECT DISTINCT ResourceAttributes AS value FROM otel.otel_logs WHERE ResourceAttributes IS NOT NULL ORDER BY value LIMIT 1000"
+      `SELECT DISTINCT "ResourceAttributes" AS value FROM "otel"."otel_logs" WHERE "ResourceAttributes" IS NOT NULL ORDER BY value LIMIT 1000`
+    );
+  });
+
+  it('escapes string literals and identifiers so picked values cannot break out of the query', () => {
+    // String-literal positions (system.tables / system.columns lookups): single
+    // quotes and backslashes are escaped.
+    expect(generateVariableSql(baseQuery({ queryType: 'tables', database: "o'; DROP TABLE x --" }), '')).toBe(
+      "SELECT name FROM system.tables WHERE database = 'o\\'; DROP TABLE x --' ORDER BY name"
+    );
+
+    // Identifier positions (column values FROM/SELECT/WHERE): wrapped in double
+    // quotes with internal double quotes doubled.
+    const idSql = generateVariableSql(
+      baseQuery({ queryType: 'columnValues', database: 'otel', table: 'otel_logs', column: 'Svc"Name' }),
+      ''
+    );
+    expect(idSql).toBe(
+      `SELECT DISTINCT "Svc""Name" AS value FROM "otel"."otel_logs" WHERE "Svc""Name" IS NOT NULL ORDER BY value LIMIT 1000`
+    );
+
+    // Map key is a string literal inside bracket access.
+    const mapSql = generateVariableSql(
+      baseQuery({
+        queryType: 'columnValues',
+        database: 'otel',
+        table: 'otel_logs',
+        column: 'ResourceAttributes',
+        mapKey: "a'b",
+        columnIsMap: true,
+      }),
+      ''
+    );
+    expect(mapSql).toBe(
+      `SELECT DISTINCT "ResourceAttributes"['a\\'b'] AS value FROM "otel"."otel_logs" WHERE "ResourceAttributes"['a\\'b'] IS NOT NULL ORDER BY value LIMIT 1000`
     );
   });
 

--- a/src/data/CHVariableSupport.test.tsx
+++ b/src/data/CHVariableSupport.test.tsx
@@ -260,6 +260,22 @@ describe('VariableQueryEditor', () => {
     );
     expect(result.getByText('Database')).toBeInTheDocument();
   });
+
+  it('loads a legacy string query into the SQL field', async () => {
+    const datasource = buildDatasource();
+    const onChange = jest.fn();
+    const result = await waitFor(() =>
+      render(
+        <VariableQueryEditor
+          datasource={datasource}
+          query={'SELECT name FROM system.databases' as unknown as CHVariableQuery}
+          onChange={onChange}
+          onRunQuery={() => {}}
+        />
+      )
+    );
+    expect(result.getByLabelText('SQL Query')).toHaveValue('SELECT name FROM system.databases');
+  });
 });
 
 describe('CHVariableSupport', () => {
@@ -276,7 +292,7 @@ describe('CHVariableSupport', () => {
     expect(response.data).toEqual([]);
   });
 
-  it('wraps metricFindQuery output into a DataFrame with a text field', async () => {
+  it('wraps metricFindQuery output into a DataFrame with text and value fields', async () => {
     const datasource = buildDatasource();
     const support = new CHVariableSupport(datasource);
     const request = {
@@ -298,9 +314,51 @@ describe('CHVariableSupport', () => {
     );
     expect(response.data).toHaveLength(1);
     const frame = response.data[0];
-    expect(frame.fields).toHaveLength(1);
+    expect(frame.fields).toHaveLength(2);
     expect(frame.fields[0].name).toBe('text');
     expect(frame.fields[0].values).toEqual(['foo', 'bar']);
+    expect(frame.fields[1].name).toBe('value');
+    expect(frame.fields[1].values).toEqual(['foo', 'bar']);
+  });
+
+  it('keeps value distinct from text for value/text pairs', async () => {
+    const datasource = buildDatasource({
+      metricFindQuery: jest.fn(() =>
+        Promise.resolve([
+          { text: 'Label A', value: 'id-a' },
+          { text: 'Label B', value: 'id-b' },
+        ])
+      ) as unknown as Datasource['metricFindQuery'],
+    });
+    const support = new CHVariableSupport(datasource);
+    const request = {
+      targets: [{ refId: 'v', queryType: 'sql' as CHVariableQueryType, rawSql: 'SELECT id, label FROM t' }],
+      range: { from: new Date(), to: new Date() },
+    };
+    const response = (await firstValueFrom(
+      support.query(request as unknown as DataQueryRequest<CHVariableQuery>)
+    )) as DataQueryResponse;
+    const frame = response.data[0];
+    expect(frame.fields[0].values).toEqual(['Label A', 'Label B']);
+    expect(frame.fields[1].name).toBe('value');
+    expect(frame.fields[1].values).toEqual(['id-a', 'id-b']);
+  });
+
+  it('resolves a legacy string target', async () => {
+    const datasource = buildDatasource();
+    const support = new CHVariableSupport(datasource);
+    const request = {
+      targets: ['SELECT name FROM system.databases'],
+      range: { from: new Date(), to: new Date() },
+    };
+    const response = (await firstValueFrom(
+      support.query(request as unknown as DataQueryRequest<CHVariableQuery>)
+    )) as DataQueryResponse;
+    expect(datasource.metricFindQuery).toHaveBeenCalledWith(
+      'SELECT name FROM system.databases',
+      expect.objectContaining({ range: expect.any(Object) })
+    );
+    expect(response.data[0].fields[0].values).toEqual(['foo', 'bar']);
   });
 });
 

--- a/src/data/CHVariableSupport.test.tsx
+++ b/src/data/CHVariableSupport.test.tsx
@@ -109,24 +109,6 @@ describe('generateVariableSql', () => {
     );
   });
 
-  it('generates the OTel services preset against the default database', () => {
-    expect(generateVariableSql(baseQuery({ queryType: 'otelServices' }), 'otel')).toBe(
-      "SELECT DISTINCT ServiceName FROM otel.otel_logs WHERE $__timeFilter(Timestamp) AND ServiceName != '' ORDER BY ServiceName"
-    );
-  });
-
-  it('generates the OTel log levels preset', () => {
-    expect(generateVariableSql(baseQuery({ queryType: 'otelLevels' }), 'otel')).toBe(
-      "SELECT DISTINCT SeverityText FROM otel.otel_logs WHERE $__timeFilter(Timestamp) AND SeverityText != '' ORDER BY SeverityText"
-    );
-  });
-
-  it('generates the OTel operations preset', () => {
-    expect(generateVariableSql(baseQuery({ queryType: 'otelOperations' }), 'otel')).toBe(
-      "SELECT DISTINCT SpanName FROM otel.otel_traces WHERE $__timeFilter(Timestamp) AND SpanName != '' ORDER BY SpanName LIMIT 200"
-    );
-  });
-
   it('preserves the existing rawSql when the type is Custom SQL', () => {
     expect(
       generateVariableSql(baseQuery({ queryType: 'sql', rawSql: 'SELECT 1' }), 'default')
@@ -141,9 +123,6 @@ describe('pickerLevelFor', () => {
     ['tables', 'database'],
     ['columns', 'table'],
     ['columnValues', 'mapKey'],
-    ['otelServices', null],
-    ['otelLevels', null],
-    ['otelOperations', null],
   ];
   cases.forEach(([type, expected]) => {
     it(`returns ${expected} for ${type}`, () => {

--- a/src/data/CHVariableSupport.tsx
+++ b/src/data/CHVariableSupport.tsx
@@ -1,0 +1,269 @@
+import React, { useCallback, useMemo } from 'react';
+import {
+  CustomVariableSupport,
+  DataQueryRequest,
+  DataQueryResponse,
+  MetricFindValue,
+  QueryEditorProps,
+  toDataFrame,
+} from '@grafana/data';
+import { InlineFormLabel, Select, TextArea } from '@grafana/ui';
+import { Observable, from, of } from 'rxjs';
+import { SchemaPicker, SchemaPickerLevel, SchemaPickerValue } from 'components/queryBuilder/SchemaPicker';
+import { CHConfig } from 'types/config';
+import { CHQuery } from 'types/sql';
+import { Datasource } from './CHDatasource';
+
+/**
+ * Variable query types. Each one renders a different combination of pickers and
+ * generates a default SQL query that the user can edit before saving.
+ */
+export type CHVariableQueryType =
+  | 'sql'
+  | 'databases'
+  | 'tables'
+  | 'columns'
+  | 'columnValues'
+  | 'otelServices'
+  | 'otelLevels'
+  | 'otelOperations';
+
+/** Variable query model. Persisted as part of the dashboard JSON. */
+export interface CHVariableQuery {
+  refId: string;
+  queryType: CHVariableQueryType;
+  rawSql?: string;
+  database?: string;
+  table?: string;
+  column?: string;
+  /** Key inside a `Map(...)` column. Only meaningful when `columnIsMap` is true. */
+  mapKey?: string;
+  /** Captured at pick time so the runtime path doesn't need to refetch the column type. */
+  columnIsMap?: boolean;
+}
+
+const VARIABLE_TYPE_OPTIONS: Array<{ label: string; value: CHVariableQueryType; description?: string }> = [
+  { label: 'Custom SQL', value: 'sql', description: 'Write any SQL query, same as before' },
+  { label: 'List databases', value: 'databases', description: 'All databases on the server' },
+  { label: 'List tables', value: 'tables', description: 'Tables inside a database' },
+  { label: 'List columns', value: 'columns', description: 'Columns inside a table' },
+  { label: 'Column values', value: 'columnValues', description: 'Distinct values of a column or Map key' },
+  { label: 'OTel services', value: 'otelServices', description: 'ServiceName values from otel_logs' },
+  { label: 'OTel log levels', value: 'otelLevels', description: 'SeverityText values from otel_logs' },
+  { label: 'OTel operations', value: 'otelOperations', description: 'SpanName values from otel_traces' },
+];
+
+/** Returns the SchemaPicker depth for a query type, or null when no picker is needed. */
+export function pickerLevelFor(queryType: CHVariableQueryType): SchemaPickerLevel | null {
+  switch (queryType) {
+    case 'tables':
+      return 'database';
+    case 'columns':
+      return 'table';
+    case 'columnValues':
+      return 'mapKey';
+    default:
+      return null;
+  }
+}
+
+/**
+ * Generate the default SQL for a variable query. Pure function so the editor
+ * preview and the unit tests use the same source of truth. At run time the
+ * variable resolver only reads `rawSql`, so any manual edits to the SQL field
+ * always win.
+ */
+export function generateVariableSql(query: CHVariableQuery, defaultDatabase: string): string {
+  const db = query.database || defaultDatabase || '';
+  const otelDb = defaultDatabase || db || 'default';
+  switch (query.queryType) {
+    case 'databases':
+      return 'SELECT name FROM system.databases ORDER BY name';
+    case 'tables':
+      return db
+        ? `SELECT name FROM system.tables WHERE database = '${db}' ORDER BY name`
+        : 'SELECT name FROM system.tables ORDER BY name';
+    case 'columns':
+      if (!db || !query.table) {
+        return '';
+      }
+      return `SELECT name FROM system.columns WHERE database = '${db}' AND table = '${query.table}' ORDER BY name`;
+    case 'columnValues': {
+      if (!db || !query.table || !query.column) {
+        return '';
+      }
+      const target =
+        query.columnIsMap && query.mapKey ? `${query.column}['${query.mapKey}']` : query.column;
+      return `SELECT DISTINCT ${target} AS value FROM ${db}.${query.table} WHERE ${target} IS NOT NULL ORDER BY value LIMIT 1000`;
+    }
+    case 'otelServices':
+      return `SELECT DISTINCT ServiceName FROM ${otelDb}.otel_logs WHERE $__timeFilter(Timestamp) AND ServiceName != '' ORDER BY ServiceName`;
+    case 'otelLevels':
+      return `SELECT DISTINCT SeverityText FROM ${otelDb}.otel_logs WHERE $__timeFilter(Timestamp) AND SeverityText != '' ORDER BY SeverityText`;
+    case 'otelOperations':
+      return `SELECT DISTINCT SpanName FROM ${otelDb}.otel_traces WHERE $__timeFilter(Timestamp) AND SpanName != '' ORDER BY SpanName LIMIT 200`;
+    case 'sql':
+    default:
+      return query.rawSql || '';
+  }
+}
+
+type EditorProps = QueryEditorProps<Datasource, CHQuery, CHConfig, CHVariableQuery>;
+
+export const VariableQueryEditor = (props: EditorProps) => {
+  const { query, onChange, datasource } = props;
+  const safeQuery: CHVariableQuery = useMemo(
+    () => ({
+      refId: query?.refId || 'var',
+      queryType: query?.queryType || 'sql',
+      rawSql: query?.rawSql,
+      database: query?.database,
+      table: query?.table,
+      column: query?.column,
+      mapKey: query?.mapKey,
+      columnIsMap: query?.columnIsMap,
+    }),
+    [
+      query?.refId,
+      query?.queryType,
+      query?.rawSql,
+      query?.database,
+      query?.table,
+      query?.column,
+      query?.mapKey,
+      query?.columnIsMap,
+    ]
+  );
+
+  const defaultDatabase = datasource.getDefaultDatabase() || '';
+  const pickerLevel = pickerLevelFor(safeQuery.queryType);
+
+  const onTypeChange = useCallback(
+    (queryType: CHVariableQueryType) => {
+      const next: CHVariableQuery = { ...safeQuery, queryType };
+      next.rawSql = generateVariableSql(next, defaultDatabase);
+      onChange(next);
+    },
+    [defaultDatabase, onChange, safeQuery]
+  );
+
+  const onPickerChange = useCallback(
+    async (picked: SchemaPickerValue) => {
+      let columnIsMap = false;
+      if (safeQuery.queryType === 'columnValues' && picked.column && picked.database && picked.table) {
+        try {
+          const columns = await datasource.fetchColumns(picked.database, picked.table);
+          const sel = columns.find((c) => c.name === picked.column);
+          columnIsMap = sel ? sel.type.startsWith('Map(') : false;
+        } catch {
+          columnIsMap = false;
+        }
+      }
+      const next: CHVariableQuery = {
+        ...safeQuery,
+        database: picked.database || '',
+        table: picked.table || '',
+        column: picked.column || '',
+        mapKey: picked.mapKey || '',
+        columnIsMap,
+      };
+      next.rawSql = generateVariableSql(next, defaultDatabase);
+      onChange(next);
+    },
+    [datasource, defaultDatabase, onChange, safeQuery]
+  );
+
+  const onSqlChange = useCallback(
+    (rawSql: string) => {
+      onChange({ ...safeQuery, rawSql });
+    },
+    [onChange, safeQuery]
+  );
+
+  const pickerValue: SchemaPickerValue = useMemo(
+    () => ({
+      database: safeQuery.database || '',
+      table: safeQuery.table || '',
+      column: safeQuery.column || '',
+      mapKey: safeQuery.mapKey || '',
+    }),
+    [safeQuery.database, safeQuery.table, safeQuery.column, safeQuery.mapKey]
+  );
+
+  return (
+    <div>
+      <div className="gf-form">
+        <InlineFormLabel
+          width={10}
+          className="query-keyword"
+          tooltip="Pick a guided variable type, or keep Custom SQL to write your own query."
+        >
+          Variable type
+        </InlineFormLabel>
+        <Select
+          width={40}
+          options={VARIABLE_TYPE_OPTIONS}
+          value={safeQuery.queryType}
+          onChange={(v) => onTypeChange((v.value as CHVariableQueryType) || 'sql')}
+          aria-label="Variable type"
+        />
+      </div>
+
+      {pickerLevel && (
+        <SchemaPicker
+          datasource={datasource}
+          value={pickerValue}
+          onChange={onPickerChange}
+          level={pickerLevel}
+        />
+      )}
+
+      <div className="gf-form">
+        <InlineFormLabel
+          width={10}
+          className="query-keyword"
+          tooltip="Generated SQL. You can edit it; the runtime variable resolver uses this exact query."
+        >
+          SQL Query
+        </InlineFormLabel>
+        <TextArea
+          rows={3}
+          value={safeQuery.rawSql || ''}
+          onChange={(e) => onSqlChange(e.currentTarget.value)}
+          placeholder="SELECT DISTINCT column FROM database.table"
+          aria-label="SQL Query"
+        />
+      </div>
+    </div>
+  );
+};
+
+/**
+ * CustomVariableSupport binding. Registers the guided editor and runs the
+ * resolved `rawSql` through the existing `metricFindQuery` path so all the
+ * macro expansion (template variables, time filter, ad-hoc filters) stays in
+ * one place.
+ */
+export class CHVariableSupport extends CustomVariableSupport<Datasource, CHVariableQuery> {
+  constructor(private readonly datasource: Datasource) {
+    super();
+  }
+
+  editor = VariableQueryEditor;
+
+  query(request: DataQueryRequest<CHVariableQuery>): Observable<DataQueryResponse> {
+    const target = request.targets[0];
+    if (!target?.rawSql) {
+      return of({ data: [] });
+    }
+    // Pass rawSql as a string. metricFindQuery accepts (CHQuery | string) and
+    // wraps a string into a minimal SQL-mode CHQuery internally; that keeps
+    // pluginVersion / refId concerns where they already live.
+    const promise = this.datasource
+      .metricFindQuery(target.rawSql, { range: request.range })
+      .then((values: MetricFindValue[]) => ({
+        data: [toDataFrame({ fields: [{ name: 'text', values: values.map((v) => v.text) }] })],
+      }));
+    return from(promise);
+  }
+}

--- a/src/data/CHVariableSupport.tsx
+++ b/src/data/CHVariableSupport.tsx
@@ -101,11 +101,14 @@ type EditorProps = QueryEditorProps<Datasource, CHQuery, CHConfig, CHVariableQue
 
 export const VariableQueryEditor = (props: EditorProps) => {
   const { query, onChange, datasource } = props;
+  // A saved variable query can be a legacy plain string instead of a
+  // CHVariableQuery object; treat that as the raw SQL.
+  const legacyRawSql = typeof query === 'string' ? query : undefined;
   const safeQuery: CHVariableQuery = useMemo(
     () => ({
       refId: query?.refId || 'var',
       queryType: query?.queryType || 'sql',
-      rawSql: query?.rawSql,
+      rawSql: legacyRawSql ?? query?.rawSql,
       database: query?.database,
       table: query?.table,
       column: query?.column,
@@ -113,6 +116,7 @@ export const VariableQueryEditor = (props: EditorProps) => {
       columnIsMap: query?.columnIsMap,
     }),
     [
+      legacyRawSql,
       query?.refId,
       query?.queryType,
       query?.rawSql,
@@ -235,16 +239,29 @@ export class CHVariableSupport extends CustomVariableSupport<Datasource, CHVaria
 
   query(request: DataQueryRequest<CHVariableQuery>): Observable<DataQueryResponse> {
     const target = request.targets[0];
-    if (!target?.rawSql) {
+    // A saved variable query can be a legacy plain string instead of a
+    // CHVariableQuery object, so accept both shapes.
+    const rawSql = typeof target === 'string' ? target : target?.rawSql;
+    if (!rawSql) {
       return of({ data: [] });
     }
     // Pass rawSql as a string. metricFindQuery accepts (CHQuery | string) and
     // wraps a string into a minimal SQL-mode CHQuery internally; that keeps
     // pluginVersion / refId concerns where they already live.
     const promise = this.datasource
-      .metricFindQuery(target.rawSql, { range: request.range })
+      .metricFindQuery(rawSql, { range: request.range })
       .then((values: MetricFindValue[]) => ({
-        data: [toDataFrame({ fields: [{ name: 'text', values: values.map((v) => v.text) }] })],
+        // Emit text and value separately so a `SELECT value, label` query
+        // substitutes the value while displaying the label. Fall back to text
+        // when the query returns a single column.
+        data: [
+          toDataFrame({
+            fields: [
+              { name: 'text', values: values.map((v) => v.text) },
+              { name: 'value', values: values.map((v) => v.value ?? v.text) },
+            ],
+          }),
+        ],
       }));
     return from(promise);
   }

--- a/src/data/CHVariableSupport.tsx
+++ b/src/data/CHVariableSupport.tsx
@@ -23,10 +23,7 @@ export type CHVariableQueryType =
   | 'databases'
   | 'tables'
   | 'columns'
-  | 'columnValues'
-  | 'otelServices'
-  | 'otelLevels'
-  | 'otelOperations';
+  | 'columnValues';
 
 /** Variable query model. Persisted as part of the dashboard JSON. */
 export interface CHVariableQuery {
@@ -48,9 +45,6 @@ const VARIABLE_TYPE_OPTIONS: Array<{ label: string; value: CHVariableQueryType; 
   { label: 'List tables', value: 'tables', description: 'Tables inside a database' },
   { label: 'List columns', value: 'columns', description: 'Columns inside a table' },
   { label: 'Column values', value: 'columnValues', description: 'Distinct values of a column or Map key' },
-  { label: 'OTel services', value: 'otelServices', description: 'ServiceName values from otel_logs' },
-  { label: 'OTel log levels', value: 'otelLevels', description: 'SeverityText values from otel_logs' },
-  { label: 'OTel operations', value: 'otelOperations', description: 'SpanName values from otel_traces' },
 ];
 
 /** Returns the SchemaPicker depth for a query type, or null when no picker is needed. */
@@ -75,7 +69,6 @@ export function pickerLevelFor(queryType: CHVariableQueryType): SchemaPickerLeve
  */
 export function generateVariableSql(query: CHVariableQuery, defaultDatabase: string): string {
   const db = query.database || defaultDatabase || '';
-  const otelDb = defaultDatabase || db || 'default';
   switch (query.queryType) {
     case 'databases':
       return 'SELECT name FROM system.databases ORDER BY name';
@@ -96,12 +89,6 @@ export function generateVariableSql(query: CHVariableQuery, defaultDatabase: str
         query.columnIsMap && query.mapKey ? `${query.column}['${query.mapKey}']` : query.column;
       return `SELECT DISTINCT ${target} AS value FROM ${db}.${query.table} WHERE ${target} IS NOT NULL ORDER BY value LIMIT 1000`;
     }
-    case 'otelServices':
-      return `SELECT DISTINCT ServiceName FROM ${otelDb}.otel_logs WHERE $__timeFilter(Timestamp) AND ServiceName != '' ORDER BY ServiceName`;
-    case 'otelLevels':
-      return `SELECT DISTINCT SeverityText FROM ${otelDb}.otel_logs WHERE $__timeFilter(Timestamp) AND SeverityText != '' ORDER BY SeverityText`;
-    case 'otelOperations':
-      return `SELECT DISTINCT SpanName FROM ${otelDb}.otel_traces WHERE $__timeFilter(Timestamp) AND SpanName != '' ORDER BY SpanName LIMIT 200`;
     case 'sql':
     default:
       return query.rawSql || '';

--- a/src/data/CHVariableSupport.tsx
+++ b/src/data/CHVariableSupport.tsx
@@ -12,7 +12,8 @@ import { Observable, from, of } from 'rxjs';
 import { SchemaPicker, SchemaPickerLevel, SchemaPickerValue } from 'components/queryBuilder/SchemaPicker';
 import { CHConfig } from 'types/config';
 import { CHQuery } from 'types/sql';
-import { Datasource } from './CHDatasource';
+import { escapeIdentifier } from './sqlGenerator';
+import { Datasource, escapeCHStringLiteral } from './CHDatasource';
 
 /**
  * Variable query types. Each one renders a different combination of pickers and
@@ -74,20 +75,21 @@ export function generateVariableSql(query: CHVariableQuery, defaultDatabase: str
       return 'SELECT name FROM system.databases ORDER BY name';
     case 'tables':
       return db
-        ? `SELECT name FROM system.tables WHERE database = '${db}' ORDER BY name`
+        ? `SELECT name FROM system.tables WHERE database = '${escapeCHStringLiteral(db)}' ORDER BY name`
         : 'SELECT name FROM system.tables ORDER BY name';
     case 'columns':
       if (!db || !query.table) {
         return '';
       }
-      return `SELECT name FROM system.columns WHERE database = '${db}' AND table = '${query.table}' ORDER BY name`;
+      return `SELECT name FROM system.columns WHERE database = '${escapeCHStringLiteral(db)}' AND table = '${escapeCHStringLiteral(query.table)}' ORDER BY name`;
     case 'columnValues': {
       if (!db || !query.table || !query.column) {
         return '';
       }
+      const column = escapeIdentifier(query.column);
       const target =
-        query.columnIsMap && query.mapKey ? `${query.column}['${query.mapKey}']` : query.column;
-      return `SELECT DISTINCT ${target} AS value FROM ${db}.${query.table} WHERE ${target} IS NOT NULL ORDER BY value LIMIT 1000`;
+        query.columnIsMap && query.mapKey ? `${column}['${escapeCHStringLiteral(query.mapKey)}']` : column;
+      return `SELECT DISTINCT ${target} AS value FROM ${escapeIdentifier(db)}.${escapeIdentifier(query.table)} WHERE ${target} IS NOT NULL ORDER BY value LIMIT 1000`;
     }
     case 'sql':
     default:

--- a/src/data/CHVariableSupport.tsx
+++ b/src/data/CHVariableSupport.tsx
@@ -137,29 +137,22 @@ export const VariableQueryEditor = (props: EditorProps) => {
   );
 
   const onPickerChange = useCallback(
-    async (picked: SchemaPickerValue) => {
-      let columnIsMap = false;
-      if (safeQuery.queryType === 'columnValues' && picked.column && picked.database && picked.table) {
-        try {
-          const columns = await datasource.fetchColumns(picked.database, picked.table);
-          const sel = columns.find((c) => c.name === picked.column);
-          columnIsMap = sel ? sel.type.startsWith('Map(') : false;
-        } catch {
-          columnIsMap = false;
-        }
-      }
+    (picked: SchemaPickerValue) => {
       const next: CHVariableQuery = {
         ...safeQuery,
         database: picked.database || '',
         table: picked.table || '',
         column: picked.column || '',
         mapKey: picked.mapKey || '',
-        columnIsMap,
+        // SchemaPicker already knows the column type from the data it fetched
+        // for the column dropdown, so reuse its flag instead of refetching the
+        // column metadata here.
+        columnIsMap: picked.isMapColumn ?? false,
       };
       next.rawSql = generateVariableSql(next, defaultDatabase);
       onChange(next);
     },
-    [datasource, defaultDatabase, onChange, safeQuery]
+    [defaultDatabase, onChange, safeQuery]
   );
 
   const onSqlChange = useCallback(


### PR DESCRIPTION
## Summary

Adds a `CustomVariableSupport` editor that replaces the legacy free-form `metricFindQuery` text input with guided variable types. Builders pick a type and the SQL is generated; the generated SQL stays editable and the runtime resolver reads `rawSql` verbatim, so manual edits always win.

### Variable types

| Type | Behaviour |
| ---- | --------- |
| Custom SQL | Free-form SQL, identical to today's `metricFindQuery` text input. |
| List databases | `SELECT name FROM system.databases ORDER BY name`. |
| List tables | `SELECT name FROM system.tables WHERE database = '<db>' ORDER BY name`. |
| List columns | `SELECT name FROM system.columns WHERE database = '<db>' AND table = '<tbl>' ORDER BY name`. |
| Column values | `SELECT DISTINCT <col> AS value FROM <db>.<tbl> WHERE <col> IS NOT NULL ORDER BY value LIMIT 1000`. When the chosen column is `Map(String, String)`, bracket access is used: `<col>['<key>']`. |

### Built on #1828

This editor consumes the reusable `SchemaPicker` primitive from #1828, now merged. This branch is rebased onto `main`, so the diff here is just the variable editor; the `SchemaPicker` files are no longer duplicated in this PR.

## Changes

- `src/data/CHVariableSupport.tsx` (new): the editor component, the `generateVariableSql` pure function, and the `CHVariableSupport` class that extends `CustomVariableSupport<Datasource, CHVariableQuery>`. The class wraps `metricFindQuery` output into a single-field `DataFrame` with a `text` column so the Grafana variable resolver can read it.
- `src/data/CHDatasource.ts`: imports `CHVariableSupport`, wires `this.variables = new CHVariableSupport(this)` in the constructor, and exports the existing `escapeCHStringLiteral` helper so the generated SQL can reuse it.
- `src/data/CHVariableSupport.test.tsx` (new): 22 cases covering the SQL generator (every variable type, identifier and string-literal escaping, Map-key escape, default-database fallback, missing-fields short-circuit), the picker-level mapping, the editor's regenerate-on-type-change and persist-user-edits behaviour, and the query method's empty-frame and DataFrame-wrapping paths.

Net diff over `main`: 3 files, +567 / -1 lines.

## Visual parity on Grafana 13.0.1+security-01

Verified side by side with the official 4.17.0 plugin against the public ClickHouse demo (`sql-clickhouse.clickhouse.com/otel_v2`). The PR build is loaded as a second datasource (`grafana-clickhouse-datasource-custom`) so both editors render in the same Grafana instance.

### Default state, type picker open

![Type picker open](https://raw.githubusercontent.com/alex-fedotyev/clickhouse-datasource/feat/variable-editor-1833-screenshots/pr-screenshots/var-editor-type-dropdown-open.png)

### Column values + Map column auto-detected + Map Key picker

![Column values cascade](https://raw.githubusercontent.com/alex-fedotyev/clickhouse-datasource/feat/variable-editor-1833-screenshots/pr-screenshots/var-editor-columnvalues-mapkey-cascade.png)

### Map key selected, generated SQL uses bracket access, preview resolves against real data

![Preview resolves to 19 services](https://raw.githubusercontent.com/alex-fedotyev/clickhouse-datasource/feat/variable-editor-1833-screenshots/pr-screenshots/var-editor-preview-resolves.png)

The preview returns 19 distinct `ResourceAttributes['service.name']` values from the OTel demo (accounting, ad, cart, checkout, ...). The variable resolution path through `metricFindQuery` is unchanged.

## Test plan

- [x] \`npm run typecheck\` is green on \`@grafana/* @ 12.4.2\` (the pinned versions on \`main\` after merging \`feat/schema-picker\`).
- [x] \`npm run lint\` is green; no new warnings introduced. The pre-existing \`Select\` deprecation warnings on the existing editors remain (broader Combobox migration, out of scope).
- [x] \`npx jest --maxWorkers=2\` passes 69 suites / 856 tests with 22 new cases in \`CHVariableSupport.test.tsx\`.
- [x] Manual verification on Grafana 13.0.1+security-01 against the public ClickHouse demo: opened a dashboard, added a query variable, selected the PR-built datasource, picked Column values + \`otel_v2.otel_logs.ResourceAttributes['service.name']\`, confirmed generated SQL and that Preview returns 19 services.

## Special notes for your reviewer

- The editor intentionally has no schema-fetch logic of its own; everything cascades through \`SchemaPicker\`, including the existing \`useDatabases\` / \`useTables\` / \`useColumns\` / \`useUniqueMapKeys\` hooks. \`SchemaPicker\` reports whether the chosen column is a \`Map(...)\` type via \`isMapColumn\` on its emitted value, so \`onPickerChange\` records that flag without any extra fetch of its own.
- \`generateVariableSql\` is pure and exported so the editor and the tests agree. The class's \`query\` method only reads \`rawSql\`, never the picker state, so any manual edits to the SQL field always win at run time.
- No \`plugin.json\`, \`CODEOWNERS\`, \`CHANGELOG.md\`, \`package.json\`, schema, or backend changes.

Please add the \`changelog\` label so this surfaces in the next release notes.

Closes #1833.


