### PR TITLE
Fix datasource variable refs in Data Analysis dashboard

### DIFF
--- a/src/dashboards/data-analysis.json
+++ b/src/dashboards/data-analysis.json
@@ -1,14 +1,4 @@
 {
-  "__inputs": [
-    {
-      "name": "DS_GRAFANA-CLICKHOUSE-DATASOURCE",
-      "label": "grafana-clickhouse-datasource",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "grafana-clickhouse-datasource",
-      "pluginName": "ClickHouse"
-    }
-  ],
   "__elements": {},
   "__requires": [
     {
@@ -145,7 +135,7 @@
         {
           "datasource": {
             "type": "grafana-clickhouse-datasource",
-            "uid": "${DS_GRAFANA-CLICKHOUSE-DATASOURCE}"
+            "uid": "${datasource}"
           },
           "format": 1,
           "meta": {
@@ -250,7 +240,7 @@
         {
           "datasource": {
             "type": "grafana-clickhouse-datasource",
-            "uid": "${DS_GRAFANA-CLICKHOUSE-DATASOURCE}"
+            "uid": "${datasource}"
           },
           "format": 1,
           "meta": {
@@ -330,7 +320,7 @@
         {
           "datasource": {
             "type": "grafana-clickhouse-datasource",
-            "uid": "${DS_GRAFANA-CLICKHOUSE-DATASOURCE}"
+            "uid": "${datasource}"
           },
           "format": 1,
           "meta": {
@@ -398,7 +388,7 @@
         {
           "datasource": {
             "type": "grafana-clickhouse-datasource",
-            "uid": "${DS_GRAFANA-CLICKHOUSE-DATASOURCE}"
+            "uid": "${datasource}"
           },
           "format": 1,
           "meta": {
@@ -584,7 +574,7 @@
         {
           "datasource": {
             "type": "grafana-clickhouse-datasource",
-            "uid": "${DS_GRAFANA-CLICKHOUSE-DATASOURCE}"
+            "uid": "${datasource}"
           },
           "editorType": "sql",
           "format": 1,
@@ -689,7 +679,7 @@
           },
           "datasource": {
             "type": "grafana-clickhouse-datasource",
-            "uid": "${DS_GRAFANA-CLICKHOUSE-DATASOURCE}"
+            "uid": "${datasource}"
           },
           "format": 1,
           "meta": {
@@ -773,7 +763,7 @@
           },
           "datasource": {
             "type": "grafana-clickhouse-datasource",
-            "uid": "${DS_GRAFANA-CLICKHOUSE-DATASOURCE}"
+            "uid": "${datasource}"
           },
           "format": 1,
           "meta": {
@@ -877,7 +867,7 @@
           },
           "datasource": {
             "type": "grafana-clickhouse-datasource",
-            "uid": "${DS_GRAFANA-CLICKHOUSE-DATASOURCE}"
+            "uid": "${datasource}"
           },
           "format": 1,
           "meta": {
@@ -980,7 +970,7 @@
           },
           "datasource": {
             "type": "grafana-clickhouse-datasource",
-            "uid": "${DS_GRAFANA-CLICKHOUSE-DATASOURCE}"
+            "uid": "${datasource}"
           },
           "format": 1,
           "meta": {
@@ -1174,7 +1164,7 @@
         {
           "datasource": {
             "type": "grafana-clickhouse-datasource",
-            "uid": "${DS_GRAFANA-CLICKHOUSE-DATASOURCE}"
+            "uid": "${datasource}"
           },
           "editorType": "sql",
           "format": 1,
@@ -1326,7 +1316,7 @@
           },
           "datasource": {
             "type": "grafana-clickhouse-datasource",
-            "uid": "${DS_GRAFANA-CLICKHOUSE-DATASOURCE}"
+            "uid": "${datasource}"
           },
           "format": 1,
           "meta": {
@@ -1556,7 +1546,7 @@
         {
           "datasource": {
             "type": "grafana-clickhouse-datasource",
-            "uid": "${DS_GRAFANA-CLICKHOUSE-DATASOURCE}"
+            "uid": "${datasource}"
           },
           "editorType": "sql",
           "format": 1,
@@ -1785,7 +1775,7 @@
           },
           "datasource": {
             "type": "grafana-clickhouse-datasource",
-            "uid": "${DS_GRAFANA-CLICKHOUSE-DATASOURCE}"
+            "uid": "${datasource}"
           },
           "format": 1,
           "meta": {
@@ -1914,7 +1904,7 @@
           },
           "datasource": {
             "type": "grafana-clickhouse-datasource",
-            "uid": "${DS_GRAFANA-CLICKHOUSE-DATASOURCE}"
+            "uid": "${datasource}"
           },
           "format": 1,
           "meta": {
@@ -2021,7 +2011,7 @@
           },
           "datasource": {
             "type": "grafana-clickhouse-datasource",
-            "uid": "${DS_GRAFANA-CLICKHOUSE-DATASOURCE}"
+            "uid": "${datasource}"
           },
           "format": 1,
           "meta": {
@@ -2260,7 +2250,7 @@
           },
           "datasource": {
             "type": "grafana-clickhouse-datasource",
-            "uid": "${DS_GRAFANA-CLICKHOUSE-DATASOURCE}"
+            "uid": "${datasource}"
           },
           "format": 1,
           "meta": {
@@ -2352,7 +2342,7 @@
         "current": {},
         "datasource": {
           "type": "grafana-clickhouse-datasource",
-          "uid": "${DS_GRAFANA-CLICKHOUSE-DATASOURCE}"
+          "uid": "${datasource}"
         },
         "definition": "SELECT name FROM system.tables WHERE database IN (${database})",
         "includeAll": true,


### PR DESCRIPTION
## Type of Change

_Please check the relevant option._

- [ ] 🚀 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧹 Refactor / Chore

---

## Bug Fix

### What is the bug?

The bundled Data Analysis dashboard defines its ClickHouse datasource template variable as datasource, but some panel/query datasource UID references still used the legacy import placeholder
${DS_GRAFANA-CLICKHOUSE-DATASOURCE}.

When the dashboard is provisioned, Grafana cannot resolve that placeholder and shows:

```txt
Datasource ${DS_GRAFANA-CLICKHOUSE-DATASOURCE} was not found
```

### How to reproduce

1. Provision or import the bundled Data Analysis dashboard from src/dashboards/data-analysis.json.
2. Select/configure a ClickHouse datasource using the dashboard’s datasource variable.
3. Open affected panels and observe that Grafana reports Datasource ${DS_GRAFANA-CLICKHOUSE-DATASOURCE} was not found because those panels reference the wrong datasource UID variable.
