### PR TITLE
ci(cron): grant minimum permissions for Cloud E2E reusable workflow

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -8,10 +8,11 @@ on:
   # Allow engineers to run Cloud E2E on-demand (useful for debugging)
   workflow_dispatch:
 
-# Top-level token is empty; the called workflow declares the scopes it needs.
-# `secrets: inherit` below intentionally exposes repo secrets to the shared
-# workflow — this is a trust delegation to grafana/data-sources-ci-workflows.
-permissions: {}
+# Reusable workflows can only narrow caller permissions, not escalate.
+# `id-token: write` is needed by the Vault OIDC step in playwright-cloud.yml.
+permissions:
+  contents: read
+  id-token: write
 
 jobs:
   playwright-cloud:
@@ -20,6 +21,9 @@ jobs:
     # policy (`grafana/*: any`); review periodically.
     uses: grafana/data-sources-ci-workflows/.github/workflows/playwright-cloud.yml@main
     secrets: inherit
+    permissions:
+      contents: read
+      id-token: write
     with:
       pdc-network-name: datasources-pdc-network-aws-datasourcese2e
       repo-secrets: |


### PR DESCRIPTION
## Type of Change

- [x] 🐛 Bug Fix

---

## Bug Fix

### What is the bug?

The `Scheduled Cloud E2E tests` workflow ([.github/workflows/cron.yml](.github/workflows/cron.yml)) has been hitting `startup_failure` on every nightly schedule since [65b790e](https://github.com/grafana/clickhouse-datasource/commit/65b790e) (2026-05-27) — 15+ consecutive dead-on-arrival runs (0–1 s, no logs, "workflow file issue"). Examples:

- https://github.com/grafana/clickhouse-datasource/actions/runs/27269975784 (2026-06-10)
- https://github.com/grafana/clickhouse-datasource/actions/runs/27199476672 (2026-06-09)
- …back through 2026-05-27.

### Root cause

That commit set `permissions: {}` at the top level of `cron.yml`. A reusable workflow's GITHUB_TOKEN permissions can only be a **subset** of what the caller grants — they cannot escalate. With nothing granted at the caller level, the called `playwright-cloud.yml` reusable workflow cannot acquire the `contents: read` and `id-token: write` it declares for its jobs, so GitHub fails validation before any runner is allocated.

The comment in the original commit ("Top-level token is empty; the called workflow declares the scopes it needs") reflects the misunderstanding — the called workflow can only narrow, never escalate.

### Fix

Grant the minimum permissions the called workflow declares, both at the workflow and job level (matches [grafana/data-sources-ci-workflows/.github/workflows/playwright-cloud.yml](https://github.com/grafana/data-sources-ci-workflows/blob/main/.github/workflows/playwright-cloud.yml)):

```yaml
permissions:
  contents: read
  id-token: write
```

`id-token: write` is required by the Vault OIDC step (`grafana/shared-workflows/actions/get-vault-secrets`) that fetches the cloud instance credentials.

### How to reproduce

1. Open the [Actions tab → Scheduled Cloud E2E tests](https://github.com/grafana/clickhouse-datasource/actions/workflows/cron.yml). Every nightly since 2026-05-27 shows `startup_failure`.
2. Or trigger manually via `workflow_dispatch` on `main` — same outcome.

### Related Issues

N/A — discovered while auditing `main` CI health.

### Environment (if no related issue)

- **Plugin version**: `main`

---

## Please check that:

- [x] Tests for this change have been added/updated. _(N/A — CI-only change; the next scheduled run is the test.)_
- [x] Documentation has been added/updated (where applicable). _(N/A)_

## Special notes for your reviewer

Merging this should make tomorrow's 09:00 UTC scheduled run actually execute. To verify before merging, the workflow can be `workflow_dispatch`-triggered from this branch via the Actions UI.

This is the inverse pattern from a typical "least-privilege" hardening fix — but only because the trust boundary already lives in the called reusable workflow (`grafana/data-sources-ci-workflows`). `secrets: inherit` was already exposing repo secrets to it; explicitly granting the two scopes it needs is strictly less surprising than the empty-permissions misconfiguration that broke the run.