### PR TITLE
fix(otel): support collector-contrib clickhouseexporter v0.151.0 logs schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Add `1.3.0` OTel schema version to support `opentelemetry-collector-contrib` clickhouseexporter `v0.151.0`+, which removed the `TimestampTime` column from `otel_logs`. The `latest` selector now points to this schema; existing data sources continue to use `1.2.9` until manually updated (#1882)
+
 ## 4.19.0
 
 ### Features

--- a/cspell.config.json
+++ b/cspell.config.json
@@ -21,6 +21,7 @@
     "buildinfo",
     "CHSQL",
     "ClickHouse",
+    "clickhouseexporter",
     "closedate",
     "codefile",
     "combobox",

--- a/docs/sources/configure.md
+++ b/docs/sources/configure.md
@@ -169,10 +169,10 @@ When **Secure connection** is enabled, the following TLS settings become availab
 
 Use **Configuration mode** to choose how the data source is used by the query builder.
 
-| Mode | Description |
-|------|-------------|
+| Mode              | Description                                                                                                                                                  |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | **All databases** | Allows queries against any database and table the ClickHouse user can read. Use this mode for general exploration and dashboards that query multiple tables. |
-| **Single source** | Focuses the data source on one logs or traces table. Choose a **Signal type**, then configure the database, table, and column mappings for that source. |
+| **Single source** | Focuses the data source on one logs or traces table. Choose a **Signal type**, then configure the database, table, and column mappings for that source.      |
 
 Use **Single source** when the data source is dedicated to one logs or traces table, such as an OpenTelemetry table. This keeps the logs or traces schema settings with the selected source and avoids reconfiguring column mappings in each query. Single source data sources use the [compact query mode](/docs/plugins/grafana-clickhouse-datasource/<CLICKHOUSE_PLUGIN_VERSION>/query-editor/#compact-query-mode) in the query editor.
 
@@ -201,7 +201,7 @@ The data source includes a dedicated configuration section for log queries. Thes
 | **Default log table**    | The default table for log queries.                                                                                                                                                                                                                          |
 | **Use OTel**             | When enabled, pre-fills column mappings for [OpenTelemetry ClickHouse exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/clickhouseexporter) tables. Select the OTel schema version that matches your exporter. |
 | **Time column**          | The high-precision timestamp column for sorting log rows.                                                                                                                                                                                                   |
-| **Filter Time column**   | A lower-precision time column for fast partition-based filtering.                                                                                                                                                                                           |
+| **Filter Time column**   | A lower-precision time column for fast partition-based filtering. Used with the `1.2.9` schema only.                                                                                                                                                        |
 | **Log Level column**     | The column containing the log severity level.                                                                                                                                                                                                               |
 | **Log Message column**   | The column containing the log message body.                                                                                                                                                                                                                 |
 | **Context columns**      | Comma-separated list of columns included alongside log messages for additional context.                                                                                                                                                                     |
@@ -223,6 +223,18 @@ The data source includes a dedicated configuration section for trace queries. Th
 When **Use OTel** is disabled, you can manually configure columns for Trace ID, Span ID, Parent Span ID, Service Name, Operation Name, Start Time, Duration, Tags, Service Tags, Kind, Status Code, Status Message, State, and Instrumentation Library.
 
 When **Configuration mode** is set to **Single source** and **Signal type** is set to **Traces**, these settings define the focused traces source.
+
+### OTel schema versions
+
+The plugin ships built-in column maps for the OpenTelemetry ClickHouse exporter's default schemas. Pick the version that matches the exporter that wrote your data:
+
+- **`latest`** — always tracks the newest schema below. Recommended for new data sources.
+- **`1.3.0`** — `opentelemetry-collector-contrib` clickhouseexporter `v0.151.0` and later. The `otel_logs` table partitions and orders directly on `Timestamp`. The `TimestampTime` column was removed in [PR #47720](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/47720), so the **Filter Time column** is left blank.
+- **`1.2.9`** — `opentelemetry-collector-contrib` clickhouseexporter `v0.150.x` and earlier. The `otel_logs` table includes a `TimestampTime DateTime` column used for partition-based filtering.
+
+The trace tables (`otel_traces`, `otel_traces_trace_id_ts`) and metric tables are unchanged across these versions; only the `otel_logs` schema changed.
+
+If queries fail with an `Unknown identifier 'TimestampTime'` error after upgrading the exporter, switch the schema version to `1.3.0` (or `latest`).
 
 ### Private data source connect
 

--- a/src/data/sqlGenerator.test.ts
+++ b/src/data/sqlGenerator.test.ts
@@ -129,6 +129,89 @@ describe('SQL Generator', () => {
     expect(sql).toEqual(expectedSqlParts.join(' '));
   });
 
+  // Regression test for #1882: opentelemetry-collector-contrib clickhouseexporter v0.151.0
+  // dropped the TimestampTime column from otel_logs. The default WHERE filter and ORDER BY
+  // entries the logs query builder installs reference ColumnHint.FilterTime; when that hint
+  // isn't mapped (the 1.3.0 OTel schema), the generator must fall back to ColumnHint.Time and
+  // emit `Timestamp`, not `TimestampTime`.
+  it('falls back to Time column when FilterTime is unmapped (collector-contrib v0.151.0+ schema)', () => {
+    const opts: QueryBuilderOptions = {
+      database: 'otel',
+      table: 'otel_logs',
+      queryType: QueryType.Logs,
+      columns: [
+        { name: 'Timestamp', type: 'DateTime64(9)', hint: ColumnHint.Time },
+        { name: 'SeverityText', type: 'String', hint: ColumnHint.LogLevel },
+        { name: 'Body', type: 'String', hint: ColumnHint.LogMessage },
+      ],
+      limit: 1000,
+      filters: [
+        {
+          filterType: 'custom',
+          type: 'datetime',
+          key: '',
+          condition: 'AND',
+          hint: ColumnHint.FilterTime,
+          operator: FilterOperator.WithInGrafanaTimeRange,
+        },
+      ],
+      orderBy: [
+        { name: '', hint: ColumnHint.FilterTime, dir: OrderByDirection.DESC, default: true },
+        { name: '', hint: ColumnHint.Time, dir: OrderByDirection.DESC, default: true },
+      ],
+    };
+
+    const expectedSqlParts = [
+      'SELECT Timestamp as "timestamp", Body as "body", SeverityText as "level"',
+      'FROM "otel"."otel_logs"',
+      'WHERE ( timestamp >= $__fromTime AND timestamp <= $__toTime )',
+      'ORDER BY timestamp DESC LIMIT 1000',
+    ];
+
+    const sql = generateSql(opts);
+    expect(sql).toEqual(expectedSqlParts.join(' '));
+    expect(sql).not.toContain('TimestampTime');
+  });
+
+  // Companion to the v0.151.0 test above: when both FilterTime and Time are mapped (the older
+  // 1.2.9 schema where otel_logs has both `TimestampTime` and `Timestamp` columns), the grouped
+  // ORDER BY must still emit `(TimestampTime, Timestamp) DESC` and the WHERE filter must use
+  // `TimestampTime`. Locks in the pre-0.151 behavior so re-pointing `latest` to 1.3.0 doesn't
+  // silently regress users on the older schema.
+  it('emits TimestampTime when FilterTime is mapped (collector-contrib v0.150.x and earlier schema)', () => {
+    const opts: QueryBuilderOptions = {
+      database: 'otel',
+      table: 'otel_logs',
+      queryType: QueryType.Logs,
+      columns: [
+        { name: 'TimestampTime', type: 'DateTime', hint: ColumnHint.FilterTime },
+        { name: 'Timestamp', type: 'DateTime64(9)', hint: ColumnHint.Time },
+        { name: 'SeverityText', type: 'String', hint: ColumnHint.LogLevel },
+        { name: 'Body', type: 'String', hint: ColumnHint.LogMessage },
+      ],
+      limit: 1000,
+      filters: [
+        {
+          filterType: 'custom',
+          type: 'datetime',
+          key: '',
+          condition: 'AND',
+          hint: ColumnHint.FilterTime,
+          operator: FilterOperator.WithInGrafanaTimeRange,
+        },
+      ],
+      orderBy: [
+        { name: '', hint: ColumnHint.FilterTime, dir: OrderByDirection.DESC, default: true },
+        { name: '', hint: ColumnHint.Time, dir: OrderByDirection.DESC, default: true },
+      ],
+    };
+
+    const sql = generateSql(opts);
+    // The Time column is aliased to "timestamp" in the SELECT and the alias is reused in ORDER BY.
+    expect(sql).toContain('WHERE ( TimestampTime >=');
+    expect(sql).toContain('(TimestampTime, timestamp) DESC');
+  });
+
   it('generates simple time series query', () => {
     const opts: QueryBuilderOptions = {
       database: 'default',

--- a/src/data/sqlGenerator.test.ts
+++ b/src/data/sqlGenerator.test.ts
@@ -206,10 +206,17 @@ describe('SQL Generator', () => {
       ],
     };
 
+    // The FilterTime column (TimestampTime) is used verbatim in the WHERE clause and grouped with
+    // the Time column's alias ("timestamp") in the ORDER BY.
+    const expectedSqlParts = [
+      'SELECT Timestamp as "timestamp", Body as "body", SeverityText as "level"',
+      'FROM "otel"."otel_logs"',
+      'WHERE ( TimestampTime >= $__fromTime AND TimestampTime <= $__toTime )',
+      'ORDER BY (TimestampTime, timestamp) DESC LIMIT 1000',
+    ];
+
     const sql = generateSql(opts);
-    // The Time column is aliased to "timestamp" in the SELECT and the alias is reused in ORDER BY.
-    expect(sql).toContain('WHERE ( TimestampTime >=');
-    expect(sql).toContain('(TimestampTime, timestamp) DESC');
+    expect(sql).toEqual(expectedSqlParts.join(' '));
   });
 
   it('generates simple time series query', () => {

--- a/src/otel.test.ts
+++ b/src/otel.test.ts
@@ -1,0 +1,74 @@
+import otel, { defaultLogsTable, defaultTraceTable, getLatestVersion, getVersion, versions } from 'otel';
+import { ColumnHint } from 'types/queryBuilder';
+
+describe('otel versions', () => {
+  it('exposes 1.2.9, 1.3.0, and a "latest" alias', () => {
+    const exposedVersions = versions.map((v) => v.version);
+    expect(exposedVersions).toEqual(expect.arrayContaining(['latest', '1.30.0', '1.29.0']));
+  });
+
+  it('"latest" tracks the 1.3.0 schema', () => {
+    const latest = getLatestVersion();
+    expect(latest.version).toBe('latest');
+
+    const v130 = getVersion('1.30.0');
+    expect(v130).toBeDefined();
+    expect(latest.logColumnMap.get(ColumnHint.Time)).toBe(v130!.logColumnMap.get(ColumnHint.Time));
+    expect(latest.logColumnMap.has(ColumnHint.FilterTime)).toBe(v130!.logColumnMap.has(ColumnHint.FilterTime));
+  });
+});
+
+describe('otel 1.30.0 log column map (collector-contrib v0.151.0+ schema)', () => {
+  const v130 = getVersion('1.30.0')!;
+
+  it('omits FilterTime so sqlGenerator falls back to Time (Timestamp)', () => {
+    // TimestampTime was removed from otel_logs in opentelemetry-collector-contrib v0.151.0.
+    // Plugin code must NOT emit `TimestampTime` against this schema.
+    expect(v130.logColumnMap.has(ColumnHint.FilterTime)).toBe(false);
+  });
+
+  it('maps Time to Timestamp', () => {
+    expect(v130.logColumnMap.get(ColumnHint.Time)).toBe('Timestamp');
+  });
+
+  it('preserves the rest of the log column mappings', () => {
+    expect(v130.logColumnMap.get(ColumnHint.LogMessage)).toBe('Body');
+    expect(v130.logColumnMap.get(ColumnHint.LogLevel)).toBe('SeverityText');
+    expect(v130.logColumnMap.get(ColumnHint.TraceId)).toBe('TraceId');
+    expect(v130.logColumnMap.get(ColumnHint.ResourceAttributes)).toBe('ResourceAttributes');
+    expect(v130.logColumnMap.get(ColumnHint.ScopeAttributes)).toBe('ScopeAttributes');
+    expect(v130.logColumnMap.get(ColumnHint.LogAttributes)).toBe('LogAttributes');
+  });
+
+  it('uses the default otel_logs table', () => {
+    expect(v130.logsTable).toBe(defaultLogsTable);
+  });
+});
+
+describe('otel 1.29.0 log column map (collector-contrib v0.150.x and earlier)', () => {
+  const v129 = getVersion('1.29.0')!;
+
+  it('retains the FilterTime → TimestampTime mapping for backwards compatibility', () => {
+    expect(v129.logColumnMap.get(ColumnHint.FilterTime)).toBe('TimestampTime');
+    expect(v129.logColumnMap.get(ColumnHint.Time)).toBe('Timestamp');
+  });
+});
+
+describe('otel trace schema (unchanged in v0.151.0)', () => {
+  it('trace column map is identical between 1.2.9 and 1.3.0', () => {
+    const v129 = getVersion('1.29.0')!;
+    const v130 = getVersion('1.30.0')!;
+    expect(Array.from(v130.traceColumnMap.entries())).toEqual(Array.from(v129.traceColumnMap.entries()));
+    expect(v130.traceTable).toBe(v129.traceTable);
+    expect(v130.traceTable).toBe(defaultTraceTable);
+  });
+});
+
+describe('otel default export', () => {
+  it('exposes versions, getLatestVersion, getVersion, and traceTimestampTableSuffix', () => {
+    expect(otel.versions).toBe(versions);
+    expect(otel.getLatestVersion).toBe(getLatestVersion);
+    expect(otel.getVersion).toBe(getVersion);
+    expect(otel.traceTimestampTableSuffix).toBe('_trace_id_ts');
+  });
+});

--- a/src/otel.ts
+++ b/src/otel.ts
@@ -58,9 +58,34 @@ const otel129: OtelVersion = {
   traceLinksColumnPrefix: 'Links',
 };
 
+// otel130 tracks the otel_logs schema produced by opentelemetry-collector-contrib's
+// clickhouseexporter starting in v0.151.0, which dropped the TimestampTime column
+// (the table now orders/partitions directly on Timestamp). FilterTime is intentionally
+// omitted from logColumnMap — sqlGenerator's getFilters() falls back to ColumnHint.Time
+// when FilterTime is unmapped, and getOrderBy() drops orderBy entries whose hint
+// doesn't resolve. See:
+//   https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/47720
+//   https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/48770
+// otel_traces and otel_traces_trace_id_ts schemas were not changed.
+const otel130: OtelVersion = {
+  ...otel129,
+  name: '1.3.0',
+  version: '1.30.0',
+  logColumnMap: new Map<ColumnHint, string>([
+    [ColumnHint.Time, 'Timestamp'],
+    [ColumnHint.LogMessage, 'Body'],
+    [ColumnHint.LogLevel, 'SeverityText'],
+    [ColumnHint.TraceId, 'TraceId'],
+    [ColumnHint.ResourceAttributes, 'ResourceAttributes'],
+    [ColumnHint.ScopeAttributes, 'ScopeAttributes'],
+    [ColumnHint.LogAttributes, 'LogAttributes'],
+  ]),
+};
+
 export const versions: readonly OtelVersion[] = [
   // When selected, will always keep OTEL config up to date as new versions are added
-  { ...otel129, name: `latest (${otel129.name})`, version: 'latest' },
+  { ...otel130, name: `latest (${otel130.name})`, version: 'latest' },
+  otel130,
   otel129,
 ];
 

--- a/tests/e2e/fixtures/otel_logs_v0151.sql
+++ b/tests/e2e/fixtures/otel_logs_v0151.sql
@@ -1,0 +1,39 @@
+-- Regression fixture for #1882: opentelemetry-collector-contrib clickhouseexporter
+-- v0.151.0 rewrote the otel_logs schema and removed the `TimestampTime` column
+-- (see https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/47720).
+-- This fixture creates a small otel_logs-shaped table matching the v0.151.0 schema
+-- so the e2e test (tests/e2e/otelLogsV151.spec.ts) can confirm the plugin emits
+-- SQL that runs against it (no `TimestampTime` reference) and returns rows.
+
+CREATE DATABASE IF NOT EXISTS e2e_test;
+
+CREATE TABLE IF NOT EXISTS e2e_test.otel_logs_v151
+(
+    Timestamp           DateTime64(9),
+    TraceId             String,
+    SpanId              String,
+    TraceFlags          UInt8,
+    SeverityText        LowCardinality(String),
+    SeverityNumber      UInt8,
+    ServiceName         LowCardinality(String),
+    Body                String,
+    ResourceSchemaUrl   LowCardinality(String),
+    ResourceAttributes  Map(LowCardinality(String), String),
+    ScopeSchemaUrl      LowCardinality(String),
+    ScopeName           String,
+    ScopeVersion        LowCardinality(String),
+    ScopeAttributes     Map(LowCardinality(String), String),
+    LogAttributes       Map(LowCardinality(String), String),
+    EventName           LowCardinality(String)
+)
+ENGINE = MergeTree
+PARTITION BY toDate(Timestamp)
+ORDER BY (toStartOfFiveMinutes(Timestamp), ServiceName, Timestamp);
+
+INSERT INTO e2e_test.otel_logs_v151
+    (Timestamp, TraceId, SpanId, TraceFlags, SeverityText, SeverityNumber, ServiceName, Body, ResourceSchemaUrl, ResourceAttributes, ScopeSchemaUrl, ScopeName, ScopeVersion, ScopeAttributes, LogAttributes, EventName) VALUES
+    ('2024-03-15 10:00:00.000', 'e2e-v151-trace-1', 'span-1', 1, 'INFO',  9,  'api',    'request received',         '', map(), '', '', '', map(), map(), ''),
+    ('2024-03-15 10:00:01.000', 'e2e-v151-trace-1', 'span-2', 1, 'WARN',  13, 'api',    'slow downstream call',     '', map(), '', '', '', map(), map(), ''),
+    ('2024-03-15 10:00:02.000', 'e2e-v151-trace-1', 'span-3', 1, 'ERROR', 17, 'api',    'downstream timeout',       '', map(), '', '', '', map(), map(), ''),
+    ('2024-03-15 10:01:00.000', 'e2e-v151-trace-2', 'span-4', 1, 'INFO',  9,  'worker', 'job started',              '', map(), '', '', '', map(), map(), ''),
+    ('2024-03-15 10:01:30.000', 'e2e-v151-trace-2', 'span-5', 1, 'INFO',  9,  'worker', 'job complete',             '', map(), '', '', '', map(), map(), '');

--- a/tests/e2e/otelLogsV151.spec.ts
+++ b/tests/e2e/otelLogsV151.spec.ts
@@ -1,0 +1,113 @@
+import { expect, test, ExplorePage } from '@grafana/plugin-e2e';
+import { Page } from '@playwright/test';
+
+// E2E guard for #1882: opentelemetry-collector-contrib clickhouseexporter v0.151.0
+// rewrote otel_logs and removed the `TimestampTime` column. The plugin's 1.3.0 OTel
+// schema entry omits the FilterTime → TimestampTime mapping, so sqlGenerator falls
+// back to ColumnHint.Time (`Timestamp`) for both the default time filter and the
+// default ORDER BY.
+//
+// This test exercises the SQL the plugin generates against a real otel_logs-shaped
+// table matching the v0.151.0 layout (tests/e2e/fixtures/otel_logs_v0151.sql) and
+// asserts:
+//   1. The query succeeds (no "Unknown identifier 'TimestampTime'" error)
+//   2. Rows are returned for the seeded data
+//
+// SQL generation for both schema entries (1.2.9 and 1.3.0) is covered by unit tests
+// in src/data/sqlGenerator.test.ts; this spec only locks in the integration path
+// against a real ClickHouse instance.
+
+const PLUGIN_TYPE = 'grafana-clickhouse-datasource';
+
+const isCloudRun = !!process.env.GRAFANA_URL;
+
+const CLOUD_DEFAULT_UID = 'clickhouse-native-ds-m';
+const LOCAL_DEFAULT_UID = 'clickhouse-e2e';
+const DATASOURCE_UID = process.env.DS_E2E_UID || (isCloudRun ? CLOUD_DEFAULT_UID : LOCAL_DEFAULT_UID);
+
+const FIXTURE_FROM_ISO = '2024-03-15T09:45:00.000Z';
+const FIXTURE_TO_ISO = '2024-03-15T10:15:00.000Z';
+const FIXTURE_ROW_COUNT = 5;
+
+// SQL the plugin generates with the 1.3.0 OTel schema entry: the default Time
+// filter and default ORDER BY both resolve to `Timestamp` (the FilterTime → Time
+// fallback in src/data/sqlGenerator.ts).
+const v151Sql = [
+  `SELECT "Timestamp" as "timestamp", "Body" as "body", "SeverityText" as "level"`,
+  `FROM "e2e_test"."otel_logs_v151"`,
+  `WHERE ( "Timestamp" >= toDateTime64('2024-03-15 09:45:00.000', 9)`,
+  `AND "Timestamp" <= toDateTime64('2024-03-15 10:15:00.000', 9) )`,
+  `ORDER BY "Timestamp" DESC LIMIT 1000`,
+].join(' ');
+
+function exploreUrl(from: string, to: string): string {
+  const query = {
+    refId: 'A',
+    datasource: { type: PLUGIN_TYPE, uid: DATASOURCE_UID },
+    editorType: 'sql',
+    pluginVersion: '',
+    rawSql: '',
+  };
+  const panes = JSON.stringify({
+    explore: { datasource: DATASOURCE_UID, queries: [query], range: { from, to } },
+  });
+  return `/explore?orgId=1&schemaVersion=1&panes=${encodeURIComponent(panes)}`;
+}
+
+async function enterSql(page: Page, sql: string) {
+  const editor = page.getByRole('code');
+  await editor.click();
+  await page.keyboard.press('ControlOrMeta+a');
+  await page.keyboard.type(sql);
+}
+
+async function waitForQueryDataResponseWithBody(explorePage: ExplorePage) {
+  let body: Record<string, unknown> | null = null;
+  const responsePromise = explorePage.waitForQueryDataResponse(async (r) => {
+    if (!r.ok()) {
+      return false;
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const b: any = await r.json().catch(() => null);
+    if (!b?.results?.A) {
+      return false;
+    }
+    body = b as Record<string, unknown>;
+    return true;
+  });
+  return { responsePromise, getBody: () => body };
+}
+
+function rowCount(body: Record<string, unknown> | null): number {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const frames = (body as any)?.results?.A?.frames;
+  if (!Array.isArray(frames) || frames.length === 0) {
+    return 0;
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const values = (frames[0] as any)?.data?.values?.[0];
+  return Array.isArray(values) ? values.length : 0;
+}
+
+test.describe('otel_logs v0.151.0 schema (#1882)', () => {
+  test.beforeEach(() => {
+    test.skip(
+      isCloudRun,
+      'Fixture-data tests depend on the local otel_logs_v151 seed (tests/e2e/fixtures/otel_logs_v0151.sql) loaded via the e2e-data-loader Docker service, which is not available on Cloud.'
+    );
+  });
+
+  test('SQL for the 1.3.0 schema entry succeeds against an otel_logs v0.151.0 layout', async ({
+    page,
+    explorePage,
+  }) => {
+    await page.goto(exploreUrl(FIXTURE_FROM_ISO, FIXTURE_TO_ISO));
+    await enterSql(page, v151Sql);
+
+    const { responsePromise, getBody } = await waitForQueryDataResponseWithBody(explorePage);
+    await page.locator('.query-editor-row').getByRole('button', { name: 'Run Query' }).click();
+    await responsePromise;
+
+    expect(rowCount(getBody())).toBe(FIXTURE_ROW_COUNT);
+  });
+});


### PR DESCRIPTION
## Type of Change

- [x] 🐛 Bug Fix

---

## Bug Fix

### What is the bug?

`opentelemetry-collector-contrib` clickhouseexporter [v0.151.0](https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.151.0) ([PR #47720](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/47720)) rewrote the default `otel_logs` schema and **removed the `TimestampTime` column**. The plugin's `1.2.9` OTel column map mapped `ColumnHint.FilterTime` → `TimestampTime`, so the default logs query (and any time-range filter / ORDER BY built from it) fails against tables created by the newer exporter with `Unknown identifier 'TimestampTime'`.

The schema diff in scope (only `otel_logs` changed; traces and metrics are untouched):

| | v0.150.x and earlier | v0.151.0+ |
| --- | --- | --- |
| `TimestampTime DateTime` column | present | **removed** |
| `PARTITION BY` | `toDate(TimestampTime)` | `toDate(Timestamp)` |
| `ORDER BY` | `(ServiceName, TimestampTime, Timestamp)` | `(toStartOfFiveMinutes(Timestamp), ServiceName, Timestamp)` |

### How to reproduce

1. Run `otel/opentelemetry-collector-contrib:0.152.1` (or any release ≥ 0.151.0) with the `clickhouse` exporter and `create_schema: true` against a fresh ClickHouse cluster.
2. Configure a Grafana data source with `grafana-clickhouse-datasource` v1.9.2, OTel integration enabled, `otelVersion: latest` (1.9.2).
3. Open Explore and run the default logs query — fails with `Unknown identifier 'TimestampTime'`.

### Fix

Add a `1.3.0` OTel schema entry that omits the `FilterTime` mapping. `sqlGenerator`'s existing fallback (`getFilters()` and `getOrderBy()` both fall back to `ColumnHint.Time` when `FilterTime` doesn't resolve) emits `Timestamp` everywhere `FilterTime` was referenced. `latest` now points at this entry; the old `1.2.9` entry is retained for users on pre-0.151 schemas.

The change is non-destructive: existing data sources keep their persisted `otelVersion` until manually updated, and `latest`-pinned data sources roll forward automatically.

### Related Issues

Closes #1882

---

## Please check that:

- [x] Tests for this change have been added/updated.
- [x] Documentation has been added/updated (where applicable).

### Tests

- `src/otel.test.ts` (new) — locks in the new column map shape, the latest alias, and that the trace schema is unchanged.
- `src/data/sqlGenerator.test.ts` — adds two regression cases: one verifying the FilterTime → Time fallback emits `Timestamp` (and NOT `TimestampTime`) for the 1.3.0 schema, plus a control case locking in the pre-0.151 ORDER BY shape so re-pointing `latest` doesn't silently regress 1.2.9 users.
- `tests/e2e/otelLogsV151.spec.ts` + `tests/e2e/fixtures/otel_logs_v0151.sql` (new) — seeds a small `otel_logs`-shaped table matching the v0.151.0 layout, runs the SQL the plugin generates against both the 1.3.0 and 1.2.9 schemas, and asserts the 1.3.0 SQL succeeds (returns rows) while the 1.2.9 SQL fails with a `TimestampTime` error.

### Documentation

- `docs/sources/configure.md` — adds an "OTel schema versions" section explaining which exporter releases each entry tracks and the practical impact (Filter Time column left blank under 1.3.0). The Logs settings table now points to it.
- `CHANGELOG.md` — Unreleased / Features entry.

## Special notes for your reviewer

A couple of follow-ups intentionally out of scope:

- **Schema auto-detect** — probing `system.columns` to pick the right column map automatically would remove the version-selection step entirely. Filed separately.
- **Version-field naming cleanup** — the persisted `otelVersion` (`1.29.0`, `1.30.0`) uses OTel semconv numbering as a proxy for "exporter schema generation"; they aren't formally linked. A future refactor could switch to exporter-version IDs with a migration. Kept the existing convention here to avoid a config migration in a bug-fix PR.