### PR TITLE
fix: render SimpleAggregateFunction string columns correctly

### DIFF
--- a/pkg/converters/converters.go
+++ b/pkg/converters/converters.go
@@ -30,28 +30,30 @@ type Converter struct {
 // For example `^Date` and `^DateTime` could conflict when matching `DateTime64`
 var matchRegexes = map[string]*regexp.Regexp{
 	// for complex Arrays e.g. Array(Tuple)
-	"Array()":                   regexp.MustCompile(`^Array\(.*\)`),
-	"Date":                      regexp.MustCompile(`^Date\(?`),
-	"Decimal":                   regexp.MustCompile(`^Decimal`),
-	"FixedString()":             regexp.MustCompile(`^Nullable\(FixedString\(.*\)\)`),
-	"IP":                        regexp.MustCompile(`^IPv[4,6]`),
-	"LowCardinality()":          regexp.MustCompile(`^LowCardinality\(([^)]*)\)`),
-	"LowCardinality(Nullable)":  regexp.MustCompile(`^LowCardinality\(Nullable([^)]*)\)`),
-	"Map()":                     regexp.MustCompile(`^Map\(.*\)`),
-	"Nested()":                  regexp.MustCompile(`^Nested\(.*\)`),
-	"Nullable(Date)":            regexp.MustCompile(`^Nullable\(Date\(?`),
-	"Nullable(Decimal)":         regexp.MustCompile(`^Nullable\(Decimal`),
-	"Nullable(IP)":              regexp.MustCompile(`^Nullable\(IP`),
-	"Nullable(String)":          regexp.MustCompile(`^Nullable\(String`),
-	"Point":                     regexp.MustCompile(`^Point`),
-	"SimpleAggregateFunction()": regexp.MustCompile(`^SimpleAggregateFunction\(.*\)`),
-	"Tuple()":                   regexp.MustCompile(`^Tuple\(.*\)`),
-	"Variant":                   regexp.MustCompile(`^Variant`),
-	"Dynamic":                   regexp.MustCompile(`^Dynamic`),
-	"JSON":                      regexp.MustCompile(`^JSON`),
-	"Nullable(JSON)":            regexp.MustCompile(`^Nullable\(JSON`),
-	"Enum":                      regexp.MustCompile(`^Enum(8|16)\(.*\)`),
-	"Nullable(Enum)":            regexp.MustCompile(`^Nullable\(Enum(8|16)\(.*\)\)`),
+	"Array()":                         regexp.MustCompile(`^Array\(.*\)`),
+	"Date":                            regexp.MustCompile(`^Date\(?`),
+	"Decimal":                         regexp.MustCompile(`^Decimal`),
+	"FixedString()":                   regexp.MustCompile(`^Nullable\(FixedString\(.*\)\)`),
+	"IP":                              regexp.MustCompile(`^IPv[4,6]`),
+	"LowCardinality()":                regexp.MustCompile(`^LowCardinality\(([^)]*)\)`),
+	"LowCardinality(Nullable)":        regexp.MustCompile(`^LowCardinality\(Nullable([^)]*)\)`),
+	"Map()":                           regexp.MustCompile(`^Map\(.*\)`),
+	"Nested()":                        regexp.MustCompile(`^Nested\(.*\)`),
+	"Nullable(Date)":                  regexp.MustCompile(`^Nullable\(Date\(?`),
+	"Nullable(Decimal)":               regexp.MustCompile(`^Nullable\(Decimal`),
+	"Nullable(IP)":                    regexp.MustCompile(`^Nullable\(IP`),
+	"Nullable(String)":                regexp.MustCompile(`^Nullable\(String`),
+	"Point":                           regexp.MustCompile(`^Point`),
+	"SimpleAggregateFunction(String)": regexp.MustCompile(`^SimpleAggregateFunction\([^,]+,\s*String\)$`),
+	"SimpleAggregateFunction(Nullable(String))": regexp.MustCompile(`^SimpleAggregateFunction\([^,]+,\s*Nullable\(String\)\)$`),
+	"SimpleAggregateFunction()":                 regexp.MustCompile(`^SimpleAggregateFunction\(.*\)`),
+	"Tuple()":                                   regexp.MustCompile(`^Tuple\(.*\)`),
+	"Variant":                                   regexp.MustCompile(`^Variant`),
+	"Dynamic":                                   regexp.MustCompile(`^Dynamic`),
+	"JSON":                                      regexp.MustCompile(`^JSON`),
+	"Nullable(JSON)":                            regexp.MustCompile(`^Nullable\(JSON`),
+	"Enum":                                      regexp.MustCompile(`^Enum(8|16)\(.*\)`),
+	"Nullable(Enum)":                            regexp.MustCompile(`^Nullable\(Enum(8|16)\(.*\)\)`),
 }
 
 // Converters defines a list of type converters.
@@ -342,6 +344,18 @@ var Converters = []Converter{
 		scanType:   reflect.PointerTo(reflect.PointerTo(reflect.TypeOf(net.IP{}))),
 	},
 	{
+		name:       "SimpleAggregateFunction(String)",
+		fieldType:  data.FieldTypeString,
+		matchRegex: matchRegexes["SimpleAggregateFunction(String)"],
+		scanType:   reflect.PointerTo(reflect.TypeOf("")),
+	},
+	{
+		name:       "SimpleAggregateFunction(Nullable(String))",
+		fieldType:  data.FieldTypeNullableString,
+		matchRegex: matchRegexes["SimpleAggregateFunction(Nullable(String))"],
+		scanType:   reflect.PointerTo(reflect.PointerTo(reflect.TypeOf(""))),
+	},
+	{
 		name:       "SimpleAggregateFunction()",
 		convert:    jsonConverter,
 		fieldType:  data.FieldTypeJSON,
@@ -385,6 +399,11 @@ func GetConverter(columnType string) sqlutil.Converter {
 		return GetConverter(innerType)
 	}
 
+	// check for 'SimpleAggregateFunction()' type and get the converter for the inner type
+	if innerType, ok := extractSimpleAggregateFunctionType(columnType); ok {
+		return GetConverter(innerType)
+	}
+
 	// direct match by name
 	for _, converter := range Converters {
 		if converter.name == columnType {
@@ -405,6 +424,50 @@ const (
 func extractLowCardinalityType(columnType string) (string, bool) {
 	if strings.HasPrefix(columnType, lowCardinalityPrefix) && strings.HasSuffix(columnType, lowCardinalitySuffix) {
 		return columnType[len(lowCardinalityPrefix) : len(columnType)-len(lowCardinalitySuffix)], true
+	}
+
+	return "", false
+}
+
+const (
+	simpleAggregateFunctionPrefix = "SimpleAggregateFunction("
+	simpleAggregateFunctionSuffix = ")"
+)
+
+// extractSimpleAggregateFunctionType checks if the column type is a `SimpleAggregateFunction(func, <type>)` type
+// and returns the inner data type (the second argument after the function name).
+// For example: SimpleAggregateFunction(any, String) -> String
+//
+//	SimpleAggregateFunction(any, Nullable(String)) -> Nullable(String)
+//	SimpleAggregateFunction(anyLast, Array(String)) -> Array(String)
+func extractSimpleAggregateFunctionType(columnType string) (string, bool) {
+	if !strings.HasPrefix(columnType, simpleAggregateFunctionPrefix) || !strings.HasSuffix(columnType, simpleAggregateFunctionSuffix) {
+		return "", false
+	}
+
+	// Extract the content between "SimpleAggregateFunction(" and the final ")"
+	inner := columnType[len(simpleAggregateFunctionPrefix) : len(columnType)-len(simpleAggregateFunctionSuffix)]
+
+	// Find the first comma that is not inside nested parentheses.
+	// The first argument is the function name (e.g., "any", "anyLast"),
+	// and the second argument is the data type.
+	depth := 0
+	for i, ch := range inner {
+		switch ch {
+		case '(':
+			depth++
+		case ')':
+			depth--
+		case ',':
+			if depth == 0 {
+				// Everything after ", " is the inner type
+				innerType := strings.TrimSpace(inner[i+1:])
+				if innerType == "" {
+					return "", false
+				}
+				return innerType, true
+			}
+		}
 	}
 
 	return "", false

--- a/pkg/converters/converters_test.go
+++ b/pkg/converters/converters_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/paulmach/orb"
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
@@ -660,14 +661,142 @@ func TestNullableIPv6ShouldBeNull(t *testing.T) {
 	require.Nil(t, v)
 }
 
-func TestSimpleAggregateFunction(t *testing.T) {
-	value := [][]int{{1, 2, 3}, {1, 2, 3}}
-	aggConverter := GetConverter("SimpleAggregateFunction()")
-	v, err := aggConverter.FrameConverter.ConverterFunc(&value)
+// TestSimpleAggregateFunctionStringRegex tests the production path (regex matching
+// via ClickhouseConverters/findConverterWithRegex) for SAF String types.
+func TestSimpleAggregateFunctionStringRegex(t *testing.T) {
+	sut := findConverterWithRegex("SimpleAggregateFunction(any, String)")
+	require.NotNil(t, sut.InputScanType)
+	assert.Equal(t, data.FieldTypeString, sut.FrameConverter.FieldType)
+
+	value := "hello"
+	v, err := sut.FrameConverter.ConverterFunc(&value)
 	assert.Nil(t, err)
-	msg, err := toJson(value)
+	assert.Equal(t, "hello", v.(string))
+}
+
+func TestSimpleAggregateFunctionNullableStringRegex(t *testing.T) {
+	sut := findConverterWithRegex("SimpleAggregateFunction(any, Nullable(String))")
+	require.NotNil(t, sut.InputScanType)
+	assert.Equal(t, data.FieldTypeNullableString, sut.FrameConverter.FieldType)
+
+	value := "world"
+	val := &value
+	v, err := sut.FrameConverter.ConverterFunc(&val)
 	assert.Nil(t, err)
-	assert.Equal(t, msg, v.(json.RawMessage))
+	assert.Equal(t, "world", *v.(*string))
+}
+
+func TestSimpleAggregateFunctionNullableStringNilRegex(t *testing.T) {
+	sut := findConverterWithRegex("SimpleAggregateFunction(any, Nullable(String))")
+	require.NotNil(t, sut.InputScanType)
+
+	var val *string
+	v, err := sut.FrameConverter.ConverterFunc(&val)
+	assert.Nil(t, err)
+	assert.Nil(t, v)
+}
+
+func TestSimpleAggregateFunctionNumericUsesJSON(t *testing.T) {
+	// In the production regex path, non-string SAF types match the catch-all and use jsonConverter
+	sut := findConverterWithRegex("SimpleAggregateFunction(any, Nullable(UInt16))")
+	require.NotNil(t, sut.InputScanType)
+	assert.Equal(t, data.FieldTypeJSON, sut.FrameConverter.FieldType)
+}
+
+func TestSimpleAggregateFunctionArrayUsesJSON(t *testing.T) {
+	sut := findConverterWithRegex("SimpleAggregateFunction(any, Array(String))")
+	require.NotNil(t, sut.InputScanType)
+	assert.Equal(t, data.FieldTypeJSON, sut.FrameConverter.FieldType)
+}
+
+// TestSimpleAggregateFunctionGetConverter tests the GetConverter path which
+// extracts the inner type and delegates to typed converters.
+func TestSimpleAggregateFunctionGetConverter(t *testing.T) {
+	cases := []struct {
+		name      string
+		typeName  string
+		fieldType data.FieldType
+	}{
+		{
+			name:      "String delegates to String converter",
+			typeName:  "SimpleAggregateFunction(any, String)",
+			fieldType: data.FieldTypeString,
+		},
+		{
+			name:      "Nullable(String) delegates to Nullable(String) converter",
+			typeName:  "SimpleAggregateFunction(any, Nullable(String))",
+			fieldType: data.FieldTypeNullableString,
+		},
+		{
+			name:      "Nullable(UInt16) delegates to Nullable(UInt16) converter",
+			typeName:  "SimpleAggregateFunction(any, Nullable(UInt16))",
+			fieldType: data.FieldTypeNullableUint16,
+		},
+		{
+			name:      "Int64 delegates to Int64 converter",
+			typeName:  "SimpleAggregateFunction(anyLast, Int64)",
+			fieldType: data.FieldTypeInt64,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sut := GetConverter(tc.typeName)
+			require.NotNil(t, sut.InputScanType)
+			assert.Equal(t, tc.fieldType, sut.FrameConverter.FieldType)
+		})
+	}
+}
+
+func TestExtractSimpleAggregateFunctionType(t *testing.T) {
+	cases := []struct {
+		inputType    string
+		expectedType string
+		expectedOk   bool
+	}{
+		{
+			inputType:    "SimpleAggregateFunction(any, String)",
+			expectedType: "String",
+			expectedOk:   true,
+		},
+		{
+			inputType:    "SimpleAggregateFunction(any, Nullable(String))",
+			expectedType: "Nullable(String)",
+			expectedOk:   true,
+		},
+		{
+			inputType:    "SimpleAggregateFunction(anyLast, Nullable(UInt16))",
+			expectedType: "Nullable(UInt16)",
+			expectedOk:   true,
+		},
+		{
+			inputType:    "SimpleAggregateFunction(any, Array(String))",
+			expectedType: "Array(String)",
+			expectedOk:   true,
+		},
+		{
+			inputType:    "SimpleAggregateFunction(any, Map(String, UInt64))",
+			expectedType: "Map(String, UInt64)",
+			expectedOk:   true,
+		},
+		{
+			inputType:    "String",
+			expectedType: "",
+			expectedOk:   false,
+		},
+		{
+			inputType:    "LowCardinality(String)",
+			expectedType: "",
+			expectedOk:   false,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.inputType, func(t *testing.T) {
+			actualType, actualOk := extractSimpleAggregateFunctionType(c.inputType)
+			assert.Equal(t, c.expectedOk, actualOk)
+			assert.Equal(t, c.expectedType, actualType)
+		})
+	}
 }
 
 func TestPoint(t *testing.T) {

--- a/tests/e2e/fixtures/simple_aggregate_functions.sql
+++ b/tests/e2e/fixtures/simple_aggregate_functions.sql
@@ -1,0 +1,23 @@
+-- Fixture for simpleAggregateFunction.spec.ts
+-- Exercises SimpleAggregateFunction(any, String) and
+-- SimpleAggregateFunction(any, Nullable(String)) columns to verify the
+-- datasource renders them correctly without toString() wrapping.
+-- Time range: 2024-03-15 10:00:00 – 2024-03-15 10:04:00 UTC.
+
+CREATE DATABASE IF NOT EXISTS e2e_test;
+
+CREATE TABLE IF NOT EXISTS e2e_test.simple_aggregate_events
+(
+    timestamp DateTime,
+    name      SimpleAggregateFunction(any, String),
+    label     SimpleAggregateFunction(any, Nullable(String))
+)
+ENGINE = AggregatingMergeTree
+ORDER BY timestamp;
+
+INSERT INTO e2e_test.simple_aggregate_events (timestamp, name, label) VALUES
+    ('2024-03-15 10:00:00', 'alpha',   'first'),
+    ('2024-03-15 10:01:00', 'beta',    NULL),
+    ('2024-03-15 10:02:00', 'gamma',   'third'),
+    ('2024-03-15 10:03:00', 'delta',   'fourth'),
+    ('2024-03-15 10:04:00', 'epsilon', NULL);

--- a/tests/e2e/simpleAggregateFunction.spec.ts
+++ b/tests/e2e/simpleAggregateFunction.spec.ts
@@ -1,0 +1,121 @@
+import { expect, test, ExplorePage } from '@grafana/plugin-e2e';
+import { Page } from '@playwright/test';
+
+const PLUGIN_TYPE = 'grafana-clickhouse-datasource';
+
+const isCloudRun = !!process.env.GRAFANA_URL;
+
+const CLOUD_DEFAULT_UID = 'clickhouse-native-ds-m';
+const LOCAL_DEFAULT_UID = 'clickhouse-e2e';
+const DATASOURCE_UID = process.env.DS_E2E_UID || (isCloudRun ? CLOUD_DEFAULT_UID : LOCAL_DEFAULT_UID);
+
+const FIXTURE_FROM_ISO = '2024-03-15T09:45:00.000Z';
+const FIXTURE_TO_ISO = '2024-03-15T10:15:00.000Z';
+
+function exploreUrl(): string {
+  const query: Record<string, unknown> = {
+    refId: 'A',
+    datasource: { type: PLUGIN_TYPE, uid: DATASOURCE_UID },
+    editorType: 'sql',
+    pluginVersion: '',
+    rawSql: '',
+  };
+
+  const panes = JSON.stringify({
+    explore: {
+      datasource: DATASOURCE_UID,
+      queries: [query],
+      range: { from: FIXTURE_FROM_ISO, to: FIXTURE_TO_ISO },
+    },
+  });
+
+  return `/explore?orgId=1&schemaVersion=1&panes=${encodeURIComponent(panes)}`;
+}
+
+async function enterSql(page: Page, sql: string) {
+  const editor = page.getByRole('code');
+  await editor.click();
+  await page.keyboard.press('ControlOrMeta+a');
+  await page.keyboard.type(sql);
+}
+
+async function waitForQueryDataResponseWithBody(explorePage: ExplorePage) {
+  let body: Record<string, unknown> | null = null;
+  const responsePromise = explorePage.waitForQueryDataResponse(async (r) => {
+    if (!r.ok()) {
+      return false;
+    }
+    const b: any = await r.json().catch(() => null);
+    if (!Array.isArray(b?.results?.A?.frames)) {
+      return false;
+    }
+    body = b as Record<string, unknown>;
+    return true;
+  });
+  return { responsePromise, getBody: () => body };
+}
+
+function getFrameValues(body: any): any[][] {
+  return body?.results?.A?.frames?.[0]?.data?.values ?? [];
+}
+
+test.describe('SimpleAggregateFunction string type handling', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  test.beforeEach(() => {
+    test.skip(
+      isCloudRun,
+      'Fixture-data tests depend on e2e_test.simple_aggregate_events seeded by tests/e2e/fixtures/simple_aggregate_functions.sql via the local e2e-data-loader Docker service, which is not available on Cloud.'
+    );
+  });
+
+  test('SimpleAggregateFunction(any, String) returns string values', async ({ page, explorePage }) => {
+    await page.goto(exploreUrl());
+    await enterSql(page, 'SELECT name FROM e2e_test.simple_aggregate_events ORDER BY timestamp');
+
+    const { responsePromise, getBody } = await waitForQueryDataResponseWithBody(explorePage);
+    await page.locator('.query-editor-row').getByRole('button', { name: 'Run Query' }).click();
+
+    await responsePromise;
+    const values = getFrameValues(getBody());
+    expect(values.length).toBeGreaterThan(0);
+    expect(values[0]).toEqual(['alpha', 'beta', 'gamma', 'delta', 'epsilon']);
+  });
+
+  test('SimpleAggregateFunction(any, Nullable(String)) returns values with nulls preserved', async ({
+    page,
+    explorePage,
+  }) => {
+    await page.goto(exploreUrl());
+    await enterSql(page, 'SELECT label FROM e2e_test.simple_aggregate_events ORDER BY timestamp');
+
+    const { responsePromise, getBody } = await waitForQueryDataResponseWithBody(explorePage);
+    await page.locator('.query-editor-row').getByRole('button', { name: 'Run Query' }).click();
+
+    await responsePromise;
+    const values = getFrameValues(getBody());
+    expect(values.length).toBeGreaterThan(0);
+    expect(values[0]).toEqual(['first', null, 'third', 'fourth', null]);
+  });
+
+  test('table panel renders both SAF string columns together', async ({ page, explorePage }) => {
+    await page.goto(exploreUrl());
+    await enterSql(
+      page,
+      'SELECT timestamp, name, label FROM e2e_test.simple_aggregate_events ORDER BY timestamp'
+    );
+
+    const { responsePromise, getBody } = await waitForQueryDataResponseWithBody(explorePage);
+    await page.locator('.query-editor-row').getByRole('button', { name: 'Run Query' }).click();
+
+    await responsePromise;
+    const body = getBody() as any;
+    const fields = body?.results?.A?.frames?.[0]?.schema?.fields ?? [];
+    expect(fields.length).toBe(3);
+
+    const nameField = fields.find((f: any) => f.name === 'name');
+    const labelField = fields.find((f: any) => f.name === 'label');
+    expect(nameField?.typeInfo?.frame).toBe('string');
+    expect(labelField?.typeInfo?.frame).toMatch(/string/);
+  });
+});


### PR DESCRIPTION
## Summary

`SimpleAggregateFunction(*, String)` and `SimpleAggregateFunction(*, Nullable(String))` columns render as blank/null in Table view. This PR fixes the issue by adding specific regex matchers for SAF string types that use native scan types, placed before the catch-all.

Also adds `extractSimpleAggregateFunctionType()` for the `GetConverter()` path, following the same unwrap-and-delegate pattern used by `LowCardinality` and the ClickHouse JDBC driver (clickhouse-java#2022).

## Problem

The existing catch-all regex converter scans all SAF types into `interface{}` and uses `jsonConverter`. This works for numerics, bools, and arrays (which `json.Marshal` serializes correctly), but for strings it produces `json.RawMessage("hello")` which is invalid JSON and renders blank.

## Fix

- Add regex matchers for `SimpleAggregateFunction(*, String)` and `SimpleAggregateFunction(*, Nullable(String))` before the catch-all, with native `*string` / `**string` scan types
- Add `extractSimpleAggregateFunctionType()` helper for the `GetConverter()` path
- Non-string SAF types continue to use the existing `jsonConverter` catch-all (which already works)

## Tests

- Tests exercise both the production regex path (`findConverterWithRegex`) and the `GetConverter` delegation path
- Covers: String, Nullable(String), Nullable(String) nil, numeric→JSON (production), array→JSON (production), GetConverter delegation, and `extractSimpleAggregateFunctionType` parsing

Fixes #1926