### PR TITLE
feat(datasource): config macros for OTel logs/traces database and table

### DIFF
--- a/docs/sources/query-editor.md
+++ b/docs/sources/query-editor.md
@@ -285,8 +285,14 @@ WHERE $__timeFilter(date_time)
 | `$__timeInterval(columnName)`                | Interval from panel time range (seconds), for grouping.                                          | `toStartOfInterval(toDateTime(column), INTERVAL 20 second)`                                                                           |
 | `$__timeInterval_ms(columnName)`             | Interval from panel time range (milliseconds), for grouping.                                     | `toStartOfInterval(toDateTime64(column, 3), INTERVAL 20 millisecond)`                                                                 |
 | `$__conditionalAll(condition, $templateVar)` | Uses the first parameter when the template variable does not select all values; otherwise `1=1`. | `condition` or `1=1`                                                                                                                  |
+| `$__logsDatabase`                            | Configured OTel logs database for this data source (or the default database when unset).         | `otel`                                                                                                                                |
+| `$__logsTable`                               | Configured OTel logs table for this data source (or `otel_logs` when unset).                     | `otel_logs`                                                                                                                           |
+| `$__tracesDatabase`                          | Configured OTel traces database for this data source (or the default database when unset).       | `otel`                                                                                                                                |
+| `$__tracesTable`                             | Configured OTel traces table for this data source (or `otel_traces` when unset).                 | `otel_traces`                                                                                                                         |
 
 You can also use brace notation `{}` when the macro parameter must contain a query or other expression.
+
+The `$__logsDatabase` / `$__logsTable` / `$__tracesDatabase` / `$__tracesTable` macros resolve to the database and table configured on the data source for that signal. Use them instead of hard-coding table names so a dashboard follows whatever the selected data source is configured for.
 
 ## Next steps
 

--- a/src/data/CHDatasource.test.ts
+++ b/src/data/CHDatasource.test.ts
@@ -100,6 +100,38 @@ describe('ClickHouseDatasource', () => {
       expect(spyOnReplace).toHaveBeenCalled();
       expect(val).toEqual({ rawSql, editorType: EditorType.SQL });
     });
+    it('resolves config macros to the configured logs/traces database and table', () => {
+      jest.spyOn(templateSrvMock, 'replace').mockImplementation((x?: string) => x ?? '');
+      jest.spyOn(templateSrvMock, 'getVariables').mockImplementation(() => []);
+      const ds = createInstance({});
+      ds.settings.jsonData = {
+        ...ds.settings.jsonData,
+        defaultDatabase: 'conn_default',
+        logs: { defaultDatabase: 'logs_db', defaultTable: 'logs_tbl' },
+        traces: { defaultDatabase: 'traces_db', defaultTable: 'traces_tbl' },
+      };
+      const query = {
+        rawSql:
+          'SELECT count() FROM $__logsDatabase.$__logsTable UNION ALL SELECT count() FROM $__tracesDatabase.$__tracesTable',
+        editorType: EditorType.SQL,
+      } as CHQuery;
+      const result = ds.applyTemplateVariables(query, {});
+      expect(result.rawSql).toBe(
+        'SELECT count() FROM logs_db.logs_tbl UNION ALL SELECT count() FROM traces_db.traces_tbl'
+      );
+    });
+    it('config macros fall back to the default database and conventional OTel tables when per-signal config is unset', () => {
+      jest.spyOn(templateSrvMock, 'replace').mockImplementation((x?: string) => x ?? '');
+      jest.spyOn(templateSrvMock, 'getVariables').mockImplementation(() => []);
+      const ds = createInstance({});
+      ds.settings.jsonData = { ...ds.settings.jsonData, defaultDatabase: 'conn_default', logs: {}, traces: {} };
+      const query = {
+        rawSql: 'SELECT 1 FROM $__logsDatabase.$__logsTable, $__tracesDatabase.$__tracesTable',
+        editorType: EditorType.SQL,
+      } as CHQuery;
+      const result = ds.applyTemplateVariables(query, {});
+      expect(result.rawSql).toBe('SELECT 1 FROM conn_default.otel_logs, conn_default.otel_traces');
+    });
     it('should handle $__conditionalAll and not replace', async () => {
       const query = { rawSql: '$__conditionalAll(foo, $fieldVal)', editorType: EditorType.SQL } as CHQuery;
       const vars = [{ current: { value: `'val1', 'val2'` }, name: 'fieldVal' }] as TypedVariableModel[];

--- a/src/data/CHDatasource.ts
+++ b/src/data/CHDatasource.ts
@@ -25,7 +25,7 @@ import { DataSourceWithBackend, getTemplateSrv } from '@grafana/runtime';
 import { trackClickhouseHealthCheckFailed } from 'tracking';
 import LogsContextPanel from 'components/LogsContextPanel';
 import { cloneDeep, isEmpty, isString } from 'lodash';
-import otel from 'otel';
+import otel, { defaultLogsTable, defaultTraceTable } from 'otel';
 import { createElement as createReactElement, ReactNode } from 'react';
 import { concatMap, firstValueFrom, Observable } from 'rxjs';
 import { CHConfig } from 'types/config';
@@ -339,6 +339,7 @@ export class Datasource
 
     // resolve template variables
     rawQuery = this.applyConditionalAll(rawQuery, templateSrvVariables);
+    rawQuery = this.applyConfigMacros(rawQuery);
     rawQuery = this.replace(rawQuery, scoped) || '';
 
     if (!this.skipAdHocFilter) {
@@ -409,6 +410,31 @@ export class Datasource
       builderOptions,
       rawSql: generateSql(builderOptions),
     };
+  }
+
+  /**
+   * Resolve datasource-config macros to the configured per-signal database and
+   * table. Lets queries and dashboards reference the datasource's OTel
+   * configuration instead of hard-coding names, so a single-table datasource
+   * binds to its configured table and a classic datasource binds to its
+   * configured logs/traces defaults. Falls back to the connection default
+   * database and the conventional OTel table names when a per-signal value is
+   * unset.
+   */
+  applyConfigMacros(rawQuery: string): string {
+    if (!rawQuery) {
+      return rawQuery;
+    }
+    const macros: Record<string, string> = {
+      $__logsDatabase: this.getDefaultLogsDatabase() || this.getDefaultDatabase(),
+      $__logsTable: this.getDefaultLogsTable() || defaultLogsTable,
+      $__tracesDatabase: this.getDefaultTraceDatabase() || this.getDefaultDatabase(),
+      $__tracesTable: this.getDefaultTraceTable() || defaultTraceTable,
+    };
+    for (const [macro, value] of Object.entries(macros)) {
+      rawQuery = rawQuery.split(macro).join(value);
+    }
+    return rawQuery;
   }
 
   applyConditionalAll(rawQuery: string, templateVars: TypedVariableModel[]): string {
@@ -930,9 +956,7 @@ export class Datasource
       return [];
     }
     const timeColumn = this.getMapKeyProbeTimeColumn(db, table);
-    const whereClause = timeColumn
-      ? ` WHERE ${escapeIdentifier(timeColumn)} >= now() - INTERVAL 6 HOUR`
-      : '';
+    const whereClause = timeColumn ? ` WHERE ${escapeIdentifier(timeColumn)} >= now() - INTERVAL 6 HOUR` : '';
     const rawSql = `SELECT DISTINCT arrayJoin(${escapeIdentifier(mapColumn)}.keys) as keys FROM ${escapeIdentifier(db)}.${escapeIdentifier(table)}${whereClause} LIMIT 1000`;
     return this.fetchData(rawSql);
   }


### PR DESCRIPTION
> **Status (2026-06-30): draft, reworking on top of #1802.** Per review, these macros currently expand in the frontend `applyTemplateVariables` hook, which the backend does not run for alerting or recorded queries, so the raw token would reach ClickHouse on those paths. Moving them to backend macros built on the macropro engine in #1802 so they expand server-side. The summary below describes the original frontend approach and will be updated once the rework lands.

---

## Summary

Adds four query macros that resolve to the database and table configured on the data source for each OpenTelemetry signal:

- `$__logsDatabase` / `$__logsTable`
- `$__tracesDatabase` / `$__tracesTable`

They expand to the data source's configured per-signal values (`logs.defaultDatabase` / `logs.defaultTable` / `traces.defaultDatabase` / `traces.defaultTable`), falling back to the connection default database and the conventional OTel table names (`otel_logs` / `otel_traces`) when a value is unset. Resolution happens in `applyTemplateVariables`, next to the existing `$__conditionalAll` handling, so it covers both panel queries and template-variable queries.

## Why

Queries and dashboards currently hard-code table names like `otel_logs`, which only works when the data source's default database happens to hold those tables. With these macros a query can reference the data source's configured schema instead:

- A single-table data source binds to its configured table automatically.
- A classic data source binds to its configured logs/traces defaults, and a dashboard can still override per panel.

This is the building block that lets the pre-built OTel dashboards follow whatever data source is selected instead of assuming a fixed schema.

## Test plan

- [x] Unit tests in `src/data/CHDatasource.test.ts`: macros resolve to the configured per-signal database/table, and fall back to the default database and `otel_logs` / `otel_traces` when per-signal config is unset.
- [x] `npm run typecheck`, `npm run lint`, `npm run test:ci`, `prettier --check`, and `cspell` all clean.
- [x] Docs: the four macros are documented in the query-editor Macros reference.

## Special notes for the reviewer

- Macro names (`$__logsDatabase` and friends) are open to your preference; happy to rename if a different convention fits better.
- They expand to bare identifiers, matching the existing `$clickhouse_adhoc_query` behavior. If you would prefer backtick-quoted identifiers for safety with non-standard names, that is a small change.
- No UI surface in this PR (query-engine + docs only). [ui-check: allow]

Please add the `changelog` label so it surfaces in the next release notes.
