### PR TITLE
fix(ci): relax npm engine floor so Scheduled Cloud E2E passes

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Clickhouse Datasource",
   "engines": {
     "node": ">=24",
-    "npm": ">=11.12.1"
+    "npm": ">=11.6.2"
   },
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",


### PR DESCRIPTION
## Type of Change

- [x] 🐛 Bug Fix

---

## Bug Fix

### What is the bug?

The nightly **Scheduled Cloud E2E tests** cron (`.github/workflows/cron.yml`) has failed every day since 2026-06-12. It never reaches a test — it dies during Grafana Bench's "prepare codebase" step (`npm ci`) with:

```
npm error code EBADENGINE
npm error notsup Required: {"node":">=24","npm":">=11.12.1"}
npm error notsup Actual:   {"npm":"11.6.2","node":"v24.13.0"}
```

`engines.npm` required `>=11.12.1` and `.npmrc` has `engine-strict=true`, which promotes the EBADENGINE warning into a hard error. The Grafana Bench Playwright runner image runs the **Node-bundled** npm (11.6.2), which is below that floor. The `>=11.12.1` floor was introduced by the auto-audit hygiene PR (#1862) and is higher than what the shared Bench environment provides.

This lowers the floor to `>=11.6.2` to match the Bench environment and decouple the repo from the image's npm drift. The exact `packageManager` pin (`npm@11.12.1`) is unchanged, so local dev tooling is unaffected.

### How to reproduce

1. Trigger the **Scheduled Cloud E2E tests** workflow (`workflow_dispatch`) on `main`.
2. The **Run Grafana Bench tests** step fails with exit code 2 at `npm ci` (EBADENGINE), before any Playwright test runs.

Example failing run: https://github.com/grafana/clickhouse-datasource/actions/runs/28231422778/job/83635833537

### Environment (if no related issue)

- **Plugin version**: 4.18.0
- **Grafana Bench image**: `grafana-bench-playwright:v1.0.9` (node 24.13.0 / npm 11.6.2)

---

## Please check that:

- [x] Tests for this change have been added/updated. _(N/A — CI config only; `npm run spellcheck` passes on the changed file.)_
- [x] Documentation has been added/updated (where applicable). _(N/A)_

## Special notes for your reviewer

The Bench image's `Dockerfile-playwright` *attempts* to ship the latest npm via `corepack install -g npm@latest`, but corepack does not shim `npm`, so the runtime npm is whatever Node bundles (11.6.2) — not the latest. Because the image's npm floats with the base-image Node, pinning a recent `engines.npm` floor here will keep breaking whenever the floor outpaces the image. The repo-side relax is the robust fix. Filed upstream: grafana/grafana-bench#1003.
