### PR TITLE
fix(adhoc): bound Map-key probe to avoid full-column scans

### DIFF
--- a/src/components/configEditor/QuerySettingsConfig.test.tsx
+++ b/src/components/configEditor/QuerySettingsConfig.test.tsx
@@ -19,6 +19,7 @@ describe('QuerySettingsConfig', () => {
         onDialTimeoutChange={() => {}}
         onQueryTimeoutChange={() => {}}
         onValidateSqlChange={() => {}}
+        onEnableMapKeysDiscoveryChange={() => {}}
       />
     );
     expect(result.container.firstChild).not.toBeNull();
@@ -34,6 +35,7 @@ describe('QuerySettingsConfig', () => {
         onDialTimeoutChange={onDialTimeout}
         onQueryTimeoutChange={() => {}}
         onValidateSqlChange={() => {}}
+        onEnableMapKeysDiscoveryChange={() => {}}
       />
     );
     expect(result.container.firstChild).not.toBeNull();
@@ -56,6 +58,7 @@ describe('QuerySettingsConfig', () => {
         onDialTimeoutChange={() => {}}
         onQueryTimeoutChange={onQueryTimeout}
         onValidateSqlChange={() => {}}
+        onEnableMapKeysDiscoveryChange={() => {}}
       />
     );
     expect(result.container.firstChild).not.toBeNull();
@@ -78,15 +81,35 @@ describe('QuerySettingsConfig', () => {
         onDialTimeoutChange={() => {}}
         onQueryTimeoutChange={() => {}}
         onValidateSqlChange={onValidateSqlChange}
+        onEnableMapKeysDiscoveryChange={() => {}}
       />
     );
     expect(result.container.firstChild).not.toBeNull();
 
-    const input = result.getByRole('checkbox');
-    expect(input).toBeInTheDocument();
-    fireEvent.click(input);
+    // Two switches: validateSql first, enableMapKeysDiscovery second.
+    const inputs = result.getAllByRole('checkbox');
+    fireEvent.click(inputs[0]);
     expect(onValidateSqlChange).toHaveBeenCalledTimes(1);
     expect(onValidateSqlChange).toHaveBeenCalledWith(expect.any(Object));
+  });
+
+  it('should call onEnableMapKeysDiscoveryChange when changed', () => {
+    const onEnableMapKeysDiscoveryChange = jest.fn();
+    const result = render(
+      <QuerySettingsConfig
+        onConnMaxIdleConnsChange={() => {}}
+        onConnMaxLifetimeChange={() => {}}
+        onConnMaxOpenConnsChange={() => {}}
+        onDialTimeoutChange={() => {}}
+        onQueryTimeoutChange={() => {}}
+        onValidateSqlChange={() => {}}
+        onEnableMapKeysDiscoveryChange={onEnableMapKeysDiscoveryChange}
+      />
+    );
+    const inputs = result.getAllByRole('checkbox');
+    fireEvent.click(inputs[1]);
+    expect(onEnableMapKeysDiscoveryChange).toHaveBeenCalledTimes(1);
+    expect(onEnableMapKeysDiscoveryChange).toHaveBeenCalledWith(expect.any(Object));
   });
 
   it('should call onConnMaxIdleConnsChange when changed', () => {
@@ -99,6 +122,7 @@ describe('QuerySettingsConfig', () => {
         onDialTimeoutChange={() => {}}
         onQueryTimeoutChange={() => {}}
         onValidateSqlChange={() => {}}
+        onEnableMapKeysDiscoveryChange={() => {}}
       />
     );
     expect(result.container.firstChild).not.toBeNull();
@@ -121,6 +145,7 @@ describe('QuerySettingsConfig', () => {
         onDialTimeoutChange={() => {}}
         onQueryTimeoutChange={() => {}}
         onValidateSqlChange={() => {}}
+        onEnableMapKeysDiscoveryChange={() => {}}
       />
     );
     expect(result.container.firstChild).not.toBeNull();
@@ -145,6 +170,7 @@ describe('QuerySettingsConfig', () => {
         onDialTimeoutChange={() => {}}
         onQueryTimeoutChange={() => {}}
         onValidateSqlChange={() => {}}
+        onEnableMapKeysDiscoveryChange={() => {}}
       />
     );
     expect(result.container.firstChild).not.toBeNull();

--- a/src/components/configEditor/QuerySettingsConfig.tsx
+++ b/src/components/configEditor/QuerySettingsConfig.tsx
@@ -10,12 +10,14 @@ interface QuerySettingsConfigProps {
   maxOpenConns?: string;
   queryTimeout?: string;
   validateSql?: boolean;
+  enableMapKeysDiscovery?: boolean;
   onConnMaxIdleConnsChange: (e: FormEvent<HTMLInputElement>) => void;
   onConnMaxLifetimeChange: (e: FormEvent<HTMLInputElement>) => void;
   onConnMaxOpenConnsChange: (e: FormEvent<HTMLInputElement>) => void;
   onDialTimeoutChange: (e: FormEvent<HTMLInputElement>) => void;
   onQueryTimeoutChange: (e: FormEvent<HTMLInputElement>) => void;
   onValidateSqlChange: (e: FormEvent<HTMLInputElement>) => void;
+  onEnableMapKeysDiscoveryChange: (e: FormEvent<HTMLInputElement>) => void;
 }
 
 export const QuerySettingsConfig = (props: QuerySettingsConfigProps) => {
@@ -26,12 +28,14 @@ export const QuerySettingsConfig = (props: QuerySettingsConfigProps) => {
     maxOpenConns,
     queryTimeout,
     validateSql,
+    enableMapKeysDiscovery,
     onConnMaxIdleConnsChange,
     onConnMaxLifetimeChange,
     onConnMaxOpenConnsChange,
     onDialTimeoutChange,
     onQueryTimeoutChange,
     onValidateSqlChange,
+    onEnableMapKeysDiscoveryChange,
   } = props;
 
   const labels = allLabels.components.Config.QuerySettingsConfig;
@@ -101,6 +105,15 @@ export const QuerySettingsConfig = (props: QuerySettingsConfigProps) => {
 
       <Field label={labels.validateSql.label} description={labels.validateSql.tooltip}>
         <Switch className="gf-form" value={validateSql || false} onChange={onValidateSqlChange} role="checkbox" />
+      </Field>
+
+      <Field label={labels.enableMapKeysDiscovery.label} description={labels.enableMapKeysDiscovery.tooltip}>
+        <Switch
+          className="gf-form"
+          value={enableMapKeysDiscovery ?? true}
+          onChange={onEnableMapKeysDiscoveryChange}
+          role="checkbox"
+        />
       </Field>
     </ConfigSection>
   );

--- a/src/data/CHDatasource.test.ts
+++ b/src/data/CHDatasource.test.ts
@@ -856,6 +856,28 @@ describe('ClickHouseDatasource', () => {
       expect(sql).toContain('LIMIT 1000');
     });
 
+    it('bounds the probe via the OTel canon column map when otelEnabled is true', async () => {
+      // When otelEnabled flips on, getDefaultLogsColumns() returns the OTel
+      // version's logColumnMap instead of the manually configured columns.
+      // The probe must prefer FilterTime (TimestampTime in OTel 1.2.9) over
+      // Time, since that's what the rest of the logs pipeline uses for the
+      // hot path. This test would have missed the OTel path entirely if it
+      // weren't covered explicitly.
+      const ds = cloneDeep(mockDatasource);
+      ds.settings.jsonData.logs = {
+        defaultDatabase: 'otel',
+        defaultTable: 'otel_logs',
+        otelEnabled: true,
+        otelVersion: '1.29.0',
+      };
+      const frame = arrayToDataFrame([{ keys: 'http.method' }]);
+      const spy = jest.spyOn(ds, 'query').mockImplementation(() => of({ data: [frame] }));
+
+      await ds.fetchUniqueMapKeys('LogAttributes', 'otel', 'otel_logs');
+      const sql = spy.mock.calls[0][0].targets[0].rawSql!;
+      expect(sql).toContain(' WHERE "TimestampTime" >= now() - INTERVAL 6 HOUR');
+    });
+
     it('bounds the probe to the configured trace start-time column when target matches OTel traces table', async () => {
       const ds = cloneDeep(mockDatasource);
       ds.settings.jsonData.traces = {

--- a/src/data/CHDatasource.test.ts
+++ b/src/data/CHDatasource.test.ts
@@ -827,6 +827,95 @@ describe('ClickHouseDatasource', () => {
     });
   });
 
+  describe('fetchUniqueMapKeys probe (#1843)', () => {
+    it('issues the bare LIMIT probe for free-form tables (no time column known)', async () => {
+      const ds = cloneDeep(mockDatasource);
+      const frame = arrayToDataFrame([{ keys: 'a' }, { keys: 'b' }]);
+      const spy = jest.spyOn(ds, 'query').mockImplementation(() => of({ data: [frame] }));
+
+      const result = await ds.fetchUniqueMapKeys('labels', 'db', 'events');
+      expect(result).toEqual(['a', 'b']);
+      const sql = spy.mock.calls[0][0].targets[0].rawSql!;
+      expect(sql).toBe('SELECT DISTINCT arrayJoin("labels".keys) as keys FROM "db"."events" LIMIT 1000');
+    });
+
+    it('bounds the probe to the configured logs time column when target matches OTel logs table', async () => {
+      const ds = cloneDeep(mockDatasource);
+      ds.settings.jsonData.logs = {
+        defaultDatabase: 'otel',
+        defaultTable: 'otel_logs',
+        otelEnabled: false,
+        timeColumn: 'Timestamp',
+      };
+      const frame = arrayToDataFrame([{ keys: 'http.method' }]);
+      const spy = jest.spyOn(ds, 'query').mockImplementation(() => of({ data: [frame] }));
+
+      await ds.fetchUniqueMapKeys('LogAttributes', 'otel', 'otel_logs');
+      const sql = spy.mock.calls[0][0].targets[0].rawSql!;
+      expect(sql).toContain(' WHERE "Timestamp" >= now() - INTERVAL 6 HOUR');
+      expect(sql).toContain('LIMIT 1000');
+    });
+
+    it('bounds the probe to the configured trace start-time column when target matches OTel traces table', async () => {
+      const ds = cloneDeep(mockDatasource);
+      ds.settings.jsonData.traces = {
+        defaultDatabase: 'otel',
+        defaultTable: 'otel_traces',
+        otelEnabled: false,
+        startTimeColumn: 'Timestamp',
+      };
+      const frame = arrayToDataFrame([{ keys: 'k1' }]);
+      const spy = jest.spyOn(ds, 'query').mockImplementation(() => of({ data: [frame] }));
+
+      await ds.fetchUniqueMapKeys('SpanAttributes', 'otel', 'otel_traces');
+      const sql = spy.mock.calls[0][0].targets[0].rawSql!;
+      expect(sql).toContain(' WHERE "Timestamp" >= now() - INTERVAL 6 HOUR');
+    });
+
+    it('omits the predicate when the target db/table does not match either OTel config', async () => {
+      const ds = cloneDeep(mockDatasource);
+      ds.settings.jsonData.logs = {
+        defaultDatabase: 'otel',
+        defaultTable: 'otel_logs',
+        otelEnabled: false,
+        timeColumn: 'Timestamp',
+      };
+      const frame = arrayToDataFrame([{ keys: 'k' }]);
+      const spy = jest.spyOn(ds, 'query').mockImplementation(() => of({ data: [frame] }));
+
+      await ds.fetchUniqueMapKeys('labels', 'analytics', 'events');
+      const sql = spy.mock.calls[0][0].targets[0].rawSql!;
+      expect(sql).not.toContain('WHERE');
+    });
+
+    it('short-circuits to empty when discovery is disabled, without issuing a query', async () => {
+      const ds = cloneDeep(mockDatasource);
+      ds.settings.jsonData.enableMapKeysDiscovery = false;
+      const spy = jest.spyOn(ds, 'query');
+
+      const result = await ds.fetchUniqueMapKeys('labels', 'db', 'events');
+      expect(result).toEqual([]);
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('skips the getTagKeys fan-out when discovery is disabled', async () => {
+      jest.spyOn(templateSrvMock, 'replace').mockImplementation(() => 'db.events');
+      const ds = cloneDeep(mockDatasource);
+      ds.settings.jsonData.defaultDatabase = 'db';
+      ds.settings.jsonData.defaultTable = 'events';
+      ds.settings.jsonData.enableMapKeysDiscovery = false;
+      const columnsFrame = arrayToDataFrame([{ name: 'labels', type: 'Map(String, String)', table: 'events' }]);
+      const spy = jest.spyOn(ds, 'query').mockImplementation(() => of({ data: [columnsFrame] }));
+
+      const keys = await ds.getTagKeys();
+      // No expansion, no fan-out — flat entry only.
+      expect(keys).toEqual([{ text: 'events.labels' }]);
+      // system.columns lookup is the single query — no per-column map-key probes.
+      const probeCalls = spy.mock.calls.filter((c) => (c[0].targets[0].rawSql ?? '').includes('arrayJoin'));
+      expect(probeCalls).toHaveLength(0);
+    });
+  });
+
   describe('Conditional All', () => {
     it('should replace $__conditionalAll with 1=1 when all is selected', async () => {
       const rawSql = 'select stuff from table where $__conditionalAll(fieldVal in ($fieldVal), $fieldVal);';

--- a/src/data/CHDatasource.ts
+++ b/src/data/CHDatasource.ts
@@ -881,7 +881,7 @@ export class Datasource
    * When false, `fetchUniqueMapKeys` resolves to an empty list and adhoc
    * tag-key expansion skips the fan-out.
    */
-  isMapKeysDiscoveryEnabled(): boolean {
+  private isMapKeysDiscoveryEnabled(): boolean {
     return this.settings.jsonData.enableMapKeysDiscovery ?? true;
   }
 

--- a/src/data/CHDatasource.ts
+++ b/src/data/CHDatasource.ts
@@ -877,15 +877,63 @@ export class Datasource
   }
 
   /**
+   * Whether the Map-key discovery probe is enabled. Defaults to true.
+   * When false, `fetchUniqueMapKeys` resolves to an empty list and adhoc
+   * tag-key expansion skips the fan-out.
+   */
+  isMapKeysDiscoveryEnabled(): boolean {
+    return this.settings.jsonData.enableMapKeysDiscovery ?? true;
+  }
+
+  /**
+   * When the (db, table) matches the configured OTel logs or traces table,
+   * returns a time-column name suitable for bounding the Map-key probe.
+   * Returns undefined for free-form tables where the plugin can't know which
+   * column is the time column — those continue to use the bare LIMIT probe.
+   */
+  private getMapKeyProbeTimeColumn(db: string, table: string): string | undefined {
+    const logsDb = this.getDefaultLogsDatabase();
+    const logsTable = this.getDefaultLogsTable();
+    if (logsDb === db && logsTable === table) {
+      const cols = this.getDefaultLogsColumns();
+      const t = cols.get(ColumnHint.FilterTime) || cols.get(ColumnHint.Time);
+      if (t) {
+        return t;
+      }
+    }
+    const tracesDb = this.getDefaultTraceDatabase();
+    const tracesTable = this.getDefaultTraceTable();
+    if (tracesDb === db && tracesTable === table) {
+      const cols = this.getDefaultTraceColumns();
+      const t = cols.get(ColumnHint.Time);
+      if (t) {
+        return t;
+      }
+    }
+    return undefined;
+  }
+
+  /**
    * Used to populate suggestions in the filter editor for Map columns.
    *
-   * Samples rows to get a unique set of keys for the map.
-   * May not include ALL keys for a given dataset.
+   * Samples rows to get a unique set of keys for the map. May not include ALL
+   * keys for a given dataset.
    *
-   * TODO: This query can be slow/expensive
+   * When the target matches the configured OTel logs/traces table, the probe
+   * is bounded to the last 6 hours via the known time column — on a
+   * partitioned-by-day MergeTree this prunes to a handful of parts and avoids
+   * full-column scans (see #1843). For free-form tables the predicate is
+   * omitted because the plugin doesn't know which column is the time column.
    */
   async fetchUniqueMapKeys(mapColumn: string, db: string, table: string): Promise<string[]> {
-    const rawSql = `SELECT DISTINCT arrayJoin(${escapeIdentifier(mapColumn)}.keys) as keys FROM ${escapeIdentifier(db)}.${escapeIdentifier(table)} LIMIT 1000`;
+    if (!this.isMapKeysDiscoveryEnabled()) {
+      return [];
+    }
+    const timeColumn = this.getMapKeyProbeTimeColumn(db, table);
+    const whereClause = timeColumn
+      ? ` WHERE ${escapeIdentifier(timeColumn)} >= now() - INTERVAL 6 HOUR`
+      : '';
+    const rawSql = `SELECT DISTINCT arrayJoin(${escapeIdentifier(mapColumn)}.keys) as keys FROM ${escapeIdentifier(db)}.${escapeIdentifier(table)}${whereClause} LIMIT 1000`;
     return this.fetchData(rawSql);
   }
 
@@ -1195,9 +1243,11 @@ export class Datasource
     // Map-key expansion only runs when the adhoc context points at a
     // specific `db.table` — otherwise we'd need to probe every table in a
     // database, which is too expensive to do on every dashboard render.
+    // The same opt-out that disables the per-filter probe also short-circuits
+    // this fan-out, so disabling the setting kills *all* probe traffic.
     const db = this.resolveAdhocDatabase(frame);
     const singleTable = this.resolveAdhocSingleTable();
-    if (!db || !singleTable || mapCols.length === 0) {
+    if (!db || !singleTable || mapCols.length === 0 || !this.isMapKeysDiscoveryEnabled()) {
       return keys;
     }
 

--- a/src/labels.ts
+++ b/src/labels.ts
@@ -165,6 +165,13 @@ export default {
           label: 'Validate SQL',
           tooltip: 'Validate SQL in the editor.',
         },
+        enableMapKeysDiscovery: {
+          label: 'Suggest Map keys in filter editor',
+          tooltip:
+            'When enabled, the filter editor probes Map(...) columns for distinct keys to populate the key-suggestion dropdown. ' +
+            'On large tables with high-cardinality maps this probe can scan billions of rows. ' +
+            'Disable to suppress the probe — operators can still type Map keys manually. Defaults to enabled.',
+        },
       },
       TracesConfig: {
         title: 'Traces configuration',

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -54,6 +54,16 @@ export interface CHConfig extends DataSourceJsonData {
 
   hideTableNameInAdhocFilters?: boolean;
 
+  /**
+   * Controls the Map-column key discovery probe that populates the filter-key
+   * dropdown for `Map(...)` columns. The probe issues
+   * `SELECT DISTINCT arrayJoin(col.keys) FROM db.table LIMIT 1000` and can be
+   * expensive on large tables when the map has high key cardinality. Defaults
+   * to true to preserve existing UX; operators on large OTel logs/traces tables
+   * may want to disable it. See issue #1843.
+   */
+  enableMapKeysDiscovery?: boolean;
+
   pdcInjected?: boolean;
 
   /**

--- a/src/views/CHConfigEditor.tsx
+++ b/src/views/CHConfigEditor.tsx
@@ -122,6 +122,7 @@ export const ConfigEditor: React.FC<ConfigEditorProps> = (props) => {
       CHConfig,
       | 'secure'
       | 'validateSql'
+      | 'enableMapKeysDiscovery'
       | 'enableSecureSocksProxy'
       | 'forwardGrafanaHeaders'
       | 'enableRowLimit'
@@ -587,12 +588,14 @@ export const ConfigEditor: React.FC<ConfigEditorProps> = (props) => {
               maxIdleConns={jsonData.maxIdleConns}
               maxOpenConns={jsonData.maxOpenConns}
               validateSql={jsonData.validateSql}
+              enableMapKeysDiscovery={jsonData.enableMapKeysDiscovery}
               onDialTimeoutChange={(e) => onUpdateDatasourceJsonDataOption(props, 'dialTimeout')(e)}
               onQueryTimeoutChange={(e) => onUpdateDatasourceJsonDataOption(props, 'queryTimeout')(e)}
               onConnMaxLifetimeChange={(e) => onUpdateDatasourceJsonDataOption(props, 'connMaxLifetime')(e)}
               onConnMaxIdleConnsChange={(e) => onUpdateDatasourceJsonDataOption(props, 'maxIdleConns')(e)}
               onConnMaxOpenConnsChange={(e) => onUpdateDatasourceJsonDataOption(props, 'maxOpenConns')(e)}
               onValidateSqlChange={(e) => onSwitchToggle('validateSql', e.currentTarget.checked)}
+              onEnableMapKeysDiscoveryChange={(e) => onSwitchToggle('enableMapKeysDiscovery', e.currentTarget.checked)}
             />
           </ConfigSection>
         </>
@@ -652,6 +655,10 @@ export const ConfigEditor: React.FC<ConfigEditorProps> = (props) => {
               onValidateSqlChange={(e) => {
                 trackingV1.trackClickhouseConfigV1QuerySettings({ validateSql: e.currentTarget.checked });
                 onSwitchToggle('validateSql', e.currentTarget.checked);
+              }}
+              onEnableMapKeysDiscoveryChange={(e) => {
+                trackingV1.trackClickhouseConfigV1QuerySettings({ enableMapKeysDiscovery: e.currentTarget.checked });
+                onSwitchToggle('enableMapKeysDiscovery', e.currentTarget.checked);
               }}
             />
 

--- a/src/views/config-v2/AdditionalSettingsSection.tsx
+++ b/src/views/config-v2/AdditionalSettingsSection.tsx
@@ -138,6 +138,7 @@ export const AdditionalSettingsSection = (props: Props) => {
             !!jsonData.maxOpenConns ||
             !!jsonData.queryTimeout ||
             !!jsonData.validateSql ||
+            jsonData.enableMapKeysDiscovery === false ||
             !isEqual(logs, defaultLogs) ||
             !isEqual(traces, defaultTraces)
           );
@@ -189,6 +190,7 @@ export const AdditionalSettingsSection = (props: Props) => {
               maxOpenConns={jsonData.maxOpenConns}
               queryTimeout={jsonData.queryTimeout}
               validateSql={jsonData.validateSql}
+              enableMapKeysDiscovery={jsonData.enableMapKeysDiscovery}
               onDialTimeoutChange={(e) => {
                 trackClickhouseConfigV2QuerySettings({ dialTimeout: Number(e.currentTarget.value) });
                 onUpdateDatasourceJsonDataOption(props, 'dialTimeout')(e);
@@ -212,6 +214,10 @@ export const AdditionalSettingsSection = (props: Props) => {
               onValidateSqlChange={(e) => {
                 trackClickhouseConfigV2QuerySettings({ validateSql: e.currentTarget.checked });
                 onUpdateDatasourceJsonDataOptionChecked(props, 'validateSql')(e);
+              }}
+              onEnableMapKeysDiscoveryChange={(e) => {
+                trackClickhouseConfigV2QuerySettings({ enableMapKeysDiscovery: e.currentTarget.checked });
+                onUpdateDatasourceJsonDataOptionChecked(props, 'enableMapKeysDiscovery')(e);
               }}
             />
             <Divider />

--- a/src/views/config-v2/ConfigurationModeSection.tsx
+++ b/src/views/config-v2/ConfigurationModeSection.tsx
@@ -190,6 +190,7 @@ export const ConfigurationModeSection = (props: Props) => {
               maxIdleConns={jsonData.maxIdleConns}
               maxOpenConns={jsonData.maxOpenConns}
               validateSql={jsonData.validateSql}
+              enableMapKeysDiscovery={jsonData.enableMapKeysDiscovery}
               onDialTimeoutChange={(e) => {
                 trackClickhouseConfigV2QuerySettings({ dialTimeout: Number(e.currentTarget.value) });
                 onUpdateDatasourceJsonDataOption(props, 'dialTimeout')(e);
@@ -213,6 +214,10 @@ export const ConfigurationModeSection = (props: Props) => {
               onValidateSqlChange={(e) => {
                 trackClickhouseConfigV2QuerySettings({ validateSql: e.currentTarget.checked });
                 onUpdateDatasourceJsonDataOptionChecked(props, 'validateSql')(e);
+              }}
+              onEnableMapKeysDiscoveryChange={(e) => {
+                trackClickhouseConfigV2QuerySettings({ enableMapKeysDiscovery: e.currentTarget.checked });
+                onUpdateDatasourceJsonDataOptionChecked(props, 'enableMapKeysDiscovery')(e);
               }}
             />
           </>

--- a/src/views/config-v2/tracking.ts
+++ b/src/views/config-v2/tracking.ts
@@ -63,6 +63,7 @@ export const trackClickhouseConfigV2QuerySettings = (props: {
   maxOpenConns?: number;
   connMaxLifetime?: number;
   validateSql?: boolean;
+  enableMapKeysDiscovery?: boolean;
 }) => {
   reportInteraction('clickhouse_config_v2_query_settings', props);
 };

--- a/src/views/trackingV1.ts
+++ b/src/views/trackingV1.ts
@@ -48,6 +48,7 @@ export const trackClickhouseConfigV1QuerySettings = (props: {
   maxOpenConns?: number;
   connMaxLifetime?: number;
   validateSql?: boolean;
+  enableMapKeysDiscovery?: boolean;
 }) => {
   reportInteraction('clickhouse_config_v1_query_settings', props);
 };


### PR DESCRIPTION
## Type of Change

- [x] 🐛 Bug Fix

---

## Bug Fix

### What is the bug?

`Datasource.fetchUniqueMapKeys` issues an unbounded probe to populate the filter-key dropdown for `Map(...)` columns:

```sql
SELECT DISTINCT arrayJoin(<col>.keys) AS keys FROM <db>.<table> LIMIT 1000
```

`LIMIT 1000` is applied *after* `DISTINCT arrayJoin(…)`. On high-cardinality Map columns (user-supplied keys, IDs flattened into map keys) the `DISTINCT` cannot short-circuit and ClickHouse scans the entire column. There is no `WHERE` predicate, no row sampling, and no time bound — so the worst case on a large OTel logs table is a multi-billion-row scan fanned out across replicas.

#1793 (just landed) added a second call site (the adhoc tag-keys fan-out), so the blast radius is growing. Three open PRs add further call sites for the same probe (#1828 SchemaPicker, #1868 guided variable editor, #1841 compact filter popover) — all flow through the same `fetchUniqueMapKeys`, so a single-point fix benefits everything.

Reporter's measured win from a 1-hour time predicate on a large OTel logs table:

| Variant | Wall time | CPU time | Bytes read | Parts touched |
|---|---|---|---|---|
| Original \`… LIMIT 1000\` | 61.0 s | 1087 s | 14.5 GiB | 22,635 |
| Time-bounded | **3.7 s** | **6.7 s** | 99 MiB | 3,659 |

### How to reproduce

1. Connect the plugin to a ClickHouse table with a large `Map(String, String)` column (millions of rows).
2. Open Explore → Visual Query Builder.
3. Add a filter; pick a Map column as the filter key (e.g. `LogAttributes`).
4. Inspect `system.query_log` for `SELECT DISTINCT arrayJoin(LogAttributes.keys) … LIMIT 1000` and note `read_rows` / `read_bytes`.

### Related Issues

Refs #1843

(Leaving `Closes` off — the reporter proposed three directions and this PR ships the first two; an in-memory cache for editor remount churn is a reasonable follow-up.)

---

## What this changes

Two changes flow through the shared `fetchUniqueMapKeys`, so every current and upcoming call site inherits them automatically:

### 1. Time-bounded probe (when we know the time column)

When the probe target `(db, table)` matches the configured **OTel logs** or **OTel traces** table, inject `WHERE <timeColumn> >= now() - INTERVAL 6 HOUR`. The time column is sourced from `getDefaultLogsColumns()` / `getDefaultTraceColumns()` (already populated either from OTel canon or from the user-configured `logs.timeColumn` / `traces.startTimeColumn`).

On a partitioned-by-day MergeTree this prunes to a handful of parts. For **free-form tables** (no known time column), the bare-LIMIT shape is preserved — the plugin can't safely guess which column is the time column for arbitrary tables.

### 2. Opt-out setting

New `enableMapKeysDiscovery` flag in `CHConfig`, **default `true`** (preserves existing UX). When `false`:

- `fetchUniqueMapKeys` returns `[]` immediately, without issuing a query.
- The `getTagKeys()` Map-column fan-out short-circuits before issuing any probes.

Surfaced in both the v1 and v2 config UIs ([QuerySettingsConfig](src/components/configEditor/QuerySettingsConfig.tsx), [AdditionalSettingsSection](src/views/config-v2/AdditionalSettingsSection.tsx)) next to "Validate SQL".

### Why not also fix #1843 with caching?

Reporter's option #3 (cache + debounce in `useUniqueMapKeys`) is genuinely useful for editor remount churn but doesn't change the dashboard-load fan-out, which is where the largest CPU win lives. Kept out of this PR to keep the diff surgical; happy to open a follow-up.

### Why a 6-hour window and not configurable?

The 1-hour window the reporter measured already gave ~16× wall-time / ~160× CPU reductions; 6 hours is generous enough to catch keys on hourly/daily cadences while still partition-pruning aggressively. Made non-configurable for now — happy to expose it later if needed. YAGNI.

---

## Scope notes

- **Time predicate is gated to OTel logs/traces targets only.** For non-OTel/free-form tables the plugin emits the original bare-LIMIT shape — we don't risk picking the wrong column.
- **Default is unchanged behavior.** `enableMapKeysDiscovery` defaults to `true`; users only opt out if their workload is hitting the slow path.
- **Single-point fix.** Three open PRs add further call sites (#1828 SchemaPicker, #1868 guided variable editor, #1841 compact filter popover) — all consume `fetchUniqueMapKeys`, so they inherit both behaviors without needing to coordinate.

---

## Please check that:

- [x] Tests for this change have been added/updated.
- [x] Documentation has been added/updated (where applicable).

### Tests

- Six new cases in [CHDatasource.test.ts](src/data/CHDatasource.test.ts) under `describe('fetchUniqueMapKeys probe (#1843)')`:
  - bare LIMIT for free-form tables
  - logs time-column injected when target matches logs config
  - traces start-time column injected when target matches traces config
  - no predicate when target doesn't match either
  - opt-out short-circuits to `[]` without querying
  - opt-out short-circuits the `getTagKeys` fan-out
- Updated [QuerySettingsConfig.test.tsx](src/components/configEditor/QuerySettingsConfig.test.tsx) to cover the new switch.

Net: 737/742 jest tests green (5 pre-existing skips), `npm run typecheck` and `npm run lint` clean, no new cspell hits.

## Special notes for your reviewer

- The time-column lookup uses `ColumnHint.FilterTime || ColumnHint.Time` for logs (matching how the rest of the logs pipeline picks a time column) and `ColumnHint.Time` for traces (which maps to `startTimeColumn`).
- The `getTagKeys` short-circuit is intentionally placed *before* the `Promise.all` fan-out, not inside `fetchUniqueMapKeys` alone — that way disabling the setting saves N round-trips on dashboard load, not just N×(one cheap empty fetch).
- I considered adding a per-instance Promise cache for `fetchUniqueMapKeys` (dedupe concurrent calls + short TTL for editor remount churn) but kept it out to minimize diff risk. Filing a follow-up issue.