### PR TITLE
Release 4.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## 4.18.0
+
+### Features
+
+- Introduce single-table mode for logs and traces configuration (#1832)
+- Auto-detect log/trace column roles by conventional names (#1791)
+- Add JSON attributes (tags) support (#1866)
+
+### Performance
+
+- Decouple trace ID lookup optimization from OTel mode (#1786)
+
+### Fixes
+
+- Bound Map-key probe to avoid full-column scans in ad-hoc filters (#1885)
+- Open the linked trace when following a span link (#1890)
+- Default trace optimization to true (#1853)
+- Support Map-typed columns in ad-hoc filters (#1793)
+- Support scope variables in the datasource (#1840)
+- Support JSON column filters and JSON-typed trace tags (#1792)
+- Preserve `grafanaDependency` compatibility with Grafana prereleases (#1892)
+- Remove Grafana 13 hard-break call sites (#1861)
+- Trim whitespace from host setting (#1830, #1831)
+- Dependency updates
+
 ## 4.17.1
 
 ### Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clickhouse-datasource",
-  "version": "4.17.1",
+  "version": "4.18.0",
   "description": "Clickhouse Datasource",
   "engines": {
     "node": ">=24",


### PR DESCRIPTION
## 4.18.0

### Features

- Introduce single-table mode for logs and traces configuration (#1832)
- Auto-detect log/trace column roles by conventional names (#1791)
- Add JSON attributes (tags) support (#1866)
- Add config error categorization (#1776)

### Performance

- Decouple trace ID lookup optimization from OTel mode (#1786)

### Fixes

- Bound Map-key probe to avoid full-column scans in ad-hoc filters (#1885)
- Open the linked trace when following a span link (#1890)
- Default trace optimization to true (#1853)
- Support Map-typed columns in ad-hoc filters (#1793)
- Support scope variables in the datasource (#1840)
- Support JSON column filters and JSON-typed trace tags (#1792)
- Preserve `grafanaDependency` compatibility with Grafana prereleases (#1892)
- Remove Grafana 13 hard-break call sites (#1861)
- Trim whitespace from host setting (#1830, #1831)
- Dependency updates