### PR TITLE
feat(auth): add Forward OAuth Identity authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-- Add Forward OAuth Identity authentication: forward the signed-in Grafana user's OAuth token to ClickHouse Cloud as a JWT so queries are attributed to the real user instead of a shared service account. Requires a verified TLS connection. Alert and other backend queries have no signed-in user and are blocked by default; enable **Allow service account fallback** to let them run with the configured username/password
+- Add Forward OAuth Identity authentication: forward the signed-in Grafana user's OAuth token to ClickHouse Cloud as a JWT so queries are attributed to the real user instead of a shared service account. Requires a verified TLS connection. Alert and other backend queries have no signed-in user and are blocked by default; enable **Allow service account fallback** to let them run with the configured username/password (#1987)
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- Add Forward OAuth Identity authentication: forward the signed-in Grafana user's OAuth token to ClickHouse Cloud as a JWT so queries are attributed to the real user instead of a shared service account. Requires a verified TLS connection. Alert and other backend queries have no signed-in user and are blocked by default; enable **Allow service account fallback** to let them run with the configured username/password
+
 ### Fixes
 
 - Apply the log message search to the logs volume and logs sample queries, so the volume histogram matches the filtered log list (#2092)

--- a/docs/sources/configure.md
+++ b/docs/sources/configure.md
@@ -298,7 +298,7 @@ To enable it, turn on **Forward OAuth Identity** in the **Database credentials**
 
 ### Requirements and behavior
 
-- **A secure (TLS) connection is required.** Enable **Secure connection** and set the **Port** to a TLS-enabled port. The plugin rejects the connection if JWT authentication is enabled without TLS.
+- **A secure (TLS) connection is required.** Enable **Secure connection** and set the **Port** to a TLS-enabled port. The plugin rejects the connection if JWT authentication is enabled without TLS. It also rejects the connection when **Skip TLS Verify** is enabled, because forwarding a real user's token over an unverified connection exposes it to interception.
 - **Credentials are suppressed on query connections.** When enabled, the configured username and password are not sent on per-query connections; the forwarded token is the sole credential.
 - **Health checks fall back to username and password.** **Save & test** and other health checks run outside a user request, where no user token is available, so they use the configured username and password. Keep valid credentials configured so connection tests can succeed.
 - **Alerting is blocked by default.** Alert rule evaluation also runs outside a user session, so there is no identity to forward. By default these queries are **rejected** rather than run as a shared account. To keep alerting working, enable **Allow service account fallback** in the **Database credentials** section.

--- a/docs/sources/configure.md
+++ b/docs/sources/configure.md
@@ -130,6 +130,7 @@ After adding the data source, configure the following settings.
 | **Secure connection** | Enable when your ClickHouse server uses TLS. When enabled, update the **Port** to a TLS-enabled port and configure [TLS settings](#tls-settings) below. |
 | **Username**          | ClickHouse user name. Use a [read-only user](#clickhouse-user-and-permissions).                                                                         |
 | **Password**          | ClickHouse user password.                                                                                                                               |
+| **Forward OAuth Identity** | Forward the logged-in Grafana user's OAuth token to ClickHouse as a JWT instead of authenticating with the configured username and password. ClickHouse Cloud only; requires a [secure (TLS) connection](#tls-settings). See [JWT authentication](#jwt-authentication). |
 | **Default database**  | The database the query builder uses when no database is selected. If left blank, the plugin defaults to `default`.                                      |
 | **Default table**     | The default table used by the query builder.                                                                                                            |
 
@@ -283,6 +284,25 @@ With header forwarding enabled, connections are keyed by the forwarded header se
 
 To forward headers other than the Grafana-set ones — for example, bearer tokens or tenant identifiers — add them as **Custom HTTP headers** in the same **Optional HTTP settings** panel. Custom headers are sent on every query regardless of the **Forward Grafana HTTP headers** toggle.
 
+## JWT authentication
+
+{{< admonition type="note" >}}
+JWT authentication requires server-side support for JSON Web Tokens, which is currently [ClickHouse Cloud only](https://clickhouse.com/docs/en/operations/external-authenticators/jwt). It is not available on self-hosted or open source ClickHouse.
+{{< /admonition >}}
+
+When **Forward OAuth Identity** is enabled, the plugin forwards the logged-in Grafana user's OAuth access token to ClickHouse as a JSON Web Token (JWT). ClickHouse then authenticates each query as the real user rather than as a shared service account, so you can drive per-user access rights, [row policies](https://clickhouse.com/docs/en/operations/access-rights/#row-policies), and query-log attribution from ClickHouse-side identities.
+
+For the token to be available, Grafana must be configured to forward the user's OAuth access token to the data source. For server-side setup, refer to [ClickHouse JWT authentication](https://clickhouse.com/docs/en/operations/external-authenticators/jwt).
+
+To enable it, turn on **Forward OAuth Identity** in the **Database credentials** section of the data source configuration.
+
+### Requirements and behavior
+
+- **A secure (TLS) connection is required.** Enable **Secure connection** and set the **Port** to a TLS-enabled port. The plugin rejects the connection if JWT authentication is enabled without TLS.
+- **Credentials are suppressed on query connections.** When enabled, the configured username and password are not sent on per-query connections; the forwarded token is the sole credential.
+- **Health checks and alerts fall back to username and password.** **Save & test**, other health checks, and alert rule evaluation run outside a user request, where no user token is available, so they use the configured username and password. Keep valid credentials configured so connection tests and alert queries can succeed.
+- **Connections are keyed per user.** Enabling JWT authentication automatically turns on header forwarding, so each Grafana user opens a separate ClickHouse connection. See [Connection pool implications](#connection-pool-implications) for sizing guidance.
+
 ## Provision the data source
 
 You can define the data source in YAML files as part of the Grafana provisioning system. For more information, refer to [Provisioning Grafana data sources](https://grafana.com/docs/grafana/latest/administration/provisioning/#data-sources).
@@ -320,6 +340,7 @@ datasources:
       # validateSql: <bool>
       # enableRowLimit: <bool>
       # forwardGrafanaHeaders: <bool>
+      # oauthPassThru: <bool>  # forward the user's OAuth token as a JWT (ClickHouse Cloud only); requires secure: true
       # path: <string>  # HTTP URL path (HTTP protocol only)
       # httpHeaders:     # HTTP protocol only
       #   - name: X-Example-Header
@@ -362,6 +383,7 @@ resource "grafana_data_source" "clickhouse" {
     # queryTimeout    = "60"
     # validateSql     = true
     # enableRowLimit  = true
+    # oauthPassThru   = true  # forward the user's OAuth token as a JWT (ClickHouse Cloud only); requires secure = true
   })
 
   secure_json_data_encoded = jsonencode({

--- a/docs/sources/configure.md
+++ b/docs/sources/configure.md
@@ -300,7 +300,12 @@ To enable it, turn on **Forward OAuth Identity** in the **Database credentials**
 
 - **A secure (TLS) connection is required.** Enable **Secure connection** and set the **Port** to a TLS-enabled port. The plugin rejects the connection if JWT authentication is enabled without TLS.
 - **Credentials are suppressed on query connections.** When enabled, the configured username and password are not sent on per-query connections; the forwarded token is the sole credential.
-- **Health checks and alerts fall back to username and password.** **Save & test**, other health checks, and alert rule evaluation run outside a user request, where no user token is available, so they use the configured username and password. Keep valid credentials configured so connection tests and alert queries can succeed.
+- **Health checks fall back to username and password.** **Save & test** and other health checks run outside a user request, where no user token is available, so they use the configured username and password. Keep valid credentials configured so connection tests can succeed.
+- **Alerting is blocked by default.** Alert rule evaluation also runs outside a user session, so there is no identity to forward. By default these queries are **rejected** rather than run as a shared account. To keep alerting working, enable **Allow service account fallback** in the **Database credentials** section.
+
+  {{< admonition type="warning" >}}
+  Enabling **Allow service account fallback** lets alert rules and other backend queries fall back to the configured username and password. Those queries then authenticate as the shared service account and are **not** subject to the per-user [row policies](https://clickhouse.com/docs/en/operations/access-rights/#row-policies), quotas, or query-log attribution that OAuth pass-through enforces for interactive queries — so an alert may read rows a given dashboard user could not see interactively. Scope the configured service account to the least privilege your alert queries require. The plugin emits a backend warning log each time this fallback is exercised.
+  {{< /admonition >}}
 - **Connections are keyed per user.** Enabling JWT authentication automatically turns on header forwarding, so each Grafana user opens a separate ClickHouse connection. See [Connection pool implications](#connection-pool-implications) for sizing guidance.
 
 ## Provision the data source

--- a/docs/sources/configure.md
+++ b/docs/sources/configure.md
@@ -130,7 +130,7 @@ After adding the data source, configure the following settings.
 | **Secure connection** | Enable when your ClickHouse server uses TLS. When enabled, update the **Port** to a TLS-enabled port and configure [TLS settings](#tls-settings) below. |
 | **Username**          | ClickHouse user name. Use a [read-only user](#clickhouse-user-and-permissions).                                                                         |
 | **Password**          | ClickHouse user password.                                                                                                                               |
-| **Forward OAuth Identity** | Forward the logged-in Grafana user's OAuth token to ClickHouse as a JWT instead of authenticating with the configured username and password. ClickHouse Cloud only; requires a [secure (TLS) connection](#tls-settings). See [JWT authentication](#jwt-authentication). |
+| **Forward OAuth Identity** | Forward the logged-in Grafana user's OAuth token to ClickHouse as a JWT instead of authenticating with the configured username and password. ClickHouse Cloud only; requires a [secure (TLS) connection](#tls-settings). See [Forward OAuth Identity](#forward-oauth-identity). |
 | **Default database**  | The database the query builder uses when no database is selected. If left blank, the plugin defaults to `default`.                                      |
 | **Default table**     | The default table used by the query builder.                                                                                                            |
 
@@ -284,7 +284,7 @@ With header forwarding enabled, connections are keyed by the forwarded header se
 
 To forward headers other than the Grafana-set ones — for example, bearer tokens or tenant identifiers — add them as **Custom HTTP headers** in the same **Optional HTTP settings** panel. Custom headers are sent on every query regardless of the **Forward Grafana HTTP headers** toggle.
 
-## JWT authentication
+## Forward OAuth Identity
 
 {{< admonition type="note" >}}
 JWT authentication requires server-side support for JSON Web Tokens, which is currently [ClickHouse Cloud only](https://clickhouse.com/docs/en/operations/external-authenticators/jwt). It is not available on self-hosted or open source ClickHouse.

--- a/pkg/plugin/connection_error.go
+++ b/pkg/plugin/connection_error.go
@@ -61,6 +61,38 @@ func httpStatusCode(errStr string) int {
 	return code
 }
 
+// authErrorHint returns human-readable guidance for an authentication failure,
+// distinguishing "who are you" (expired/invalid credentials — sign out and back
+// in to refresh a forwarded token) from "you may not do that" (missing role or
+// privilege). It returns an empty string when the error is not a recognized
+// auth failure. Both HTTP status codes and native ClickHouse exception codes
+// are handled.
+func authErrorHint(err error) string {
+	const (
+		unauthenticated = "authentication failed — the credentials or forwarded token may be missing or expired; if using Forward OAuth Identity, sign out and back in to refresh the token"
+		unauthorized    = "access denied — the authenticated identity is missing a required ClickHouse role or privilege"
+	)
+
+	switch httpStatusCode(err.Error()) {
+	case 401:
+		return unauthenticated
+	case 403:
+		return unauthorized
+	}
+
+	var exception *clickhouse.Exception
+	if errors.As(err, &exception) {
+		switch exception.Code {
+		case 516: // AUTHENTICATION_FAILED
+			return unauthenticated
+		case 497, 164: // NOT_ENOUGH_PRIVILEGES, READONLY
+			return unauthorized
+		}
+	}
+
+	return ""
+}
+
 // CategorizeConnectionError classifies a connection error into a ConnectionErrorCategory.
 // Typed errors are checked first; string matching is used as a fallback for HTTP
 // transport errors that the clickhouse-go driver surfaces as plain strings.

--- a/pkg/plugin/connection_error_test.go
+++ b/pkg/plugin/connection_error_test.go
@@ -294,3 +294,29 @@ func TestCategorizeConnectionError(t *testing.T) {
 		})
 	}
 }
+
+func TestAuthErrorHint(t *testing.T) {
+	tests := []struct {
+		name        string
+		err         error
+		wantSubstr  string
+		wantNoMatch bool
+	}{
+		{name: "HTTP 401", err: errors.New("clickhouse [HTTP 401]: Unauthorized"), wantSubstr: "sign out and back in"},
+		{name: "HTTP 403", err: errors.New("clickhouse [HTTP 403]: Forbidden"), wantSubstr: "missing a required ClickHouse role"},
+		{name: "native AUTHENTICATION_FAILED", err: &clickhouse.Exception{Code: 516, Message: "Authentication failed"}, wantSubstr: "sign out and back in"},
+		{name: "native NOT_ENOUGH_PRIVILEGES", err: &clickhouse.Exception{Code: 497, Message: "Not enough privileges"}, wantSubstr: "missing a required ClickHouse role"},
+		{name: "non-auth error yields no hint", err: errors.New("dial tcp: connection refused"), wantNoMatch: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := authErrorHint(tt.err)
+			if tt.wantNoMatch {
+				assert.Empty(t, got)
+				return
+			}
+			assert.Contains(t, got, tt.wantSubstr)
+		})
+	}
+}

--- a/pkg/plugin/connection_error_test.go
+++ b/pkg/plugin/connection_error_test.go
@@ -297,15 +297,15 @@ func TestCategorizeConnectionError(t *testing.T) {
 
 func TestAuthErrorHint(t *testing.T) {
 	tests := []struct {
-		name        string
-		err         error
-		wantSubstr  string
-		wantNoMatch bool
+		name         string
+		err          error
+		wantContains string
+		wantNoMatch  bool
 	}{
-		{name: "HTTP 401", err: errors.New("clickhouse [HTTP 401]: Unauthorized"), wantSubstr: "sign out and back in"},
-		{name: "HTTP 403", err: errors.New("clickhouse [HTTP 403]: Forbidden"), wantSubstr: "missing a required ClickHouse role"},
-		{name: "native AUTHENTICATION_FAILED", err: &clickhouse.Exception{Code: 516, Message: "Authentication failed"}, wantSubstr: "sign out and back in"},
-		{name: "native NOT_ENOUGH_PRIVILEGES", err: &clickhouse.Exception{Code: 497, Message: "Not enough privileges"}, wantSubstr: "missing a required ClickHouse role"},
+		{name: "HTTP 401", err: errors.New("clickhouse [HTTP 401]: Unauthorized"), wantContains: "sign out and back in"},
+		{name: "HTTP 403", err: errors.New("clickhouse [HTTP 403]: Forbidden"), wantContains: "missing a required ClickHouse role"},
+		{name: "native AUTHENTICATION_FAILED", err: &clickhouse.Exception{Code: 516, Message: "Authentication failed"}, wantContains: "sign out and back in"},
+		{name: "native NOT_ENOUGH_PRIVILEGES", err: &clickhouse.Exception{Code: 497, Message: "Not enough privileges"}, wantContains: "missing a required ClickHouse role"},
 		{name: "non-auth error yields no hint", err: errors.New("dial tcp: connection refused"), wantNoMatch: true},
 	}
 
@@ -316,7 +316,7 @@ func TestAuthErrorHint(t *testing.T) {
 				assert.Empty(t, got)
 				return
 			}
-			assert.Contains(t, got, tt.wantSubstr)
+			assert.Contains(t, got, tt.wantContains)
 		})
 	}
 }

--- a/pkg/plugin/driver.go
+++ b/pkg/plugin/driver.go
@@ -226,6 +226,13 @@ func buildClickHouseOptions(ctx context.Context, settings Settings, message json
 		return nil, backend.DownstreamError(fmt.Errorf("JWT authentication requires a secure (TLS) connection"))
 	}
 
+	// Forwarding a real user's token over a connection whose server
+	// certificate is not verified exposes the token to interception. This is a
+	// higher bar than a shared service credential, so reject the combination.
+	if settings.OAuthPassThru && settings.InsecureSkipVerify {
+		return nil, backend.DownstreamError(fmt.Errorf("Forward OAuth Identity cannot be used with \"Skip TLS Verify\": forwarding a user token over an unverified TLS connection would expose it to interception"))
+	}
+
 	// When Forward OAuth Identity is enabled, a data query (message != nil)
 	// that arrives without a forwarded user token is a backend query with no
 	// user to attribute it to — typically alert rule evaluation. Health checks

--- a/pkg/plugin/driver.go
+++ b/pkg/plugin/driver.go
@@ -165,6 +165,11 @@ func resolveJWTAuth(settings Settings, httpHeaders map[string]string) (clickhous
 func wrapCategorizedConnectionError(err error) error {
 	category := CategorizeConnectionError(err)
 	backend.Logger.Error("failed to create ClickHouse client", "error_category", string(category))
+	if category == ConnectionErrorCategoryAuth {
+		if hint := authErrorHint(err); hint != "" {
+			return backend.DownstreamError(fmt.Errorf("[%s] %w (%s)", category, err, hint))
+		}
+	}
 	return backend.DownstreamError(fmt.Errorf("[%s] %w", category, err))
 }
 

--- a/pkg/plugin/driver.go
+++ b/pkg/plugin/driver.go
@@ -226,6 +226,27 @@ func buildClickHouseOptions(ctx context.Context, settings Settings, message json
 		return nil, backend.DownstreamError(fmt.Errorf("JWT authentication requires a secure (TLS) connection"))
 	}
 
+	// When Forward OAuth Identity is enabled, a data query (message != nil)
+	// that arrives without a forwarded user token is a backend query with no
+	// user to attribute it to — typically alert rule evaluation. Health checks
+	// and schema introspection pass a nil message and always fall back, since
+	// no user token is ever available for them.
+	if settings.OAuthPassThru && message != nil && httpHeaders[backend.OAuthIdentityTokenHeaderName] == "" {
+		if !settings.OAuthPassThruAllowFallback {
+			return nil, backend.DownstreamError(fmt.Errorf(
+				"Forward OAuth Identity is enabled but this query carries no user identity; " +
+					"it is running outside a user session (for example, an alert rule). Enable " +
+					"\"Allow service account fallback\" on the data source to let these queries " +
+					"run with the configured username/password, or ensure the request forwards a user OAuth token"))
+		}
+		// Fallback is opt-in and exercised: warn so the privilege divergence is
+		// not silent. These queries run as the shared service account and are
+		// not subject to the per-user row policies or quotas that OAuth
+		// pass-through enforces for interactive queries.
+		backend.Logger.Warn("Forward OAuth Identity: query has no forwarded user identity; " +
+			"falling back to the configured username/password (service account)")
+	}
+
 	auth, getJWT := resolveJWTAuth(settings, httpHeaders)
 
 	opts := &clickhouse.Options{

--- a/pkg/plugin/driver.go
+++ b/pkg/plugin/driver.go
@@ -141,30 +141,36 @@ func CheckMinServerVersion(conn *sql.DB, major, minor, patch uint64) (bool, erro
 	return true, nil
 }
 
+// resolveJWTAuth builds the ClickHouse Auth and GetJWT callback when JWT
+// authentication is enabled. The Bearer token is removed from httpHeaders
+// (mutated in-place) and returned via the GetJWT callback instead.
+func resolveJWTAuth(settings Settings, httpHeaders map[string]string) (clickhouse.Auth, clickhouse.GetJWTFunc) {
+	auth := clickhouse.Auth{
+		Database: settings.DefaultDatabase,
+		Username: settings.Username,
+		Password: settings.Password,
+	}
+
+	authHeader := httpHeaders[backend.OAuthIdentityTokenHeaderName]
+	if !settings.OAuthPassThru || authHeader == "" {
+		return auth, nil
+	}
+
+	delete(httpHeaders, backend.OAuthIdentityTokenHeaderName)
+	token := strings.TrimPrefix(authHeader, "Bearer ")
+	return clickhouse.Auth{Database: settings.DefaultDatabase},
+		func(context.Context) (string, error) { return token, nil }
+}
+
 func wrapCategorizedConnectionError(err error) error {
 	category := CategorizeConnectionError(err)
 	backend.Logger.Error("failed to create ClickHouse client", "error_category", string(category))
 	return backend.DownstreamError(fmt.Errorf("[%s] %w", category, err))
 }
 
-// Connect opens a sql.DB connection using datasource settings
-func (h *Clickhouse) Connect(
-	ctx context.Context,
-	config backend.DataSourceInstanceSettings,
-	message json.RawMessage,
-) (*sql.DB, error) {
-	ctx, span := tracing.DefaultTracer().Start(ctx, "clickhouse connect", trace.WithAttributes(
-		attribute.String("db.system", "clickhouse"),
-	))
-
-	defer span.End()
-
-	settings, err := LoadSettings(ctx, config)
-	if err != nil {
-		return nil, wrapCategorizedConnectionError(err)
-	}
-
+func buildClickHouseOptions(ctx context.Context, settings Settings, message json.RawMessage) (*clickhouse.Options, error) {
 	var tlsConfig *tls.Config
+	var err error
 	if settings.TlsAuthWithCACert || settings.TlsClientAuth {
 		tlsConfig, err = getTLSConfig(settings)
 		if err != nil {
@@ -216,13 +222,15 @@ func (h *Clickhouse) Connect(
 		httpHeaders[k] = v
 	}
 
+	if settings.OAuthPassThru && tlsConfig == nil {
+		return nil, backend.DownstreamError(fmt.Errorf("JWT authentication requires a secure (TLS) connection"))
+	}
+
+	auth, getJWT := resolveJWTAuth(settings, httpHeaders)
+
 	opts := &clickhouse.Options{
 		Addr: []string{fmt.Sprintf("%s:%d", settings.Host, settings.Port)},
-		Auth: clickhouse.Auth{
-			Database: settings.DefaultDatabase,
-			Password: settings.Password,
-			Username: settings.Username,
-		},
+		Auth: auth,
 		ClientInfo: clickhouse.ClientInfo{
 			Products: getClientInfoProducts(ctx),
 		},
@@ -230,6 +238,7 @@ func (h *Clickhouse) Connect(
 			Method: compression,
 		},
 		DialTimeout: time.Duration(t) * time.Second,
+		GetJWT:      getJWT,
 		HttpHeaders: httpHeaders,
 		HttpUrlPath: settings.Path,
 		Protocol:    protocol,
@@ -238,7 +247,7 @@ func (h *Clickhouse) Connect(
 		TLS:         tlsConfig,
 	}
 
-	// dialCtx is used to create a connection to PDC, if it is enabled
+	// dialCtx is used to create a connection to PDC, if it is enabled above
 	dialCtx, err := getPDCDialContext(settings)
 	if err != nil {
 		return nil, err
@@ -247,7 +256,32 @@ func (h *Clickhouse) Connect(
 		opts.DialContext = dialCtx
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, time.Duration(t)*time.Second)
+	return opts, nil
+}
+
+// Connect opens a sql.DB connection using datasource settings
+func (h *Clickhouse) Connect(
+	ctx context.Context,
+	config backend.DataSourceInstanceSettings,
+	message json.RawMessage,
+) (*sql.DB, error) {
+	ctx, span := tracing.DefaultTracer().Start(ctx, "clickhouse connect", trace.WithAttributes(
+		attribute.String("db.system", "clickhouse"),
+	))
+
+	defer span.End()
+
+	settings, err := LoadSettings(ctx, config)
+	if err != nil {
+		return nil, wrapCategorizedConnectionError(err)
+	}
+
+	opts, err := buildClickHouseOptions(ctx, settings, message)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, opts.DialTimeout)
 	defer cancel()
 
 	db := clickhouse.OpenDB(opts)
@@ -373,7 +407,7 @@ func (h *Clickhouse) Settings(ctx context.Context, config backend.DataSourceInst
 		FillMode: &data.FillMissing{
 			Mode: data.FillModeNull,
 		},
-		ForwardHeaders:  settings.ForwardGrafanaHeaders,
+		ForwardHeaders:  settings.ForwardGrafanaHeaders || settings.OAuthPassThru,
 		RowCapacityHint: settings.RowCapacityHint,
 	}
 }

--- a/pkg/plugin/driver.go
+++ b/pkg/plugin/driver.go
@@ -235,7 +235,7 @@ func buildClickHouseOptions(ctx context.Context, settings Settings, message json
 	// certificate is not verified exposes the token to interception. This is a
 	// higher bar than a shared service credential, so reject the combination.
 	if settings.OAuthPassThru && settings.InsecureSkipVerify {
-		return nil, backend.DownstreamError(fmt.Errorf("Forward OAuth Identity cannot be used with \"Skip TLS Verify\": forwarding a user token over an unverified TLS connection would expose it to interception"))
+		return nil, backend.DownstreamError(fmt.Errorf("the \"Forward OAuth Identity\" and \"Skip TLS Verify\" options cannot be combined: forwarding a user token over an unverified TLS connection would expose it to interception"))
 	}
 
 	// When Forward OAuth Identity is enabled, a data query (message != nil)
@@ -246,7 +246,7 @@ func buildClickHouseOptions(ctx context.Context, settings Settings, message json
 	if settings.OAuthPassThru && message != nil && httpHeaders[backend.OAuthIdentityTokenHeaderName] == "" {
 		if !settings.OAuthPassThruAllowFallback {
 			return nil, backend.DownstreamError(fmt.Errorf(
-				"Forward OAuth Identity is enabled but this query carries no user identity; " +
+				"this query carries no user identity but \"Forward OAuth Identity\" is enabled; " +
 					"it is running outside a user session (for example, an alert rule). Enable " +
 					"\"Allow service account fallback\" on the data source to let these queries " +
 					"run with the configured username/password, or ensure the request forwards a user OAuth token"))

--- a/pkg/plugin/driver_test.go
+++ b/pkg/plugin/driver_test.go
@@ -724,6 +724,18 @@ func TestBuildClickHouseOptionsJWTHealthCheckAlwaysFallsBack(t *testing.T) {
 	}
 }
 
+func TestBuildClickHouseOptionsJWTRequiresTLS(t *testing.T) {
+	// Forward OAuth Identity must never be used over a plaintext connection.
+	message := json.RawMessage(`{"grafana-http-headers":{"Authorization":["Bearer my-jwt-token"]}}`)
+
+	settings := baseJWTSettings()
+	settings.Secure = false
+
+	_, err := buildClickHouseOptions(t.Context(), settings, message)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "secure (TLS) connection")
+}
+
 func TestBuildClickHouseOptionsJWTRejectsSkipTLSVerify(t *testing.T) {
 	// Forwarding a user token over a connection whose server certificate is
 	// not verified would expose it to interception.

--- a/pkg/plugin/driver_test.go
+++ b/pkg/plugin/driver_test.go
@@ -663,10 +663,10 @@ func TestBuildClickHouseOptionsJWTBothProtocols(t *testing.T) {
 	}
 }
 
-func TestBuildClickHouseOptionsJWTFallbackWithoutToken(t *testing.T) {
-	message := json.RawMessage(`{}`)
-
-	settings := Settings{
+// baseJWTSettings returns a valid secure OAuthPassThru configuration with a
+// service-account username/password configured as the fallback credential.
+func baseJWTSettings() Settings {
+	return Settings{
 		Host:          "localhost",
 		Port:          9440,
 		Protocol:      "native",
@@ -677,13 +677,51 @@ func TestBuildClickHouseOptionsJWTFallbackWithoutToken(t *testing.T) {
 		DialTimeout:   "5",
 		QueryTimeout:  "30",
 	}
+}
 
-	opts, err := buildClickHouseOptions(t.Context(), settings, message)
-	assert.NoError(t, err)
+func TestBuildClickHouseOptionsJWTTokenlessDataQuery(t *testing.T) {
+	// A data query (non-nil message) with no forwarded user token is a backend
+	// query with no identity to attribute it to — typically alert evaluation.
+	dataQuery := json.RawMessage(`{}`)
 
-	assert.Nil(t, opts.GetJWT, "GetJWT must be nil when no token is forwarded")
-	assert.Equal(t, "svc", opts.Auth.Username)
-	assert.Equal(t, "fallback", opts.Auth.Password)
+	t.Run("blocked by default", func(t *testing.T) {
+		settings := baseJWTSettings()
+
+		_, err := buildClickHouseOptions(t.Context(), settings, dataQuery)
+		require.Error(t, err, "tokenless data queries must be rejected when fallback is not allowed")
+		assert.Contains(t, err.Error(), "no user identity")
+	})
+
+	t.Run("falls back to service account when fallback is allowed", func(t *testing.T) {
+		settings := baseJWTSettings()
+		settings.OAuthPassThruAllowFallback = true
+
+		opts, err := buildClickHouseOptions(t.Context(), settings, dataQuery)
+		require.NoError(t, err)
+
+		assert.Nil(t, opts.GetJWT, "GetJWT must be nil when no token is forwarded")
+		assert.Equal(t, "svc", opts.Auth.Username)
+		assert.Equal(t, "fallback", opts.Auth.Password)
+	})
+}
+
+func TestBuildClickHouseOptionsJWTHealthCheckAlwaysFallsBack(t *testing.T) {
+	// Health checks and schema introspection pass a nil message; no user token
+	// is ever available for them, so they always fall back regardless of the
+	// OAuthPassThruAllowFallback setting.
+	for _, allowFallback := range []bool{false, true} {
+		t.Run(fmt.Sprintf("allowFallback=%v", allowFallback), func(t *testing.T) {
+			settings := baseJWTSettings()
+			settings.OAuthPassThruAllowFallback = allowFallback
+
+			opts, err := buildClickHouseOptions(t.Context(), settings, nil)
+			require.NoError(t, err, "health checks (nil message) must never be blocked")
+
+			assert.Nil(t, opts.GetJWT)
+			assert.Equal(t, "svc", opts.Auth.Username)
+			assert.Equal(t, "fallback", opts.Auth.Password)
+		})
+	}
 }
 
 func TestInterpolateMacros(t *testing.T) {

--- a/pkg/plugin/driver_test.go
+++ b/pkg/plugin/driver_test.go
@@ -328,10 +328,10 @@ func TestMutateQueryData(t *testing.T) {
 	h := &Clickhouse{}
 
 	tests := []struct {
-		name   string
+		name    string
 		headers map[string]string
-		want   grafanaHeaders
-		stored bool
+		want    grafanaHeaders
+		stored  bool
 	}{
 		{
 			name: "all headers",
@@ -679,7 +679,7 @@ func baseJWTSettings() Settings {
 	}
 }
 
-func TestBuildClickHouseOptionsJWTTokenlessDataQuery(t *testing.T) {
+func TestBuildClickHouseOptionsJWTDataQueryWithoutToken(t *testing.T) {
 	// A data query (non-nil message) with no forwarded user token is a backend
 	// query with no identity to attribute it to — typically alert evaluation.
 	dataQuery := json.RawMessage(`{}`)
@@ -688,7 +688,7 @@ func TestBuildClickHouseOptionsJWTTokenlessDataQuery(t *testing.T) {
 		settings := baseJWTSettings()
 
 		_, err := buildClickHouseOptions(t.Context(), settings, dataQuery)
-		require.Error(t, err, "tokenless data queries must be rejected when fallback is not allowed")
+		require.Error(t, err, "data queries without a forwarded token must be rejected when fallback is not allowed")
 		assert.Contains(t, err.Error(), "no user identity")
 	})
 

--- a/pkg/plugin/driver_test.go
+++ b/pkg/plugin/driver_test.go
@@ -724,6 +724,19 @@ func TestBuildClickHouseOptionsJWTHealthCheckAlwaysFallsBack(t *testing.T) {
 	}
 }
 
+func TestBuildClickHouseOptionsJWTRejectsSkipTLSVerify(t *testing.T) {
+	// Forwarding a user token over a connection whose server certificate is
+	// not verified would expose it to interception.
+	message := json.RawMessage(`{"grafana-http-headers":{"Authorization":["Bearer my-jwt-token"]}}`)
+
+	settings := baseJWTSettings()
+	settings.InsecureSkipVerify = true
+
+	_, err := buildClickHouseOptions(t.Context(), settings, message)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Skip TLS Verify")
+}
+
 func TestInterpolateMacros(t *testing.T) {
 	from, _ := time.Parse("2006-01-02T15:04:05.000Z", "2014-11-12T11:45:26.371Z")
 	to, _ := time.Parse("2006-01-02T15:04:05.000Z", "2015-11-12T11:45:26.371Z")

--- a/pkg/plugin/driver_test.go
+++ b/pkg/plugin/driver_test.go
@@ -505,6 +505,187 @@ func TestMutateQueryData_XGrafanaUserForwarding(t *testing.T) {
 	})
 }
 
+func TestSettingsForwardHeadersWithJWT(t *testing.T) {
+	h := &Clickhouse{}
+
+	t.Run("ForwardHeaders is true when oauthPassThru is enabled", func(t *testing.T) {
+		config := backend.DataSourceInstanceSettings{
+			JSONData:                []byte(`{"host": "test", "port": 443, "oauthPassThru": true, "forwardGrafanaHeaders": false}`),
+			DecryptedSecureJSONData: map[string]string{},
+		}
+		ds := h.Settings(t.Context(), config)
+		assert.True(t, ds.ForwardHeaders)
+	})
+
+	t.Run("ForwardHeaders is true when forwardGrafanaHeaders is enabled", func(t *testing.T) {
+		config := backend.DataSourceInstanceSettings{
+			JSONData:                []byte(`{"host": "test", "port": 443, "oauthPassThru": false, "forwardGrafanaHeaders": true}`),
+			DecryptedSecureJSONData: map[string]string{},
+		}
+		ds := h.Settings(t.Context(), config)
+		assert.True(t, ds.ForwardHeaders)
+	})
+
+	t.Run("ForwardHeaders is false when both are disabled", func(t *testing.T) {
+		config := backend.DataSourceInstanceSettings{
+			JSONData:                []byte(`{"host": "test", "port": 443}`),
+			DecryptedSecureJSONData: map[string]string{},
+		}
+		ds := h.Settings(t.Context(), config)
+		assert.False(t, ds.ForwardHeaders)
+	})
+}
+
+func TestExtractForwardedHeadersWithAuthorization(t *testing.T) {
+	t.Run("extracts Authorization header from message", func(t *testing.T) {
+		message := json.RawMessage(`{
+			"grafana-http-headers": {
+				"Authorization": ["Bearer test-token-123"],
+				"X-Grafana-User": ["alice"]
+			}
+		}`)
+		headers, err := extractForwardedHeadersFromMessage(message)
+		assert.NoError(t, err)
+		assert.Equal(t, "Bearer test-token-123", headers["Authorization"])
+		assert.Equal(t, "alice", headers["X-Grafana-User"])
+	})
+
+	t.Run("returns empty map when message is nil", func(t *testing.T) {
+		headers, err := extractForwardedHeadersFromMessage(nil)
+		assert.NoError(t, err)
+		assert.Empty(t, headers)
+	})
+}
+
+func TestResolveJWTAuth(t *testing.T) {
+	baseSettings := Settings{
+		DefaultDatabase: "default",
+		Username:        "admin",
+		Password:        "secret",
+	}
+
+	t.Run("JWT enabled clears credentials and moves token to GetJWT", func(t *testing.T) {
+		s := baseSettings
+		s.OAuthPassThru = true
+		headers := map[string]string{"Authorization": "Bearer my-jwt-token"}
+
+		auth, getJWT := resolveJWTAuth(s, headers)
+
+		assert.Empty(t, auth.Username)
+		assert.Empty(t, auth.Password)
+		assert.Equal(t, "default", auth.Database)
+		assert.NotNil(t, getJWT)
+
+		token, err := getJWT(context.Background())
+		assert.NoError(t, err)
+		assert.Equal(t, "my-jwt-token", token)
+
+		_, exists := headers["Authorization"]
+		assert.False(t, exists, "Authorization header should be removed from httpHeaders")
+	})
+
+	t.Run("token is read from the SDK OAuth identity header constant", func(t *testing.T) {
+		s := baseSettings
+		s.OAuthPassThru = true
+		// Key the header with the SDK constant rather than a literal so this
+		// fails if backend.OAuthIdentityTokenHeaderName ever stops being the
+		// header resolveJWTAuth reads.
+		headers := map[string]string{backend.OAuthIdentityTokenHeaderName: "Bearer my-jwt-token"}
+
+		auth, getJWT := resolveJWTAuth(s, headers)
+
+		assert.Empty(t, auth.Username)
+		assert.Empty(t, auth.Password)
+		assert.NotNil(t, getJWT)
+
+		token, err := getJWT(context.Background())
+		assert.NoError(t, err)
+		assert.Equal(t, "my-jwt-token", token)
+
+		_, exists := headers[backend.OAuthIdentityTokenHeaderName]
+		assert.False(t, exists, "OAuth identity header should be removed from httpHeaders")
+	})
+
+	t.Run("JWT enabled but no token falls back to credentials", func(t *testing.T) {
+		s := baseSettings
+		s.OAuthPassThru = true
+		headers := map[string]string{}
+
+		auth, getJWT := resolveJWTAuth(s, headers)
+
+		assert.Equal(t, "admin", auth.Username)
+		assert.Equal(t, "secret", auth.Password)
+		assert.Nil(t, getJWT)
+	})
+
+	t.Run("JWT disabled uses credentials regardless of token", func(t *testing.T) {
+		s := baseSettings
+		s.OAuthPassThru = false
+		headers := map[string]string{"Authorization": "Bearer some-token"}
+
+		auth, getJWT := resolveJWTAuth(s, headers)
+
+		assert.Equal(t, "admin", auth.Username)
+		assert.Equal(t, "secret", auth.Password)
+		assert.Nil(t, getJWT)
+		assert.Equal(t, "Bearer some-token", headers["Authorization"])
+	})
+}
+
+func TestBuildClickHouseOptionsJWTBothProtocols(t *testing.T) {
+	message := json.RawMessage(`{"grafana-http-headers":{"Authorization":["Bearer my-jwt-token"]}}`)
+
+	for _, protocol := range []string{"native", "http"} {
+		t.Run(protocol, func(t *testing.T) {
+			settings := Settings{
+				Host:          "localhost",
+				Port:          9440,
+				Protocol:      protocol,
+				Secure:        true,
+				OAuthPassThru: true,
+				Username:      "svc",
+				Password:      "fallback",
+				DialTimeout:   "5",
+				QueryTimeout:  "30",
+			}
+
+			opts, err := buildClickHouseOptions(t.Context(), settings, message)
+			assert.NoError(t, err)
+
+			assert.NotNil(t, opts.GetJWT, "GetJWT must be set for %s protocol", protocol)
+			token, err := opts.GetJWT(context.Background())
+			assert.NoError(t, err)
+			assert.Equal(t, "my-jwt-token", token)
+
+			assert.Empty(t, opts.Auth.Username, "username must be cleared when JWT is active")
+			assert.Empty(t, opts.Auth.Password, "password must be cleared when JWT is active")
+		})
+	}
+}
+
+func TestBuildClickHouseOptionsJWTFallbackWithoutToken(t *testing.T) {
+	message := json.RawMessage(`{}`)
+
+	settings := Settings{
+		Host:          "localhost",
+		Port:          9440,
+		Protocol:      "native",
+		Secure:        true,
+		OAuthPassThru: true,
+		Username:      "svc",
+		Password:      "fallback",
+		DialTimeout:   "5",
+		QueryTimeout:  "30",
+	}
+
+	opts, err := buildClickHouseOptions(t.Context(), settings, message)
+	assert.NoError(t, err)
+
+	assert.Nil(t, opts.GetJWT, "GetJWT must be nil when no token is forwarded")
+	assert.Equal(t, "svc", opts.Auth.Username)
+	assert.Equal(t, "fallback", opts.Auth.Password)
+}
+
 func TestInterpolateMacros(t *testing.T) {
 	from, _ := time.Parse("2006-01-02T15:04:05.000Z", "2014-11-12T11:45:26.371Z")
 	to, _ := time.Parse("2006-01-02T15:04:05.000Z", "2015-11-12T11:45:26.371Z")

--- a/pkg/plugin/settings.go
+++ b/pkg/plugin/settings.go
@@ -43,6 +43,7 @@ type Settings struct {
 
 	HttpHeaders           map[string]string `json:"-"`
 	ForwardGrafanaHeaders bool              `json:"forwardGrafanaHeaders,omitempty"`
+	OAuthPassThru         bool              `json:"oauthPassThru,omitempty"`
 	CustomSettings        []CustomSetting   `json:"customSettings"`
 	ProxyOptions          *proxy.Options
 
@@ -215,6 +216,17 @@ func LoadSettings(ctx context.Context, config backend.DataSourceInstanceSettings
 			}
 		} else {
 			settings.ForwardGrafanaHeaders = jsonData["forwardGrafanaHeaders"].(bool)
+		}
+	}
+
+	if jsonData["oauthPassThru"] != nil {
+		if oauthPassThru, ok := jsonData["oauthPassThru"].(string); ok {
+			settings.OAuthPassThru, err = strconv.ParseBool(oauthPassThru)
+			if err != nil {
+				return settings, backend.DownstreamError(fmt.Errorf("could not parse oauthPassThru value: %w", err))
+			}
+		} else {
+			settings.OAuthPassThru = jsonData["oauthPassThru"].(bool)
 		}
 	}
 

--- a/pkg/plugin/settings.go
+++ b/pkg/plugin/settings.go
@@ -44,6 +44,14 @@ type Settings struct {
 	HttpHeaders           map[string]string `json:"-"`
 	ForwardGrafanaHeaders bool              `json:"forwardGrafanaHeaders,omitempty"`
 	OAuthPassThru         bool              `json:"oauthPassThru,omitempty"`
+	// OAuthPassThruAllowFallback controls what happens when Forward OAuth
+	// Identity is enabled but a data query arrives without a forwarded user
+	// token (for example, alert rule evaluation, which runs outside a user
+	// session). When false (the default) such queries are rejected; when true
+	// they fall back to the configured username/password (service account).
+	// Health checks and schema introspection always fall back regardless of
+	// this setting, since no user token is ever available for them.
+	OAuthPassThruAllowFallback bool `json:"oauthPassThruAllowFallback,omitempty"`
 	CustomSettings        []CustomSetting   `json:"customSettings"`
 	ProxyOptions          *proxy.Options
 
@@ -227,6 +235,17 @@ func LoadSettings(ctx context.Context, config backend.DataSourceInstanceSettings
 			}
 		} else {
 			settings.OAuthPassThru = jsonData["oauthPassThru"].(bool)
+		}
+	}
+
+	if jsonData["oauthPassThruAllowFallback"] != nil {
+		if allowFallback, ok := jsonData["oauthPassThruAllowFallback"].(string); ok {
+			settings.OAuthPassThruAllowFallback, err = strconv.ParseBool(allowFallback)
+			if err != nil {
+				return settings, backend.DownstreamError(fmt.Errorf("could not parse oauthPassThruAllowFallback value: %w", err))
+			}
+		} else {
+			settings.OAuthPassThruAllowFallback = jsonData["oauthPassThruAllowFallback"].(bool)
 		}
 	}
 

--- a/pkg/plugin/settings_test.go
+++ b/pkg/plugin/settings_test.go
@@ -407,3 +407,34 @@ func TestLoadSettings(t *testing.T) {
 		}
 	})
 }
+
+func TestLoadSettingsOAuthPassThru(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("should parse oauthPassThru as bool", func(t *testing.T) {
+		settings, err := LoadSettings(ctx, backend.DataSourceInstanceSettings{
+			JSONData:                []byte(`{"host": "test", "port": 443, "oauthPassThru": true}`),
+			DecryptedSecureJSONData: map[string]string{},
+		})
+		assert.NoError(t, err)
+		assert.True(t, settings.OAuthPassThru)
+	})
+
+	t.Run("should parse oauthPassThru as string", func(t *testing.T) {
+		settings, err := LoadSettings(ctx, backend.DataSourceInstanceSettings{
+			JSONData:                []byte(`{"host": "test", "port": 443, "oauthPassThru": "true"}`),
+			DecryptedSecureJSONData: map[string]string{},
+		})
+		assert.NoError(t, err)
+		assert.True(t, settings.OAuthPassThru)
+	})
+
+	t.Run("should default oauthPassThru to false", func(t *testing.T) {
+		settings, err := LoadSettings(ctx, backend.DataSourceInstanceSettings{
+			JSONData:                []byte(`{"host": "test", "port": 443}`),
+			DecryptedSecureJSONData: map[string]string{},
+		})
+		assert.NoError(t, err)
+		assert.False(t, settings.OAuthPassThru)
+	})
+}

--- a/pkg/plugin/settings_test.go
+++ b/pkg/plugin/settings_test.go
@@ -438,3 +438,34 @@ func TestLoadSettingsOAuthPassThru(t *testing.T) {
 		assert.False(t, settings.OAuthPassThru)
 	})
 }
+
+func TestLoadSettingsOAuthPassThruAllowFallback(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("should parse oauthPassThruAllowFallback as bool", func(t *testing.T) {
+		settings, err := LoadSettings(ctx, backend.DataSourceInstanceSettings{
+			JSONData:                []byte(`{"host": "test", "port": 443, "oauthPassThruAllowFallback": true}`),
+			DecryptedSecureJSONData: map[string]string{},
+		})
+		assert.NoError(t, err)
+		assert.True(t, settings.OAuthPassThruAllowFallback)
+	})
+
+	t.Run("should parse oauthPassThruAllowFallback as string", func(t *testing.T) {
+		settings, err := LoadSettings(ctx, backend.DataSourceInstanceSettings{
+			JSONData:                []byte(`{"host": "test", "port": 443, "oauthPassThruAllowFallback": "true"}`),
+			DecryptedSecureJSONData: map[string]string{},
+		})
+		assert.NoError(t, err)
+		assert.True(t, settings.OAuthPassThruAllowFallback)
+	})
+
+	t.Run("should default oauthPassThruAllowFallback to false", func(t *testing.T) {
+		settings, err := LoadSettings(ctx, backend.DataSourceInstanceSettings{
+			JSONData:                []byte(`{"host": "test", "port": 443}`),
+			DecryptedSecureJSONData: map[string]string{},
+		})
+		assert.NoError(t, err)
+		assert.False(t, settings.OAuthPassThruAllowFallback)
+	})
+}

--- a/src/labels.ts
+++ b/src/labels.ts
@@ -44,7 +44,7 @@ export default {
         oauthPassThruAllowFallback: {
           label: 'Allow service account fallback',
           tooltip:
-            'When Forward OAuth Identity is enabled, alert rules and other backend queries run without a signed-in user. By default they are blocked. Enable this to let them fall back to the configured username/password. Those queries then run as the shared service account and are NOT subject to the per-user row policies or quotas enforced for interactive queries.',
+            'Run queries with no signed-in user (alert rules and other backend queries) using the configured username and password instead of failing them; per-user row policies and quotas will not apply.',
         },
         tlsSkipVerify: {
           label: 'Skip TLS Verify',

--- a/src/labels.ts
+++ b/src/labels.ts
@@ -41,6 +41,11 @@ export default {
         oauthPassThru: {
           label: 'Forward OAuth Identity',
         },
+        oauthPassThruAllowFallback: {
+          label: 'Allow service account fallback',
+          tooltip:
+            'When Forward OAuth Identity is enabled, alert rules and other backend queries run without a signed-in user. By default they are blocked. Enable this to let them fall back to the configured username/password. Those queries then run as the shared service account and are NOT subject to the per-user row policies or quotas enforced for interactive queries.',
+        },
         tlsSkipVerify: {
           label: 'Skip TLS Verify',
           tooltip: 'Skip TLS Verify',

--- a/src/labels.ts
+++ b/src/labels.ts
@@ -38,6 +38,9 @@ export default {
           placeholder: 'password',
           tooltip: 'ClickHouse password',
         },
+        oauthPassThru: {
+          label: 'Forward OAuth Identity',
+        },
         tlsSkipVerify: {
           label: 'Skip TLS Verify',
           tooltip: 'Skip TLS Verify',

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -47,6 +47,7 @@ export interface CHConfig extends DataSourceJsonData {
 
   httpHeaders?: CHHttpHeader[];
   forwardGrafanaHeaders?: boolean;
+  oauthPassThru?: boolean;
 
   customSettings?: CHCustomSetting[];
   enableSecureSocksProxy?: boolean;

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -48,6 +48,7 @@ export interface CHConfig extends DataSourceJsonData {
   httpHeaders?: CHHttpHeader[];
   forwardGrafanaHeaders?: boolean;
   oauthPassThru?: boolean;
+  oauthPassThruAllowFallback?: boolean;
 
   customSettings?: CHCustomSetting[];
   enableSecureSocksProxy?: boolean;

--- a/src/views/CHConfigEditor.test.tsx
+++ b/src/views/CHConfigEditor.test.tsx
@@ -134,6 +134,13 @@ describe('ConfigEditor', () => {
     expect(screen.getByTestId(labels.enableRowLimit.testid)).toBeChecked();
   });
 
+  it('reflects oauthPassThru=true from jsonData', () => {
+    render(<ConfigEditor {...mockConfigEditorProps({ oauthPassThru: true })} />);
+    const toggle = document.getElementById('oauthPassThru') as HTMLInputElement;
+    expect(toggle).toBeInTheDocument();
+    expect(toggle.checked).toBe(true);
+  });
+
   it('shows the required-field error on an empty host when config validation is not enabled', () => {
     // On a default install the clickHouseConfigValidation feature toggle is off,
     // so `validation` is undefined. The required host field must still show an

--- a/src/views/CHConfigEditor.tsx
+++ b/src/views/CHConfigEditor.tsx
@@ -4,7 +4,19 @@ import {
   onUpdateDatasourceJsonDataOption,
   onUpdateDatasourceSecureJsonDataOption,
 } from '@grafana/data';
-import { RadioButtonGroup, Switch, Input, SecretInput, Button, Field, Alert, Stack } from '@grafana/ui';
+import {
+  RadioButtonGroup,
+  Switch,
+  Input,
+  SecretInput,
+  Button,
+  Field,
+  Alert,
+  Stack,
+  TextLink,
+  Tooltip,
+  Icon,
+} from '@grafana/ui';
 import { CertificationKey } from '../components/ui/CertificationKey';
 import {
   CHConfig,
@@ -476,6 +488,39 @@ export const ConfigEditor: React.FC<ConfigEditorProps> = (props) => {
             isConfigured={(secureJsonFields && secureJsonFields.password) as boolean}
             onReset={onResetPassword}
             onChange={onUpdateDatasourceSecureJsonDataOption(props, 'password')}
+          />
+        </Field>
+        <Field label={labels.oauthPassThru.label} description={
+          <>
+            {'Authenticate using '}
+            <TextLink
+              variant="bodySmall"
+              href="https://clickhouse.com/docs/en/operations/external-authenticators/jwt"
+              external
+            >
+              JWT
+            </TextLink>
+            {' '}
+            <Tooltip content="ClickHouse Cloud only" placement="top">
+              <Icon name="info-circle" size="sm" />
+            </Tooltip>
+            {'. When enabled, credentials are only used for health checks.'}
+          </>
+        }>
+          <Switch
+            id="oauthPassThru"
+            className="gf-form"
+            value={jsonData.oauthPassThru || false}
+            onChange={(e) => {
+              const checked = e.currentTarget.checked;
+              onOptionsChange({
+                ...options,
+                jsonData: {
+                  ...jsonData,
+                  oauthPassThru: checked,
+                },
+              });
+            }}
           />
         </Field>
       </ConfigSection>

--- a/src/views/CHConfigEditor.tsx
+++ b/src/views/CHConfigEditor.tsx
@@ -523,6 +523,28 @@ export const ConfigEditor: React.FC<ConfigEditorProps> = (props) => {
             }}
           />
         </Field>
+        {jsonData.oauthPassThru && (
+          <Field
+            label={labels.oauthPassThruAllowFallback.label}
+            description={labels.oauthPassThruAllowFallback.tooltip}
+          >
+            <Switch
+              id="oauthPassThruAllowFallback"
+              className="gf-form"
+              value={jsonData.oauthPassThruAllowFallback || false}
+              onChange={(e) => {
+                const checked = e.currentTarget.checked;
+                onOptionsChange({
+                  ...options,
+                  jsonData: {
+                    ...jsonData,
+                    oauthPassThruAllowFallback: checked,
+                  },
+                });
+              }}
+            />
+          </Field>
+        )}
       </ConfigSection>
 
       <Divider />

--- a/src/views/config-v2/DatabaseCredentialsSection.test.tsx
+++ b/src/views/config-v2/DatabaseCredentialsSection.test.tsx
@@ -120,6 +120,28 @@ describe('DatabaseCredentialsSection', () => {
 
       expect(screen.queryByText('Username is required')).not.toBeInTheDocument();
     });
+
+    it('still requires username when Forward OAuth Identity is enabled', async () => {
+      // Username backs health checks and (when enabled) alert fallback, so it
+      // must stay required even with oauthPassThru on — otherwise validation
+      // passes but Save & test fails.
+      const oauthEmptyProps = createTestProps({
+        options: {
+          jsonData: { username: '', oauthPassThru: true },
+          secureJsonData: {},
+          secureJsonFields: {},
+        },
+        mocks: { onOptionsChange: jest.fn() },
+      });
+      const validation = createMockValidation();
+      render(<DatabaseCredentialsSection {...oauthEmptyProps} validation={validation} />);
+
+      await act(async () => {
+        validation.runValidator();
+      });
+
+      expect(screen.getByText('Username is required')).toBeInTheDocument();
+    });
   });
 
   it('reflects oauthPassThru=true from jsonData', () => {

--- a/src/views/config-v2/DatabaseCredentialsSection.test.tsx
+++ b/src/views/config-v2/DatabaseCredentialsSection.test.tsx
@@ -122,6 +122,63 @@ describe('DatabaseCredentialsSection', () => {
     });
   });
 
+  it('reflects oauthPassThru=true from jsonData', () => {
+    const jwtProps = createTestProps({
+      options: {
+        jsonData: {
+          username: 'default',
+          oauthPassThru: true,
+        },
+        secureJsonData: {},
+        secureJsonFields: {},
+      },
+      mocks: {
+        onOptionsChange: onOptionsChangeMock,
+      },
+    });
+
+    render(<DatabaseCredentialsSection {...jwtProps} />);
+
+    const toggle = screen.getByRole('checkbox', { name: /forward oauth identity/i });
+    expect(toggle).toBeChecked();
+  });
+
+  it('sets oauthPassThru when toggled on', () => {
+    render(<DatabaseCredentialsSection {...defaultProps} />);
+
+    const toggle = screen.getByRole('checkbox', { name: /forward oauth identity/i });
+    fireEvent.click(toggle);
+
+    expect(onOptionsChangeMock).toHaveBeenCalled();
+    const lastArgs = onOptionsChangeMock.mock.lastCall?.[0];
+    expect(lastArgs.jsonData?.oauthPassThru).toBe(true);
+  });
+
+  it('clears oauthPassThru when toggled off', () => {
+    const jwtProps = createTestProps({
+      options: {
+        jsonData: {
+          username: 'default',
+          oauthPassThru: true,
+        },
+        secureJsonData: {},
+        secureJsonFields: {},
+      },
+      mocks: {
+        onOptionsChange: onOptionsChangeMock,
+      },
+    });
+
+    render(<DatabaseCredentialsSection {...jwtProps} />);
+
+    const toggle = screen.getByRole('checkbox', { name: /forward oauth identity/i });
+    fireEvent.click(toggle);
+
+    expect(onOptionsChangeMock).toHaveBeenCalled();
+    const lastArgs = onOptionsChangeMock.mock.lastCall?.[0];
+    expect(lastArgs.jsonData?.oauthPassThru).toBe(false);
+  });
+
   it('resets password when Reset is clicked (isConfigured=true)', () => {
     const configuredProps = createTestProps({
       options: {

--- a/src/views/config-v2/DatabaseCredentialsSection.test.tsx
+++ b/src/views/config-v2/DatabaseCredentialsSection.test.tsx
@@ -139,14 +139,14 @@ describe('DatabaseCredentialsSection', () => {
 
     render(<DatabaseCredentialsSection {...jwtProps} />);
 
-    const toggle = screen.getByRole('checkbox', { name: /forward oauth identity/i });
+    const toggle = screen.getByRole('checkbox', { name: /^forward oauth identity/i });
     expect(toggle).toBeChecked();
   });
 
   it('sets oauthPassThru when toggled on', () => {
     render(<DatabaseCredentialsSection {...defaultProps} />);
 
-    const toggle = screen.getByRole('checkbox', { name: /forward oauth identity/i });
+    const toggle = screen.getByRole('checkbox', { name: /^forward oauth identity/i });
     fireEvent.click(toggle);
 
     expect(onOptionsChangeMock).toHaveBeenCalled();
@@ -171,7 +171,7 @@ describe('DatabaseCredentialsSection', () => {
 
     render(<DatabaseCredentialsSection {...jwtProps} />);
 
-    const toggle = screen.getByRole('checkbox', { name: /forward oauth identity/i });
+    const toggle = screen.getByRole('checkbox', { name: /^forward oauth identity/i });
     fireEvent.click(toggle);
 
     expect(onOptionsChangeMock).toHaveBeenCalled();

--- a/src/views/config-v2/DatabaseCredentialsSection.tsx
+++ b/src/views/config-v2/DatabaseCredentialsSection.tsx
@@ -175,6 +175,25 @@ export const DatabaseCredentialsSection = (props: Props) => {
             });
           }}
         />
+        {jsonData.oauthPassThru && (
+          <Box marginTop={1}>
+            <Checkbox
+              label={labels.oauthPassThruAllowFallback.label}
+              description={labels.oauthPassThruAllowFallback.tooltip}
+              checked={jsonData.oauthPassThruAllowFallback || false}
+              onChange={(e) => {
+                const checked = e.currentTarget.checked;
+                onOptionsChange({
+                  ...options,
+                  jsonData: {
+                    ...jsonData,
+                    oauthPassThruAllowFallback: checked,
+                  },
+                });
+              }}
+            />
+          </Box>
+        )}
       </CollapsableSection>
     </Box>
   );

--- a/src/views/config-v2/DatabaseCredentialsSection.tsx
+++ b/src/views/config-v2/DatabaseCredentialsSection.tsx
@@ -43,7 +43,7 @@ export const DatabaseCredentialsSection = (props: Props) => {
   useEffect(() => {
     // Always clear the error eagerly when the user fills in the field,
     // regardless of whether the ValidationAPI is available.
-    if (jsonData.username || jsonData.oauthPassThru) {
+    if (jsonData.username) {
       setFieldErrors((prev) => {
         const next = { ...prev };
         delete next.username;
@@ -56,14 +56,18 @@ export const DatabaseCredentialsSection = (props: Props) => {
     }
     return validation.registerValidation(() => {
       const errors: Record<string, string> = {};
-      if (!jsonData.username && !jsonData.oauthPassThru) {
+      // Username stays required even under Forward OAuth Identity: health
+      // checks and (when enabled) alert fallback authenticate with these
+      // static credentials, so a blank username would pass validation but
+      // fail Save & test.
+      if (!jsonData.username) {
         errors.username = labels.username.error;
       }
       setFieldErrors(errors);
       Object.entries(errors).forEach(([field, msg]) => validation.setError(field, msg));
       return Object.keys(errors).length === 0;
     });
-  }, [jsonData.username, jsonData.oauthPassThru, validation, labels.username.error]);
+  }, [jsonData.username, validation, labels.username.error]);
 
   const onResetPassword = () => {
     onOptionsChange({
@@ -107,7 +111,7 @@ export const DatabaseCredentialsSection = (props: Props) => {
                 </TextLink>
               </>
             }
-            required={!jsonData.oauthPassThru}
+            required
             invalid={!!fieldErrors.username}
             error={fieldErrors.username}
           >

--- a/src/views/config-v2/DatabaseCredentialsSection.tsx
+++ b/src/views/config-v2/DatabaseCredentialsSection.tsx
@@ -1,4 +1,16 @@
-import { Box, CollapsableSection, Field, Input, SecretInput, Text, TextLink, useStyles2 } from '@grafana/ui';
+import {
+  Box,
+  Checkbox,
+  CollapsableSection,
+  Field,
+  Icon,
+  Input,
+  SecretInput,
+  Text,
+  TextLink,
+  Tooltip,
+  useStyles2,
+} from '@grafana/ui';
 import React, { useEffect, useState } from 'react';
 import { CONFIG_SECTION_HEADERS, CONTAINER_MIN_WIDTH } from './constants';
 import {
@@ -31,7 +43,7 @@ export const DatabaseCredentialsSection = (props: Props) => {
   useEffect(() => {
     // Always clear the error eagerly when the user fills in the field,
     // regardless of whether the ValidationAPI is available.
-    if (jsonData.username) {
+    if (jsonData.username || jsonData.oauthPassThru) {
       setFieldErrors((prev) => {
         const next = { ...prev };
         delete next.username;
@@ -44,14 +56,14 @@ export const DatabaseCredentialsSection = (props: Props) => {
     }
     return validation.registerValidation(() => {
       const errors: Record<string, string> = {};
-      if (!jsonData.username) {
+      if (!jsonData.username && !jsonData.oauthPassThru) {
         errors.username = labels.username.error;
       }
       setFieldErrors(errors);
       Object.entries(errors).forEach(([field, msg]) => validation.setError(field, msg));
       return Object.keys(errors).length === 0;
     });
-  }, [jsonData.username, validation, labels.username.error]);
+  }, [jsonData.username, jsonData.oauthPassThru, validation, labels.username.error]);
 
   const onResetPassword = () => {
     onOptionsChange({
@@ -95,7 +107,7 @@ export const DatabaseCredentialsSection = (props: Props) => {
                 </TextLink>
               </>
             }
-            required
+            required={!jsonData.oauthPassThru}
             invalid={!!fieldErrors.username}
             error={fieldErrors.username}
           >
@@ -132,6 +144,37 @@ export const DatabaseCredentialsSection = (props: Props) => {
             />
           </Field>
         </div>
+        <Checkbox
+          label={labels.oauthPassThru.label}
+          description={
+            <>
+              {'Authenticate using '}
+              <TextLink
+                variant="bodySmall"
+                href="https://clickhouse.com/docs/en/operations/external-authenticators/jwt"
+                external
+              >
+                JWT
+              </TextLink>
+              {' '}
+              <Tooltip content="ClickHouse Cloud only" placement="top">
+                <Icon name="info-circle" size="sm" />
+              </Tooltip>
+              {'. When enabled, credentials are only used for health checks.'}
+            </>
+          }
+          checked={jsonData.oauthPassThru || false}
+          onChange={(e) => {
+            const checked = e.currentTarget.checked;
+            onOptionsChange({
+              ...options,
+              jsonData: {
+                ...jsonData,
+                oauthPassThru: checked,
+              },
+            });
+          }}
+        />
       </CollapsableSection>
     </Box>
   );

--- a/src/views/config-v2/labelsV2.ts
+++ b/src/views/config-v2/labelsV2.ts
@@ -43,6 +43,11 @@ export default {
         oauthPassThru: {
           label: 'Forward OAuth Identity',
         },
+        oauthPassThruAllowFallback: {
+          label: 'Allow service account fallback',
+          tooltip:
+            'When Forward OAuth Identity is enabled, alert rules and other backend queries run without a signed-in user. By default they are blocked. Enable this to let them fall back to the configured username/password. Those queries then run as the shared service account and are NOT subject to the per-user row policies or quotas enforced for interactive queries.',
+        },
         tlsSkipVerify: {
           label: 'Skip TLS Verify',
           tooltip: 'Skip TLS Verify',

--- a/src/views/config-v2/labelsV2.ts
+++ b/src/views/config-v2/labelsV2.ts
@@ -46,7 +46,7 @@ export default {
         oauthPassThruAllowFallback: {
           label: 'Allow service account fallback',
           tooltip:
-            'When Forward OAuth Identity is enabled, alert rules and other backend queries run without a signed-in user. By default they are blocked. Enable this to let them fall back to the configured username/password. Those queries then run as the shared service account and are NOT subject to the per-user row policies or quotas enforced for interactive queries.',
+            'Run queries with no signed-in user (alert rules and other backend queries) using the configured username and password instead of failing them; per-user row policies and quotas will not apply.',
         },
         tlsSkipVerify: {
           label: 'Skip TLS Verify',

--- a/src/views/config-v2/labelsV2.ts
+++ b/src/views/config-v2/labelsV2.ts
@@ -40,6 +40,9 @@ export default {
           placeholder: 'Enter password',
           tooltip: 'ClickHouse password',
         },
+        oauthPassThru: {
+          label: 'Forward OAuth Identity',
+        },
         tlsSkipVerify: {
           label: 'Skip TLS Verify',
           tooltip: 'Skip TLS Verify',


### PR DESCRIPTION
## Type of Change

- [x] 🚀 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧹 Refactor / Chore

---

## Feature

### What is this feature?

Adds an opt-in **Forward OAuth Identity** option to the data source configuration. When enabled, the plugin forwards the logged-in Grafana user's OAuth access token to ClickHouse as a JWT, using clickhouse-go's native `GetJWT` callback, instead of authenticating with the configured username and password.

When the toggle is on:
- Static username/password are suppressed on per-query connections, so the JWT is the sole credential.
- Health checks (e.g. Save & test) and alert rule evaluation fall back to the configured username/password, since no user token is available outside a query request.
- Header forwarding and per-user connection pooling are enabled automatically (`ForwardHeaders` is OR'd with `oauthPassThru`).
- A secure (TLS) connection is required; the connection is rejected otherwise.

### Why is this feature needed?

Today the plugin authenticates every query with static credentials, so all queries reach ClickHouse as a single shared account. This makes it impossible to attribute queries to the actual Grafana user or to apply ClickHouse-side access rights, row policies, and quotas per user. `Forward Grafana HTTP headers` carries user *metadata* (e.g. `X-Grafana-User`) but does not establish the user as an authenticated principal. Forwarding the user's OAuth token as a JWT closes that gap.

### Who is this feature for?

Operators connecting Grafana to **ClickHouse Cloud** (where JWT authentication is available) who want per-user identity end-to-end — for query-log attribution, row policies, or quotas keyed on the real user rather than a shared service account.

### How to test this feature

Automated:
1. Backend: `go test ./pkg/plugin/...` (see `TestResolveJWTAuth`, `TestBuildClickHouseOptionsJWT*`, `TestSettingsForwardHeadersWithJWT`, `TestLoadSettingsOAuthPassThru`).
2. Frontend: `npm run test` (see the `oauthPassThru` cases in `CHConfigEditor` and `DatabaseCredentialsSection`).

Manual (requires ClickHouse Cloud with JWT auth configured and Grafana set up to forward the user's OAuth token):
1. Add a ClickHouse data source, enable **Secure connection**, and set a username/password (used for health checks).
2. Enable **Forward OAuth Identity** under **Database credentials**, then **Save & test** (succeeds via the fallback credentials).
3. Run a query from a dashboard and confirm in `system.query_log` that it is attributed to the logged-in user rather than the service account.
4. Disable **Secure connection** with the toggle on and confirm the connection is rejected with a TLS-required error.

---

## Screenshots / Videos

**With Forward OAuth Identity**
<img width="752" height="249" alt="image" src="https://github.com/user-attachments/assets/27d3c325-1e88-4ab4-93c2-32d3ca65eecf" />

**Query result with JWT auth**
<img width="1075" height="484" alt="Screenshot 2026-07-01 at 1 34 58 PM" src="https://github.com/user-attachments/assets/477860f1-2ab3-407f-a331-324c43b63374" />

---

## Please check that:

- [x] Tests for this change have been added/updated.
- [x] Documentation has been added/updated (where applicable).

## Special notes for your reviewer
- **Availability:** JWT authentication is currently [ClickHouse Cloud only](https://clickhouse.com/docs/en/operations/external-authenticators/jwt) server-side. This is called out in the UI tooltip and the docs.
- **Refactor:** `Connect()` is split to extract `buildClickHouseOptions()` so option assembly and JWT/header resolution can be unit-tested in isolation. This accounts for most of the non-additive diff in `driver.go`.
- **No behavior change when the toggle is off** — existing username/password and header-forwarding paths are untouched.
