### PR TITLE
refactor(config): migrate newClickhouseConfigPageDesign to OpenFeature

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -1,22 +1,16 @@
-import { DataSourcePlugin, DashboardLoadedEvent, FeatureToggles } from '@grafana/data';
+import { DataSourcePlugin, DashboardLoadedEvent } from '@grafana/data';
 import { Datasource } from './data/CHDatasource';
-import { ConfigEditor as ConfigEditorV1 } from './views/CHConfigEditor';
-import { ConfigEditor as ConfigEditorV2 } from './views/config-v2/CHConfigEditor';
+import { ConfigEditor } from './views/ConfigEditor';
 import { CHQueryEditor } from './views/CHQueryEditor';
 import { CHConfig } from 'types/config';
 import { CHQuery } from 'types/sql';
-import { config, getAppEvents } from '@grafana/runtime';
+import { getAppEvents } from '@grafana/runtime';
 import { analyzeQueries, trackClickhouseDashboardLoaded } from 'tracking';
 import pluginJson from './plugin.json';
 import clickhouseVersion from '../package.json';
 
-// ConfigEditorV2 is the new design for the ClickHouse configuration page
-const configEditor = config.featureToggles['newClickhouseConfigPageDesign' as keyof FeatureToggles]
-  ? ConfigEditorV2
-  : ConfigEditorV1;
-
 export const plugin = new DataSourcePlugin<Datasource, CHQuery, CHConfig>(Datasource)
-  .setConfigEditor(configEditor)
+  .setConfigEditor(ConfigEditor)
   .setQueryEditor(CHQueryEditor);
 
 // Track dashboard loads to RudderStack

--- a/src/views/ConfigEditor.tsx
+++ b/src/views/ConfigEditor.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { DataSourcePluginOptionsEditorProps } from '@grafana/data';
+import { OpenFeature } from '@openfeature/web-sdk';
+import { CHConfig, CHSecureConfig } from 'types/config';
+import { ConfigEditor as ConfigEditorV1 } from './CHConfigEditor';
+import { ConfigEditor as ConfigEditorV2 } from './config-v2/CHConfigEditor';
+
+// Mirrors GRAFANA_CORE_OPEN_FEATURE_DOMAIN from @grafana/runtime/internal, which
+// isn't exposed to external plugins via the published exports map.
+const GRAFANA_CORE_OPEN_FEATURE_DOMAIN = 'internal-grafana-core';
+
+export type ConfigEditorProps = DataSourcePluginOptionsEditorProps<CHConfig, CHSecureConfig>;
+
+export const ConfigEditor: React.FC<ConfigEditorProps> = (props) => {
+  const useV2 = OpenFeature.getClient(GRAFANA_CORE_OPEN_FEATURE_DOMAIN).getBooleanValue(
+    'newClickhouseConfigPageDesign',
+    false
+  );
+  return useV2 ? <ConfigEditorV2 {...props} /> : <ConfigEditorV1 {...props} />;
+};


### PR DESCRIPTION
## Type of Change

- [x] 🧹 Refactor / Chore

---

## What is the change?

Swap the `newClickhouseConfigPageDesign` read from the legacy `config.featureToggles[...]` map to the OpenFeature client. The module-level ternary that picked between `ConfigEditorV1` and `ConfigEditorV2` is replaced by a small functional wrapper (`src/views/ConfigEditor.tsx`) that evaluates the flag at render time and renders the appropriate editor.

## Why is this change needed?

In fully multi-tenant Grafana environments, the legacy `config.featureToggles` map isn't populated with all flags — flags registered for OpenFeature evaluation return `undefined` from the legacy accessor and the gated branch silently disappears. Reading via the OpenFeature client keeps the V2 editor reachable in those environments.

Reading at render time (rather than module load) also matters because the OpenFeature provider isn't initialised until after the plugin module is evaluated — a module-level `OpenFeature.getClient(...).getBooleanValue(...)` would always return the default.

## Implementation notes

- `@grafana/runtime` does not expose `useFlag*` hooks or `getFeatureFlagClient()` to external plugins (the `./internal` export is stripped from the published package). The wrapper uses `@openfeature/web-sdk` directly on the well-known `internal-grafana-core` domain. `@openfeature/web-sdk` is already a direct dependency of this plugin.
- The wrapper calls `getBooleanValue('newClickhouseConfigPageDesign', false)` on each render — no caching in `this`, no module-level constant, matching the [official Grafana guidance](https://github.com/grafana/grafana/blob/main/contribute/feature-toggles.md#using-the-client-directly-non-react-contexts) for non-hook OpenFeature consumers.
- The other `config.featureToggles` reader in this repo (`clickHouseConfigValidation`, used in both `CHConfigEditor` variants) is intentionally **not** migrated in this PR — one toggle per PR for easier review and revert.

## How to test

1. Build the plugin (`npm run build`) and load it in a Grafana instance with `feature_toggles.newClickhouseConfigPageDesign = true` in `custom.ini`. Open the ClickHouse datasource config page and confirm the V2 editor renders (the "You are viewing a new design…" banner is visible).
2. Disable the toggle (`= false` or remove it) and reload. Confirm the V1 editor renders (no banner, classic layout).
3. Run the existing E2E suite — `tests/e2e/configEditor.spec.ts` covers both editor variants and gates V2-only assertions behind `isV2Editor(page)`.

---

## Please check that:

- [ ] Tests for this change have been added/updated.
- [x] Documentation has been added/updated (where applicable).

## Special notes for your reviewer

This is the consumer-side counterpart to migrating the toggle's `Generate` field in `grafana/grafana`'s `pkg/services/featuremgmt/registry.go`. That registry edit lives in a separate PR against grafana/grafana — this plugin-side change is safe to merge independently because `getBooleanValue` falls back to the supplied default (`false`) when no provider has the flag registered.

Closes #2036