### PR TITLE
fix(traces): prevent crash when running Traces queries on older Grafana

### DIFF
--- a/cspell.config.json
+++ b/cspell.config.json
@@ -72,6 +72,7 @@
     "OFREP",
     "otel",
     "otelcol",
+    "pageerror",
     "semconv",
     "OUTFILE",
     "paulmach",

--- a/src/data/utils.test.ts
+++ b/src/data/utils.test.ts
@@ -465,6 +465,39 @@ describe('transformQueryResponseWithTraceAndLogLinks', () => {
     expect(out.data[0].fields[0].config.links ?? []).toHaveLength(0);
   });
 
+  it('embeds a serializable datasource ref (not the live instance) in trace/log link queries', async () => {
+    // The live Datasource instance contains a circular reference (datasource.variables.datasource
+    // === datasource, added with CustomVariableSupport). Embedding the instance in a data link's
+    // internal query makes Grafana's link scanner (getStringsFromObject) recurse infinitely on
+    // older Grafana, throwing "Maximum call stack size exceeded". The link must carry a plain
+    // { uid, type } ref instead.
+    const mockDatasource = newMockDatasource();
+    configureOtelLogs(mockDatasource);
+    configureOtelTraces(mockDatasource);
+    jest.spyOn(mockDatasource, 'fetchColumns').mockResolvedValue([]);
+
+    const [request, response] = buildTestRequestResponse({
+      queryType: QueryType.Traces,
+      columns: [{ name: 'a' }],
+    });
+    const out = await transformQueryResponseWithTraceAndLogLinks(mockDatasource, request, response);
+
+    const links = out?.data[0]?.fields[0]?.config?.links ?? [];
+    const viewTrace = links.find((l) => l.title === 'View trace');
+    const viewLogs = links.find((l) => l.title === 'View logs');
+    expect(viewTrace).toBeDefined();
+    expect(viewLogs).toBeDefined();
+
+    for (const link of [viewTrace!, viewLogs!]) {
+      const embedded = (link.internal!.query as CHBuilderQuery).datasource;
+      // Must be a plain ref, not the live instance (which is circular).
+      expect(embedded).not.toBe(mockDatasource);
+      expect(embedded).toEqual({ uid: 'clickhouse_ds', type: 'grafana-clickhouse-datasource' });
+      // The whole internal query must be JSON-serializable (no circular references reach Grafana).
+      expect(() => JSON.stringify(link.internal!.query)).not.toThrow();
+    }
+  });
+
   describe('trace ID link rawSql pre-generation', () => {
     const newOtelMockDatasource = (): Datasource => {
       const ds = newMockDatasource();

--- a/src/data/utils.test.ts
+++ b/src/data/utils.test.ts
@@ -482,7 +482,8 @@ describe('transformQueryResponseWithTraceAndLogLinks', () => {
     });
     const out = await transformQueryResponseWithTraceAndLogLinks(mockDatasource, request, response);
 
-    const links = out?.data[0]?.fields[0]?.config?.links ?? [];
+    const frame = out.data[0] as DataFrame;
+    const links = frame.fields[0].config.links ?? [];
     const viewTrace = links.find((l) => l.title === 'View trace');
     const viewLogs = links.find((l) => l.title === 'View logs');
     expect(viewTrace).toBeDefined();

--- a/src/data/utils.ts
+++ b/src/data/utils.ts
@@ -1,4 +1,4 @@
-import { CoreApp, DataFrame, DataQueryRequest, DataQueryResponse, FieldConfig } from '@grafana/data';
+import { CoreApp, DataFrame, DataQueryRequest, DataQueryResponse, FieldConfig, getDataSourceRef } from '@grafana/data';
 import {
   ColumnHint,
   FilterOperator,
@@ -366,7 +366,10 @@ export const transformQueryResponseWithTraceAndLogLinks = async (
       datasource.getTracesTraceIdColumn() || defaultLogsColumns.get(ColumnHint.TraceId) || 'TraceId';
 
     const traceIdQuery: CHBuilderQuery = {
-      datasource: datasource,
+      // Embed only a datasource ref ({ uid, type }), never the live Datasource instance:
+      // the instance is circular (datasource.variables.datasource === datasource) and Grafana's
+      // data-link scanner recurses into it, overflowing the stack on older Grafana.
+      datasource: getDataSourceRef(datasource),
       editorType: EditorType.Builder,
       rawSql: '',
       builderOptions: {} as QueryBuilderOptions,
@@ -509,7 +512,10 @@ export const transformQueryResponseWithTraceAndLogLinks = async (
     traceIdQuery.format = mapQueryBuilderOptionsToGrafanaFormat(traceIdQuery.builderOptions);
 
     const traceLogsQuery: CHBuilderQuery = {
-      datasource: datasource,
+      // Embed only a datasource ref ({ uid, type }), never the live Datasource instance:
+      // the instance is circular (datasource.variables.datasource === datasource) and Grafana's
+      // data-link scanner recurses into it, overflowing the stack on older Grafana.
+      datasource: getDataSourceRef(datasource),
       editorType: EditorType.Builder,
       rawSql: '',
       builderOptions: {} as QueryBuilderOptions,

--- a/src/data/utils.ts
+++ b/src/data/utils.ts
@@ -1,4 +1,4 @@
-import { CoreApp, DataFrame, DataQueryRequest, DataQueryResponse, FieldConfig, getDataSourceRef } from '@grafana/data';
+import { CoreApp, DataFrame, DataQueryRequest, DataQueryResponse, FieldConfig } from '@grafana/data';
 import {
   ColumnHint,
   FilterOperator,
@@ -369,7 +369,7 @@ export const transformQueryResponseWithTraceAndLogLinks = async (
       // Embed only a datasource ref ({ uid, type }), never the live Datasource instance:
       // the instance is circular (datasource.variables.datasource === datasource) and Grafana's
       // data-link scanner recurses into it, overflowing the stack on older Grafana.
-      datasource: getDataSourceRef(datasource),
+      datasource: { uid: datasource.uid, type: datasource.type },
       editorType: EditorType.Builder,
       rawSql: '',
       builderOptions: {} as QueryBuilderOptions,
@@ -515,7 +515,7 @@ export const transformQueryResponseWithTraceAndLogLinks = async (
       // Embed only a datasource ref ({ uid, type }), never the live Datasource instance:
       // the instance is circular (datasource.variables.datasource === datasource) and Grafana's
       // data-link scanner recurses into it, overflowing the stack on older Grafana.
-      datasource: getDataSourceRef(datasource),
+      datasource: { uid: datasource.uid, type: datasource.type },
       editorType: EditorType.Builder,
       rawSql: '',
       builderOptions: {} as QueryBuilderOptions,

--- a/tests/e2e/traceQueryNoCrash.spec.ts
+++ b/tests/e2e/traceQueryNoCrash.spec.ts
@@ -1,0 +1,155 @@
+import { expect, test, ExplorePage } from '@grafana/plugin-e2e';
+import { Page } from '@playwright/test';
+
+// Regression guard for the Traces query-builder crash on older Grafana
+// (reproduced on the >=11.6 floor, worked on 13.x).
+//
+// Running a Traces query in Explore attaches "View trace" / "View logs" data
+// links to the traceID field. The link's internal query embedded the live
+// Datasource instance, which is circular (datasource.variables.datasource ===
+// datasource, introduced with CustomVariableSupport). Grafana's Explore link
+// scanner (getStringsFromObject in explore/utils/links.ts) walks the internal
+// query with no cycle guard, so on Grafana versions without the upstream guard
+// it recursed forever and threw "RangeError: Maximum call stack size exceeded",
+// blanking the results panel. The fix embeds a plain { uid, type } ref instead
+// (src/data/utils.ts); unit coverage lives in src/data/utils.test.ts.
+//
+// This test is intentionally generic: it fails on ANY uncaught exception or
+// fatal console error while a Traces query renders, so future regressions in
+// the trace render/transform path (stack overflows, React "Maximum update
+// depth" render loops, etc.) are caught here too — not just this exact bug.
+// Its value is the cross-version matrix: the reusable plugin CI runs Playwright
+// against the grafanaDependency floor, where this class of crash manifests.
+
+const PLUGIN_TYPE = 'grafana-clickhouse-datasource';
+
+const isCloudRun = !!process.env.GRAFANA_URL;
+
+const CLOUD_DEFAULT_UID = 'clickhouse-native-ds-m';
+const LOCAL_DEFAULT_UID = 'clickhouse-e2e';
+const DATASOURCE_UID = process.env.DS_E2E_UID || (isCloudRun ? CLOUD_DEFAULT_UID : LOCAL_DEFAULT_UID);
+
+// trace_spans (tests/e2e/fixtures/trace_spans.sql) seeds spans for e2e-trace-a
+// and e2e-trace-b between 2024-03-15 10:00:00 and 10:00:10 UTC.
+const FIXTURE_FROM_ISO = '2024-03-15T09:45:00.000Z';
+const FIXTURE_TO_ISO = '2024-03-15T10:15:00.000Z';
+
+// Fatal client-side error signatures. Matching any of these means a render or
+// transform blew up rather than failing gracefully.
+const FATAL_ERROR_PATTERNS = [
+  /maximum call stack size exceeded/i, // infinite recursion (this bug)
+  /too much recursion/i, // same, Firefox wording
+  /maximum update depth exceeded/i, // React #185 render loop
+];
+
+function isFatal(text: string): boolean {
+  return FATAL_ERROR_PATTERNS.some((re) => re.test(text));
+}
+
+/**
+ * Attaches listeners that record uncaught page exceptions and fatal console
+ * errors for the lifetime of the test. Returns a getter for the collected
+ * messages so the test can assert on them after the query has rendered.
+ */
+function collectClientErrors(page: Page): { getErrors: () => string[] } {
+  const errors: string[] = [];
+  // Uncaught exceptions that escape to the window.
+  page.on('pageerror', (err) => errors.push(`pageerror: ${err.message}`));
+  // Errors logged to the console (React error boundaries and Grafana's query
+  // runner report crashes here rather than as uncaught page errors).
+  page.on('console', (msg) => {
+    if (msg.type() === 'error' && isFatal(msg.text())) {
+      errors.push(`console.error: ${msg.text()}`);
+    }
+  });
+  return { getErrors: () => errors };
+}
+
+/**
+ * Builds an Explore URL for a Traces query-builder query against trace_spans.
+ * A builder query (queryType=traces) is used deliberately: it always attaches
+ * the View trace / View logs data links — the exact path that crashed — without
+ * needing datasource-level trace defaults.
+ */
+function traceExploreUrl(): string {
+  const builderOptions = {
+    database: 'e2e_test',
+    table: 'trace_spans',
+    queryType: 'traces',
+    mode: 'list',
+    columns: [
+      { name: 'TraceId', type: 'String', hint: 'trace_id' },
+      { name: 'SpanId', type: 'String', hint: 'trace_span_id' },
+      { name: 'ParentSpanId', type: 'String', hint: 'trace_parent_span_id' },
+      { name: 'ServiceName', type: 'LowCardinality(String)', hint: 'trace_service_name' },
+      { name: 'SpanName', type: 'LowCardinality(String)', hint: 'trace_operation_name' },
+      { name: 'Timestamp', type: 'DateTime64(9)', hint: 'time' },
+      { name: 'Duration', type: 'Int64', hint: 'trace_duration_time' },
+    ],
+    meta: {},
+    limit: 1000,
+    filters: [],
+    orderBy: [],
+  };
+
+  const query = {
+    refId: 'A',
+    datasource: { type: PLUGIN_TYPE, uid: DATASOURCE_UID },
+    editorType: 'builder',
+    pluginVersion: '',
+    // The builder normally generates this; supply it so the query runs
+    // deterministically on load without depending on editor re-generation.
+    rawSql:
+      'SELECT "TraceId" as traceID, "ServiceName" as serviceName, "SpanName" as operationName, ' +
+      '"Timestamp" as startTime, "Duration" as duration FROM "e2e_test"."trace_spans" ' +
+      'WHERE ( "Timestamp" >= $__fromTime AND "Timestamp" <= $__toTime ) ORDER BY "Timestamp" DESC LIMIT 1000',
+    builderOptions,
+    format: 1,
+  };
+
+  const panes = JSON.stringify({
+    explore: {
+      datasource: DATASOURCE_UID,
+      queries: [query],
+      range: { from: FIXTURE_FROM_ISO, to: FIXTURE_TO_ISO },
+    },
+  });
+  return `/explore?orgId=1&schemaVersion=1&panes=${encodeURIComponent(panes)}`;
+}
+
+test.describe('Traces query renders without crashing', () => {
+  test.beforeEach(() => {
+    test.skip(
+      isCloudRun,
+      'Fixture-data tests depend on the local trace_spans seed (tests/e2e/fixtures/trace_spans.sql) loaded via the e2e-data-loader Docker service, which is not available on Cloud.'
+    );
+  });
+
+  test('a Traces query with rendered trace-detail links throws no uncaught/fatal client errors', async ({
+    page,
+    explorePage,
+  }: {
+    page: Page;
+    explorePage: ExplorePage;
+  }) => {
+    const { getErrors } = collectClientErrors(page);
+
+    const responsePromise = explorePage.waitForQueryDataResponse();
+    await page.goto(traceExploreUrl());
+    await responsePromise;
+
+    // Let the results panel render and any deferred link scan run. The crash
+    // surfaces here (during render), after the data response resolves.
+    await page.waitForTimeout(2000);
+
+    // Primary, descriptive guard: no stack overflow / render-loop crash. Checked
+    // first so a regression reports the actual fatal message rather than a
+    // downstream "element not found" once the crash has blanked the panel.
+    expect(getErrors(), `Unexpected fatal client errors:\n${getErrors().join('\n')}`).toEqual([]);
+
+    // Secondary: the link-bearing traceID field actually rendered, so the clean
+    // error log above is meaningful rather than vacuous. The "View trace" link
+    // is exactly what Grafana's scanner walks (and what used to crash it).
+    await expect(page.getByRole('link', { name: 'e2e-trace-a' }).first()).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Type of Change

- [x] 🐛 Bug Fix

---

## Bug Fix

### What is the bug?

Running a **Traces** query in Explore crashes with `RangeError: Maximum call stack size exceeded` and blanks the results panel. It reproduces on Grafana versions below 13.x and works on 13.x.

Root cause: trace results attach **View trace** / **View logs** data links whose `internal.query` embedded the **live `Datasource` instance**. That instance became circular (`datasource.variables.datasource === datasource`) once the guided variable editor wired up `CustomVariableSupport`. Grafana's Explore link scanner (`getStringsFromObject` in `explore/utils/links.ts`) walks the internal query recursively with no cycle guard, so on Grafana without the upstream guard it recurses until the stack overflows.

### How to reproduce

1. On Grafana < 13 (e.g. 12.2), open Explore with the ClickHouse data source.
2. Switch **Query Type** to **Traces** and run a query against a table containing trace data.
3. The results panel is blank and the browser console shows `RangeError: Maximum call stack size exceeded`.

### Environment (if no related issue)

- **Grafana version**: reproduces below 13.x (verified on 12.2.0); plugin floor is `>=11.6.0`
- **Plugin version**: 4.18.0 / `main`

---

## The fix

Embed a plain `{ uid, type }` datasource ref via `getDataSourceRef(datasource)` in the link's internal query instead of the live instance. `datasourceUid` / `datasourceName` are already passed separately, so the links behave identically. Fixing this plugin-side covers every Grafana version rather than relying on the newer-Grafana guard.

---

## Please check that:

- [x] Tests for this change have been added/updated.
- [ ] Documentation has been added/updated (where applicable).

## Special notes for your reviewer

- **Unit** (`src/data/utils.test.ts`): asserts the link's internal query carries a serializable `{ uid, type }` ref (not the live instance) and is JSON-serializable. It fails on the pre-fix code with the circular `variables.datasource` reference.
- **E2E** (`tests/e2e/traceQueryNoCrash.spec.ts`): loads a Traces query in Explore and fails on any uncaught/fatal client error — matching the stack-overflow class **and** the React "maximum update depth" render-loop class — so future trace-render regressions are caught too, not just this one. Its value is the version matrix: the reusable Playwright CI runs down to the `>=11.6` floor where this crash manifests (a latest-only run would miss it).
- Verified locally on Grafana 12.2: the E2E fails on the pre-fix bundle (`console.error: RangeError: Maximum call stack size exceeded`) and passes after the fix; full unit suite green (69 suites / 855 tests).

Closes #2034