### PR TITLE
feat: native type support for SimpleAggregateFunction numeric/bool/date columns

### DIFF
--- a/pkg/converters/converters.go
+++ b/pkg/converters/converters.go
@@ -548,6 +548,9 @@ func safConvertNullableUint8(in interface{}) (interface{}, error) {
 	if val, ok := v.(*uint8); ok {
 		return val, nil
 	}
+	if val, ok := v.(uint8); ok {
+		return &val, nil
+	}
 	return jsonConverter(in)
 }
 
@@ -558,6 +561,9 @@ func safConvertNullableUint16(in interface{}) (interface{}, error) {
 	}
 	if val, ok := v.(*uint16); ok {
 		return val, nil
+	}
+	if val, ok := v.(uint16); ok {
+		return &val, nil
 	}
 	return jsonConverter(in)
 }
@@ -570,6 +576,9 @@ func safConvertNullableUint32(in interface{}) (interface{}, error) {
 	if val, ok := v.(*uint32); ok {
 		return val, nil
 	}
+	if val, ok := v.(uint32); ok {
+		return &val, nil
+	}
 	return jsonConverter(in)
 }
 
@@ -580,6 +589,9 @@ func safConvertNullableUint64(in interface{}) (interface{}, error) {
 	}
 	if val, ok := v.(*uint64); ok {
 		return val, nil
+	}
+	if val, ok := v.(uint64); ok {
+		return &val, nil
 	}
 	return jsonConverter(in)
 }
@@ -592,6 +604,9 @@ func safConvertNullableInt8(in interface{}) (interface{}, error) {
 	if val, ok := v.(*int8); ok {
 		return val, nil
 	}
+	if val, ok := v.(int8); ok {
+		return &val, nil
+	}
 	return jsonConverter(in)
 }
 
@@ -602,6 +617,9 @@ func safConvertNullableInt16(in interface{}) (interface{}, error) {
 	}
 	if val, ok := v.(*int16); ok {
 		return val, nil
+	}
+	if val, ok := v.(int16); ok {
+		return &val, nil
 	}
 	return jsonConverter(in)
 }
@@ -614,6 +632,9 @@ func safConvertNullableInt32(in interface{}) (interface{}, error) {
 	if val, ok := v.(*int32); ok {
 		return val, nil
 	}
+	if val, ok := v.(int32); ok {
+		return &val, nil
+	}
 	return jsonConverter(in)
 }
 
@@ -624,6 +645,9 @@ func safConvertNullableInt64(in interface{}) (interface{}, error) {
 	}
 	if val, ok := v.(*int64); ok {
 		return val, nil
+	}
+	if val, ok := v.(int64); ok {
+		return &val, nil
 	}
 	return jsonConverter(in)
 }
@@ -636,6 +660,9 @@ func safConvertNullableFloat32(in interface{}) (interface{}, error) {
 	if val, ok := v.(*float32); ok {
 		return val, nil
 	}
+	if val, ok := v.(float32); ok {
+		return &val, nil
+	}
 	return jsonConverter(in)
 }
 
@@ -647,6 +674,9 @@ func safConvertNullableFloat64(in interface{}) (interface{}, error) {
 	if val, ok := v.(*float64); ok {
 		return val, nil
 	}
+	if val, ok := v.(float64); ok {
+		return &val, nil
+	}
 	return jsonConverter(in)
 }
 
@@ -657,6 +687,9 @@ func safConvertNullableBool(in interface{}) (interface{}, error) {
 	}
 	if val, ok := v.(*bool); ok {
 		return val, nil
+	}
+	if val, ok := v.(bool); ok {
+		return &val, nil
 	}
 	return jsonConverter(in)
 }

--- a/pkg/converters/converters.go
+++ b/pkg/converters/converters.go
@@ -467,77 +467,77 @@ func safConvertUint8(in interface{}) (interface{}, error) {
 	if v, ok := (*(in.(*interface{}))).(uint8); ok {
 		return v, nil
 	}
-	return jsonConverter(in)
+	return nil, fmt.Errorf("unexpected type %T for SAF uint8", *(in.(*interface{})))
 }
 
 func safConvertUint16(in interface{}) (interface{}, error) {
 	if v, ok := (*(in.(*interface{}))).(uint16); ok {
 		return v, nil
 	}
-	return jsonConverter(in)
+	return nil, fmt.Errorf("unexpected type %T for SAF uint16", *(in.(*interface{})))
 }
 
 func safConvertUint32(in interface{}) (interface{}, error) {
 	if v, ok := (*(in.(*interface{}))).(uint32); ok {
 		return v, nil
 	}
-	return jsonConverter(in)
+	return nil, fmt.Errorf("unexpected type %T for SAF uint32", *(in.(*interface{})))
 }
 
 func safConvertUint64(in interface{}) (interface{}, error) {
 	if v, ok := (*(in.(*interface{}))).(uint64); ok {
 		return v, nil
 	}
-	return jsonConverter(in)
+	return nil, fmt.Errorf("unexpected type %T for SAF uint64", *(in.(*interface{})))
 }
 
 func safConvertInt8(in interface{}) (interface{}, error) {
 	if v, ok := (*(in.(*interface{}))).(int8); ok {
 		return v, nil
 	}
-	return jsonConverter(in)
+	return nil, fmt.Errorf("unexpected type %T for SAF int8", *(in.(*interface{})))
 }
 
 func safConvertInt16(in interface{}) (interface{}, error) {
 	if v, ok := (*(in.(*interface{}))).(int16); ok {
 		return v, nil
 	}
-	return jsonConverter(in)
+	return nil, fmt.Errorf("unexpected type %T for SAF int16", *(in.(*interface{})))
 }
 
 func safConvertInt32(in interface{}) (interface{}, error) {
 	if v, ok := (*(in.(*interface{}))).(int32); ok {
 		return v, nil
 	}
-	return jsonConverter(in)
+	return nil, fmt.Errorf("unexpected type %T for SAF int32", *(in.(*interface{})))
 }
 
 func safConvertInt64(in interface{}) (interface{}, error) {
 	if v, ok := (*(in.(*interface{}))).(int64); ok {
 		return v, nil
 	}
-	return jsonConverter(in)
+	return nil, fmt.Errorf("unexpected type %T for SAF int64", *(in.(*interface{})))
 }
 
 func safConvertFloat32(in interface{}) (interface{}, error) {
 	if v, ok := (*(in.(*interface{}))).(float32); ok {
 		return v, nil
 	}
-	return jsonConverter(in)
+	return nil, fmt.Errorf("unexpected type %T for SAF float32", *(in.(*interface{})))
 }
 
 func safConvertFloat64(in interface{}) (interface{}, error) {
 	if v, ok := (*(in.(*interface{}))).(float64); ok {
 		return v, nil
 	}
-	return jsonConverter(in)
+	return nil, fmt.Errorf("unexpected type %T for SAF float64", *(in.(*interface{})))
 }
 
 func safConvertBool(in interface{}) (interface{}, error) {
 	if v, ok := (*(in.(*interface{}))).(bool); ok {
 		return v, nil
 	}
-	return jsonConverter(in)
+	return nil, fmt.Errorf("unexpected type %T for SAF bool", *(in.(*interface{})))
 }
 
 func safConvertNullableUint8(in interface{}) (interface{}, error) {
@@ -551,7 +551,7 @@ func safConvertNullableUint8(in interface{}) (interface{}, error) {
 	if val, ok := v.(uint8); ok {
 		return &val, nil
 	}
-	return jsonConverter(in)
+	return nil, fmt.Errorf("unexpected type %T for SAF Nullable(uint8)", v)
 }
 
 func safConvertNullableUint16(in interface{}) (interface{}, error) {
@@ -565,7 +565,7 @@ func safConvertNullableUint16(in interface{}) (interface{}, error) {
 	if val, ok := v.(uint16); ok {
 		return &val, nil
 	}
-	return jsonConverter(in)
+	return nil, fmt.Errorf("unexpected type %T for SAF Nullable(uint16)", v)
 }
 
 func safConvertNullableUint32(in interface{}) (interface{}, error) {
@@ -579,7 +579,7 @@ func safConvertNullableUint32(in interface{}) (interface{}, error) {
 	if val, ok := v.(uint32); ok {
 		return &val, nil
 	}
-	return jsonConverter(in)
+	return nil, fmt.Errorf("unexpected type %T for SAF Nullable(uint32)", v)
 }
 
 func safConvertNullableUint64(in interface{}) (interface{}, error) {
@@ -593,7 +593,7 @@ func safConvertNullableUint64(in interface{}) (interface{}, error) {
 	if val, ok := v.(uint64); ok {
 		return &val, nil
 	}
-	return jsonConverter(in)
+	return nil, fmt.Errorf("unexpected type %T for SAF Nullable(uint64)", v)
 }
 
 func safConvertNullableInt8(in interface{}) (interface{}, error) {
@@ -607,7 +607,7 @@ func safConvertNullableInt8(in interface{}) (interface{}, error) {
 	if val, ok := v.(int8); ok {
 		return &val, nil
 	}
-	return jsonConverter(in)
+	return nil, fmt.Errorf("unexpected type %T for SAF Nullable(int8)", v)
 }
 
 func safConvertNullableInt16(in interface{}) (interface{}, error) {
@@ -621,7 +621,7 @@ func safConvertNullableInt16(in interface{}) (interface{}, error) {
 	if val, ok := v.(int16); ok {
 		return &val, nil
 	}
-	return jsonConverter(in)
+	return nil, fmt.Errorf("unexpected type %T for SAF Nullable(int16)", v)
 }
 
 func safConvertNullableInt32(in interface{}) (interface{}, error) {
@@ -635,7 +635,7 @@ func safConvertNullableInt32(in interface{}) (interface{}, error) {
 	if val, ok := v.(int32); ok {
 		return &val, nil
 	}
-	return jsonConverter(in)
+	return nil, fmt.Errorf("unexpected type %T for SAF Nullable(int32)", v)
 }
 
 func safConvertNullableInt64(in interface{}) (interface{}, error) {
@@ -649,7 +649,7 @@ func safConvertNullableInt64(in interface{}) (interface{}, error) {
 	if val, ok := v.(int64); ok {
 		return &val, nil
 	}
-	return jsonConverter(in)
+	return nil, fmt.Errorf("unexpected type %T for SAF Nullable(int64)", v)
 }
 
 func safConvertNullableFloat32(in interface{}) (interface{}, error) {
@@ -663,7 +663,7 @@ func safConvertNullableFloat32(in interface{}) (interface{}, error) {
 	if val, ok := v.(float32); ok {
 		return &val, nil
 	}
-	return jsonConverter(in)
+	return nil, fmt.Errorf("unexpected type %T for SAF Nullable(float32)", v)
 }
 
 func safConvertNullableFloat64(in interface{}) (interface{}, error) {
@@ -677,7 +677,7 @@ func safConvertNullableFloat64(in interface{}) (interface{}, error) {
 	if val, ok := v.(float64); ok {
 		return &val, nil
 	}
-	return jsonConverter(in)
+	return nil, fmt.Errorf("unexpected type %T for SAF Nullable(float64)", v)
 }
 
 func safConvertNullableBool(in interface{}) (interface{}, error) {
@@ -691,14 +691,14 @@ func safConvertNullableBool(in interface{}) (interface{}, error) {
 	if val, ok := v.(bool); ok {
 		return &val, nil
 	}
-	return jsonConverter(in)
+	return nil, fmt.Errorf("unexpected type %T for SAF Nullable(bool)", v)
 }
 
 func safConvertTime(in interface{}) (interface{}, error) {
 	if v, ok := (*(in.(*interface{}))).(time.Time); ok {
 		return v, nil
 	}
-	return jsonConverter(in)
+	return nil, fmt.Errorf("unexpected type %T for SAF time", *(in.(*interface{})))
 }
 
 func safConvertNullableTime(in interface{}) (interface{}, error) {
@@ -712,7 +712,7 @@ func safConvertNullableTime(in interface{}) (interface{}, error) {
 	if val, ok := v.(time.Time); ok {
 		return &val, nil
 	}
-	return jsonConverter(in)
+	return nil, fmt.Errorf("unexpected type %T for SAF Nullable(time)", v)
 }
 
 // GetConverter returns a sqlutil.Converter for the given column type.

--- a/pkg/converters/converters.go
+++ b/pkg/converters/converters.go
@@ -402,55 +402,57 @@ func ClickHouseConverters() []sqlutil.Converter {
 // a converter function that extracts the native value from interface{}.
 type safTypeEntry struct {
 	innerPattern string         // regex for the inner type (after the function name)
+	displayName  string         // human-readable label for logs/debugging
 	fieldType    data.FieldType // Grafana field type to report
 	convert      func(in interface{}) (interface{}, error)
 }
 
 var safTypeMappings = []safTypeEntry{
 	// Non-nullable numeric types
-	{"UInt8", data.FieldTypeUint8, safConvertUint8},
-	{"UInt16", data.FieldTypeUint16, safConvertUint16},
-	{"UInt32", data.FieldTypeUint32, safConvertUint32},
-	{"UInt64", data.FieldTypeUint64, safConvertUint64},
-	{"Int8", data.FieldTypeInt8, safConvertInt8},
-	{"Int16", data.FieldTypeInt16, safConvertInt16},
-	{"Int32", data.FieldTypeInt32, safConvertInt32},
-	{"Int64", data.FieldTypeInt64, safConvertInt64},
-	{"Float32", data.FieldTypeFloat32, safConvertFloat32},
-	{"Float64", data.FieldTypeFloat64, safConvertFloat64},
-	{"Bool", data.FieldTypeBool, safConvertBool},
+	{"UInt8", "UInt8", data.FieldTypeUint8, safConvertUint8},
+	{"UInt16", "UInt16", data.FieldTypeUint16, safConvertUint16},
+	{"UInt32", "UInt32", data.FieldTypeUint32, safConvertUint32},
+	{"UInt64", "UInt64", data.FieldTypeUint64, safConvertUint64},
+	{"Int8", "Int8", data.FieldTypeInt8, safConvertInt8},
+	{"Int16", "Int16", data.FieldTypeInt16, safConvertInt16},
+	{"Int32", "Int32", data.FieldTypeInt32, safConvertInt32},
+	{"Int64", "Int64", data.FieldTypeInt64, safConvertInt64},
+	{"Float32", "Float32", data.FieldTypeFloat32, safConvertFloat32},
+	{"Float64", "Float64", data.FieldTypeFloat64, safConvertFloat64},
+	{"Bool", "Bool", data.FieldTypeBool, safConvertBool},
 	// Nullable numeric types
-	{"Nullable\\(UInt8\\)", data.FieldTypeNullableUint8, safConvertNullableUint8},
-	{"Nullable\\(UInt16\\)", data.FieldTypeNullableUint16, safConvertNullableUint16},
-	{"Nullable\\(UInt32\\)", data.FieldTypeNullableUint32, safConvertNullableUint32},
-	{"Nullable\\(UInt64\\)", data.FieldTypeNullableUint64, safConvertNullableUint64},
-	{"Nullable\\(Int8\\)", data.FieldTypeNullableInt8, safConvertNullableInt8},
-	{"Nullable\\(Int16\\)", data.FieldTypeNullableInt16, safConvertNullableInt16},
-	{"Nullable\\(Int32\\)", data.FieldTypeNullableInt32, safConvertNullableInt32},
-	{"Nullable\\(Int64\\)", data.FieldTypeNullableInt64, safConvertNullableInt64},
-	{"Nullable\\(Float32\\)", data.FieldTypeNullableFloat32, safConvertNullableFloat32},
-	{"Nullable\\(Float64\\)", data.FieldTypeNullableFloat64, safConvertNullableFloat64},
-	{"Nullable\\(Bool\\)", data.FieldTypeNullableBool, safConvertNullableBool},
+	{"Nullable\\(UInt8\\)", "Nullable(UInt8)", data.FieldTypeNullableUint8, safConvertNullableUint8},
+	{"Nullable\\(UInt16\\)", "Nullable(UInt16)", data.FieldTypeNullableUint16, safConvertNullableUint16},
+	{"Nullable\\(UInt32\\)", "Nullable(UInt32)", data.FieldTypeNullableUint32, safConvertNullableUint32},
+	{"Nullable\\(UInt64\\)", "Nullable(UInt64)", data.FieldTypeNullableUint64, safConvertNullableUint64},
+	{"Nullable\\(Int8\\)", "Nullable(Int8)", data.FieldTypeNullableInt8, safConvertNullableInt8},
+	{"Nullable\\(Int16\\)", "Nullable(Int16)", data.FieldTypeNullableInt16, safConvertNullableInt16},
+	{"Nullable\\(Int32\\)", "Nullable(Int32)", data.FieldTypeNullableInt32, safConvertNullableInt32},
+	{"Nullable\\(Int64\\)", "Nullable(Int64)", data.FieldTypeNullableInt64, safConvertNullableInt64},
+	{"Nullable\\(Float32\\)", "Nullable(Float32)", data.FieldTypeNullableFloat32, safConvertNullableFloat32},
+	{"Nullable\\(Float64\\)", "Nullable(Float64)", data.FieldTypeNullableFloat64, safConvertNullableFloat64},
+	{"Nullable\\(Bool\\)", "Nullable(Bool)", data.FieldTypeNullableBool, safConvertNullableBool},
 	// DateTime types (patterns account for optional timezone parameter)
-	{"DateTime64\\(\\d+(,\\s*'[^']*')?\\)", data.FieldTypeTime, safConvertTime},
-	{"DateTime(\\('[^']*'\\))?", data.FieldTypeTime, safConvertTime},
-	{"Date32", data.FieldTypeTime, safConvertTime},
-	{"Date", data.FieldTypeTime, safConvertTime},
-	{"Nullable\\(DateTime64\\(\\d+(,\\s*'[^']*')?\\)\\)", data.FieldTypeNullableTime, safConvertNullableTime},
-	{"Nullable\\(DateTime(\\('[^']*'\\))?\\)", data.FieldTypeNullableTime, safConvertNullableTime},
-	{"Nullable\\(Date32\\)", data.FieldTypeNullableTime, safConvertNullableTime},
-	{"Nullable\\(Date\\)", data.FieldTypeNullableTime, safConvertNullableTime},
+	{"DateTime64\\(\\d+(,\\s*'[^']*')?\\)", "DateTime64", data.FieldTypeTime, safConvertTime},
+	{"DateTime(\\('[^']*'\\))?", "DateTime", data.FieldTypeTime, safConvertTime},
+	{"Date32", "Date32", data.FieldTypeTime, safConvertTime},
+	{"Date", "Date", data.FieldTypeTime, safConvertTime},
+	{"Nullable\\(DateTime64\\(\\d+(,\\s*'[^']*')?\\)\\)", "Nullable(DateTime64)", data.FieldTypeNullableTime, safConvertNullableTime},
+	{"Nullable\\(DateTime(\\('[^']*'\\))?\\)", "Nullable(DateTime)", data.FieldTypeNullableTime, safConvertNullableTime},
+	{"Nullable\\(Date32\\)", "Nullable(Date32)", data.FieldTypeNullableTime, safConvertNullableTime},
+	{"Nullable\\(Date\\)", "Nullable(Date)", data.FieldTypeNullableTime, safConvertNullableTime},
 }
 
 func generateSAFConverters() []sqlutil.Converter {
 	var converters []sqlutil.Converter
 	for _, entry := range safTypeMappings {
 		pattern := `^SimpleAggregateFunction\([^,]+,\s*` + entry.innerPattern + `\)$`
+		label := "SimpleAggregateFunction(*, " + entry.displayName + ")"
 		converters = append(converters, sqlutil.Converter{
-			Name:           "SimpleAggregateFunction(" + entry.innerPattern + ")",
+			Name:           label,
 			InputScanType:  reflect.TypeOf((*interface{})(nil)).Elem(),
 			InputTypeRegex: regexp.MustCompile(pattern),
-			InputTypeName:  "SimpleAggregateFunction(" + entry.innerPattern + ")",
+			InputTypeName:  label,
 			FrameConverter: sqlutil.FrameConverter{
 				FieldType:     entry.fieldType,
 				ConverterFunc: entry.convert,
@@ -464,80 +466,124 @@ func generateSAFConverters() []sqlutil.Converter {
 // and the underlying value is the native Go type matching the inner column type.
 
 func safConvertUint8(in interface{}) (interface{}, error) {
-	if v, ok := (*(in.(*interface{}))).(uint8); ok {
-		return v, nil
+	v := (*(in.(*interface{})))
+	if val, ok := v.(uint8); ok {
+		return val, nil
 	}
-	return nil, fmt.Errorf("unexpected type %T for SAF uint8", *(in.(*interface{})))
+	if val, ok := v.(*uint8); ok {
+		return *val, nil
+	}
+	return nil, fmt.Errorf("unexpected type %T for SAF UInt8", v)
 }
 
 func safConvertUint16(in interface{}) (interface{}, error) {
-	if v, ok := (*(in.(*interface{}))).(uint16); ok {
-		return v, nil
+	v := (*(in.(*interface{})))
+	if val, ok := v.(uint16); ok {
+		return val, nil
 	}
-	return nil, fmt.Errorf("unexpected type %T for SAF uint16", *(in.(*interface{})))
+	if val, ok := v.(*uint16); ok {
+		return *val, nil
+	}
+	return nil, fmt.Errorf("unexpected type %T for SAF UInt16", v)
 }
 
 func safConvertUint32(in interface{}) (interface{}, error) {
-	if v, ok := (*(in.(*interface{}))).(uint32); ok {
-		return v, nil
+	v := (*(in.(*interface{})))
+	if val, ok := v.(uint32); ok {
+		return val, nil
 	}
-	return nil, fmt.Errorf("unexpected type %T for SAF uint32", *(in.(*interface{})))
+	if val, ok := v.(*uint32); ok {
+		return *val, nil
+	}
+	return nil, fmt.Errorf("unexpected type %T for SAF UInt32", v)
 }
 
 func safConvertUint64(in interface{}) (interface{}, error) {
-	if v, ok := (*(in.(*interface{}))).(uint64); ok {
-		return v, nil
+	v := (*(in.(*interface{})))
+	if val, ok := v.(uint64); ok {
+		return val, nil
 	}
-	return nil, fmt.Errorf("unexpected type %T for SAF uint64", *(in.(*interface{})))
+	if val, ok := v.(*uint64); ok {
+		return *val, nil
+	}
+	return nil, fmt.Errorf("unexpected type %T for SAF UInt64", v)
 }
 
 func safConvertInt8(in interface{}) (interface{}, error) {
-	if v, ok := (*(in.(*interface{}))).(int8); ok {
-		return v, nil
+	v := (*(in.(*interface{})))
+	if val, ok := v.(int8); ok {
+		return val, nil
 	}
-	return nil, fmt.Errorf("unexpected type %T for SAF int8", *(in.(*interface{})))
+	if val, ok := v.(*int8); ok {
+		return *val, nil
+	}
+	return nil, fmt.Errorf("unexpected type %T for SAF Int8", v)
 }
 
 func safConvertInt16(in interface{}) (interface{}, error) {
-	if v, ok := (*(in.(*interface{}))).(int16); ok {
-		return v, nil
+	v := (*(in.(*interface{})))
+	if val, ok := v.(int16); ok {
+		return val, nil
 	}
-	return nil, fmt.Errorf("unexpected type %T for SAF int16", *(in.(*interface{})))
+	if val, ok := v.(*int16); ok {
+		return *val, nil
+	}
+	return nil, fmt.Errorf("unexpected type %T for SAF Int16", v)
 }
 
 func safConvertInt32(in interface{}) (interface{}, error) {
-	if v, ok := (*(in.(*interface{}))).(int32); ok {
-		return v, nil
+	v := (*(in.(*interface{})))
+	if val, ok := v.(int32); ok {
+		return val, nil
 	}
-	return nil, fmt.Errorf("unexpected type %T for SAF int32", *(in.(*interface{})))
+	if val, ok := v.(*int32); ok {
+		return *val, nil
+	}
+	return nil, fmt.Errorf("unexpected type %T for SAF Int32", v)
 }
 
 func safConvertInt64(in interface{}) (interface{}, error) {
-	if v, ok := (*(in.(*interface{}))).(int64); ok {
-		return v, nil
+	v := (*(in.(*interface{})))
+	if val, ok := v.(int64); ok {
+		return val, nil
 	}
-	return nil, fmt.Errorf("unexpected type %T for SAF int64", *(in.(*interface{})))
+	if val, ok := v.(*int64); ok {
+		return *val, nil
+	}
+	return nil, fmt.Errorf("unexpected type %T for SAF Int64", v)
 }
 
 func safConvertFloat32(in interface{}) (interface{}, error) {
-	if v, ok := (*(in.(*interface{}))).(float32); ok {
-		return v, nil
+	v := (*(in.(*interface{})))
+	if val, ok := v.(float32); ok {
+		return val, nil
 	}
-	return nil, fmt.Errorf("unexpected type %T for SAF float32", *(in.(*interface{})))
+	if val, ok := v.(*float32); ok {
+		return *val, nil
+	}
+	return nil, fmt.Errorf("unexpected type %T for SAF Float32", v)
 }
 
 func safConvertFloat64(in interface{}) (interface{}, error) {
-	if v, ok := (*(in.(*interface{}))).(float64); ok {
-		return v, nil
+	v := (*(in.(*interface{})))
+	if val, ok := v.(float64); ok {
+		return val, nil
 	}
-	return nil, fmt.Errorf("unexpected type %T for SAF float64", *(in.(*interface{})))
+	if val, ok := v.(*float64); ok {
+		return *val, nil
+	}
+	return nil, fmt.Errorf("unexpected type %T for SAF Float64", v)
 }
 
 func safConvertBool(in interface{}) (interface{}, error) {
-	if v, ok := (*(in.(*interface{}))).(bool); ok {
-		return v, nil
+	v := (*(in.(*interface{})))
+	if val, ok := v.(bool); ok {
+		return val, nil
 	}
-	return nil, fmt.Errorf("unexpected type %T for SAF bool", *(in.(*interface{})))
+	if val, ok := v.(*bool); ok {
+		return *val, nil
+	}
+	return nil, fmt.Errorf("unexpected type %T for SAF Bool", v)
 }
 
 func safConvertNullableUint8(in interface{}) (interface{}, error) {
@@ -695,10 +741,14 @@ func safConvertNullableBool(in interface{}) (interface{}, error) {
 }
 
 func safConvertTime(in interface{}) (interface{}, error) {
-	if v, ok := (*(in.(*interface{}))).(time.Time); ok {
-		return v, nil
+	v := (*(in.(*interface{})))
+	if val, ok := v.(time.Time); ok {
+		return val, nil
 	}
-	return nil, fmt.Errorf("unexpected type %T for SAF time", *(in.(*interface{})))
+	if val, ok := v.(*time.Time); ok {
+		return *val, nil
+	}
+	return nil, fmt.Errorf("unexpected type %T for SAF DateTime", v)
 }
 
 func safConvertNullableTime(in interface{}) (interface{}, error) {

--- a/pkg/converters/converters.go
+++ b/pkg/converters/converters.go
@@ -356,13 +356,6 @@ var Converters = []Converter{
 		scanType:   reflect.PointerTo(reflect.PointerTo(reflect.TypeOf(""))),
 	},
 	{
-		name:       "SimpleAggregateFunction()",
-		convert:    jsonConverter,
-		fieldType:  data.FieldTypeJSON,
-		matchRegex: matchRegexes["SimpleAggregateFunction()"],
-		scanType:   reflect.TypeOf((*interface{})(nil)).Elem(),
-	},
-	{
 		name:       "Point",
 		convert:    pointConverter,
 		fieldType:  data.FieldTypeJSON,
@@ -389,7 +382,302 @@ func ClickHouseConverters() []sqlutil.Converter {
 	for _, converter := range Converters {
 		list = append(list, createConverter(converter))
 	}
+	list = append(list, generateSAFConverters()...)
+	// SAF catch-all for any remaining unrecognized inner types (e.g. custom types)
+	list = append(list, sqlutil.Converter{
+		Name:           "SimpleAggregateFunction()",
+		InputScanType:  reflect.TypeOf((*interface{})(nil)).Elem(),
+		InputTypeRegex: matchRegexes["SimpleAggregateFunction()"],
+		InputTypeName:  "SimpleAggregateFunction()",
+		FrameConverter: sqlutil.FrameConverter{
+			FieldType:     data.FieldTypeJSON,
+			ConverterFunc: jsonConverter,
+		},
+	})
 	return list
+}
+
+// safTypeMapping defines inner types for which we generate native SAF converters.
+// Each entry maps a regex pattern for the inner type to the Grafana field type and
+// a converter function that extracts the native value from interface{}.
+type safTypeEntry struct {
+	innerPattern string         // regex for the inner type (after the function name)
+	fieldType    data.FieldType // Grafana field type to report
+	convert      func(in interface{}) (interface{}, error)
+}
+
+var safTypeMappings = []safTypeEntry{
+	// Non-nullable numeric types
+	{"UInt8", data.FieldTypeUint8, safConvertUint8},
+	{"UInt16", data.FieldTypeUint16, safConvertUint16},
+	{"UInt32", data.FieldTypeUint32, safConvertUint32},
+	{"UInt64", data.FieldTypeUint64, safConvertUint64},
+	{"Int8", data.FieldTypeInt8, safConvertInt8},
+	{"Int16", data.FieldTypeInt16, safConvertInt16},
+	{"Int32", data.FieldTypeInt32, safConvertInt32},
+	{"Int64", data.FieldTypeInt64, safConvertInt64},
+	{"Float32", data.FieldTypeFloat32, safConvertFloat32},
+	{"Float64", data.FieldTypeFloat64, safConvertFloat64},
+	{"Bool", data.FieldTypeBool, safConvertBool},
+	// Nullable numeric types
+	{"Nullable\\(UInt8\\)", data.FieldTypeNullableUint8, safConvertNullableUint8},
+	{"Nullable\\(UInt16\\)", data.FieldTypeNullableUint16, safConvertNullableUint16},
+	{"Nullable\\(UInt32\\)", data.FieldTypeNullableUint32, safConvertNullableUint32},
+	{"Nullable\\(UInt64\\)", data.FieldTypeNullableUint64, safConvertNullableUint64},
+	{"Nullable\\(Int8\\)", data.FieldTypeNullableInt8, safConvertNullableInt8},
+	{"Nullable\\(Int16\\)", data.FieldTypeNullableInt16, safConvertNullableInt16},
+	{"Nullable\\(Int32\\)", data.FieldTypeNullableInt32, safConvertNullableInt32},
+	{"Nullable\\(Int64\\)", data.FieldTypeNullableInt64, safConvertNullableInt64},
+	{"Nullable\\(Float32\\)", data.FieldTypeNullableFloat32, safConvertNullableFloat32},
+	{"Nullable\\(Float64\\)", data.FieldTypeNullableFloat64, safConvertNullableFloat64},
+	{"Nullable\\(Bool\\)", data.FieldTypeNullableBool, safConvertNullableBool},
+	// DateTime types
+	{"DateTime64\\(\\d+\\)", data.FieldTypeTime, safConvertTime},
+	{"DateTime", data.FieldTypeTime, safConvertTime},
+	{"Date", data.FieldTypeTime, safConvertTime},
+	{"Nullable\\(DateTime64\\(\\d+\\)\\)", data.FieldTypeNullableTime, safConvertNullableTime},
+	{"Nullable\\(DateTime\\)", data.FieldTypeNullableTime, safConvertNullableTime},
+	{"Nullable\\(Date\\)", data.FieldTypeNullableTime, safConvertNullableTime},
+}
+
+func generateSAFConverters() []sqlutil.Converter {
+	var converters []sqlutil.Converter
+	for _, entry := range safTypeMappings {
+		pattern := `^SimpleAggregateFunction\([^,]+,\s*` + entry.innerPattern + `\)$`
+		converters = append(converters, sqlutil.Converter{
+			Name:           "SimpleAggregateFunction(" + entry.innerPattern + ")",
+			InputScanType:  reflect.TypeOf((*interface{})(nil)).Elem(),
+			InputTypeRegex: regexp.MustCompile(pattern),
+			InputTypeName:  "SimpleAggregateFunction(" + entry.innerPattern + ")",
+			FrameConverter: sqlutil.FrameConverter{
+				FieldType:     entry.fieldType,
+				ConverterFunc: entry.convert,
+			},
+		})
+	}
+	return converters
+}
+
+// SAF converter functions. The ClickHouse driver scans SAF values into interface{},
+// and the underlying value is the native Go type matching the inner column type.
+
+func safConvertUint8(in interface{}) (interface{}, error) {
+	if v, ok := (*(in.(*interface{}))).(uint8); ok {
+		return v, nil
+	}
+	return jsonConverter(in)
+}
+
+func safConvertUint16(in interface{}) (interface{}, error) {
+	if v, ok := (*(in.(*interface{}))).(uint16); ok {
+		return v, nil
+	}
+	return jsonConverter(in)
+}
+
+func safConvertUint32(in interface{}) (interface{}, error) {
+	if v, ok := (*(in.(*interface{}))).(uint32); ok {
+		return v, nil
+	}
+	return jsonConverter(in)
+}
+
+func safConvertUint64(in interface{}) (interface{}, error) {
+	if v, ok := (*(in.(*interface{}))).(uint64); ok {
+		return v, nil
+	}
+	return jsonConverter(in)
+}
+
+func safConvertInt8(in interface{}) (interface{}, error) {
+	if v, ok := (*(in.(*interface{}))).(int8); ok {
+		return v, nil
+	}
+	return jsonConverter(in)
+}
+
+func safConvertInt16(in interface{}) (interface{}, error) {
+	if v, ok := (*(in.(*interface{}))).(int16); ok {
+		return v, nil
+	}
+	return jsonConverter(in)
+}
+
+func safConvertInt32(in interface{}) (interface{}, error) {
+	if v, ok := (*(in.(*interface{}))).(int32); ok {
+		return v, nil
+	}
+	return jsonConverter(in)
+}
+
+func safConvertInt64(in interface{}) (interface{}, error) {
+	if v, ok := (*(in.(*interface{}))).(int64); ok {
+		return v, nil
+	}
+	return jsonConverter(in)
+}
+
+func safConvertFloat32(in interface{}) (interface{}, error) {
+	if v, ok := (*(in.(*interface{}))).(float32); ok {
+		return v, nil
+	}
+	return jsonConverter(in)
+}
+
+func safConvertFloat64(in interface{}) (interface{}, error) {
+	if v, ok := (*(in.(*interface{}))).(float64); ok {
+		return v, nil
+	}
+	return jsonConverter(in)
+}
+
+func safConvertBool(in interface{}) (interface{}, error) {
+	if v, ok := (*(in.(*interface{}))).(bool); ok {
+		return v, nil
+	}
+	return jsonConverter(in)
+}
+
+func safConvertNullableUint8(in interface{}) (interface{}, error) {
+	v := (*(in.(*interface{})))
+	if v == nil {
+		return (*uint8)(nil), nil
+	}
+	if val, ok := v.(*uint8); ok {
+		return val, nil
+	}
+	return jsonConverter(in)
+}
+
+func safConvertNullableUint16(in interface{}) (interface{}, error) {
+	v := (*(in.(*interface{})))
+	if v == nil {
+		return (*uint16)(nil), nil
+	}
+	if val, ok := v.(*uint16); ok {
+		return val, nil
+	}
+	return jsonConverter(in)
+}
+
+func safConvertNullableUint32(in interface{}) (interface{}, error) {
+	v := (*(in.(*interface{})))
+	if v == nil {
+		return (*uint32)(nil), nil
+	}
+	if val, ok := v.(*uint32); ok {
+		return val, nil
+	}
+	return jsonConverter(in)
+}
+
+func safConvertNullableUint64(in interface{}) (interface{}, error) {
+	v := (*(in.(*interface{})))
+	if v == nil {
+		return (*uint64)(nil), nil
+	}
+	if val, ok := v.(*uint64); ok {
+		return val, nil
+	}
+	return jsonConverter(in)
+}
+
+func safConvertNullableInt8(in interface{}) (interface{}, error) {
+	v := (*(in.(*interface{})))
+	if v == nil {
+		return (*int8)(nil), nil
+	}
+	if val, ok := v.(*int8); ok {
+		return val, nil
+	}
+	return jsonConverter(in)
+}
+
+func safConvertNullableInt16(in interface{}) (interface{}, error) {
+	v := (*(in.(*interface{})))
+	if v == nil {
+		return (*int16)(nil), nil
+	}
+	if val, ok := v.(*int16); ok {
+		return val, nil
+	}
+	return jsonConverter(in)
+}
+
+func safConvertNullableInt32(in interface{}) (interface{}, error) {
+	v := (*(in.(*interface{})))
+	if v == nil {
+		return (*int32)(nil), nil
+	}
+	if val, ok := v.(*int32); ok {
+		return val, nil
+	}
+	return jsonConverter(in)
+}
+
+func safConvertNullableInt64(in interface{}) (interface{}, error) {
+	v := (*(in.(*interface{})))
+	if v == nil {
+		return (*int64)(nil), nil
+	}
+	if val, ok := v.(*int64); ok {
+		return val, nil
+	}
+	return jsonConverter(in)
+}
+
+func safConvertNullableFloat32(in interface{}) (interface{}, error) {
+	v := (*(in.(*interface{})))
+	if v == nil {
+		return (*float32)(nil), nil
+	}
+	if val, ok := v.(*float32); ok {
+		return val, nil
+	}
+	return jsonConverter(in)
+}
+
+func safConvertNullableFloat64(in interface{}) (interface{}, error) {
+	v := (*(in.(*interface{})))
+	if v == nil {
+		return (*float64)(nil), nil
+	}
+	if val, ok := v.(*float64); ok {
+		return val, nil
+	}
+	return jsonConverter(in)
+}
+
+func safConvertNullableBool(in interface{}) (interface{}, error) {
+	v := (*(in.(*interface{})))
+	if v == nil {
+		return (*bool)(nil), nil
+	}
+	if val, ok := v.(*bool); ok {
+		return val, nil
+	}
+	return jsonConverter(in)
+}
+
+func safConvertTime(in interface{}) (interface{}, error) {
+	if v, ok := (*(in.(*interface{}))).(time.Time); ok {
+		return v, nil
+	}
+	return jsonConverter(in)
+}
+
+func safConvertNullableTime(in interface{}) (interface{}, error) {
+	v := (*(in.(*interface{})))
+	if v == nil {
+		return (*time.Time)(nil), nil
+	}
+	if val, ok := v.(*time.Time); ok {
+		return val, nil
+	}
+	if val, ok := v.(time.Time); ok {
+		return &val, nil
+	}
+	return jsonConverter(in)
 }
 
 // GetConverter returns a sqlutil.Converter for the given column type.

--- a/pkg/converters/converters.go
+++ b/pkg/converters/converters.go
@@ -431,12 +431,14 @@ var safTypeMappings = []safTypeEntry{
 	{"Nullable\\(Float32\\)", data.FieldTypeNullableFloat32, safConvertNullableFloat32},
 	{"Nullable\\(Float64\\)", data.FieldTypeNullableFloat64, safConvertNullableFloat64},
 	{"Nullable\\(Bool\\)", data.FieldTypeNullableBool, safConvertNullableBool},
-	// DateTime types
-	{"DateTime64\\(\\d+\\)", data.FieldTypeTime, safConvertTime},
-	{"DateTime", data.FieldTypeTime, safConvertTime},
+	// DateTime types (patterns account for optional timezone parameter)
+	{"DateTime64\\(\\d+(,\\s*'[^']*')?\\)", data.FieldTypeTime, safConvertTime},
+	{"DateTime(\\('[^']*'\\))?", data.FieldTypeTime, safConvertTime},
+	{"Date32", data.FieldTypeTime, safConvertTime},
 	{"Date", data.FieldTypeTime, safConvertTime},
-	{"Nullable\\(DateTime64\\(\\d+\\)\\)", data.FieldTypeNullableTime, safConvertNullableTime},
-	{"Nullable\\(DateTime\\)", data.FieldTypeNullableTime, safConvertNullableTime},
+	{"Nullable\\(DateTime64\\(\\d+(,\\s*'[^']*')?\\)\\)", data.FieldTypeNullableTime, safConvertNullableTime},
+	{"Nullable\\(DateTime(\\('[^']*'\\))?\\)", data.FieldTypeNullableTime, safConvertNullableTime},
+	{"Nullable\\(Date32\\)", data.FieldTypeNullableTime, safConvertNullableTime},
 	{"Nullable\\(Date\\)", data.FieldTypeNullableTime, safConvertNullableTime},
 }
 

--- a/pkg/converters/converters_test.go
+++ b/pkg/converters/converters_test.go
@@ -836,6 +836,42 @@ func TestSimpleAggregateFunctionNativeConverterValues(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Equal(t, &ts, v)
 	})
+
+	t.Run("UInt16 pointer form (driver inconsistency)", func(t *testing.T) {
+		sut := find("SimpleAggregateFunction(any, UInt16)")
+		u := uint16(200)
+		var val interface{} = &u
+		v, err := sut.FrameConverter.ConverterFunc(&val)
+		assert.Nil(t, err)
+		assert.Equal(t, uint16(200), v)
+	})
+
+	t.Run("Float64 pointer form (driver inconsistency)", func(t *testing.T) {
+		sut := find("SimpleAggregateFunction(any, Float64)")
+		f := float64(3.14)
+		var val interface{} = &f
+		v, err := sut.FrameConverter.ConverterFunc(&val)
+		assert.Nil(t, err)
+		assert.Equal(t, float64(3.14), v)
+	})
+
+	t.Run("Bool pointer form (driver inconsistency)", func(t *testing.T) {
+		sut := find("SimpleAggregateFunction(any, Bool)")
+		b := true
+		var val interface{} = &b
+		v, err := sut.FrameConverter.ConverterFunc(&val)
+		assert.Nil(t, err)
+		assert.Equal(t, true, v)
+	})
+
+	t.Run("DateTime pointer form (driver inconsistency)", func(t *testing.T) {
+		sut := find("SimpleAggregateFunction(min, DateTime64(9))")
+		ts := time.Date(2026, 6, 24, 10, 0, 0, 0, time.UTC)
+		var val interface{} = &ts
+		v, err := sut.FrameConverter.ConverterFunc(&val)
+		assert.Nil(t, err)
+		assert.Equal(t, ts, v)
+	})
 }
 
 // TestSimpleAggregateFunctionGetConverter tests the GetConverter path which

--- a/pkg/converters/converters_test.go
+++ b/pkg/converters/converters_test.go
@@ -721,7 +721,14 @@ func TestSimpleAggregateFunctionNativeTypes(t *testing.T) {
 		{"Bool", "SimpleAggregateFunction(any, Bool)", data.FieldTypeBool},
 		{"Nullable(Bool)", "SimpleAggregateFunction(any, Nullable(Bool))", data.FieldTypeNullableBool},
 		{"DateTime64", "SimpleAggregateFunction(min, DateTime64(9))", data.FieldTypeTime},
+		{"DateTime64 with timezone", "SimpleAggregateFunction(min, DateTime64(9, 'UTC'))", data.FieldTypeTime},
+		{"DateTime", "SimpleAggregateFunction(any, DateTime)", data.FieldTypeTime},
+		{"DateTime with timezone", "SimpleAggregateFunction(any, DateTime('Europe/London'))", data.FieldTypeTime},
+		{"Date32", "SimpleAggregateFunction(any, Date32)", data.FieldTypeTime},
 		{"Nullable(DateTime64)", "SimpleAggregateFunction(any, Nullable(DateTime64(9)))", data.FieldTypeNullableTime},
+		{"Nullable(DateTime64 with tz)", "SimpleAggregateFunction(any, Nullable(DateTime64(9, 'UTC')))", data.FieldTypeNullableTime},
+		{"Nullable(DateTime with tz)", "SimpleAggregateFunction(any, Nullable(DateTime('Asia/Tokyo')))", data.FieldTypeNullableTime},
+		{"Nullable(Date32)", "SimpleAggregateFunction(any, Nullable(Date32))", data.FieldTypeNullableTime},
 		{"Array(String) falls to catch-all", "SimpleAggregateFunction(any, Array(String))", data.FieldTypeJSON},
 	}
 	for _, tc := range cases {

--- a/pkg/converters/converters_test.go
+++ b/pkg/converters/converters_test.go
@@ -791,6 +791,51 @@ func TestSimpleAggregateFunctionNativeConverterValues(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Equal(t, true, v)
 	})
+
+	t.Run("Nullable(UInt16) bare value (driver inconsistency)", func(t *testing.T) {
+		sut := find("SimpleAggregateFunction(any, Nullable(UInt16))")
+		var val interface{} = uint16(42)
+		v, err := sut.FrameConverter.ConverterFunc(&val)
+		assert.Nil(t, err)
+		expected := uint16(42)
+		assert.Equal(t, &expected, v)
+	})
+
+	t.Run("Nullable(Float64) bare value", func(t *testing.T) {
+		sut := find("SimpleAggregateFunction(any, Nullable(Float64))")
+		var val interface{} = float64(9.81)
+		v, err := sut.FrameConverter.ConverterFunc(&val)
+		assert.Nil(t, err)
+		expected := float64(9.81)
+		assert.Equal(t, &expected, v)
+	})
+
+	t.Run("Nullable(Bool) bare value", func(t *testing.T) {
+		sut := find("SimpleAggregateFunction(any, Nullable(Bool))")
+		var val interface{} = true
+		v, err := sut.FrameConverter.ConverterFunc(&val)
+		assert.Nil(t, err)
+		expected := true
+		assert.Equal(t, &expected, v)
+	})
+
+	t.Run("DateTime value", func(t *testing.T) {
+		sut := find("SimpleAggregateFunction(min, DateTime64(9))")
+		ts := time.Date(2026, 6, 24, 10, 0, 0, 0, time.UTC)
+		var val interface{} = ts
+		v, err := sut.FrameConverter.ConverterFunc(&val)
+		assert.Nil(t, err)
+		assert.Equal(t, ts, v)
+	})
+
+	t.Run("Nullable(DateTime) bare value", func(t *testing.T) {
+		sut := find("SimpleAggregateFunction(any, Nullable(DateTime64(9)))")
+		ts := time.Date(2026, 6, 24, 10, 0, 0, 0, time.UTC)
+		var val interface{} = ts
+		v, err := sut.FrameConverter.ConverterFunc(&val)
+		assert.Nil(t, err)
+		assert.Equal(t, &ts, v)
+	})
 }
 
 // TestSimpleAggregateFunctionGetConverter tests the GetConverter path which

--- a/pkg/converters/converters_test.go
+++ b/pkg/converters/converters_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"github.com/grafana/grafana-plugin-sdk-go/data/sqlutil"
 	"github.com/paulmach/orb"
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
@@ -696,17 +697,93 @@ func TestSimpleAggregateFunctionNullableStringNilRegex(t *testing.T) {
 	assert.Nil(t, v)
 }
 
-func TestSimpleAggregateFunctionNumericUsesJSON(t *testing.T) {
-	// In the production regex path, non-string SAF types match the catch-all and use jsonConverter
-	sut := findConverterWithRegex("SimpleAggregateFunction(any, Nullable(UInt16))")
-	require.NotNil(t, sut.InputScanType)
-	assert.Equal(t, data.FieldTypeJSON, sut.FrameConverter.FieldType)
+func TestSimpleAggregateFunctionNativeTypes(t *testing.T) {
+	// Generated SAF converters resolve numeric/bool/date types to native Grafana types
+	converters := ClickHouseConverters()
+	find := func(typeName string) sqlutil.Converter {
+		for _, c := range converters {
+			if c.InputTypeRegex != nil && c.InputTypeRegex.MatchString(typeName) {
+				return c
+			}
+		}
+		return sqlutil.Converter{}
+	}
+
+	cases := []struct {
+		name      string
+		typeName  string
+		fieldType data.FieldType
+	}{
+		{"UInt16", "SimpleAggregateFunction(any, UInt16)", data.FieldTypeUint16},
+		{"Nullable(UInt16)", "SimpleAggregateFunction(any, Nullable(UInt16))", data.FieldTypeNullableUint16},
+		{"Int64", "SimpleAggregateFunction(anyLast, Int64)", data.FieldTypeInt64},
+		{"Float64", "SimpleAggregateFunction(any, Float64)", data.FieldTypeFloat64},
+		{"Bool", "SimpleAggregateFunction(any, Bool)", data.FieldTypeBool},
+		{"Nullable(Bool)", "SimpleAggregateFunction(any, Nullable(Bool))", data.FieldTypeNullableBool},
+		{"DateTime64", "SimpleAggregateFunction(min, DateTime64(9))", data.FieldTypeTime},
+		{"Nullable(DateTime64)", "SimpleAggregateFunction(any, Nullable(DateTime64(9)))", data.FieldTypeNullableTime},
+		{"Array(String) falls to catch-all", "SimpleAggregateFunction(any, Array(String))", data.FieldTypeJSON},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sut := find(tc.typeName)
+			require.NotNil(t, sut.InputScanType, "converter not found for %s", tc.typeName)
+			assert.Equal(t, tc.fieldType, sut.FrameConverter.FieldType)
+		})
+	}
 }
 
-func TestSimpleAggregateFunctionArrayUsesJSON(t *testing.T) {
-	sut := findConverterWithRegex("SimpleAggregateFunction(any, Array(String))")
-	require.NotNil(t, sut.InputScanType)
-	assert.Equal(t, data.FieldTypeJSON, sut.FrameConverter.FieldType)
+func TestSimpleAggregateFunctionNativeConverterValues(t *testing.T) {
+	converters := ClickHouseConverters()
+	find := func(typeName string) sqlutil.Converter {
+		for _, c := range converters {
+			if c.InputTypeRegex != nil && c.InputTypeRegex.MatchString(typeName) {
+				return c
+			}
+		}
+		return sqlutil.Converter{}
+	}
+
+	t.Run("UInt16 value", func(t *testing.T) {
+		sut := find("SimpleAggregateFunction(any, UInt16)")
+		var val interface{} = uint16(200)
+		v, err := sut.FrameConverter.ConverterFunc(&val)
+		assert.Nil(t, err)
+		assert.Equal(t, uint16(200), v)
+	})
+
+	t.Run("Nullable(UInt16) value", func(t *testing.T) {
+		sut := find("SimpleAggregateFunction(any, Nullable(UInt16))")
+		u := uint16(200)
+		var val interface{} = &u
+		v, err := sut.FrameConverter.ConverterFunc(&val)
+		assert.Nil(t, err)
+		assert.Equal(t, &u, v)
+	})
+
+	t.Run("Nullable(UInt16) nil", func(t *testing.T) {
+		sut := find("SimpleAggregateFunction(any, Nullable(UInt16))")
+		var val interface{} = nil
+		v, err := sut.FrameConverter.ConverterFunc(&val)
+		assert.Nil(t, err)
+		assert.Nil(t, v)
+	})
+
+	t.Run("Float64 value", func(t *testing.T) {
+		sut := find("SimpleAggregateFunction(any, Float64)")
+		var val interface{} = float64(3.14)
+		v, err := sut.FrameConverter.ConverterFunc(&val)
+		assert.Nil(t, err)
+		assert.Equal(t, float64(3.14), v)
+	})
+
+	t.Run("Bool value", func(t *testing.T) {
+		sut := find("SimpleAggregateFunction(any, Bool)")
+		var val interface{} = true
+		v, err := sut.FrameConverter.ConverterFunc(&val)
+		assert.Nil(t, err)
+		assert.Equal(t, true, v)
+	})
 }
 
 // TestSimpleAggregateFunctionGetConverter tests the GetConverter path which

--- a/tests/e2e/fixtures/simple_aggregate_functions.sql
+++ b/tests/e2e/fixtures/simple_aggregate_functions.sql
@@ -1,23 +1,27 @@
 -- Fixture for simpleAggregateFunction.spec.ts
--- Exercises SimpleAggregateFunction(any, String) and
--- SimpleAggregateFunction(any, Nullable(String)) columns to verify the
--- datasource renders them correctly without toString() wrapping.
+-- Exercises SimpleAggregateFunction columns across all supported inner types:
+-- String, Nullable(String), Float64, UInt64, Bool, DateTime64, Nullable(Float64).
 -- Time range: 2024-03-15 10:00:00 – 2024-03-15 10:04:00 UTC.
 
 CREATE DATABASE IF NOT EXISTS e2e_test;
 
 CREATE TABLE IF NOT EXISTS e2e_test.simple_aggregate_events
 (
-    timestamp DateTime,
-    name      SimpleAggregateFunction(any, String),
-    label     SimpleAggregateFunction(any, Nullable(String))
+    timestamp       DateTime,
+    name            SimpleAggregateFunction(any, String),
+    label           SimpleAggregateFunction(any, Nullable(String)),
+    value           SimpleAggregateFunction(any, Float64),
+    nullable_value  SimpleAggregateFunction(any, Nullable(Float64)),
+    count           SimpleAggregateFunction(sum, UInt64),
+    is_active       SimpleAggregateFunction(any, Bool),
+    last_seen       SimpleAggregateFunction(max, DateTime64(3))
 )
 ENGINE = AggregatingMergeTree
 ORDER BY timestamp;
 
-INSERT INTO e2e_test.simple_aggregate_events (timestamp, name, label) VALUES
-    ('2024-03-15 10:00:00', 'alpha',   'first'),
-    ('2024-03-15 10:01:00', 'beta',    NULL),
-    ('2024-03-15 10:02:00', 'gamma',   'third'),
-    ('2024-03-15 10:03:00', 'delta',   'fourth'),
-    ('2024-03-15 10:04:00', 'epsilon', NULL);
+INSERT INTO e2e_test.simple_aggregate_events (timestamp, name, label, value, nullable_value, count, is_active, last_seen) VALUES
+    ('2024-03-15 10:00:00', 'alpha',   'first',  1.5,  1.5,  10, true,  '2024-03-15 10:00:00.000'),
+    ('2024-03-15 10:01:00', 'beta',    NULL,     2.0,  NULL, 20, false, '2024-03-15 10:01:00.000'),
+    ('2024-03-15 10:02:00', 'gamma',   'third',  3.5,  3.5,  30, true,  '2024-03-15 10:02:00.000'),
+    ('2024-03-15 10:03:00', 'delta',   'fourth', 4.0,  NULL, 40, true,  '2024-03-15 10:03:00.000'),
+    ('2024-03-15 10:04:00', 'epsilon', NULL,     5.5,  5.5,  50, false, '2024-03-15 10:04:00.000');

--- a/tests/e2e/simpleAggregateFunction.spec.ts
+++ b/tests/e2e/simpleAggregateFunction.spec.ts
@@ -59,7 +59,11 @@ function getFrameValues(body: any): any[][] {
   return body?.results?.A?.frames?.[0]?.data?.values ?? [];
 }
 
-test.describe('SimpleAggregateFunction string type handling', () => {
+function getFrameFields(body: any): any[] {
+  return body?.results?.A?.frames?.[0]?.schema?.fields ?? [];
+}
+
+test.describe('SimpleAggregateFunction type handling', () => {
   test.describe.configure({ mode: 'serial' });
 
   test.beforeEach(() => {
@@ -98,24 +102,95 @@ test.describe('SimpleAggregateFunction string type handling', () => {
     expect(values[0]).toEqual(['first', null, 'third', 'fourth', null]);
   });
 
-  test('table panel renders both SAF string columns together', async ({ page, explorePage }) => {
+  test('SimpleAggregateFunction(any, Float64) returns numeric values', async ({ page, explorePage }) => {
+    await page.goto(exploreUrl());
+    await enterSql(page, 'SELECT value FROM e2e_test.simple_aggregate_events ORDER BY timestamp');
+
+    const { responsePromise, getBody } = await waitForQueryDataResponseWithBody(explorePage);
+    await page.locator('.query-editor-row').getByRole('button', { name: 'Run Query' }).click();
+
+    await responsePromise;
+    const values = getFrameValues(getBody());
+    expect(values.length).toBeGreaterThan(0);
+    expect(values[0]).toEqual([1.5, 2.0, 3.5, 4.0, 5.5]);
+  });
+
+  test('SimpleAggregateFunction(any, Nullable(Float64)) returns numbers with nulls', async ({
+    page,
+    explorePage,
+  }) => {
+    await page.goto(exploreUrl());
+    await enterSql(page, 'SELECT nullable_value FROM e2e_test.simple_aggregate_events ORDER BY timestamp');
+
+    const { responsePromise, getBody } = await waitForQueryDataResponseWithBody(explorePage);
+    await page.locator('.query-editor-row').getByRole('button', { name: 'Run Query' }).click();
+
+    await responsePromise;
+    const values = getFrameValues(getBody());
+    expect(values.length).toBeGreaterThan(0);
+    expect(values[0]).toEqual([1.5, null, 3.5, null, 5.5]);
+  });
+
+  test('SimpleAggregateFunction(sum, UInt64) returns integer values', async ({ page, explorePage }) => {
+    await page.goto(exploreUrl());
+    await enterSql(page, 'SELECT count FROM e2e_test.simple_aggregate_events ORDER BY timestamp');
+
+    const { responsePromise, getBody } = await waitForQueryDataResponseWithBody(explorePage);
+    await page.locator('.query-editor-row').getByRole('button', { name: 'Run Query' }).click();
+
+    await responsePromise;
+    const values = getFrameValues(getBody());
+    expect(values.length).toBeGreaterThan(0);
+    expect(values[0]).toEqual([10, 20, 30, 40, 50]);
+  });
+
+  test('SimpleAggregateFunction(any, Bool) returns boolean values', async ({ page, explorePage }) => {
+    await page.goto(exploreUrl());
+    await enterSql(page, 'SELECT is_active FROM e2e_test.simple_aggregate_events ORDER BY timestamp');
+
+    const { responsePromise, getBody } = await waitForQueryDataResponseWithBody(explorePage);
+    await page.locator('.query-editor-row').getByRole('button', { name: 'Run Query' }).click();
+
+    await responsePromise;
+    const values = getFrameValues(getBody());
+    expect(values.length).toBeGreaterThan(0);
+    expect(values[0]).toEqual([true, false, true, true, false]);
+  });
+
+  test('SimpleAggregateFunction(max, DateTime64) returns time values', async ({ page, explorePage }) => {
+    await page.goto(exploreUrl());
+    await enterSql(page, 'SELECT last_seen FROM e2e_test.simple_aggregate_events ORDER BY timestamp');
+
+    const { responsePromise, getBody } = await waitForQueryDataResponseWithBody(explorePage);
+    await page.locator('.query-editor-row').getByRole('button', { name: 'Run Query' }).click();
+
+    await responsePromise;
+    const fields = getFrameFields(getBody());
+    const lastSeenField = fields.find((f: any) => f.name === 'last_seen');
+    expect(lastSeenField?.typeInfo?.frame).toBe('time.Time');
+  });
+
+  test('table panel renders all SAF types with correct field metadata', async ({ page, explorePage }) => {
     await page.goto(exploreUrl());
     await enterSql(
       page,
-      'SELECT timestamp, name, label FROM e2e_test.simple_aggregate_events ORDER BY timestamp'
+      'SELECT timestamp, name, label, value, nullable_value, count, is_active, last_seen FROM e2e_test.simple_aggregate_events ORDER BY timestamp'
     );
 
     const { responsePromise, getBody } = await waitForQueryDataResponseWithBody(explorePage);
     await page.locator('.query-editor-row').getByRole('button', { name: 'Run Query' }).click();
 
     await responsePromise;
-    const body = getBody() as any;
-    const fields = body?.results?.A?.frames?.[0]?.schema?.fields ?? [];
-    expect(fields.length).toBe(3);
+    const fields = getFrameFields(getBody());
+    expect(fields.length).toBe(8);
 
-    const nameField = fields.find((f: any) => f.name === 'name');
-    const labelField = fields.find((f: any) => f.name === 'label');
-    expect(nameField?.typeInfo?.frame).toBe('string');
-    expect(labelField?.typeInfo?.frame).toMatch(/string/);
+    const fieldByName = (n: string) => fields.find((f: any) => f.name === n);
+    expect(fieldByName('name')?.typeInfo?.frame).toBe('string');
+    expect(fieldByName('label')?.typeInfo?.frame).toMatch(/string/);
+    expect(fieldByName('value')?.typeInfo?.frame).toBe('float64');
+    expect(fieldByName('nullable_value')?.typeInfo?.frame).toMatch(/float64/);
+    expect(fieldByName('count')?.typeInfo?.frame).toMatch(/uint64|int64|float64/);
+    expect(fieldByName('is_active')?.typeInfo?.frame).toBe('bool');
+    expect(fieldByName('last_seen')?.typeInfo?.frame).toBe('time.Time');
   });
 });


### PR DESCRIPTION
## Summary

- Resolves `SimpleAggregateFunction`-wrapped numeric, boolean, and datetime columns to their native Grafana field types instead of falling through to the JSON catch-all
- Enables numeric sorting, graphing, and threshold evaluation for SAF columns in Table/TimeSeries panels
- Uses `interface{}` scan type with type-asserting converter functions to work around the ClickHouse Go driver's non-standard scan types

## Context

Builds on #1927 which fixed SAF String/Nullable(String) rendering. This PR includes all changes from #1927 — merging this one alone is sufficient; #1927 can be closed without merging.

The ClickHouse Go driver transparently unwraps SAF to the inner type at the scan level, but sends non-standard Go types (`*uint16`, `*float32`, etc.) that `database/sql.Scan` cannot handle with typed destinations. The solution scans into `interface{}` and type-asserts in the converter function.

### Types now natively supported:
| Inner Type | Grafana FieldType |
|---|---|
| UInt8/16/32/64, Int8/16/32/64 | number (respective width) |
| Float32/64 | number (float) |
| Bool | boolean |
| Date, Date32, DateTime, DateTime64 (with optional timezone) | time |
| Nullable variants of all above | nullable equivalents |
| Array, Map, Tuple (unchanged) | JSON |

## Test plan
- [x] Unit tests for type resolution and value conversion (including null handling and bare-value driver inconsistency)
- [x] `mage test` passes (all Go tests)
- [x] `gofmt` clean
- [x] Verified in local Grafana against ClickHouse with SAF table containing all types
- [ ] Maintainer CI approval needed (external contributor)

Fixes #1926