### PR TITLE
feat(annotations): preset-driven annotation editor with change detection

### DIFF
--- a/docs/sources/annotations.md
+++ b/docs/sources/annotations.md
@@ -19,9 +19,9 @@ last_reviewed: 2026-04-27
 
 Annotations overlay event markers on your dashboard panels. You can use ClickHouse SQL queries to create annotations that mark deployments, alerts, errors, or other events from your data.
 
-The plugin uses Grafana’s default annotation support: you write a ClickHouse SQL query that returns a time column and a text column. Grafana positions each row as an annotation on the time axis and shows the text when you hover or click.
+The plugin provides an annotation editor with presets for common patterns. You choose an annotation type, and the editor generates a ClickHouse SQL query that returns a time column and a text column. Grafana positions each row as an annotation on the time axis and shows the text when you hover or click.
 
-Annotation queries use Grafana’s built-in annotation query editor (a SQL text field with column mappings), not the full ClickHouse query builder available in panels.
+The generated SQL is always visible and editable, so you can start from a preset and adjust it, or select **Custom SQL** and write the query yourself. Annotation queries do not use the full ClickHouse query builder available in panels.
 
 For an overview of annotations in Grafana, see [Annotate visualizations](https://grafana.com/docs/grafana/latest/dashboards/build-dashboards/annotate-visualizations/).
 
@@ -40,9 +40,52 @@ To add a ClickHouse annotation to a dashboard:
 4. Click **Add annotation query**.
 5. Enter a **Name** for the annotation (for example, "Deployments", "Errors").
 6. In the **Data source** drop-down, select your ClickHouse data source.
-7. In the **Query** field, enter a ClickHouse SQL query that returns the required columns (see [Query requirements](#query-requirements)).
+7. Choose an **Annotation Type**. Select **Custom SQL** to write your own query, or the **Change Detection** preset to generate one. See [Annotation presets](#annotation-presets) and [Query requirements](#query-requirements).
 8. Use the **Column mappings** section to map your query columns to **Time**, **Text**, and optionally **Tags** (if your column names differ from Grafana’s defaults).
 9. Click **Apply** to save.
+
+## Annotation presets
+
+The **Annotation Type** selector offers two options. Both produce standard annotation SQL that you can edit by hand at any time.
+
+### Custom SQL
+
+Write your own annotation query. This is the default and behaves like a plain SQL field. Use it when none of the other presets fit, or as a starting point for an arbitrary query.
+
+### Change Detection
+
+Detect when a column value changes over time, such as a deployment (`service.version`), a configuration value, or a feature flag. The builder walks you through the schema:
+
+- **Database** and **Table**: where the values live (for example, `otel_traces`).
+- **Watch Column**: the column to track. For OpenTelemetry data this is usually a `Map` column such as `ResourceAttributes`.
+- **Map Key**: shown when the watch column is a `Map`. Pick the key to track, such as `service.version`.
+- **Group By**: track each value of this column independently. Defaults to `ServiceName`.
+
+The generated query buckets rows into 30-second intervals, takes the dominant value in each bucket, and uses `lagInFrame()` to compare each bucket with the previous one per group. Taking the dominant value keeps a service that runs two versions at once, during a rolling deploy or canary, from flapping between them. It emits one annotation per transition, so a rollback (`v1.0` to `v1.1` back to `v1.0`) produces three annotations rather than two:
+
+```sql
+SELECT
+  time,
+  "ServiceName" AS tags,
+  concat("ServiceName", ': ResourceAttributes.service.version changed to ', version,
+    if(prev_version != '', concat(' (was ', prev_version, ')'), '')) AS text,
+  'ResourceAttributes.service.version change' AS title
+FROM (
+  SELECT
+    toStartOfInterval(Timestamp, INTERVAL 30 second) AS time,
+    "ServiceName",
+    topK(1)("ResourceAttributes"['service.version'])[1] AS version,
+    lagInFrame(topK(1)("ResourceAttributes"['service.version'])[1])
+      OVER (PARTITION BY "ServiceName" ORDER BY time) AS prev_version
+  FROM "otel"."otel_traces"
+  WHERE $__timeFilter(Timestamp)
+    AND "ResourceAttributes"['service.version'] != ''
+  GROUP BY "ServiceName", time
+  ORDER BY "ServiceName", time
+)
+WHERE prev_version != '' AND prev_version != version
+ORDER BY time
+```
 
 ## Query requirements
 
@@ -56,6 +99,26 @@ Your SQL query must return at least a time column and a text column. Grafana use
 | **Tags**    | Optional | Additional columns become annotation tags. Use them to filter or group annotations.                                                                                                    |
 
 Always restrict the query to the dashboard time range so annotations load quickly. Use the **$\_\_timeFilter(column)** macro in your WHERE clause. If your time column is `DateTime64` and you need sub-second precision, use **$\_\_timeFilter_ms(column)** instead. See the [ClickHouse query editor](/docs/plugins/grafana-clickhouse-datasource/<CLICKHOUSE_PLUGIN_VERSION>/query-editor/) Macros section for the full list of available macros.
+
+## Filter annotations by a dashboard variable
+
+To scope an annotation to the value currently selected in a dashboard variable, reference the variable in your WHERE clause. This is useful on a per-service dashboard, where you want deployment markers to follow the selected service rather than show every service at once.
+
+For a single-value variable:
+
+```sql
+WHERE $__timeFilter(Timestamp)
+  AND ServiceName = '$service'
+```
+
+For a multi-value variable with an **All** option, wrap the filter in **$\_\_conditionalAll** so the annotation shows every value when **All** is selected and narrows to the chosen values otherwise:
+
+```sql
+WHERE $__timeFilter(Timestamp)
+  AND $__conditionalAll(ServiceName IN ($service), $service)
+```
+
+The Change Detection preset keeps its generated SQL editable, so you can build the query with the preset and then add a variable filter for your dashboard.
 
 ## Annotation query examples
 

--- a/docs/sources/annotations.md
+++ b/docs/sources/annotations.md
@@ -87,6 +87,8 @@ WHERE prev_version != '' AND prev_version != version
 ORDER BY time
 ```
 
+The builder uses `Timestamp` as the time column, the OpenTelemetry convention for the traces and logs tables. If your table stores time under a different column name, edit the generated query to match (the time column appears in `toStartOfInterval` and `$__timeFilter`), or write the query in Custom SQL.
+
 ## Query requirements
 
 Your SQL query must return at least a time column and a text column. Grafana uses these to place and label each annotation.

--- a/src/data/CHAnnotationSupport.test.tsx
+++ b/src/data/CHAnnotationSupport.test.tsx
@@ -1,0 +1,273 @@
+import React from 'react';
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import { AnnotationQuery } from '@grafana/data';
+import { createAnnotationSupport, generateChangeDetectionSQL, resolveTraceSchema } from './CHAnnotationSupport';
+import { Datasource } from './CHDatasource';
+import { CHQuery, EditorType } from 'types/sql';
+import { TableColumn } from 'types/queryBuilder';
+
+const columns: readonly TableColumn[] = [
+  { name: 'ServiceName', type: 'String', picklistValues: [] },
+  { name: 'Environment', type: 'String', picklistValues: [] },
+  { name: 'ResourceAttributes', type: 'Map(String, String)', picklistValues: [] },
+  { name: 'Timestamp', type: 'DateTime64(9)', picklistValues: [] },
+];
+
+interface DatasourceConfig {
+  defaultDb?: string;
+  defaultTable?: string;
+  tracesDb?: string;
+  tracesTable?: string;
+  configMode?: 'classic' | 'single-table';
+  signalType?: 'logs' | 'traces';
+}
+
+const buildDatasource = (config: DatasourceConfig = {}): Datasource => {
+  const ds = {} as Datasource; // [as-cast: allow] test mock, mirrors SchemaPicker.test.tsx
+  ds.settings = {
+    jsonData: { configMode: config.configMode, signalType: config.signalType },
+  } as Datasource['settings']; // [as-cast: allow] minimal settings stub for resolveTraceSchema
+  ds.getDefaultDatabase = jest.fn(() => config.defaultDb ?? 'default');
+  ds.getDefaultTable = jest.fn(() => config.defaultTable);
+  ds.getDefaultTraceDatabase = jest.fn(() => config.tracesDb);
+  ds.getDefaultTraceTable = jest.fn(() => config.tracesTable);
+  ds.fetchDatabases = jest.fn(() => Promise.resolve(['default', 'otel_v2']));
+  ds.fetchTables = jest.fn(() => Promise.resolve(['otel_traces', 'otel_logs']));
+  ds.fetchColumns = jest.fn(() => Promise.resolve([...columns]));
+  ds.fetchUniqueMapKeys = jest.fn(() => Promise.resolve(['service.version']));
+  return ds;
+};
+
+describe('generateChangeDetectionSQL', () => {
+  it('generates lagInFrame change detection over 30-second buckets for a plain column', () => {
+    const sql = generateChangeDetectionSQL({ table: 'deploys', column: 'version' });
+    // Dominant value per bucket (topK), not any(): a service running two
+    // versions at once must not flap. Validated against the live OTel demo
+    // where any() produced a marker storm for a concurrently-versioned service.
+    expect(sql).toContain('lagInFrame(topK(1)("version")[1])');
+    expect(sql).not.toContain('any(');
+    expect(sql).toContain('toStartOfInterval(Timestamp, INTERVAL 30 second)');
+    expect(sql).toContain('OVER (PARTITION BY "ServiceName" ORDER BY time)');
+    expect(sql).toContain('"ServiceName" AS tags');
+    expect(sql).toContain('FROM "deploys"');
+    // The prev_version != '' guard drops each group's first bucket, where
+    // lagInFrame returns '' and would otherwise mark every group at the window edge.
+    expect(sql).toContain("WHERE prev_version != '' AND prev_version != version");
+  });
+
+  it('accesses the map key in both the aggregate and the filter', () => {
+    const sql = generateChangeDetectionSQL({
+      database: 'otel',
+      table: 'otel_traces',
+      column: 'ResourceAttributes',
+      mapKey: 'service.version',
+    });
+    expect(sql).toContain(`topK(1)("ResourceAttributes"['service.version'])[1]`);
+    expect(sql).toContain(`AND "ResourceAttributes"['service.version'] != ''`);
+    expect(sql).toContain('FROM "otel"."otel_traces"');
+    expect(sql).toContain('ResourceAttributes.service.version change');
+  });
+
+  it('partitions and tags by a custom group-by column', () => {
+    const sql = generateChangeDetectionSQL({ table: 't', column: 'c', groupBy: 'Environment' });
+    expect(sql).toContain('PARTITION BY "Environment"');
+    expect(sql).toContain('"Environment" AS tags');
+    expect(sql).toContain('GROUP BY "Environment", time');
+  });
+
+  it('returns a placeholder comment when the table or column is missing', () => {
+    const placeholder = '-- Select a table and column above to generate the change detection query';
+    expect(generateChangeDetectionSQL({})).toBe(placeholder);
+    expect(generateChangeDetectionSQL({ table: 'only_table' })).toBe(placeholder);
+    expect(generateChangeDetectionSQL({ column: 'only_column' })).toBe(placeholder);
+  });
+
+  it('escapes single quotes in the map key so the string literal cannot break out', () => {
+    const sql = generateChangeDetectionSQL({ table: 't', column: 'attrs', mapKey: "a'b" });
+    expect(sql).toContain(`['a\\'b']`);
+    expect(sql).not.toContain(`['a'b']`);
+    expect(sql).toContain(`attrs.a\\'b change`);
+  });
+});
+
+describe('resolveTraceSchema (compact vs complete datasource)', () => {
+  it('uses the traces OTel config on a complete (classic) datasource', () => {
+    const ds = buildDatasource({ defaultDb: 'fallback', tracesDb: 'otel', tracesTable: 'spans' });
+    expect(resolveTraceSchema(ds)).toEqual({ database: 'otel', table: 'spans' });
+  });
+
+  it('uses the configured single table on a compact (single-table) traces datasource', () => {
+    const ds = buildDatasource({
+      defaultDb: 'otel_v2',
+      defaultTable: 'my_traces',
+      configMode: 'single-table',
+      signalType: 'traces',
+    });
+    expect(resolveTraceSchema(ds)).toEqual({ database: 'otel_v2', table: 'my_traces' });
+  });
+
+  it('ignores the single table when it is configured for a different signal', () => {
+    const ds = buildDatasource({
+      defaultDb: 'otel_v2',
+      defaultTable: 'my_logs',
+      configMode: 'single-table',
+      signalType: 'logs',
+    });
+    expect(resolveTraceSchema(ds)).toEqual({ database: 'otel_v2', table: 'otel_traces' });
+  });
+
+  it('falls back to the general default db and conventional table for a bare datasource', () => {
+    expect(resolveTraceSchema(buildDatasource({}))).toEqual({ database: 'default', table: 'otel_traces' });
+  });
+
+  it('prefers the traces database over the general default', () => {
+    const ds = buildDatasource({ defaultDb: 'general', tracesDb: 'tracing' });
+    expect(resolveTraceSchema(ds)).toEqual({ database: 'tracing', table: 'otel_traces' });
+  });
+});
+
+describe('createAnnotationSupport: prepareAnnotation', () => {
+  const support = createAnnotationSupport(buildDatasource());
+
+  it('migrates a legacy rawQuery annotation into the modern target shape', () => {
+    const migrated = support.prepareAnnotation?.({
+      name: 'legacy',
+      enable: true,
+      iconColor: 'red',
+      rawQuery: 'SELECT 1 AS time',
+    });
+    expect(migrated?.target?.rawSql).toBe('SELECT 1 AS time');
+    expect(migrated?.target?.editorType).toBe(EditorType.SQL);
+    expect(migrated?.target?.refId).toBe('annotation');
+  });
+
+  it('leaves a modern annotation untouched', () => {
+    const modern: AnnotationQuery<CHQuery> = {
+      name: 'modern',
+      enable: true,
+      iconColor: 'red',
+      target: { refId: 'a', pluginVersion: '', editorType: EditorType.SQL, rawSql: 'SELECT 2 AS time' },
+    };
+    const result = support.prepareAnnotation?.(modern);
+    expect(result?.target?.rawSql).toBe('SELECT 2 AS time');
+  });
+
+  it('does not invent a target when rawQuery is absent', () => {
+    const result = support.prepareAnnotation?.({ name: 'empty', enable: true, iconColor: 'red' });
+    expect(result?.target).toBeUndefined();
+  });
+});
+
+describe('createAnnotationSupport: getDefaultQuery', () => {
+  it('returns a service.version deployment change-detection default', () => {
+    const support = createAnnotationSupport(buildDatasource({ defaultDb: 'mydb' }));
+    const query = support.getDefaultQuery?.();
+    expect(query?.editorType).toBe(EditorType.SQL);
+    expect(query?.refId).toBe('annotation');
+    expect(query?.rawSql).toContain(`"ResourceAttributes"['service.version']`);
+    expect(query?.rawSql).toContain('PARTITION BY "ServiceName"');
+    expect(query?.rawSql).toContain('FROM "mydb"."otel_traces"');
+  });
+
+  it('targets the configured trace table on a complete (classic) datasource', () => {
+    const support = createAnnotationSupport(buildDatasource({ tracesDb: 'otel', tracesTable: 'spans' }));
+    expect(support.getDefaultQuery?.().rawSql).toContain('FROM "otel"."spans"');
+  });
+});
+
+describe('AnnotationQueryEditor', () => {
+  const getEditor = (ds: Datasource) => {
+    const editor = createAnnotationSupport(ds).QueryEditor;
+    if (!editor) {
+      throw new Error('annotation QueryEditor is not defined');
+    }
+    return editor;
+  };
+
+  const baseQuery: CHQuery = { refId: 'annotation', pluginVersion: '', editorType: EditorType.SQL, rawSql: '' };
+
+  const renderEditor = (
+    ds: Datasource,
+    annotation: AnnotationQuery<CHQuery>,
+    onAnnotationChange?: (annotation: AnnotationQuery<CHQuery>) => void
+  ) => {
+    const QueryEditor = getEditor(ds);
+    return waitFor(() =>
+      render(
+        <QueryEditor
+          datasource={ds}
+          query={baseQuery}
+          onChange={() => {}}
+          onRunQuery={() => {}}
+          annotation={annotation}
+          onAnnotationChange={onAnnotationChange}
+        />
+      )
+    );
+  };
+
+  const annotationWith = (extra: Record<string, unknown>): AnnotationQuery<CHQuery> => ({
+    name: 'test',
+    enable: true,
+    iconColor: 'red',
+    ...extra,
+  });
+
+  it('hides the schema picker for the custom preset', async () => {
+    const result = await renderEditor(buildDatasource(), annotationWith({ preset: 'custom' }));
+    expect(result.getByText('Annotation Type')).toBeInTheDocument();
+    expect(result.queryByText('Database')).not.toBeInTheDocument();
+    expect(result.getByRole('textbox')).toBeInTheDocument();
+  });
+
+  it('shows the schema picker for the change detection preset', async () => {
+    const result = await renderEditor(
+      buildDatasource(),
+      annotationWith({ preset: 'change_detection', changeDetection: {} })
+    );
+    expect(result.getByText('Database')).toBeInTheDocument();
+    expect(result.getByText('Watch Column')).toBeInTheDocument();
+  });
+
+  it('shows the Group By picker once a watch column is selected', async () => {
+    const result = await renderEditor(
+      buildDatasource(),
+      annotationWith({
+        preset: 'change_detection',
+        changeDetection: { database: 'default', table: 'otel_traces', column: 'ResourceAttributes' },
+      })
+    );
+    expect(result.getByText('Group By')).toBeInTheDocument();
+  });
+
+  it('emits the edited SQL through onAnnotationChange', async () => {
+    const onAnnotationChange = jest.fn();
+    const result = await renderEditor(buildDatasource(), annotationWith({ preset: 'custom' }), onAnnotationChange);
+    fireEvent.change(result.getByRole('textbox'), { target: { value: 'SELECT 99 AS time' } });
+    expect(onAnnotationChange).toHaveBeenCalledTimes(1);
+    expect(onAnnotationChange.mock.calls[0][0].target.rawSql).toBe('SELECT 99 AS time');
+  });
+
+  it('is a no-op when no onAnnotationChange handler is provided', async () => {
+    const result = await renderEditor(buildDatasource(), annotationWith({ preset: 'custom' }));
+    expect(() => fireEvent.change(result.getByRole('textbox'), { target: { value: 'SELECT 1' } })).not.toThrow();
+  });
+
+  it('regenerates the SQL when switching to the change detection preset', async () => {
+    const onAnnotationChange = jest.fn();
+    const result = await renderEditor(
+      buildDatasource({ defaultDb: 'default' }),
+      annotationWith({ preset: 'custom' }),
+      onAnnotationChange
+    );
+
+    const presetSelect = result.getAllByRole('combobox')[0];
+    fireEvent.keyDown(presetSelect, { key: 'ArrowDown' });
+    fireEvent.click(await result.findByText('Change Detection'));
+
+    expect(onAnnotationChange).toHaveBeenCalled();
+    const emitted = onAnnotationChange.mock.calls[onAnnotationChange.mock.calls.length - 1][0];
+    expect(emitted.preset).toBe('change_detection');
+    expect(emitted.target.rawSql).toContain('Select a table and column');
+  });
+});

--- a/src/data/CHAnnotationSupport.test.tsx
+++ b/src/data/CHAnnotationSupport.test.tsx
@@ -1,7 +1,12 @@
 import React from 'react';
 import { fireEvent, render, waitFor } from '@testing-library/react';
 import { AnnotationQuery } from '@grafana/data';
-import { createAnnotationSupport, generateChangeDetectionSQL, resolveTraceSchema } from './CHAnnotationSupport';
+import {
+  buildGroupByOptions,
+  createAnnotationSupport,
+  generateChangeDetectionSQL,
+  resolveTraceSchema,
+} from './CHAnnotationSupport';
 import { Datasource } from './CHDatasource';
 import { CHQuery, EditorType } from 'types/sql';
 import { TableColumn } from 'types/queryBuilder';
@@ -90,6 +95,65 @@ describe('generateChangeDetectionSQL', () => {
   });
 });
 
+describe('generateChangeDetectionSQL: guards and quoting', () => {
+  it('returns the placeholder for a Map watch column until a key is chosen', () => {
+    const sql = generateChangeDetectionSQL({
+      table: 'otel_traces',
+      column: 'ResourceAttributes',
+      columnType: 'Map(String, String)',
+    });
+    expect(sql).toContain('Select a table and column');
+    expect(sql).not.toContain('lagInFrame');
+  });
+
+  it('generates once a Map watch column has a key', () => {
+    const sql = generateChangeDetectionSQL({
+      table: 'otel_traces',
+      column: 'ResourceAttributes',
+      columnType: 'Map(String, String)',
+      mapKey: 'service.version',
+    });
+    expect(sql).toContain(`topK(1)("ResourceAttributes"['service.version'])[1]`);
+    expect(sql).toContain('lagInFrame');
+  });
+
+  it('does not require a key for a non-Map watch column', () => {
+    const sql = generateChangeDetectionSQL({ table: 'deploys', column: 'version', columnType: 'String' });
+    expect(sql).toContain('lagInFrame(topK(1)("version")[1])');
+  });
+
+  it('quotes the database and table via the shared identifier helper', () => {
+    expect(generateChangeDetectionSQL({ database: 'db', table: 't', column: 'c' })).toContain('FROM "db"."t"');
+    // No leading dot when the database is empty (single-table datasources).
+    expect(generateChangeDetectionSQL({ table: 't', column: 'c' })).toContain('FROM "t"');
+    expect(generateChangeDetectionSQL({ table: 't', column: 'c' })).not.toContain('FROM ".');
+  });
+});
+
+describe('buildGroupByOptions', () => {
+  it('lists ServiceName once even when it is a real column', () => {
+    expect(buildGroupByOptions(columns, undefined, undefined).filter((o) => o.value === 'ServiceName')).toHaveLength(1);
+  });
+
+  it('excludes Map columns, the timestamp, and the watched column', () => {
+    const values = buildGroupByOptions(columns, 'Environment', undefined).map((o) => o.value);
+    expect(values).not.toContain('ResourceAttributes');
+    expect(values).not.toContain('Timestamp');
+    expect(values).not.toContain('Environment');
+    expect(values).toContain('ServiceName');
+  });
+
+  it('keeps a saved group-by that the filter would drop (Map or timestamp)', () => {
+    expect(buildGroupByOptions(columns, undefined, 'Timestamp').map((o) => o.value)).toContain('Timestamp');
+  });
+
+  it('does not duplicate a saved group-by that is already an option', () => {
+    expect(
+      buildGroupByOptions(columns, undefined, 'ServiceName').filter((o) => o.value === 'ServiceName')
+    ).toHaveLength(1);
+  });
+});
+
 describe('resolveTraceSchema (compact vs complete datasource)', () => {
   it('uses the traces OTel config on a complete (classic) datasource', () => {
     const ds = buildDatasource({ defaultDb: 'fallback', tracesDb: 'otel', tracesTable: 'spans' });
@@ -159,19 +223,16 @@ describe('createAnnotationSupport: prepareAnnotation', () => {
 });
 
 describe('createAnnotationSupport: getDefaultQuery', () => {
-  it('returns a service.version deployment change-detection default', () => {
+  it('defaults to an empty Custom SQL query so the default query and editor mode agree', () => {
     const support = createAnnotationSupport(buildDatasource({ defaultDb: 'mydb' }));
     const query = support.getDefaultQuery?.();
     expect(query?.editorType).toBe(EditorType.SQL);
     expect(query?.refId).toBe('annotation');
-    expect(query?.rawSql).toContain(`"ResourceAttributes"['service.version']`);
-    expect(query?.rawSql).toContain('PARTITION BY "ServiceName"');
-    expect(query?.rawSql).toContain('FROM "mydb"."otel_traces"');
-  });
-
-  it('targets the configured trace table on a complete (classic) datasource', () => {
-    const support = createAnnotationSupport(buildDatasource({ tracesDb: 'otel', tracesTable: 'spans' }));
-    expect(support.getDefaultQuery?.().rawSql).toContain('FROM "otel"."spans"');
+    expect(query?.rawSql).toBe('');
+    // The editor opens in Custom SQL mode (preset undefined -> 'custom'), so the
+    // default query must not be a change-detection query the hidden builder cannot show.
+    expect(query?.rawSql).not.toContain('lagInFrame');
+    expect(query?.rawSql).not.toContain('topK(1)');
   });
 });
 
@@ -253,10 +314,10 @@ describe('AnnotationQueryEditor', () => {
     expect(() => fireEvent.change(result.getByRole('textbox'), { target: { value: 'SELECT 1' } })).not.toThrow();
   });
 
-  it('regenerates the SQL when switching to the change detection preset', async () => {
+  it('seeds a populated deployment query when switching to the change detection preset', async () => {
     const onAnnotationChange = jest.fn();
     const result = await renderEditor(
-      buildDatasource({ defaultDb: 'default' }),
+      buildDatasource({ tracesDb: 'otel', tracesTable: 'spans' }),
       annotationWith({ preset: 'custom' }),
       onAnnotationChange
     );
@@ -265,9 +326,58 @@ describe('AnnotationQueryEditor', () => {
     fireEvent.keyDown(presetSelect, { key: 'ArrowDown' });
     fireEvent.click(await result.findByText('Change Detection'));
 
-    expect(onAnnotationChange).toHaveBeenCalled();
     const emitted = onAnnotationChange.mock.calls[onAnnotationChange.mock.calls.length - 1][0];
     expect(emitted.preset).toBe('change_detection');
-    expect(emitted.target.rawSql).toContain('Select a table and column');
+    // The builder opens pre-filled with a runnable query, not the placeholder.
+    expect(emitted.changeDetection.table).toBe('spans');
+    expect(emitted.changeDetection.mapKey).toBe('service.version');
+    expect(emitted.target.rawSql).toContain('lagInFrame');
+    expect(emitted.target.rawSql).toContain('FROM "otel"."spans"');
+    expect(emitted.target.rawSql).not.toContain('Select a table and column');
+  });
+
+  it('stashes Custom SQL when entering Change Detection', async () => {
+    const onAnnotationChange = jest.fn();
+    const result = await renderEditor(
+      buildDatasource({ defaultDb: 'default' }),
+      annotationWith({ preset: 'custom', target: { ...baseQuery, rawSql: 'SELECT mine AS time' } }),
+      onAnnotationChange
+    );
+    const presetSelect = result.getAllByRole('combobox')[0];
+    fireEvent.keyDown(presetSelect, { key: 'ArrowDown' });
+    fireEvent.click(await result.findByText('Change Detection'));
+    const emitted = onAnnotationChange.mock.calls[onAnnotationChange.mock.calls.length - 1][0];
+    expect(emitted.customSql).toBe('SELECT mine AS time');
+  });
+
+  it('restores stashed Custom SQL when returning to the Custom preset', async () => {
+    const onAnnotationChange = jest.fn();
+    const result = await renderEditor(
+      buildDatasource({ defaultDb: 'default' }),
+      annotationWith({
+        preset: 'change_detection',
+        changeDetection: {
+          database: 'default',
+          table: 'otel_traces',
+          column: 'ResourceAttributes',
+          mapKey: 'service.version',
+        },
+        customSql: 'SELECT mine AS time',
+        target: { ...baseQuery, rawSql: 'SELECT generated AS time' },
+      }),
+      onAnnotationChange
+    );
+    const presetSelect = result.getAllByRole('combobox')[0];
+    fireEvent.keyDown(presetSelect, { key: 'ArrowDown' });
+    fireEvent.click(await result.findByText('Custom SQL'));
+    const emitted = onAnnotationChange.mock.calls[onAnnotationChange.mock.calls.length - 1][0];
+    expect(emitted.target.rawSql).toBe('SELECT mine AS time');
+  });
+
+  it('opens a fresh annotation (no preset) in Custom SQL mode', async () => {
+    const result = await renderEditor(buildDatasource(), annotationWith({}));
+    expect(result.getByText('Annotation Type')).toBeInTheDocument();
+    expect(result.queryByText('Database')).not.toBeInTheDocument();
+    expect(result.getByRole('textbox')).toBeInTheDocument();
   });
 });

--- a/src/data/CHAnnotationSupport.tsx
+++ b/src/data/CHAnnotationSupport.tsx
@@ -1,0 +1,310 @@
+import React, { useCallback, useMemo } from 'react';
+import { AnnotationQuery, AnnotationSupport, GrafanaTheme2, QueryEditorProps } from '@grafana/data';
+import { InlineFormLabel, Select, TextArea, useStyles2 } from '@grafana/ui';
+import { css } from '@emotion/css';
+import { Datasource } from './CHDatasource';
+import { escapeIdentifier } from './sqlGenerator';
+import { CHQuery, CHSqlQuery, EditorType } from 'types/sql';
+import { CHConfig } from 'types/config';
+import { SchemaPicker, SchemaPickerValue } from 'components/queryBuilder/SchemaPicker';
+import useColumns from 'hooks/useColumns';
+
+/** Annotation preset types. */
+type AnnotationPreset = 'custom' | 'change_detection';
+
+/** Builder state for the change-detection preset: a schema selection plus a group-by column. */
+type ChangeDetectionState = SchemaPickerValue & { groupBy?: string };
+
+/** Annotation query extended with the builder state the editor needs to round-trip. */
+interface CHAnnotationQuery extends AnnotationQuery<CHQuery> {
+  preset?: AnnotationPreset;
+  changeDetection?: ChangeDetectionState;
+}
+
+/** Props Grafana passes to an annotation QueryEditor (the base props plus annotation-specific ones). */
+type AnnotationEditorProps = QueryEditorProps<Datasource, CHQuery, CHConfig> & {
+  annotation?: CHAnnotationQuery;
+  onAnnotationChange?: (annotation: CHAnnotationQuery) => void;
+};
+
+const ANNOTATION_REF_ID = 'annotation';
+
+/** Minimal defaults used only when Grafana mounts the editor without an existing annotation. */
+const DEFAULT_ANNOTATION: CHAnnotationQuery = { name: '', enable: true, iconColor: 'red' };
+
+/**
+ * Escape a value for use inside a single-quoted ClickHouse string literal.
+ * Backslashes and single quotes are the only characters that can break out of
+ * the literal. There is no exported string-literal escaper in sqlGenerator
+ * (escapeValue is unexported and bails out on special characters), so this
+ * stays local and small.
+ */
+const escapeStringContent = (value: string): string => value.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+
+/** Build the SQL annotation target, preserving the existing refId and plugin version. */
+const buildTarget = (existing: Partial<CHQuery> | undefined, rawSql: string): CHSqlQuery => ({
+  pluginVersion: existing?.pluginVersion ?? '',
+  editorType: EditorType.SQL,
+  rawSql,
+  refId: existing?.refId || ANNOTATION_REF_ID,
+});
+
+/**
+ * Resolve the default database and table for the change-detection preset.
+ * Prefers the traces OTel config, then the single-table config when it is
+ * configured for traces, then the general default database with the
+ * conventional otel_traces table. This adapts to both all-databases and
+ * single-table datasources.
+ */
+export function resolveTraceSchema(datasource: Datasource): { database: string; table: string } {
+  const { jsonData } = datasource.settings;
+  const singleTable =
+    jsonData.configMode === 'single-table' && jsonData.signalType === 'traces'
+      ? datasource.getDefaultTable()
+      : undefined;
+  return {
+    database: datasource.getDefaultTraceDatabase() || datasource.getDefaultDatabase(),
+    table: datasource.getDefaultTraceTable() || singleTable || 'otel_traces',
+  };
+}
+
+/**
+ * Generate the change-detection SQL from builder selections.
+ * Per 30-second bucket take the dominant value (topK(1)) so a service running
+ * two versions at once (canary, rolling deploy, multiple replicas) does not
+ * flap between them, then use lagInFrame() to detect transitions per group,
+ * including rollbacks (v1.0 -> v1.1 -> v1.0 produces three annotations). The
+ * outer prev_version != '' guard drops each group's first bucket in the window,
+ * where lagInFrame() returns '' and would otherwise mark every group at the
+ * left edge of the dashboard range.
+ * Identifiers are escaped; the watched map key is emitted as a quoted string literal.
+ */
+export function generateChangeDetectionSQL(opts: ChangeDetectionState): string {
+  const { database, table, column, mapKey, groupBy } = opts;
+  if (!table || !column) {
+    return '-- Select a table and column above to generate the change detection query';
+  }
+
+  const fullTable = database ? `${escapeIdentifier(database)}.${escapeIdentifier(table)}` : escapeIdentifier(table);
+  const columnExpr = mapKey
+    ? `${escapeIdentifier(column)}['${escapeStringContent(mapKey)}']`
+    : escapeIdentifier(column);
+  const groupByCol = escapeIdentifier(groupBy || 'ServiceName');
+  const displayLabel = escapeStringContent(mapKey ? `${column}.${mapKey}` : column);
+
+  return [
+    'SELECT',
+    '  time,',
+    `  ${groupByCol} AS tags,`,
+    `  concat(${groupByCol}, ': ${displayLabel} changed to ', version,`,
+    `    if(prev_version != '', concat(' (was ', prev_version, ')'), '')) AS text,`,
+    `  '${displayLabel} change' AS title`,
+    'FROM (',
+    '  SELECT',
+    '    toStartOfInterval(Timestamp, INTERVAL 30 second) AS time,',
+    `    ${groupByCol},`,
+    `    topK(1)(${columnExpr})[1] AS version,`,
+    `    lagInFrame(topK(1)(${columnExpr})[1])`,
+    `      OVER (PARTITION BY ${groupByCol} ORDER BY time) AS prev_version`,
+    `  FROM ${fullTable}`,
+    '  WHERE $__timeFilter(Timestamp)',
+    `    AND ${columnExpr} != ''`,
+    `  GROUP BY ${groupByCol}, time`,
+    `  ORDER BY ${groupByCol}, time`,
+    ')',
+    "WHERE prev_version != '' AND prev_version != version",
+    'ORDER BY time',
+  ].join('\n');
+}
+
+const PRESET_OPTIONS = [
+  { label: 'Custom SQL', value: 'custom' as AnnotationPreset, description: 'Write your own annotation query' },
+  {
+    label: 'Change Detection',
+    value: 'change_detection' as AnnotationPreset,
+    description: 'Detect when a column value changes (deployments, config changes, rollbacks)',
+    icon: 'rocket',
+  },
+];
+
+/** Annotation query editor with a preset selector and a change-detection builder. */
+const AnnotationQueryEditor = (props: AnnotationEditorProps) => {
+  const { annotation, onAnnotationChange, datasource } = props;
+  const anno: CHAnnotationQuery = annotation ?? DEFAULT_ANNOTATION;
+  const preset = anno.preset || 'custom';
+  const cd: ChangeDetectionState = useMemo(() => anno.changeDetection || {}, [anno.changeDetection]);
+  const styles = useStyles2(getStyles);
+
+  // Reuse the shared column hook for the group-by picker.
+  const columns = useColumns(datasource, cd.database || '', cd.table || '');
+
+  const updateChangeDetection = useCallback(
+    (updates: Partial<ChangeDetectionState>) => {
+      if (!onAnnotationChange) {
+        return;
+      }
+      const newCd = { ...cd, ...updates };
+      onAnnotationChange({
+        ...anno,
+        preset: 'change_detection',
+        changeDetection: newCd,
+        target: buildTarget(anno.target, generateChangeDetectionSQL(newCd)),
+      });
+    },
+    [anno, cd, onAnnotationChange]
+  );
+
+  const onSchemaChange = useCallback(
+    (schemaValue: SchemaPickerValue) => {
+      updateChangeDetection(schemaValue);
+    },
+    [updateChangeDetection]
+  );
+
+  const onPresetChange = useCallback(
+    (value: AnnotationPreset) => {
+      if (!onAnnotationChange) {
+        return;
+      }
+      const next: CHAnnotationQuery = { ...anno, preset: value };
+      if (value === 'change_detection') {
+        next.target = buildTarget(anno.target, generateChangeDetectionSQL(cd));
+      } else {
+        next.target = buildTarget(anno.target, anno.target?.rawSql || '');
+      }
+      onAnnotationChange(next);
+    },
+    [anno, cd, onAnnotationChange]
+  );
+
+  const onSqlChange = useCallback(
+    (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+      if (!onAnnotationChange) {
+        return;
+      }
+      onAnnotationChange({
+        ...anno,
+        target: buildTarget(anno.target, e.currentTarget.value),
+      });
+    },
+    [anno, onAnnotationChange]
+  );
+
+  const groupByOptions = [
+    { label: 'ServiceName', value: 'ServiceName' },
+    ...columns
+      .filter((c) => !c.type.startsWith('Map(') && c.name !== 'Timestamp' && c.name !== cd.column)
+      .map((c) => ({ label: c.name, value: c.name })),
+  ];
+
+  return (
+    <div>
+      <div className="gf-form" style={{ marginBottom: 8 }}>
+        <InlineFormLabel width={10} tooltip="Select an annotation preset or write custom SQL">
+          Annotation Type
+        </InlineFormLabel>
+        <Select
+          width={40}
+          options={PRESET_OPTIONS}
+          value={preset}
+          onChange={(v) => onPresetChange(v.value || 'custom')}
+        />
+      </div>
+
+      {preset === 'change_detection' && (
+        <>
+          <SchemaPicker
+            datasource={datasource}
+            value={cd}
+            onChange={onSchemaChange}
+            level="mapKey"
+            labels={{ column: 'Watch Column', mapKey: 'Map Key' }}
+          />
+
+          {cd.column && (
+            <div className="gf-form" style={{ marginBottom: 4 }}>
+              <InlineFormLabel
+                width={10}
+                tooltip="Group changes by this column. Each unique value is tracked independently."
+              >
+                Group By
+              </InlineFormLabel>
+              <Select
+                width={30}
+                options={groupByOptions}
+                value={cd.groupBy || 'ServiceName'}
+                onChange={(v) => updateChangeDetection({ groupBy: v.value || 'ServiceName' })}
+              />
+            </div>
+          )}
+        </>
+      )}
+
+      <div className="gf-form" style={{ marginBottom: 4 }}>
+        <InlineFormLabel width={10}>SQL Query</InlineFormLabel>
+        <TextArea
+          className={styles.sqlInput}
+          rows={8}
+          value={anno.target?.rawSql || ''}
+          onChange={onSqlChange}
+          placeholder="SELECT Timestamp AS time, Body AS text, ServiceName AS tags FROM otel_logs WHERE $__timeFilter(Timestamp)"
+        />
+      </div>
+
+      <div className={styles.helpText}>
+        {preset === 'change_detection'
+          ? 'Annotations appear when the watched value changes per group, including rollbacks.'
+          : 'Return columns: time (required), text, title, tags. Standard Grafana annotation mapping.'}
+      </div>
+    </div>
+  );
+};
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  sqlInput: css({
+    fontFamily: theme.typography.fontFamilyMonospace,
+    fontSize: theme.typography.bodySmall.fontSize,
+  }),
+  helpText: css({
+    color: theme.colors.text.secondary,
+    fontSize: theme.typography.bodySmall.fontSize,
+    marginLeft: 88,
+    marginBottom: theme.spacing(1),
+  }),
+});
+
+/** Build the AnnotationSupport object wired into the datasource. */
+export function createAnnotationSupport(datasource: Datasource): AnnotationSupport<CHQuery> {
+  return {
+    prepareAnnotation: (json: AnnotationQuery<CHQuery>): AnnotationQuery<CHQuery> => {
+      // Legacy dashboards stored the SQL as a top-level `rawQuery` string. Migrate
+      // it into the modern target shape once. `rawQuery` is read via the
+      // AnnotationQuery index signature, so no cast is needed.
+      const legacyRawQuery: string | undefined = json?.rawQuery;
+      if (legacyRawQuery && !json?.target?.rawSql) {
+        return {
+          ...json,
+          target: buildTarget(json.target, legacyRawQuery),
+        };
+      }
+      return json;
+    },
+
+    getDefaultQuery: (): Partial<CHQuery> => {
+      const { database, table } = resolveTraceSchema(datasource);
+      return {
+        editorType: EditorType.SQL,
+        rawSql: generateChangeDetectionSQL({
+          database,
+          table,
+          column: 'ResourceAttributes',
+          mapKey: 'service.version',
+          groupBy: 'ServiceName',
+        }),
+        refId: ANNOTATION_REF_ID,
+      };
+    },
+
+    QueryEditor: AnnotationQueryEditor,
+  };
+}

--- a/src/data/CHAnnotationSupport.tsx
+++ b/src/data/CHAnnotationSupport.tsx
@@ -3,22 +3,30 @@ import { AnnotationQuery, AnnotationSupport, GrafanaTheme2, QueryEditorProps } f
 import { InlineFormLabel, Select, TextArea, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
 import { Datasource } from './CHDatasource';
-import { escapeIdentifier } from './sqlGenerator';
+import { escapeIdentifier, getTableIdentifier } from './sqlGenerator';
 import { CHQuery, CHSqlQuery, EditorType } from 'types/sql';
 import { CHConfig } from 'types/config';
 import { SchemaPicker, SchemaPickerValue } from 'components/queryBuilder/SchemaPicker';
 import useColumns from 'hooks/useColumns';
+import { TableColumn } from 'types/queryBuilder';
 
 /** Annotation preset types. */
 type AnnotationPreset = 'custom' | 'change_detection';
 
-/** Builder state for the change-detection preset: a schema selection plus a group-by column. */
-type ChangeDetectionState = SchemaPickerValue & { groupBy?: string };
+/**
+ * Builder state for the change-detection preset: a schema selection, the watched
+ * column's type (so a Map column can require a key before generating), and a
+ * group-by column.
+ */
+type ChangeDetectionState = SchemaPickerValue & { groupBy?: string; columnType?: string };
 
 /** Annotation query extended with the builder state the editor needs to round-trip. */
 interface CHAnnotationQuery extends AnnotationQuery<CHQuery> {
   preset?: AnnotationPreset;
   changeDetection?: ChangeDetectionState;
+  // Custom SQL stashed when entering Change Detection, restored on return so a
+  // hand-written query is not lost by the round trip.
+  customSql?: string;
 }
 
 /** Props Grafana passes to an annotation QueryEditor (the base props plus annotation-specific ones). */
@@ -31,6 +39,9 @@ const ANNOTATION_REF_ID = 'annotation';
 
 /** Minimal defaults used only when Grafana mounts the editor without an existing annotation. */
 const DEFAULT_ANNOTATION: CHAnnotationQuery = { name: '', enable: true, iconColor: 'red' };
+
+/** Shown in the generated-SQL box until the builder has enough to produce a query. */
+const CHANGE_DETECTION_PLACEHOLDER = '-- Select a table and column above to generate the change detection query';
 
 /**
  * Escape a value for use inside a single-quoted ClickHouse string literal.
@@ -80,12 +91,18 @@ export function resolveTraceSchema(datasource: Datasource): { database: string; 
  * Identifiers are escaped; the watched map key is emitted as a quoted string literal.
  */
 export function generateChangeDetectionSQL(opts: ChangeDetectionState): string {
-  const { database, table, column, mapKey, groupBy } = opts;
+  const { database, table, column, mapKey, groupBy, columnType } = opts;
   if (!table || !column) {
-    return '-- Select a table and column above to generate the change detection query';
+    return CHANGE_DETECTION_PLACEHOLDER;
+  }
+  // A Map column is only usable once a key is chosen: without one the generated
+  // query would compare the whole Map to '' and ClickHouse rejects it (code 27).
+  // Wait for the key rather than emitting a query that cannot run.
+  if (columnType?.startsWith('Map(') && !mapKey) {
+    return CHANGE_DETECTION_PLACEHOLDER;
   }
 
-  const fullTable = database ? `${escapeIdentifier(database)}.${escapeIdentifier(table)}` : escapeIdentifier(table);
+  const fullTable = getTableIdentifier(database || '', table);
   const columnExpr = mapKey
     ? `${escapeIdentifier(column)}['${escapeStringContent(mapKey)}']`
     : escapeIdentifier(column);
@@ -115,6 +132,34 @@ export function generateChangeDetectionSQL(opts: ChangeDetectionState): string {
     "WHERE prev_version != '' AND prev_version != version",
     'ORDER BY time',
   ].join('\n');
+}
+
+/**
+ * Build the Group By options for the change-detection builder. ServiceName leads
+ * (the OTel convention and the default), followed by columns that make sense to
+ * group by: Map columns, the timestamp, the watched column itself, and a duplicate
+ * ServiceName are excluded. A saved group-by that the filter would drop (for
+ * example a Map or the timestamp from an older query) is appended so the Select
+ * shows the real value instead of rendering blank while the SQL still references it.
+ */
+export function buildGroupByOptions(
+  columns: readonly TableColumn[],
+  watchColumn: string | undefined,
+  savedGroupBy: string | undefined
+): Array<{ label: string; value: string }> {
+  const options = [
+    { label: 'ServiceName', value: 'ServiceName' },
+    ...columns
+      .filter(
+        (c) =>
+          !c.type.startsWith('Map(') && c.name !== 'Timestamp' && c.name !== 'ServiceName' && c.name !== watchColumn
+      )
+      .map((c) => ({ label: c.name, value: c.name })),
+  ];
+  if (savedGroupBy && !options.some((o) => o.value === savedGroupBy)) {
+    options.push({ label: savedGroupBy, value: savedGroupBy });
+  }
+  return options;
 }
 
 const PRESET_OPTIONS = [
@@ -156,9 +201,11 @@ const AnnotationQueryEditor = (props: AnnotationEditorProps) => {
 
   const onSchemaChange = useCallback(
     (schemaValue: SchemaPickerValue) => {
-      updateChangeDetection(schemaValue);
+      // Carry the watched column's type so the generator can require a Map key.
+      const columnType = columns.find((c) => c.name === schemaValue.column)?.type;
+      updateChangeDetection({ ...schemaValue, columnType });
     },
-    [updateChangeDetection]
+    [updateChangeDetection, columns]
   );
 
   const onPresetChange = useCallback(
@@ -166,15 +213,37 @@ const AnnotationQueryEditor = (props: AnnotationEditorProps) => {
       if (!onAnnotationChange) {
         return;
       }
-      const next: CHAnnotationQuery = { ...anno, preset: value };
       if (value === 'change_detection') {
-        next.target = buildTarget(anno.target, generateChangeDetectionSQL(cd));
+        // Seed sensible deployment defaults so the builder opens populated with a
+        // working query (instead of an empty builder and a placeholder), and stash
+        // the current Custom SQL so switching back restores it.
+        const seeded: ChangeDetectionState =
+          cd.table && cd.column
+            ? cd
+            : {
+                ...resolveTraceSchema(datasource),
+                column: 'ResourceAttributes',
+                columnType: 'Map(String, String)',
+                mapKey: 'service.version',
+                groupBy: 'ServiceName',
+              };
+        onAnnotationChange({
+          ...anno,
+          preset: value,
+          customSql: anno.target?.rawSql ?? '',
+          changeDetection: seeded,
+          target: buildTarget(anno.target, generateChangeDetectionSQL(seeded)),
+        });
       } else {
-        next.target = buildTarget(anno.target, anno.target?.rawSql || '');
+        // Restore the Custom SQL stashed when Change Detection was entered.
+        onAnnotationChange({
+          ...anno,
+          preset: value,
+          target: buildTarget(anno.target, anno.customSql ?? ''),
+        });
       }
-      onAnnotationChange(next);
     },
-    [anno, cd, onAnnotationChange]
+    [anno, cd, datasource, onAnnotationChange]
   );
 
   const onSqlChange = useCallback(
@@ -190,12 +259,7 @@ const AnnotationQueryEditor = (props: AnnotationEditorProps) => {
     [anno, onAnnotationChange]
   );
 
-  const groupByOptions = [
-    { label: 'ServiceName', value: 'ServiceName' },
-    ...columns
-      .filter((c) => !c.type.startsWith('Map(') && c.name !== 'Timestamp' && c.name !== cd.column)
-      .map((c) => ({ label: c.name, value: c.name })),
-  ];
+  const groupByOptions = buildGroupByOptions(columns, cd.column, cd.groupBy);
 
   return (
     <div>
@@ -290,20 +354,14 @@ export function createAnnotationSupport(datasource: Datasource): AnnotationSuppo
       return json;
     },
 
-    getDefaultQuery: (): Partial<CHQuery> => {
-      const { database, table } = resolveTraceSchema(datasource);
-      return {
-        editorType: EditorType.SQL,
-        rawSql: generateChangeDetectionSQL({
-          database,
-          table,
-          column: 'ResourceAttributes',
-          mapKey: 'service.version',
-          groupBy: 'ServiceName',
-        }),
-        refId: ANNOTATION_REF_ID,
-      };
-    },
+    getDefaultQuery: (): Partial<CHQuery> => ({
+      // Open in Custom SQL mode (the editor's default preset) with an empty query so
+      // the default editor mode and the default query agree. Choosing Change
+      // Detection seeds a populated deployment-change builder.
+      editorType: EditorType.SQL,
+      rawSql: '',
+      refId: ANNOTATION_REF_ID,
+    }),
 
     QueryEditor: AnnotationQueryEditor,
   };

--- a/src/data/CHDatasource.ts
+++ b/src/data/CHDatasource.ts
@@ -63,6 +63,7 @@ import {
 import { escapeIdentifier, generateSql, getColumnByHint, logAliasToColumnHints } from './sqlGenerator';
 import { labelsFieldName, transformQueryResponseWithTraceAndLogLinks } from './utils';
 import { CHVariableSupport } from './CHVariableSupport';
+import { createAnnotationSupport } from './CHAnnotationSupport';
 
 interface ResolvedColumn {
   columnName: string;
@@ -135,8 +136,6 @@ export class Datasource
     DataSourceWithQueryModificationSupport<CHQuery>,
     DataSourceWithToggleableQueryFiltersSupport<CHQuery>
 {
-  // This enables default annotation support for 7.2+
-  annotations = {};
   settings: DataSourceInstanceSettings<CHConfig>;
   adHocFilter: AdHocFilter;
   skipAdHocFilter = false; // don't apply adhoc filters to the query
@@ -167,6 +166,7 @@ export class Datasource
     this.settings = instanceSettings;
     this.adHocFilter = new AdHocFilter();
     this.variables = new CHVariableSupport(this);
+    this.annotations = createAnnotationSupport(this);
   }
 
   static logVolumePrefix = 'log-volume-';

--- a/src/data/sqlGenerator.ts
+++ b/src/data/sqlGenerator.ts
@@ -696,7 +696,7 @@ const getColumnIdentifier = (col: SelectedColumn): string => {
   return colName;
 };
 
-const getTableIdentifier = (database: string, table: string): string => {
+export const getTableIdentifier = (database: string, table: string): string => {
   const sep = !database || !table ? '' : '.';
   return `${escapeIdentifier(database)}${sep}${escapeIdentifier(table)}`;
 };

--- a/src/hooks/useColumns.ts
+++ b/src/hooks/useColumns.ts
@@ -2,6 +2,14 @@ import { useState, useEffect, useRef } from 'react';
 import { TableColumn } from 'types/queryBuilder';
 import { Datasource } from 'data/CHDatasource';
 
+// Shared in-flight requests keyed by datasource + database + table. When two
+// callers mount with the same arguments (for example the annotation editor and
+// the SchemaPicker it renders), they share a single fetchColumns request instead
+// of issuing one each with separate loading states. The entry is removed once the
+// request settles, so this only collapses overlapping fetches and never serves
+// stale schema.
+const inFlightColumns = new Map<string, Promise<readonly TableColumn[]>>();
+
 export default (datasource: Datasource, database: string, table: string): readonly TableColumn[] => {
   const [columns, setColumns] = useState<readonly TableColumn[]>([]);
 
@@ -11,13 +19,23 @@ export default (datasource: Datasource, database: string, table: string): readon
     }
 
     let ignore = false;
-    datasource
-      .fetchColumns(database, table)
-      .then((columns) => {
+    const key = `${datasource.uid} ${database} ${table}`;
+    let request = inFlightColumns.get(key);
+    if (!request) {
+      request = datasource.fetchColumns(database, table);
+      inFlightColumns.set(key, request);
+      request.finally(() => {
+        if (inFlightColumns.get(key) === request) {
+          inFlightColumns.delete(key);
+        }
+      });
+    }
+    request
+      .then((cols) => {
         if (ignore) {
           return;
         }
-        setColumns(columns);
+        setColumns(cols);
       })
       .catch((ex: any) => {
         console.error(ex);

--- a/tests/e2e/annotations.spec.ts
+++ b/tests/e2e/annotations.spec.ts
@@ -1,0 +1,70 @@
+import { expect, test } from '@grafana/plugin-e2e';
+import { Page } from '@playwright/test';
+
+// The annotation editor is reached through Grafana's annotation edit page and
+// works with any ClickHouse datasource. These tests drive the locally
+// provisioned datasource (provisioning/datasources/clickhouse.yml). The Cloud
+// cron uses a different managed datasource, so the suite is local-only; the
+// editor's SQL generation is also covered by the unit tests in
+// src/data/CHAnnotationSupport.test.tsx.
+const isCloudRun = !!process.env.GRAFANA_URL;
+
+// The SQL textarea is identified by its placeholder so it is not confused with
+// the annotation Name input (both are role=textbox).
+const sqlBox = (page: Page) => page.getByPlaceholder(/SELECT Timestamp AS time/);
+
+// Two field shapes appear in this editor. The SchemaPicker fields (Database,
+// Table, Watch Column, Map Key) expose the label as the combobox's accessible
+// name. The editor's own Select rows (Annotation Type, Group By) render an
+// InlineFormLabel inside a .gf-form row with no accessible name on the control.
+// Match either shape so one helper covers both.
+const comboFor = (page: Page, label: string) =>
+  page
+    .getByRole('combobox', { name: label })
+    .or(page.locator('.gf-form', { hasText: label }).getByRole('combobox'))
+    .first();
+
+async function selectFromCombo(page: Page, label: string, optionText: string) {
+  const combo = comboFor(page, label);
+  await combo.click();
+  await combo.fill(optionText);
+  await page.keyboard.press('Enter');
+}
+
+test.describe('annotation editor', () => {
+  test.skip(isCloudRun, 'uses the locally provisioned datasource');
+
+  test('change detection preset reveals the schema builder', async ({
+    annotationEditPage,
+    page,
+    readProvisionedDataSource,
+  }) => {
+    const ds = await readProvisionedDataSource({ fileName: 'clickhouse.yml', name: 'ClickHouse' });
+    await annotationEditPage.datasource.set(ds.name);
+    await expect(comboFor(page, 'Annotation Type')).toBeVisible();
+
+    await selectFromCombo(page, 'Annotation Type', 'Change Detection');
+    await expect(comboFor(page, 'Database')).toBeVisible();
+    // Watch Column is a downstream cascade level: the row is revealed but the
+    // control stays disabled (no combobox) until a table is chosen, so assert
+    // the field label rather than an interactive combobox.
+    await expect(page.getByText('Watch Column', { exact: true })).toBeVisible();
+    // Until a table and column are picked, the generator emits a placeholder comment.
+    await expect(sqlBox(page)).toHaveValue(/Select a table and column/);
+  });
+
+  test('a custom SQL annotation query executes against ClickHouse', async ({
+    annotationEditPage,
+    page,
+    readProvisionedDataSource,
+  }) => {
+    const ds = await readProvisionedDataSource({ fileName: 'clickhouse.yml', name: 'ClickHouse' });
+    await annotationEditPage.datasource.set(ds.name);
+
+    // Custom SQL is the default preset. Use a time-independent query so the
+    // assertion does not depend on the dashboard time range or seed data.
+    await sqlBox(page).fill("SELECT now() AS time, 'smoke' AS text");
+    const response = await annotationEditPage.runQuery();
+    expect(response.ok()).toBeTruthy();
+  });
+});

--- a/tests/e2e/annotations.spec.ts
+++ b/tests/e2e/annotations.spec.ts
@@ -45,12 +45,10 @@ test.describe('annotation editor', () => {
 
     await selectFromCombo(page, 'Annotation Type', 'Change Detection');
     await expect(comboFor(page, 'Database')).toBeVisible();
-    // Watch Column is a downstream cascade level: the row is revealed but the
-    // control stays disabled (no combobox) until a table is chosen, so assert
-    // the field label rather than an interactive combobox.
     await expect(page.getByText('Watch Column', { exact: true })).toBeVisible();
-    // Until a table and column are picked, the generator emits a placeholder comment.
-    await expect(sqlBox(page)).toHaveValue(/Select a table and column/);
+    // Selecting the preset seeds a populated builder, so the box holds a runnable
+    // change-detection query rather than the empty-state placeholder.
+    await expect(sqlBox(page)).toHaveValue(/lagInFrame/);
   });
 
   test('a custom SQL annotation query executes against ClickHouse', async ({


### PR DESCRIPTION
## Summary

The plugin ships no custom annotation editor today (`CHDatasource` sets `annotations = {}`), so authoring a dashboard annotation means hand-writing ClickHouse SQL with no guidance. This adds a preset-driven annotation editor with two options:

- **Custom SQL**: a plain SQL field (the previous behavior, now explicit).
- **Change Detection**: detect when a column value changes over time, such as a deployment (`service.version`), a config value, or a feature flag. Built on the cascading schema picker, it generates rollback-aware SQL with `lagInFrame()` over 30-second buckets, so a `v1.0` to `v1.1` back to `v1.0` rollback produces three annotations rather than two.

The generated SQL is always visible and editable, so you can start from the preset and refine it, or write a query from scratch. Legacy annotations stored as a top-level `rawQuery` string are migrated into the modern target shape on load.

Fixes #1834

Builds on the cascading schema picker from #1828, now merged. The branch is rebased onto main, so the diff here is annotation-only.

## Changes

- Add `src/data/CHAnnotationSupport.tsx`: preset types, the change-detection SQL generator, the editor component, and a `createAnnotationSupport(datasource)` factory returning Grafana's `AnnotationSupport`.
- Wire it into the datasource: `this.annotations = createAnnotationSupport(this)` in the `CHDatasource` constructor, mirroring how `this.variables` is set up.
- Generated identifiers go through `escapeIdentifier`; the watched map key is emitted as an escaped single-quoted string literal.
- Resolve the default database and table from the datasource's traces config, then the single-table config, then the general default with the conventional `otel_traces` name, so the editor adapts to both all-databases and single-table datasources.
- Document the editor in `docs/sources/annotations.md`.
- Add unit tests (`src/data/CHAnnotationSupport.test.tsx`) and a Playwright spec (`tests/e2e/annotations.spec.ts`).

## Why

Change detection on a deployment attribute (`ResourceAttributes['service.version']`) is the common case, and writing the windowed `lagInFrame()` query by hand is easy to get wrong. The builder produces correct rollback-aware SQL and keeps it editable for anything bespoke. The change-detection default matches the deployment annotation already embedded in the OOTB dashboards, so the two stay consistent.

## Local verification

Built the plugin and ran it in Grafana 13 against the public ClickHouse OTel demo, side by side with the official build. Walked the annotation settings: switching between Custom SQL and Change Detection, building a change-detection query through the schema picker (Database, Table, Watch Column, Map Key, Group By), and confirming the generated SQL runs against ClickHouse with no error. Verified in light and dark themes.

| | Custom SQL | Change Detection |
|---|---|---|
| **Light** | ![Custom SQL preset, light theme](https://raw.githubusercontent.com/alex-fedotyev/clickhouse-datasource/feat/annotation-presets-1834-screenshots/pr-screenshots/custom-light.png) | ![Change Detection builder, light theme](https://raw.githubusercontent.com/alex-fedotyev/clickhouse-datasource/feat/annotation-presets-1834-screenshots/pr-screenshots/change-detection-light.png) |
| **Dark** | ![Custom SQL preset, dark theme](https://raw.githubusercontent.com/alex-fedotyev/clickhouse-datasource/feat/annotation-presets-1834-screenshots/pr-screenshots/custom-dark.png) | ![Change Detection builder, dark theme](https://raw.githubusercontent.com/alex-fedotyev/clickhouse-datasource/feat/annotation-presets-1834-screenshots/pr-screenshots/change-detection-dark.png) |

The Change Detection builder above generated and ran this query (watching `ResourceAttributes['service.version']` grouped by `ServiceName`):

```sql
SELECT
  time,
  "ServiceName" AS tags,
  concat("ServiceName", ': ResourceAttributes.service.version changed to ', version,
    if(prev_version != '', concat(' (was ', prev_version, ')'), '')) AS text,
  'ResourceAttributes.service.version change' AS title
FROM (
  SELECT
    toStartOfInterval(Timestamp, INTERVAL 30 second) AS time,
    "ServiceName",
    topK(1)("ResourceAttributes"['service.version'])[1] AS version,
    lagInFrame(topK(1)("ResourceAttributes"['service.version'])[1])
      OVER (PARTITION BY "ServiceName" ORDER BY time) AS prev_version
  FROM "otel_v2"."otel_traces"
  WHERE $__timeFilter(Timestamp)
    AND "ResourceAttributes"['service.version'] != ''
  GROUP BY "ServiceName", time
  ORDER BY "ServiceName", time
)
WHERE prev_version != '' AND prev_version != version
ORDER BY time
```

Two details in that query matter against real OTel data, both verified on the public demo: the per-bucket value uses `topK(1)` (the dominant value), not `any()`, so a service running two versions at once during a rollout does not flap between them; and the `prev_version != ''` guard drops each group's first bucket, which `lagInFrame` would otherwise report as a change from an empty previous value. A service whose version is stable across the range produces no markers.

A logs-based "lifecycle events" preset (Kubernetes restarts, OOM kills, scaling) is intentionally left for a follow-up: getting readable annotations out of real OTel k8s events needs schema-aware extraction (the event detail is nested in the log body and varies by collector), which deserves its own focused PR.

[ui-states: allow] annotation editing is a form builder; empty / loading / error are states of Grafana's annotation results panel, not this editor.
[viewport: allow] the editor renders inside Grafana's dashboard settings form, where layout width is managed by Grafana.

## Test plan

- [x] `npx jest src/data/CHAnnotationSupport.test.tsx` (21 tests: change-detection SQL generation, map-key escaping, preset switching, legacy `rawQuery` migration, and default-schema resolution for all-databases / single-table / bare datasources)
- [x] `npx jest` (full suite green, no regressions from the datasource wiring)
- [x] `npx tsc --noEmit`
- [x] `npx eslint` (clean) and `npm run spellcheck`
- [x] `tests/e2e/annotations.spec.ts` (Playwright via `@grafana/plugin-e2e`: the change-detection builder renders the schema picker and generates SQL, and a custom-SQL query runs against ClickHouse)
- [x] Manual verification in local Grafana 13, light and dark, screenshots above

Please add the `changelog` label so this surfaces in the next release notes.


