### PR TITLE
ci: bump plugin-ci-workflows pin to v9.0.0 (Go 1.26.3 default)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         environment: [dev, ops, prod]
     name: CD
-    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v8.0.1
+    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v9.0.0
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -24,7 +24,7 @@ jobs:
   ci:
     name: CI
 
-    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@ci-cd-workflows/v8.0.1
+    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@ci-cd-workflows/v9.0.0
 
     # Only run CI job for PRs / non-main refs.
     # Main publishing is handled by the CD workflow below.
@@ -58,5 +58,5 @@ jobs:
       pull-requests: read
 
     with:
-      go-version: "1.26.0"
+      go-version: "1.26.3"
       golangci-lint-version: "2.10.1"


### PR DESCRIPTION
## Type of Change

- [x] 🐛 Bug Fix

---

## Bug Fix

### What is the bug?

Every push to `main` since [b4c522c](https://github.com/grafana/clickhouse-datasource/commit/b4c522c) (2026-05-29) has failed in `Plugins - CI → Publish to Dev Catalog and Deploy → Test and build plugin → go mod download` with:

```
go: go.mod requires go >= 1.26.3 (running go 1.26.0; GOTOOLCHAIN=local)
##[error]Process completed with exit code 1.
```

Latest red run: https://github.com/grafana/clickhouse-datasource/actions/runs/27309010890

That commit bumped `go.mod` from `go 1.26.0` → `go 1.26.3`, but our shared CI pin `grafana/plugin-ci-workflows@ci-cd-workflows/v8.0.1` defaults to Go 1.25 and hard-codes `GOTOOLCHAIN=local` — so the runner cannot auto-fetch a newer toolchain. The actively-failing job receives Go 1.26.0 from the explicit `go-version: "1.26.0"` input on `push.yml`, which is still below `go.mod`'s minimum.

### Fix

Bump the shared workflow pin to `ci-cd-workflows/v9.0.0` and align the explicit `go-version` override with `go.mod`:

- `.github/workflows/push.yml`
  - `ci.yml@v8.0.1` → `v9.0.0`
  - `go-version: "1.26.0"` → `"1.26.3"` (on the `publish-and-deploy` job that goes through `data-sources-ci-workflows/cd-dev.yml@main` — that workflow still pins `v8.0.1` internally and forwards `go-version` verbatim, so the explicit input had to move in lockstep)
- `.github/workflows/publish.yml`
  - `cd.yml@v8.0.1` → `v9.0.0` (keeps manual `Plugins - CD` in sync)

[ci-cd-workflows/v9.0.0 release notes](https://github.com/grafana/plugin-ci-workflows/releases/tag/ci-cd-workflows/v9.0.0):
- 🎉 `DEFAULT_GO_VERSION` raised from `1.25` → `1.26.3`.
- 🎉 Playwright max-parallel and customizable timeouts (no behavior change for us — we don't override these).
- ⚠ BREAKING: `pnpm/action-setup` now requires `package_json_file` in subdirectories. **Does not apply** — this plugin uses npm (verified: `package-lock.json` present, no `pnpm-lock.yaml`).

### How to reproduce

1. Check out `main` at any commit since b4c522c.
2. Observe `Plugins - CI` failing at `Test and build backend`.

### Related Issues

N/A — surfaced via fleet CI health audit.

### Environment (if no related issue)

- **Plugin version**: `main`

---

## Please check that:

- [x] Tests for this change have been added/updated. _(N/A — CI-only change; the workflow run is the test.)_
- [x] Documentation has been added/updated (where applicable). _(N/A)_

## Special notes for your reviewer

Two follow-ups worth flagging but out of scope here:

1. The `go-version` override in `push.yml` is now duplicated information with `go.mod`. Once `grafana/data-sources-ci-workflows/cd-dev.yml@main` updates its internal `plugin-ci-workflows` pin to v9.0.0+, we can drop the override and rely on the new default (which itself reads from `go.mod`).
2. `golangci-lint-version: "2.10.1"` in `push.yml` is also below v9.0.0's default of `2.11.4`. Leaving as-is to keep this PR strictly scoped to the unblock.