### PR TITLE
fix: render SimpleAggregateFunction string columns correctly

### DIFF
--- a/pkg/converters/converters.go
+++ b/pkg/converters/converters.go
@@ -44,7 +44,9 @@ var matchRegexes = map[string]*regexp.Regexp{
 	"Nullable(IP)":              regexp.MustCompile(`^Nullable\(IP`),
 	"Nullable(String)":          regexp.MustCompile(`^Nullable\(String`),
 	"Point":                     regexp.MustCompile(`^Point`),
-	"SimpleAggregateFunction()": regexp.MustCompile(`^SimpleAggregateFunction\(.*\)`),
+	"SimpleAggregateFunction(String)":           regexp.MustCompile(`^SimpleAggregateFunction\([^,]+,\s*String\)$`),
+	"SimpleAggregateFunction(Nullable(String))": regexp.MustCompile(`^SimpleAggregateFunction\([^,]+,\s*Nullable\(String\)\)$`),
+	"SimpleAggregateFunction()":                 regexp.MustCompile(`^SimpleAggregateFunction\(.*\)`),
 	"Tuple()":                   regexp.MustCompile(`^Tuple\(.*\)`),
 	"Variant":                   regexp.MustCompile(`^Variant`),
 	"Dynamic":                   regexp.MustCompile(`^Dynamic`),
@@ -342,6 +344,18 @@ var Converters = []Converter{
 		scanType:   reflect.PointerTo(reflect.PointerTo(reflect.TypeOf(net.IP{}))),
 	},
 	{
+		name:      "SimpleAggregateFunction(String)",
+		fieldType: data.FieldTypeString,
+		matchRegex: matchRegexes["SimpleAggregateFunction(String)"],
+		scanType:  reflect.PointerTo(reflect.TypeOf("")),
+	},
+	{
+		name:       "SimpleAggregateFunction(Nullable(String))",
+		fieldType:  data.FieldTypeNullableString,
+		matchRegex: matchRegexes["SimpleAggregateFunction(Nullable(String))"],
+		scanType:   reflect.PointerTo(reflect.PointerTo(reflect.TypeOf(""))),
+	},
+	{
 		name:       "SimpleAggregateFunction()",
 		convert:    jsonConverter,
 		fieldType:  data.FieldTypeJSON,
@@ -385,6 +399,11 @@ func GetConverter(columnType string) sqlutil.Converter {
 		return GetConverter(innerType)
 	}
 
+	// check for 'SimpleAggregateFunction()' type and get the converter for the inner type
+	if innerType, ok := extractSimpleAggregateFunctionType(columnType); ok {
+		return GetConverter(innerType)
+	}
+
 	// direct match by name
 	for _, converter := range Converters {
 		if converter.name == columnType {
@@ -405,6 +424,50 @@ const (
 func extractLowCardinalityType(columnType string) (string, bool) {
 	if strings.HasPrefix(columnType, lowCardinalityPrefix) && strings.HasSuffix(columnType, lowCardinalitySuffix) {
 		return columnType[len(lowCardinalityPrefix) : len(columnType)-len(lowCardinalitySuffix)], true
+	}
+
+	return "", false
+}
+
+const (
+	simpleAggregateFunctionPrefix = "SimpleAggregateFunction("
+	simpleAggregateFunctionSuffix = ")"
+)
+
+// extractSimpleAggregateFunctionType checks if the column type is a `SimpleAggregateFunction(func, <type>)` type
+// and returns the inner data type (the second argument after the function name).
+// For example: SimpleAggregateFunction(any, String) -> String
+//
+//	SimpleAggregateFunction(any, Nullable(String)) -> Nullable(String)
+//	SimpleAggregateFunction(anyLast, Array(String)) -> Array(String)
+func extractSimpleAggregateFunctionType(columnType string) (string, bool) {
+	if !strings.HasPrefix(columnType, simpleAggregateFunctionPrefix) || !strings.HasSuffix(columnType, simpleAggregateFunctionSuffix) {
+		return "", false
+	}
+
+	// Extract the content between "SimpleAggregateFunction(" and the final ")"
+	inner := columnType[len(simpleAggregateFunctionPrefix) : len(columnType)-len(simpleAggregateFunctionSuffix)]
+
+	// Find the first comma that is not inside nested parentheses.
+	// The first argument is the function name (e.g., "any", "anyLast"),
+	// and the second argument is the data type.
+	depth := 0
+	for i, ch := range inner {
+		switch ch {
+		case '(':
+			depth++
+		case ')':
+			depth--
+		case ',':
+			if depth == 0 {
+				// Everything after ", " is the inner type
+				innerType := strings.TrimSpace(inner[i+1:])
+				if innerType == "" {
+					return "", false
+				}
+				return innerType, true
+			}
+		}
 	}
 
 	return "", false
@@ -465,6 +528,7 @@ func jsonConverter(in any) (any, error) {
 
 	return json.RawMessage(jBytes), nil
 }
+
 
 func defaultConvert(in interface{}) (interface{}, error) {
 	if in == nil {

--- a/pkg/converters/converters_test.go
+++ b/pkg/converters/converters_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/paulmach/orb"
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
@@ -660,14 +661,132 @@ func TestNullableIPv6ShouldBeNull(t *testing.T) {
 	require.Nil(t, v)
 }
 
-func TestSimpleAggregateFunction(t *testing.T) {
-	value := [][]int{{1, 2, 3}, {1, 2, 3}}
-	aggConverter := GetConverter("SimpleAggregateFunction()")
-	v, err := aggConverter.FrameConverter.ConverterFunc(&value)
+func TestSimpleAggregateFunctionString(t *testing.T) {
+	// The regex converter for SAF(*, String) uses the same scan type as plain String
+	value := "hello"
+	sut := GetConverter("SimpleAggregateFunction(any, String)")
+	require.NotNil(t, sut.InputScanType)
+	v, err := sut.FrameConverter.ConverterFunc(&value)
 	assert.Nil(t, err)
-	msg, err := toJson(value)
+	assert.Equal(t, "hello", v.(string))
+}
+
+func TestSimpleAggregateFunctionNullableString(t *testing.T) {
+	value := "world"
+	val := &value
+	sut := GetConverter("SimpleAggregateFunction(any, Nullable(String))")
+	require.NotNil(t, sut.InputScanType)
+	v, err := sut.FrameConverter.ConverterFunc(&val)
 	assert.Nil(t, err)
-	assert.Equal(t, msg, v.(json.RawMessage))
+	assert.Equal(t, "world", *v.(*string))
+}
+
+func TestSimpleAggregateFunctionNullableStringNil(t *testing.T) {
+	var val *string
+	sut := GetConverter("SimpleAggregateFunction(any, Nullable(String))")
+	require.NotNil(t, sut.InputScanType)
+	v, err := sut.FrameConverter.ConverterFunc(&val)
+	assert.Nil(t, err)
+	assert.Nil(t, v)
+}
+
+func TestSimpleAggregateFunctionNumericPreservesType(t *testing.T) {
+	// GetConverter extracts inner type, so Nullable(UInt16) gets its native converter
+	sut := GetConverter("SimpleAggregateFunction(any, Nullable(UInt16))")
+	require.NotNil(t, sut.InputScanType)
+	assert.Equal(t, data.FieldTypeNullableUint16, sut.FrameConverter.FieldType)
+}
+
+func TestSimpleAggregateFunctionArrayPreservesType(t *testing.T) {
+	// Arrays fall through to the regex catch-all (jsonConverter) which renders them correctly
+	sut := GetConverter("SimpleAggregateFunction(any, Array(String))")
+	require.NotNil(t, sut.InputScanType)
+	assert.Equal(t, data.FieldTypeJSON, sut.FrameConverter.FieldType)
+}
+
+// TestSimpleAggregateFunctionGetConverterPreservesTypes tests that GetConverter
+// extracts the inner type and delegates to typed converters.
+func TestSimpleAggregateFunctionGetConverterPreservesTypes(t *testing.T) {
+	cases := []struct {
+		name      string
+		typeName  string
+		input     interface{}
+		expected  interface{}
+	}{
+		{
+			name:     "String",
+			typeName: "SimpleAggregateFunction(any, String)",
+			input:    func() interface{} { s := "hello"; return &s }(),
+			expected: "hello",
+		},
+		{
+			name:     "Int64",
+			typeName: "SimpleAggregateFunction(anyLast, Int64)",
+			input:    func() interface{} { v := int64(12345); return &v }(),
+			expected: int64(12345),
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sut := GetConverter(tc.typeName)
+			require.NotNil(t, sut.InputScanType)
+			v, err := sut.FrameConverter.ConverterFunc(tc.input)
+			assert.Nil(t, err)
+			assert.Equal(t, tc.expected, v)
+		})
+	}
+}
+
+func TestExtractSimpleAggregateFunctionType(t *testing.T) {
+	cases := []struct {
+		inputType    string
+		expectedType string
+		expectedOk   bool
+	}{
+		{
+			inputType:    "SimpleAggregateFunction(any, String)",
+			expectedType: "String",
+			expectedOk:   true,
+		},
+		{
+			inputType:    "SimpleAggregateFunction(any, Nullable(String))",
+			expectedType: "Nullable(String)",
+			expectedOk:   true,
+		},
+		{
+			inputType:    "SimpleAggregateFunction(anyLast, Nullable(UInt16))",
+			expectedType: "Nullable(UInt16)",
+			expectedOk:   true,
+		},
+		{
+			inputType:    "SimpleAggregateFunction(any, Array(String))",
+			expectedType: "Array(String)",
+			expectedOk:   true,
+		},
+		{
+			inputType:    "SimpleAggregateFunction(any, Map(String, UInt64))",
+			expectedType: "Map(String, UInt64)",
+			expectedOk:   true,
+		},
+		{
+			inputType:    "String",
+			expectedType: "",
+			expectedOk:   false,
+		},
+		{
+			inputType:    "LowCardinality(String)",
+			expectedType: "",
+			expectedOk:   false,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.inputType, func(t *testing.T) {
+			actualType, actualOk := extractSimpleAggregateFunctionType(c.inputType)
+			assert.Equal(t, c.expectedOk, actualOk)
+			assert.Equal(t, c.expectedType, actualType)
+		})
+	}
 }
 
 func TestPoint(t *testing.T) {


### PR DESCRIPTION
## Summary

- `SimpleAggregateFunction(*, String)` and `SimpleAggregateFunction(*, Nullable(String))` columns render as blank/null in Table view
- The existing catch-all regex converter scans all SAF types into `interface{}` and uses `jsonConverter`, which works for numerics, bools, and arrays but produces unrenderable output for strings
- Add specific regex matchers for SAF string types that use native scan types (`*string` / `**string`), placed before the catch-all
- Also add `extractSimpleAggregateFunctionType()` for the `GetConverter()` path, following the same unwrap-and-delegate pattern used by `LowCardinality` and the ClickHouse JDBC driver ([clickhouse-java#2022](https://github.com/ClickHouse/clickhouse-java/pull/2022))

## How to reproduce

```sql
CREATE TABLE test_saf (
    id UInt64,
    name SimpleAggregateFunction(any, String),
    nullable_name SimpleAggregateFunction(any, Nullable(String)),
    status SimpleAggregateFunction(any, UInt16)
) ENGINE = AggregatingMergeTree()
ORDER BY id;

INSERT INTO test_saf VALUES (1, 'hello', 'world', 200);

SELECT id, name, nullable_name, status FROM test_saf;
```

Before fix: `name` and `nullable_name` show as blank. `status` renders correctly.
After fix: all columns render correctly with native types preserved.

## Test plan

- [x] `mage test` passes
- [x] Tested locally with Grafana + ClickHouse: String, Nullable(String), UInt16, UInt64, Float32, Bool, DateTime64, Nullable(DateTime64), Array(String) all render correctly
- [x] Verified numerics/bools/arrays still use `jsonConverter` (unchanged behavior)

Fixes #1923