### PR TITLE
fix(macros): preserve macros in queries with backslash-escaped string literals

### DIFF
--- a/pkg/macros/macros.go
+++ b/pkg/macros/macros.go
@@ -216,10 +216,19 @@ var ClickHouseMacros = macropro.MergeMacros(
 	},
 )
 
+// clickHouseComments is the comment/quote style macropro uses when stripping
+// comments before macro expansion. It keeps the standard -- and /* */
+// stripping (which protects against macros hidden inside comments) but adds
+// BackslashEscape so that ClickHouse's default C-style string escapes (e.g.
+// 'O\'Brien') are handled. Without it, macropro mis-reads a \' as the
+// closing quote, treats the trailing text as a comment, and silently drops any
+// macro that follows — corrupting the emitted SQL with no error.
+const clickHouseComments = macropro.LineComment | macropro.BlockComment | macropro.BackslashEscape
+
 // Interpolate expands all $__ macros in rawSQL using macropro's parsing engine.
 // Unknown macros are left unchanged; a handler error returns the original query and the error.
 func Interpolate(rawSQL string, q *sqlutil.Query) (string, error) {
-	return macropro.Interpolate(rawSQL, ClickHouseMacros, contextFrom(q))
+	return macropro.Interpolate(rawSQL, ClickHouseMacros, contextFrom(q), macropro.WithComments(clickHouseComments))
 }
 
 // RemoveQuotesInArgs removes all quotes from macro arguments.

--- a/pkg/macros/macros_test.go
+++ b/pkg/macros/macros_test.go
@@ -317,3 +317,53 @@ func TestInterpolate(t *testing.T) {
 		})
 	}
 }
+
+// TestInterpolateBackslashEscapedStringLiterals guards against macropro's
+// comment-stripping pass mis-terminating a ClickHouse string literal at a
+// backslash-escaped quote (\'), which would let a following -- or /* token be
+// treated as a comment and blank out any macro after it. ClickHouse enables
+// C-style backslash escapes in string literals by default, so \' is a valid,
+// common way to embed a quote and must not corrupt macro expansion.
+func TestInterpolateBackslashEscapedStringLiterals(t *testing.T) {
+	from, _ := time.Parse("2006-01-02T15:04:05.000Z", "2014-11-12T11:45:26.123Z")
+	to, _ := time.Parse("2006-01-02T15:04:05.000Z", "2015-11-12T11:45:26.456Z")
+
+	type test struct {
+		name   string
+		input  string
+		output string
+	}
+
+	tests := []test{
+		{
+			name:   "backslash-escaped quote with -- inside the literal keeps the trailing macro",
+			input:  `select * from foo where msg = 'it\'s -- fine' and $__fromTime`,
+			output: `select * from foo where msg = 'it\'s -- fine' and toDateTime(1415792726)`,
+		},
+		{
+			name:   "backslash-escaped quote with /* inside the literal keeps the trailing macro",
+			input:  `select * from foo where msg = 'a\'/*x' and $__toTime`,
+			output: `select * from foo where msg = 'a\'/*x' and toDateTime(1447328726)`,
+		},
+		{
+			name:   "doubled-quote escape is still preserved",
+			input:  `select * from foo where msg = 'it''s' and $__fromTime`,
+			output: `select * from foo where msg = 'it''s' and toDateTime(1415792726)`,
+		},
+	}
+
+	for i, tc := range tests {
+		t.Run(fmt.Sprintf("[%d/%d] %s", i+1, len(tests), tc.name), func(t *testing.T) {
+			query := &sqlutil.Query{
+				RawSQL: tc.input,
+				TimeRange: backend.TimeRange{
+					From: from,
+					To:   to,
+				},
+			}
+			interpolatedQuery, err := Interpolate(tc.input, query)
+			require.Nil(t, err)
+			assert.Equal(t, tc.output, interpolatedQuery)
+		})
+	}
+}


### PR DESCRIPTION
## Type of Change

- [x] 🐛 Bug Fix

---

## Bug Fix

### What is the bug?

`macropro` (the macro engine adopted in #1802) strips SQL comments **before** macro expansion using a string-literal scanner that only understands the SQL-standard doubled-quote (`''`) escape. ClickHouse enables C-style backslash escapes in string literals by default, so a literal such as `'O\'Brien'` is mis-parsed: the `\'` is read as the closing quote, the text after it is treated as being **outside** the string, and if a `--` or `/*` delimiter follows, the rest of the line/block is blanked — **silently dropping any `$__` macro that appears after it**.

`Interpolate` returns no error, so the corrupted SQL is sent straight to ClickHouse. The result is a truncated `WHERE` clause and a dropped time filter, which either fails at ClickHouse with a confusing parse error or (worse) returns unfiltered / wrong data. This is a regression from the pre-#1802 engine, which located macros with a regex + `ReplaceAll` and never touched string literals or comments.

### How to reproduce

1. Configure a ClickHouse data source (defaults; ClickHouse's default backslash-escape behaviour).
2. Run a query that embeds a quote via a backslash and also uses a time-filter macro, e.g.
   `SELECT * FROM t WHERE msg = 'it\'s -- fine' AND $__timeFilter(ts)`
3. **Before this fix:** the emitted SQL is `SELECT * FROM t WHERE msg = 'it\'s` followed by blanks — `$__timeFilter` is gone and the `WHERE` clause is truncated.
4. **After this fix:** the string literal is preserved and `$__timeFilter(ts)` expands correctly.

### Related Issues

Closes #

### Environment (if no related issue)

- **ClickHouse version**: any (default backslash-escape behaviour)
- **Grafana version**: 11.6+
- **Plugin version**: 4.18.0

---

## Please check that:

- [x] Tests for this change have been added/updated.
- [ ] Documentation has been added/updated (where applicable).

## Special notes for your reviewer

The fix enables `macropro`'s `BackslashEscape` comment/quote style alongside the existing `--` and `/* */` stripping (`WithComments(LineComment | BlockComment | BackslashEscape)`). The backslash-aware scanner (`scanStringLiteralBackslash`) handles **both** `\'` and `''` escapes, so all ClickHouse string-escape forms round-trip correctly while the comment-stripping protection (which guards against macros hidden inside comments) is fully preserved.

New regression test: `TestInterpolateBackslashEscapedStringLiterals` in `pkg/macros/macros_test.go` covers `\'`-before-`--`, `\'`-before-`/*`, and the `''` doubled-quote form. Verified the first two fail before the change and all pass after.

Closes #2032