### PR TITLE
chore: pin grafanaDependency with prerelease suffix

### DIFF
--- a/src/plugin.json
+++ b/src/plugin.json
@@ -63,7 +63,7 @@
     "updated": "%TODAY%"
   },
   "dependencies": {
-    "grafanaDependency": ">=11.6.0",
+    "grafanaDependency": ">=11.6.0-0",
     "plugins": []
   }
 }


### PR DESCRIPTION
## Type of Change

- [x] 🧹 Refactor / Chore

---

## What is this change?

Update `grafanaDependency` in `src/plugin.json` from `">=11.6.0"` to `">=11.6.0-0"`.

## Why is this change needed?

Per semver, `">=11.6.0"` does **not** match Grafana prerelease versions (e.g. `12.3.0-12345`), even though it appears it should. Grafana hosted instances and provisioned installs evaluate the constraint at install time against versions that may carry a prerelease suffix; when a new `.0` of Grafana is released alongside a plugin that pins exactly that version, the catalog install can fail and hosted Grafana instances may crashloop.

Adding the `-0` prerelease suffix lowers the constraint floor so the dependency matches all `>=11.6.0` versions including prereleases.

Background:
- grafana/grafana-com#17309 (merged) — surfaces this gotcha for plugins published to the catalog by Grafana teams.
- [Plugin compatibility best practices](https://grafana.com/developers/plugin-tools/key-concepts/best-practices#manage-plugin-compatibility)

## How to test

1. Inspect `src/plugin.json` — `grafanaDependency` is `">=11.6.0-0"`.
2. CI green.

---

## Please check that:

- [x] Tests for this change have been added/updated. _(N/A — manifest-only change)_
- [x] Documentation has been added/updated (where applicable). _(N/A)_