### PR TITLE
fix(traces): prevent crash on raw-SQL queries with a trace_id column

### DIFF
--- a/src/data/utils.test.ts
+++ b/src/data/utils.test.ts
@@ -3,6 +3,7 @@ import {
   applyTraceSearchFieldConfig,
   columnLabelToPlaceholder,
   dataFrameHasLogLabelWithName,
+  getBuilderOptions,
   isBuilderOptionsRunnable,
   labelsFieldName,
   transformQueryResponseWithTraceAndLogLinks,
@@ -37,6 +38,50 @@ describe('isBuilderOptionsRunnable', () => {
 
     const runnable = isBuilderOptionsRunnable(opts);
     expect(runnable).toBe(true);
+  });
+});
+
+describe('getBuilderOptions', () => {
+  const builderOptions: QueryBuilderOptions = {
+    database: 'default',
+    table: 'test',
+    queryType: QueryType.Table,
+  };
+
+  it('returns top-level builderOptions for a builder query', () => {
+    const query: CHQuery = {
+      refId: 'A',
+      editorType: EditorType.Builder,
+      rawSql: '',
+      pluginVersion: '',
+      builderOptions,
+    };
+    expect(getBuilderOptions(query)).toBe(builderOptions);
+  });
+
+  it('returns the stashed meta.builderOptions for a raw-SQL query', () => {
+    const query: CHQuery = {
+      refId: 'A',
+      editorType: EditorType.SQL,
+      rawSql: 'SELECT 1',
+      pluginVersion: '',
+      meta: { builderOptions },
+    };
+    expect(getBuilderOptions(query)).toBe(builderOptions);
+  });
+
+  it('returns undefined for a raw-SQL query with no builderOptions', () => {
+    const query: CHQuery = {
+      refId: 'A',
+      editorType: EditorType.SQL,
+      rawSql: 'SELECT 1',
+      pluginVersion: '',
+    };
+    expect(getBuilderOptions(query)).toBeUndefined();
+  });
+
+  it('returns undefined when the query is undefined', () => {
+    expect(getBuilderOptions(undefined)).toBeUndefined();
   });
 });
 
@@ -376,6 +421,48 @@ describe('transformQueryResponseWithTraceAndLogLinks', () => {
     const traceIdFilter = logsQuery.builderOptions.filters?.find((f) => (f as any).hint === ColumnHint.TraceId) as any;
     expect(traceIdFilter).toBeDefined();
     expect(traceIdFilter.key).toBe('TraceId');
+  });
+
+  it('does not crash on a raw-SQL query with a trace_id column and no trace/table defaults (issue repro)', async () => {
+    const mockDatasource = newMockDatasource();
+    // Reproduce the customer environment: raw SQL, no trace defaults, and no default table,
+    // so the trace-link transform takes the "create from defaults" branch with empty db/table.
+    jest.spyOn(mockDatasource, 'getDefaultTraceDatabase').mockReturnValue('');
+    jest.spyOn(mockDatasource, 'getDefaultTraceTable').mockReturnValue('');
+    jest.spyOn(mockDatasource, 'getDefaultDatabase').mockReturnValue('');
+    jest.spyOn(mockDatasource, 'getDefaultTable').mockReturnValue('');
+
+    const sqlQuery: CHQuery = {
+      refId: 'A',
+      editorType: EditorType.SQL,
+      rawSql: 'SELECT trace_id FROM some_table',
+      pluginVersion: '',
+    };
+
+    const request: DataQueryRequest<CHQuery> = {
+      requestId: '',
+      interval: '',
+      intervalMs: 0,
+      range: {} as any,
+      scopedVars: {} as any,
+      targets: [sqlQuery],
+      timezone: '',
+      app: CoreApp.Explore,
+      startTime: 0,
+    };
+
+    const response: DataQueryResponse = {
+      data: [
+        {
+          refId: 'A',
+          length: 1,
+          fields: [{ name: 'trace_id', type: FieldType.string, config: {}, values: ['abc123'] }],
+        } as DataFrame,
+      ],
+    };
+
+    const out = await transformQueryResponseWithTraceAndLogLinks(mockDatasource, request, response);
+    expect(out.data[0].fields[0].config.links ?? []).toHaveLength(0);
   });
 
   describe('trace ID link rawSql pre-generation', () => {

--- a/src/data/utils.ts
+++ b/src/data/utils.ts
@@ -16,6 +16,19 @@ import { generateSql, JSON_SENTINEL_KEY } from './sqlGenerator';
 import otel from 'otel';
 
 /**
+ * Resolves the QueryBuilderOptions for a query regardless of editor type. Builder queries
+ * store them at the top level; raw-SQL queries keep a converted copy under `meta.builderOptions`
+ * (and may have none at all — e.g. a hand-written, provisioned, or migrated SQL query).
+ * Returns undefined when absent, so callers must treat the result as optional.
+ */
+export const getBuilderOptions = (query?: CHQuery): QueryBuilderOptions | undefined => {
+  if (!query) {
+    return undefined;
+  }
+  return query.editorType === EditorType.Builder ? query.builderOptions : query.meta?.builderOptions;
+};
+
+/**
  * Returns true if the builder options contain enough information to start showing a query
  */
 export const isBuilderOptionsRunnable = (builderOptions: QueryBuilderOptions): boolean => {
@@ -151,7 +164,7 @@ const traceSearchFieldConfigs: Record<string, FieldConfig> = {
  */
 export const applyTraceSearchFieldConfig = (req: DataQueryRequest<CHQuery>, res: DataQueryResponse): void => {
   res.data.forEach((frame: DataFrame) => {
-    const originalQuery = req.targets.find((t) => t.refId === frame.refId) as CHBuilderQuery;
+    const originalQuery = req.targets.find((t) => t.refId === frame.refId);
     if (!originalQuery) {
       return;
     }
@@ -225,7 +238,7 @@ const expandJsonSentinel = (fields: Array<{ key: string; value: string }>): Arra
 
 export const transformTraceTagFields = (req: DataQueryRequest<CHQuery>, res: DataQueryResponse): void => {
   res.data.forEach((frame: DataFrame) => {
-    const originalQuery = req.targets.find((t) => t.refId === frame.refId) as CHBuilderQuery;
+    const originalQuery = req.targets.find((t) => t.refId === frame.refId);
 
     // For builder queries use the queryType directly — it's authoritative and avoids
     // false-positive matches on non-trace tables that happen to have a 'traceID' column.
@@ -331,10 +344,13 @@ export const transformQueryResponseWithTraceAndLogLinks = async (
   const getCachedColumns = (db: string, tbl: string) => datasource.getColumnsCached(db, tbl);
 
   for (const frame of res.data as DataFrame[]) {
-    const originalQuery = req.targets.find((t) => t.refId === frame.refId) as CHBuilderQuery;
+    const originalQuery = req.targets.find((t) => t.refId === frame.refId);
+
     if (!originalQuery) {
       continue;
     }
+
+    const originalBuilderOptions = getBuilderOptions(originalQuery);
 
     const traceField = frame.fields.find(
       (field) => field.name.toLowerCase() === 'traceid' || field.name.toLowerCase() === 'trace_id'
@@ -480,7 +496,7 @@ export const transformQueryResponseWithTraceAndLogLinks = async (
             c.type?.toLowerCase().startsWith('json')
         ) ??
           false) ||
-        (!fetchedLiveSchema && Boolean(originalQuery.builderOptions.meta?.tagsAreJSON));
+        (!fetchedLiveSchema && Boolean(originalBuilderOptions?.meta?.tagsAreJSON));
 
       options.meta!.tagsAreJSON = detectedTagsAreJSON;
       traceIdQuery.builderOptions = options;


### PR DESCRIPTION
<!-- Please take time to fill out the below template appropriately, deleting sections where necessary. -->
<!-- Doing so will aid our reviewers in providing timely feedback and allow us to reach an outcome faster. Thanks! -->
<!-- Please delete all sections that do not apply. -->
<!-- To surface this PR in the changelog add the label: changelog -->
<!-- If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way: -->
<!-- Bad: fix state bug in hooks -->
<!-- Good: Fix crash when switching from Query Builder -->

## Type of Change

_Please check the relevant option._

- [ ] 🚀 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧹 Refactor / Chore

## Bug Fix

### What is the bug?

Any raw-SQL query (Explore mode, editorType: "sql") that returns a column named trace_id or traceid crashes with "Cannot read properties of undefined (reading 'meta')". Backend response is HTTP 200 with valid data but the frontend renders nothing.

### How to reproduce

1. Make sure `builderOptions` is really undefined: don't touch anything in query builder, don't configure a default table for traces.
2. Perform a raw sql query as above.
3. Observe error in console and empty response.

## Please check that:

- [x] Tests for this change have been added/updated.
- [ ] Documentation has been added/updated (where applicable).