### PR TITLE
test(e2e): skip cloud-incompatible save & test and SQL-validation cases

### DIFF
--- a/tests/e2e/configEditor.spec.ts
+++ b/tests/e2e/configEditor.spec.ts
@@ -143,6 +143,14 @@ test.describe('Config editor', () => {
     });
 
     test('invalid credentials should return an error', async ({ createDataSourceConfigPage, page }) => {
+      // save & test runs a health check against an ad-hoc datasource. On the shared Cloud
+      // instance the managed ClickHouse host is cluster-internal (reachable only via PDC /
+      // secure socks proxy), so a health check from an ad-hoc DS built out of the repo's
+      // `ds-instance` secret hangs instead of returning. Covered by local/PR CI.
+      test.skip(
+        isCloudRun,
+        'Ad-hoc save & test connectivity is not reliable on the shared Cloud instance; covered by local/PR CI.'
+      );
       const configPage = await createDataSourceConfigPage({ type: PLUGIN_UID });
       const isV2 = await isV2Editor(page);
       await page.getByPlaceholder(isV2 ? 'Enter server address' : 'Server address').fill(resolveClickhouseUrl());
@@ -162,6 +170,13 @@ test.describe('Config editor', () => {
       test.skip(
         !process.env.CI && !process.env.DS_INSTANCE_HOST,
         'ClickHouse must be reachable from inside Grafana; set DS_INSTANCE_HOST or run in CI'
+      );
+      // On the shared Cloud instance the managed ClickHouse host is cluster-internal (PDC only);
+      // an ad-hoc DS built from the repo's `ds-instance` secret does not route there, so the
+      // health check hangs. The managed datasource's own connectivity is exercised by the query tests.
+      test.skip(
+        isCloudRun,
+        'Ad-hoc save & test connectivity is not reliable on the shared Cloud instance; covered by local/PR CI.'
       );
 
       const configPage = await createDataSourceConfigPage({ type: PLUGIN_UID });

--- a/tests/e2e/sqlValidation.spec.ts
+++ b/tests/e2e/sqlValidation.spec.ts
@@ -81,6 +81,18 @@ async function expectHasErrorMarker(page: Page) {
  * regression shows up as a failing test here rather than as a user complaint.
  */
 test.describe('SQL editor validation', () => {
+  // The managed Cloud datasource does not enable `validateSql`, so SqlEditor's validation
+  // pipeline (onKeyUp -> validate() -> setModelMarkers -> Monaco) never runs there: the
+  // "no false positive" cases pass vacuously and the genuine-error control case fails for
+  // want of a marker. The suite is only meaningful where validateSql is enabled — local/PR
+  // CI, where provisioning/datasources/clickhouse.yml sets validateSql: true.
+  test.beforeEach(() => {
+    test.skip(
+      isCloudRun,
+      'validateSql is disabled on the managed Cloud datasource, making this suite inert; covered by local/PR CI.'
+    );
+  });
+
   const validClickhouseQueries: Array<{ name: string; sql: string }> = [
     { name: 'FINAL keyword', sql: 'SELECT * FROM test.events FINAL' },
     { name: 'PREWHERE clause', sql: 'SELECT * FROM t PREWHERE x > 1 WHERE y > 2' },


### PR DESCRIPTION
## Type of Change

- [x] 🧹 Refactor / Chore (test-only)

---

## Bug Fix

### What is the bug?

The nightly **Scheduled Cloud E2E** cron was fully red. Two earlier fixes unblocked it — the npm engine floor (#1932) and granting the E2E service account datasource permissions on the shared Cloud instance — after which the suite ran end to end (33 passed) and surfaced **3 remaining failures specific to the shared Cloud instance, not the plugin**:

1. `configEditor.spec.ts` "invalid/valid credentials" (`save & test`) — `Test timeout of 30000ms`. These build an **ad-hoc** datasource and run a health check. On the shared Cloud instance the managed ClickHouse host is cluster-internal (reachable only via PDC / secure socks proxy), so a health check from an ad-hoc DS built out of this repo's `ds-instance` CI secret hangs instead of returning.
2. `sqlValidation.spec.ts` "flags a genuine error (unclosed block comment)" — `expect(locator).toBeVisible()` failed. The managed Cloud datasource does **not** set `validateSql`, so [SqlEditor.tsx](src/components/SqlEditor.tsx#L85) never runs the validation pipeline: the "no false positive" cases pass vacuously and the genuine-error control case fails for want of a Monaco marker.

### Fix

Skip these on Cloud runs (`GRAFANA_URL` set), matching the existing `test.skip(isCloudRun, …)` pattern for the provisioned-datasource tests (#1798). All three remain **fully covered by local/PR CI**, where ClickHouse is reachable from inside Grafana and `provisioning/datasources/clickhouse.yml` sets `validateSql: true`.

### How to reproduce

1. `workflow_dispatch` the **Scheduled Cloud E2E tests** workflow on a branch without this change.
2. The run reaches the suite and fails with the 3 failures above.

---

## Please check that:

- [x] Tests for this change have been added/updated. _(Test-only change; `npm run spellcheck` clean on touched files; verified green via a `workflow_dispatch` Cloud run on this branch.)_
- [x] Documentation has been added/updated (where applicable). _(N/A)_

## Special notes for your reviewer

These are skips, not silencing — each maps to a real shared-instance limitation that can't be fixed from this repo:

- The `save & test` hang stems from this repo's `ds-instance` CI secret / PDC routing not matching the managed cluster-internal host; the durable fix is on the infra side and is tracked separately.
- `validateSql` being off on the managed datasource is an infra choice; enabling it there would let the validation suite run on Cloud, if desired.

The managed datasource's own connectivity is still exercised on Cloud by the query-editor / Explore tests.

Closes #2035