### PR TITLE
ci: drop redundant matrix from publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,10 +24,6 @@ permissions: {}
 
 jobs:
   cd:
-    strategy:
-      fail-fast: false
-      matrix:
-        environment: [dev, ops, prod]
     name: CD
     uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v9.0.0
     permissions:
@@ -37,7 +33,7 @@ jobs:
       pull-requests: read
     with:
       branch: ${{ github.event.inputs.branch }}
-      environment: ${{ matrix.environment }}
+      environment: "prod"
       docs-only: ${{ fromJSON(github.event.inputs.docs-only) }}
       scopes: ${{ github.event.inputs.environment == 'cloud (recommended)' && 'grafana_cloud' || github.event.inputs.environment == 'on-prem (for emergencies fix to On Prem customers)' && 'universal' }}
       run-playwright: false


### PR DESCRIPTION
## Type of Change

- [x] 🐛 Bug Fix

---

## Bug Fix

### What is the bug?

The CD workflow ([Plugins - CD](.github/workflows/publish.yml)) fans out into a matrix of `[dev, ops, prod]`, triggering three parallel `cd.yml` invocations. This is redundant: when called with `environment: prod`, cd.yml already deploys to all three waves internally because `prod-targets-all: true` is the default. The redundant sibling invocations leave us exposed to a failure mode in cd.yml — see run [27627167516](https://github.com/grafana/clickhouse-datasource/actions/runs/27627167516):

```
evaluate job template if: Error when evaluating 'if' for job 'create-github-release'.
grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v9.0.0
(Line: 1347, Col: 9): Error from function 'fromJSON': empty input
```

Sequence of events:

1. publish.yml's matrix triggered three cd.yml invocations (dev, ops, prod).
2. The prod wave's `setup` job ran first and set `environments = ["dev","ops","prod"]`.
3. The dev and ops setup jobs queued waiting for runners and were cancelled before they ever started executing steps.
4. With `setup` cancelled in those waves, `needs.setup.outputs.environments` was empty.
5. cd.yml line 1347 evaluates `contains(fromJSON(needs.setup.outputs.environments), 'prod')` for `create-github-release`. `fromJSON("")` throws — the workflow can't recover and the prod wave gets cancelled too.

### How to reproduce

Trigger the `Plugins - CD` workflow from `main`. If the dev/ops cd.yml invocations don't acquire runners promptly, they get cancelled and `create-github-release` blows up on `fromJSON("")`.

### Fix

Drop the matrix and call cd.yml once with `environment: "prod"`. cd.yml's own internal matrix (line 921) then fans out to dev → ops → prod using `setup.outputs.environments`. This is the canonical pattern used by peer Grafana datasources on v7/v8/v9 — see [athena-datasource](https://github.com/grafana/athena-datasource/blob/main/.github/workflows/publish.yml), [grafana-mysql-datasource](https://github.com/grafana/mysql-datasource/blob/main/.github/workflows/publish.yml), [grafana-azure-monitor-datasource](https://github.com/grafana/azure-monitor-datasource/blob/main/.github/workflows/publish.yml).

The deployment surface is unchanged.

### Related Issues

History note: the matrix was introduced in #1428 ("Publish to every environment on Cloud"). The intent was correct, but the matrix is the wrong lever — the cd.yml input handles fan-out itself when `prod-targets-all: true` (default).

---

## Please check that:

- [x] Tests for this change have been added/updated. _(N/A — CI-only change; will be validated by next CD trigger)_
- [x] Documentation has been added/updated (where applicable). _(N/A)_

## Special notes for your reviewer

The empty-input `fromJSON` is technically also a robustness bug upstream in `grafana/plugin-ci-workflows` cd.yml — the `if` would be hardened by gating on `needs.setup.result == 'success'` before calling `fromJSON`. Worth raising there separately, but the right fix on our side is to stop firing the redundant matrix.