### PR TITLE
docs: add signed commits requirement to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,10 @@
 # Contributing to ClickHouse Datasource
 
+## Signed commits are required
+
+> [!IMPORTANT]
+> All commits must be [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (GPG, SSH, or S/MIME) to be merged into this repository. Pull requests with unsigned commits will need to be re-committed with signatures before they can be merged.
+
 Thank you for your interest in contributing to this repository. We are glad you want to help us to improve the project and join our community. Feel free to [browse the open issues](https://github.com/grafana/clickhouse-datasource/issues). If you want more straightforward tasks to complete, [we have some](https://github.com/grafana/clickhouse-datasource/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22). For more details about how you can help, please take a look at [Grafana’s Contributing Guide](https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md).
 
 ## Development setup


### PR DESCRIPTION
## Summary

- Adds a highly visible callout at the top of `CONTRIBUTING.md` stating that signed commits (GPG, SSH, or S/MIME) are required to merge into this repository, per the recent policy change
- Uses GitHub's `[!IMPORTANT]` alert syntax so it renders as a highlighted callout, and links to GitHub's signed-commits docs.

## Checks

- `prettier --check CONTRIBUTING.md` passes.
