### PR TITLE
fix(traces): preserve trace ID link optimization on cold cache

### DIFF
--- a/src/hooks/useHasTraceTimestampTable.test.ts
+++ b/src/hooks/useHasTraceTimestampTable.test.ts
@@ -20,16 +20,35 @@ describe('useHasTraceTimestampTable', () => {
     expect(result.current).toBe(true);
   });
 
-  it('starts false on a cold cache then updates to the resolved value', async () => {
+  it('stays undefined on a cold cache then updates to the resolved value', async () => {
+    // Returning `undefined` (rather than a transient `false`) is what lets the
+    // CHQueryEditor effect skip dispatching while the async lookup is in
+    // flight, preserving any pre-set `meta.hasTraceTimestampTable: true` baked
+    // into trace ID deep-link queries by the response transform (#1918).
     const mockDs = {} as Datasource;
     mockDs.peekTraceTimestampTable = jest.fn(() => undefined);
     mockDs.hasTraceTimestampTable = jest.fn(() => Promise.resolve(true));
 
     const { result } = renderHook(() => useHasTraceTimestampTable(mockDs, 'otel', 'otel_traces'));
-    expect(result.current).toBe(false); // cold cache → initial render is false
+    expect(result.current).toBeUndefined(); // cold cache → "don't know yet"
 
     await act(async () => {}); // flush the async check
     expect(result.current).toBe(true); // updated once it resolves
+  });
+
+  it('resolves to false when the companion table does not exist', async () => {
+    // A definitive false from the async check must propagate so the editor can
+    // correct stale optimistic meta (e.g. a saved query from a table that has
+    // since lost its companion).
+    const mockDs = {} as Datasource;
+    mockDs.peekTraceTimestampTable = jest.fn(() => undefined);
+    mockDs.hasTraceTimestampTable = jest.fn(() => Promise.resolve(false));
+
+    const { result } = renderHook(() => useHasTraceTimestampTable(mockDs, 'otel', 'otel_traces'));
+    expect(result.current).toBeUndefined();
+
+    await act(async () => {});
+    expect(result.current).toBe(false);
   });
 
   it('returns false when database or table is empty', async () => {

--- a/src/hooks/useHasTraceTimestampTable.ts
+++ b/src/hooks/useHasTraceTimestampTable.ts
@@ -1,8 +1,19 @@
 import { useState, useEffect } from 'react';
 import { Datasource } from 'data/CHDatasource';
 
-export default (datasource: Datasource, database: string, table: string): boolean => {
-  const [result, setResult] = useState(() => datasource.peekTraceTimestampTable(database, table) ?? false);
+/**
+ * Resolves whether the `<table>_trace_id_ts` companion exists.
+ *
+ * Returns `undefined` while the lookup is still in flight on a cold cache.
+ * Callers that mirror this into builder options must treat `undefined` as
+ * "don't know yet" and leave the upstream meta value alone — otherwise the
+ * transient `false` clobbers the optimized value that the response-transform
+ * path bakes into trace ID deep-link queries (see issue #1918).
+ */
+export default (datasource: Datasource, database: string, table: string): boolean | undefined => {
+  const [result, setResult] = useState<boolean | undefined>(() =>
+    datasource.peekTraceTimestampTable(database, table)
+  );
 
   useEffect(() => {
     if (!database || !table) {

--- a/src/views/CHQueryEditor.test.tsx
+++ b/src/views/CHQueryEditor.test.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, act } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { CHQueryEditor } from './CHQueryEditor';
 import * as ui from '@grafana/ui';
-import { mockDatasource } from '__mocks__/datasource';
+import { mockDatasource, newMockDatasource } from '__mocks__/datasource';
 import { EditorType } from 'types/sql';
-import { QueryType } from 'types/queryBuilder';
+import { ColumnHint, QueryType } from 'types/queryBuilder';
+import { pluginVersion } from 'utils/version';
 
 jest.mock('@grafana/ui', () => ({
   ...jest.requireActual<typeof ui>('@grafana/ui'),
@@ -79,5 +80,75 @@ describe('Query Editor', () => {
 
     // onChange should not be called since editorType is SQL
     expect(onChange).not.toHaveBeenCalled();
+  });
+
+  // Regression guard for #1918:
+  // When the response-transform path pre-generates a trace ID deep-link with
+  // `meta.hasTraceTimestampTable: true` and an optimized `rawSql` that joins
+  // against `<table>_trace_id_ts`, the editor must NOT clobber that value
+  // while `useHasTraceTimestampTable` is still resolving on a cold cache.
+  // Before the fix, the hook returned `false` on its initial render, the
+  // dispatch effect updated meta to `false`, and the next builderOptions
+  // effect regenerated rawSql without the `_trace_id_ts` clause — causing
+  // the first click after a fresh page load to time out.
+  it('preserves meta.hasTraceTimestampTable on a cold-cache trace ID deep-link (#1918)', async () => {
+    const ds = newMockDatasource();
+    // Cold cache: peek returns undefined, async eventually resolves to true.
+    jest.spyOn(ds, 'peekTraceTimestampTable').mockReturnValue(undefined);
+    jest.spyOn(ds, 'hasTraceTimestampTable').mockResolvedValue(true);
+
+    const optimizedSql =
+      `WITH 'abc' as trace_id, ` +
+      `(SELECT min(Start) FROM "otel"."otel_traces_trace_id_ts" WHERE TraceId = trace_id) as trace_start, ` +
+      `(SELECT max(End) + 1 FROM "otel"."otel_traces_trace_id_ts" WHERE TraceId = trace_id) as trace_end ` +
+      `SELECT "TraceId" as traceID FROM "otel"."otel_traces" ` +
+      `WHERE traceID = trace_id AND "Timestamp" >= trace_start AND "Timestamp" <= trace_end`;
+
+    const onChange = jest.fn();
+    render(
+      <CHQueryEditor
+        query={{
+          // Must use a v4+ pluginVersion so migrateCHQuery doesn't downgrade
+          // the query into a CHSqlQuery and strip builderOptions.
+          pluginVersion,
+          refId: 'Trace ID',
+          editorType: EditorType.Builder,
+          rawSql: optimizedSql,
+          builderOptions: {
+            database: 'otel',
+            table: 'otel_traces',
+            queryType: QueryType.Traces,
+            columns: [
+              { name: 'Timestamp', hint: ColumnHint.Time },
+              { name: 'TraceId', hint: ColumnHint.TraceId },
+            ],
+            meta: {
+              minimized: true,
+              isTraceIdMode: true,
+              traceId: 'abc',
+              hasTraceTimestampTable: true,
+            },
+          },
+        }}
+        onChange={onChange}
+        onRunQuery={jest.fn()}
+        datasource={ds}
+      />
+    );
+    // Flush the hook's async resolution and any state-driven re-renders.
+    await act(async () => {});
+
+    // The dispatch effect must never push `hasTraceTimestampTable: false`,
+    // and any regenerated rawSql must keep the `_trace_id_ts` join. Before
+    // the fix, the cold-cache initial render of `useHasTraceTimestampTable`
+    // returned `false`, the editor effect dispatched that into meta, and the
+    // next builderOptions effect emitted an onChange with the unoptimized SQL.
+    expect(onChange).toHaveBeenCalled();
+    for (const [updated] of onChange.mock.calls) {
+      expect(updated.builderOptions?.meta?.hasTraceTimestampTable).not.toBe(false);
+      if (typeof updated.rawSql === 'string' && updated.rawSql.length > 0) {
+        expect(updated.rawSql).toContain('otel_traces_trace_id_ts');
+      }
+    }
   });
 });

--- a/src/views/CHQueryEditor.tsx
+++ b/src/views/CHQueryEditor.tsx
@@ -81,6 +81,15 @@ const CHEditorByType = (props: CHQueryEditorProps) => {
       return;
     }
 
+    // While the hook resolves on a cold cache it returns `undefined`. The
+    // response-transform path has already baked the authoritative value into
+    // `meta.hasTraceTimestampTable`, so leave it alone until we have a real
+    // answer — otherwise a transient `false` regenerates rawSql without the
+    // _trace_id_ts optimization (#1918).
+    if (hasTraceTimestampTable === undefined) {
+      return;
+    }
+
     if (hasTraceTimestampTable !== builderOptions.meta?.hasTraceTimestampTable) {
       builderOptionsDispatch(
         setOptions({


### PR DESCRIPTION
<!-- To surface this PR in the changelog add the label: changelog -->

## Type of Change

- [x] 🐛 Bug Fix

---

## Bug Fix

### What is the bug?

The "View trace" data link generated by Trace Search ships with optimized `rawSql` (a `WITH … _trace_id_ts` clause that narrows the trace span scan to the time window for the trace ID) and `meta.hasTraceTimestampTable: true` baked in by `transformQueryResponseWithTraceAndLogLinks` ([src/data/utils.ts:397](https://github.com/grafana/clickhouse-datasource/blob/main/src/data/utils.ts#L397)). On a fresh page load — i.e. the deep-link opens in a new tab and the datasource's trace-timestamp-table cache is cold — three things race:

1. `useHasTraceTimestampTable` returns `false` on its initial render because `peekTraceTimestampTable()` is `undefined`.
2. The editor's dispatch effect mirrors that `false` into `builderOptions.meta.hasTraceTimestampTable`.
3. The next `builderOptions` effect calls `generateSql(builderOptions)`, which now emits the plain-`WHERE` fallback (no `_trace_id_ts` join), and onChange replaces the optimized query in Grafana's state.

The end result: the very first query Grafana runs after the link opens is the unoptimized one and times out on real traces. Hitting **refresh** regenerates SQL from the (by now resolved) `true` value, which is why a manual refresh "fixes" it.

### How to reproduce

1. Configure a ClickHouse datasource with OTel tracing and a real `<table>_trace_id_ts` companion table.
2. From a dashboard panel (so the link uses `targetBlank: true` and opens in a fresh tab with a cold datasource cache), run a Trace Search query and click **View trace** on a result row.
3. Observe the generated SQL: `WHERE traceID = '<id>'` with no `_trace_id_ts` lookup. The query eventually times out.
4. Click **refresh** — the SQL is regenerated with the `WITH trace_start/trace_end` shape and returns immediately.

### Related Issues

Closes #1918
Relates to #1705, #1786, #1853

---

## Please check that:

- [x] Tests for this change have been added/updated.
- [ ] Documentation has been added/updated (where applicable).

## Special notes for your reviewer

**Files changed**

`src/hooks/useHasTraceTimestampTable.ts` — Return type widens to `boolean | undefined`. The `useState` initializer drops the `?? false` fallback so the value stays `undefined` while the async lookup is in flight on a cold cache. Resolved values (true/false) and the empty-db/empty-table guard still set a concrete boolean.

`src/views/CHQueryEditor.tsx` — The dispatch effect that mirrors the hook into `meta.hasTraceTimestampTable` now bails out when the hook is `undefined`. This preserves the authoritative value that `transformQueryResponseWithTraceAndLogLinks` already baked into the link query, so the editor never regenerates `rawSql` with the unoptimized shape between mount and the hook's async resolution.

**Tests**

`src/hooks/useHasTraceTimestampTable.test.ts` — The cold-cache test is updated to assert the initial render is `undefined` (the regression guard for the cause), then resolves to the live value. A new case pins that a definitive `false` from the async check still propagates so the editor can still correct stale optimistic meta.

`src/views/CHQueryEditor.test.tsx` — New regression test mounts `CHQueryEditor` with a pre-baked trace ID link query against a cold-cache datasource (`peekTraceTimestampTable` returns `undefined`, `hasTraceTimestampTable` resolves `true`) and asserts that no `onChange` call ever ships `meta.hasTraceTimestampTable: false` or a `rawSql` missing the `_trace_id_ts` join. Verified that the test fails on the pre-fix code (the intermediate `onChange` carries `hasTraceTimestampTable: false` and the unoptimized SQL) and passes after.