### PR TITLE
fix(traces): open the linked trace when following a span link

### DIFF
--- a/cspell.config.json
+++ b/cspell.config.json
@@ -80,6 +80,8 @@
     "PREWHERE",
     "proxying",
     "regexes",
+    "retarget",
+    "retargets",
     "schemacache",
     "schemads",
     "sdkconfig",

--- a/src/data/CHDatasource.test.ts
+++ b/src/data/CHDatasource.test.ts
@@ -344,6 +344,68 @@ describe('ClickHouseDatasource', () => {
         "SELECT * FROM complex_table settings additional_table_filters={'table1': ' key = \\'val\\' ', 'table2': ' key = \\'val\\' ', 'table3': ' key = \\'val\\' '}"
       );
     });
+
+    describe('span link trace retarget (#1889)', () => {
+      const originalTraceId = 'a55d8be622a816047a902c60adedd776';
+      const linkedTraceId = '4ea6a6e0d0525ed05ecc350d3cdd66b6';
+
+      const traceIdBuilderQuery = (traceId: string, extra: Record<string, unknown> = {}): CHQuery =>
+        ({
+          pluginVersion: '',
+          editorType: EditorType.Builder,
+          rawSql: `SELECT "TraceId" as traceID FROM "otel"."otel_traces" WHERE traceID = '${traceId}'`,
+          builderOptions: {
+            database: 'otel',
+            table: 'otel_traces',
+            queryType: QueryType.Traces,
+            columns: [{ name: 'TraceId', hint: ColumnHint.TraceId }],
+            meta: { isTraceIdMode: true, traceId },
+          },
+          ...extra,
+        }) as unknown as CHQuery;
+
+      beforeEach(() => {
+        jest.spyOn(templateSrvMock, 'replace').mockImplementation((x) => x);
+        jest.spyOn(templateSrvMock, 'getVariables').mockImplementation(() => []);
+      });
+
+      it('retargets rawSql to the linked trace id when core injects a top-level query', () => {
+        // Grafana core builds the span-link navigation target as { ...currentQuery, query: linkedTraceId }.
+        const query = traceIdBuilderQuery(originalTraceId, { query: linkedTraceId });
+
+        const result = createInstance({}).applyTemplateVariables(query, {}) as CHBuilderQuery;
+
+        expect(result.rawSql).toContain(linkedTraceId);
+        expect(result.rawSql).not.toContain(originalTraceId);
+        expect(result.builderOptions.meta?.traceId).toEqual(linkedTraceId);
+      });
+
+      it('leaves the normal trace view untouched when there is no injected query', () => {
+        const query = traceIdBuilderQuery(originalTraceId);
+
+        const result = createInstance({}).applyTemplateVariables(query, {});
+
+        expect(result.rawSql).toContain(originalTraceId);
+        expect(result.rawSql).not.toContain(linkedTraceId);
+      });
+
+      it('does not retarget when the injected query matches the current trace id', () => {
+        const query = traceIdBuilderQuery(originalTraceId, { query: originalTraceId });
+
+        const result = createInstance({}).applyTemplateVariables(query, {});
+
+        expect(result.rawSql).toContain(originalTraceId);
+      });
+
+      it('ignores a non-trace-id injected query value', () => {
+        const query = traceIdBuilderQuery(originalTraceId, { query: 'not-a-trace-id' });
+
+        const result = createInstance({}).applyTemplateVariables(query, {});
+
+        expect(result.rawSql).toContain(originalTraceId);
+        expect(result.rawSql).not.toContain('not-a-trace-id');
+      });
+    });
   });
 
   describe('Tag Keys', () => {

--- a/src/data/CHDatasource.ts
+++ b/src/data/CHDatasource.ts
@@ -331,6 +331,8 @@ export class Datasource
   }
 
   applyTemplateVariables(query: CHQuery, scoped: ScopedVars, filters: AdHocVariableFilter[] = []): CHQuery {
+    query = this.retargetSpanLinkTrace(query);
+
     let rawQuery = query.rawSql || '';
     const templateSrv = getTemplateSrv();
     const templateSrvVariables = templateSrv.getVariables() || [];
@@ -364,6 +366,48 @@ export class Datasource
     return {
       ...query,
       rawSql: rawQuery,
+    };
+  }
+
+  /**
+   * When a user follows a span link ("View Linked Span") in the trace view, Grafana core
+   * builds the navigation target by spreading the current trace query and overriding only the
+   * top-level `query` field with the linked trace id (the convention Tempo uses). The ClickHouse
+   * trace-id query executes off builderOptions.meta.traceId, which is baked into rawSql and still
+   * points at the originating trace, so the same trace would re-open. Detect that case and
+   * regenerate rawSql for the linked trace id so the link opens the linked span's trace.
+   * See https://github.com/grafana/clickhouse-datasource/issues/1889.
+   */
+  retargetSpanLinkTrace(query: CHQuery): CHQuery {
+    if (query.editorType !== EditorType.Builder) {
+      return query;
+    }
+
+    const meta = query.builderOptions.meta;
+    if (!meta?.isTraceIdMode) {
+      return query;
+    }
+
+    // `query` is not part of CHQuery; Grafana core sets it on the navigation target when a span
+    // link is followed. Detect it with the `in` operator so the field can be read without a cast.
+    if (!('query' in query)) {
+      return query;
+    }
+
+    const linkedTraceId = query.query;
+    if (typeof linkedTraceId !== 'string' || !/^[0-9a-fA-F]+$/.test(linkedTraceId) || linkedTraceId === meta.traceId) {
+      return query;
+    }
+
+    const builderOptions: QueryBuilderOptions = {
+      ...query.builderOptions,
+      meta: { ...meta, traceId: linkedTraceId },
+    };
+
+    return {
+      ...query,
+      builderOptions,
+      rawSql: generateSql(builderOptions),
     };
   }
 


### PR DESCRIPTION
## Summary

Following a span link in the trace view (the "View Linked Span" entries under a span's References) reopened the current trace instead of the linked span's trace, so OTel span links were not navigable in Explore. This regenerates the trace-id query for the linked trace when a span link is followed, so the link opens the linked span's trace and scrolls to it.

Fixes #1889. Upstream core issue: grafana/grafana#126237.

## Why

Grafana core builds the span-link navigation target by spreading the current trace query and overriding only the top-level `query` field with the linked trace id (the convention Tempo uses). The ClickHouse trace-id query executes off `builderOptions.meta.traceId`, which is baked into `rawSql` and still points at the originating trace, so the same trace reopens and the `panelsState.trace.spanId` scroll target never matches.

`applyTemplateVariables` now detects this case: when a trace-id-mode builder query arrives carrying a top-level `query` (a hex trace id that core injected) which differs from `meta.traceId`, it regenerates `rawSql` for the linked trace id. This is a pragmatic plugin-side workaround. The underlying assumption lives in Grafana core (`createFocusSpanLink` in `TraceView.tsx`), filed upstream as grafana/grafana#126237; the proper fix is a data-source-agnostic trace-id remap there.

## Changes

- `src/data/CHDatasource.ts`: a `retargetSpanLinkTrace` guard at the top of `applyTemplateVariables`.
- `src/data/CHDatasource.test.ts`: unit tests for the retarget and the no-op cases (normal "View trace", matching id, non-hex value).

## How to reproduce

1. Point the data source at OTel `otel_traces` data where a span carries OTel links to spans in other traces (a consumer "receive" span linking to several producer spans).
2. Open the consumer trace, expand a span's References, and click a "View Linked Span" entry.
3. Before this change: the current trace reopens. After: the linked span's trace opens.

## Screenshots

Clicking "View Linked Span" for a producer reference from a consumer "orders receive" trace. Before, the linked pane shows the consumer trace again (Trace ID `a55d8be...`, fulfillment-service). After, it shows the linked producer trace (Trace ID `4ea6a6e0...`, checkout-service).

| | Before (official 4.17.0) | After (this PR) |
|---|---|---|
| **Light** | ![before light](https://raw.githubusercontent.com/alex-fedotyev/clickhouse-datasource/fix/span-link-1889-screenshots/pr-screenshots/before-light.png) | ![after light](https://raw.githubusercontent.com/alex-fedotyev/clickhouse-datasource/fix/span-link-1889-screenshots/pr-screenshots/after-light.png) |

After, dark theme: ![after dark](https://raw.githubusercontent.com/alex-fedotyev/clickhouse-datasource/fix/span-link-1889-screenshots/pr-screenshots/after-dark.png)

## Test plan

- [x] `npx jest src/data/CHDatasource.test.ts` (4 new tests) and the full suite (65 suites, 758 passing)
- [x] `npx tsc --noEmit`, `eslint`, `prettier --check` on the changed files
- [x] Manual verification in a local Grafana 13.0.2 with the build from this branch loaded alongside the official plugin, against a local ClickHouse holding OTel span-link data, light and dark themes
- No backend changes, so `go test ./...` is not affected

## Notes for the reviewer

The guard fires only for trace-id-mode builder queries that arrive with a top-level `query` hex trace id differing from `meta.traceId`, which is the shape core produces for a span-link click. The normal "View trace" path (no injected top-level `query`) is unaffected, and a unit test asserts both the positive retarget and the no-op cases. There are no SQL-generation or backend changes. Please add the `changelog` label so this surfaces in the next release notes.
