### PR TITLE
ci: drop go.mod toolchain requirement back to 1.26.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/clickhouse-datasource
 
-go 1.26.3
+go 1.26.0
 
 require (
 	github.com/ClickHouse/clickhouse-go/v2 v2.45.0


### PR DESCRIPTION
## Type of Change

- [x] 🐛 Bug Fix

---

## Bug Fix

### What is the bug?

Every `Plugins - CI` push run on `main` since [b4c522c](https://github.com/grafana/clickhouse-datasource/commit/b4c522c) (2026-05-29) has failed at `Test and build backend → go mod download` with:

```
go: go.mod requires go >= 1.26.3 (running go 1.26.0; GOTOOLCHAIN=local)
##[error]Process completed with exit code 1.
```

The shared CI workflow `grafana/plugin-ci-workflows/actions/internal/plugins/backend@ci-cd-workflows/v8.0.1` provisions Go 1.26.0 and hard-codes `GOTOOLCHAIN=local`, so the runner cannot auto-fetch a newer toolchain. The `go 1.26.0 → 1.26.3` directive bump in b4c522c came in as part of an auto-audit hygiene sweep — there is no `toolchain` directive in `go.mod` and no language feature in the backend that requires 1.26.3, so reverting unblocks `main` without changing build behavior.

Latest red run for reference: https://github.com/grafana/clickhouse-datasource/actions/runs/27309010890

### How to reproduce

1. Check out `main` at any commit since b4c522c.
2. Watch the `Plugins - CI` workflow on the push event — it fails in the `Test and build backend` step.

### Related Issues

N/A — discovered while auditing `main` CI health.

### Environment (if no related issue)

- **Plugin version**: `main`
- **CI workflow**: `grafana/plugin-ci-workflows@ci-cd-workflows/v8.0.1`

---

## Please check that:

- [x] Tests for this change have been added/updated. _(N/A — CI-only change; the existing CI run is the test.)_
- [x] Documentation has been added/updated (where applicable). _(N/A)_

## Special notes for your reviewer

Single-line change: `go 1.26.3` → `go 1.26.0` in `go.mod`. The right longer-term fix is to advance the `grafana/plugin-ci-workflows` pin to a tag that ships Go ≥ 1.26.3 (and possibly add a `toolchain` directive), but that is a larger change and not required to unblock `main` today.