### PR TITLE
fix(traces): recover OTel columns on schema-fetch failure and guard compact SQL switch

### DIFF
--- a/src/components/queryBuilder/views/traceQueryBuilderHooks.test.ts
+++ b/src/components/queryBuilder/views/traceQueryBuilderHooks.test.ts
@@ -186,9 +186,14 @@ describe('useOtelColumns', () => {
     expect(serviceTagsCol?.type).toBeUndefined();
   });
 
-  it('should defer dispatch until allColumns loads when OTel is toggled on', async () => {
-    // When OTel is toggled on with empty allColumns (schema still loading),
-    // no dispatch occurs. Once allColumns loads the Effect re-runs and dispatches once.
+  it('dispatches OTel columns immediately when toggled on even if the schema has not loaded', async () => {
+    // Regression guard: when the table schema cannot be fetched (permission
+    // denied, dropped/renamed table) allColumns stays [] indefinitely. The
+    // toggle must still apply the OTel column map so the query is not left
+    // without any column mappings — otherwise flipping OTel on is a no-op with
+    // no recovery path (every manual column selector is disabled while OTel is
+    // on). JSON detection is deferred to a later correction when/if the schema
+    // arrives.
     const builderOptionsDispatch = jest.fn();
 
     type Props = { enabled: boolean; cols: TableColumn[] };
@@ -197,13 +202,41 @@ describe('useOtelColumns', () => {
       { initialProps: { enabled: false, cols: [] as TableColumn[] } }
     );
 
-    // Toggle on but schema hasn't arrived yet
+    // Toggle on while the schema is still empty (loading or fetch failed).
     hook.rerender({ enabled: true, cols: [] });
-    expect(builderOptionsDispatch).toHaveBeenCalledTimes(0);
-
-    // Schema loads — single dispatch with correct tagsAreJSON
-    hook.rerender({ enabled: true, cols: makeAllColumns() });
     expect(builderOptionsDispatch).toHaveBeenCalledTimes(1);
+
+    const payload = builderOptionsDispatch.mock.calls[0][0].payload;
+    const dispatchedColumns: SelectedColumn[] = payload.columns;
+    expect(dispatchedColumns.find((c) => c.hint === ColumnHint.TraceId)).toBeDefined();
+    expect(payload.meta.tagsAreJSON).toBe(false);
+  });
+
+  it('stamps JSON via a correction once the schema loads after an empty toggle', async () => {
+    // After the immediate empty-schema dispatch, JSON type detection is still
+    // pending, so when the schema later arrives with JSON-typed tag columns a
+    // second dispatch corrects the column types.
+    const builderOptionsDispatch = jest.fn();
+    const tagsName = testOtelVersion.traceColumnMap.get(ColumnHint.TraceTags)!;
+    const serviceTagsName = testOtelVersion.traceColumnMap.get(ColumnHint.TraceServiceTags)!;
+
+    type Props = { enabled: boolean; cols: TableColumn[] };
+    const hook = renderHook(
+      ({ enabled, cols }: Props) => useOtelColumns(enabled, testOtelVersion.version, cols, builderOptionsDispatch),
+      { initialProps: { enabled: false, cols: [] as TableColumn[] } }
+    );
+
+    // Toggle on with an empty schema: immediate dispatch, no JSON types yet.
+    hook.rerender({ enabled: true, cols: [] });
+    expect(builderOptionsDispatch).toHaveBeenCalledTimes(1);
+
+    // Schema arrives with JSON-typed tags: a correction dispatch stamps JSON.
+    hook.rerender({ enabled: true, cols: makeAllColumns({ [tagsName]: 'JSON', [serviceTagsName]: 'JSON' }) });
+    expect(builderOptionsDispatch).toHaveBeenCalledTimes(2);
+
+    const correctedColumns: SelectedColumn[] = builderOptionsDispatch.mock.calls[1][0].payload.columns;
+    expect(correctedColumns.find((c) => c.hint === ColumnHint.TraceTags)?.type).toBe('JSON');
+    expect(correctedColumns.find((c) => c.hint === ColumnHint.TraceServiceTags)?.type).toBe('JSON');
   });
 
   it('should re-dispatch columns when otelVersion changes while OTel is enabled', async () => {

--- a/src/components/queryBuilder/views/traceQueryBuilderHooks.ts
+++ b/src/components/queryBuilder/views/traceQueryBuilderHooks.ts
@@ -99,9 +99,12 @@ function buildOtelColumns(
  * A single Effect handles both the "toggle on" path and the "saved query schema
  * correction" path to avoid a double-dispatch race window:
  *
- * - Fresh toggle: waits for allColumns to load so the first dispatch always
- *   carries the correct tagsAreJSON value. No transient Map-path SQL is sent
- *   to a JSON-typed table.
+ * - Fresh toggle: dispatches the OTel column map immediately. If allColumns is
+ *   already loaded the dispatch carries the correct tagsAreJSON value; if the
+ *   schema has not loaded (still loading, or the fetch failed — e.g. permission
+ *   denied / dropped table) the column map is still applied so the query is
+ *   never left without OTel columns, and JSON type detection is deferred to the
+ *   correction path once the schema arrives.
  * - Saved query: dispatches a correction only when allColumns loads and the
  *   schema is JSON-typed (Map schemas: no extra render).
  * - Version change: prevOtelVersion ref detects the change and resets flags so
@@ -134,12 +137,6 @@ export const useOtelColumns = (
       return;
     }
 
-    // Fresh toggle: wait for allColumns to load so the single dispatch is correct.
-    // Without a table the query can't run, so deferring is harmless.
-    if (!didSetColumns.current && allColumns.length === 0) {
-      return;
-    }
-
     // Both initial dispatch and JSON type detection are already done.
     if (didSetColumns.current && didDetectColumnTypes.current) {
       return;
@@ -163,7 +160,13 @@ export const useOtelColumns = (
       return;
     }
 
-    // Fresh toggle path: single dispatch with the correct tagsAreJSON from the start.
+    // Fresh toggle path: dispatch the OTel column map. When the schema is
+    // already loaded, tagsAreJSON is authoritative and JSON detection is done.
+    // When the schema has not loaded yet (still loading, or the fetch failed),
+    // we still apply the column map so the query is never left without OTel
+    // columns — but leave JSON detection pending so a later schema load can
+    // stamp type:'JSON' via the correction path above.
+    const schemaLoaded = allColumns.length > 0;
     builderOptionsDispatch(
       setOptions({
         columns,
@@ -177,7 +180,7 @@ export const useOtelColumns = (
       })
     );
     didSetColumns.current = true;
-    didDetectColumnTypes.current = true;
+    didDetectColumnTypes.current = schemaLoaded;
   }, [otelEnabled, otelVersion, allColumns, builderOptionsDispatch]);
 };
 

--- a/src/views/CHQueryEditor.test.tsx
+++ b/src/views/CHQueryEditor.test.tsx
@@ -214,6 +214,45 @@ describe('Query Editor', () => {
     );
   });
 
+  it('switches to compact view without crashing when the saved SQL query has no rawSql', () => {
+    // Provisioned / hand-authored / alert query models can carry
+    // { editorType: 'sql' } with no rawSql field; migrateCHQuery returns them
+    // unchanged (rawSql undefined). switchToBuilder must not dereference
+    // rawSql.trim() on undefined.
+    const datasource = newMockDatasource();
+    datasource.settings.jsonData.configMode = 'single-table';
+    datasource.settings.jsonData.signalType = 'logs';
+    datasource.settings.jsonData.logs = {
+      defaultDatabase: 'otel_v2',
+      defaultTable: 'otel_logs',
+      otelEnabled: true,
+      otelVersion: '1.29.0',
+    };
+    const onChange = jest.fn();
+
+    render(
+      <CHQueryEditor
+        query={{ pluginVersion: '', refId: 'A', editorType: EditorType.SQL } as any}
+        onChange={onChange}
+        onRunQuery={jest.fn()}
+        datasource={datasource}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Switch to compact view' }));
+
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        editorType: EditorType.Builder,
+        builderOptions: expect.objectContaining({
+          database: 'otel_v2',
+          table: 'otel_logs',
+          queryType: QueryType.Logs,
+        }),
+      })
+    );
+  });
+
   it('confirms before replacing hand-written SQL with compact defaults', async () => {
     const datasource = newMockDatasource();
     datasource.settings.jsonData.configMode = 'single-table';

--- a/src/views/CHQueryEditor.tsx
+++ b/src/views/CHQueryEditor.tsx
@@ -233,7 +233,11 @@ const CompactSqlMode = (props: CHQueryEditorProps) => {
 
     const builderOptions = buildCompactQueryDefaults(datasource, signalType);
     const compactSql = generateSql(builderOptions);
-    if (!confirmed && query.rawSql.trim() && query.rawSql.trim() !== compactSql.trim()) {
+    // rawSql may be undefined for provisioned / hand-authored / alert query
+    // models that carry only { editorType: 'sql' }; migrateCHQuery leaves those
+    // unchanged, so guard before calling .trim().
+    const currentSql = (query.rawSql ?? '').trim();
+    if (!confirmed && currentSql && currentSql !== compactSql.trim()) {
       setConfirmSwitchOpen(true);
       return;
     }


### PR DESCRIPTION
## Type of Change

- [x] 🐛 Bug Fix

---

## Bug Fix

This PR fixes two edge-case bugs in the single-table **trace** / **compact** query paths (both landed with `#1841`/single-table work since v4.17.0).

### Bug 1 — OTel column mapping is dropped when the table schema can't be fetched

**What is the bug?** `useOtelColumns`' fresh-toggle path defers dispatching the OTel column map until the table schema (`allColumns`) loads. `useColumns` swallows fetch errors and returns `[]` with no retry, so when the schema can't be introspected — permission denied on `DESC/DESC TABLE`, or a dropped/renamed/mistyped table — flipping the OTel toggle on becomes a **permanent no-op**: no `TraceId`/`SpanName`/etc. column mapping is applied. Because every manual column selector is disabled while OTel is on, the user has **no recovery path** and the query can't run. This is a regression from v4.17.0, which applied the static OTel column map immediately.

**How to reproduce**
1. Configure a Traces query (OTel off) whose ClickHouse user cannot `DESC` the table (revoke `SELECT`, or point at a not-yet-created table).
2. Flip the **OTel** toggle on.
3. **Before:** no OTel columns are applied and the query is unrunnable, with no way to fix it in the UI.
4. **After:** the OTel column map is applied immediately; if the schema later loads and reports JSON-typed tag columns, a correction dispatch stamps `type:'JSON'`.

### Bug 2 — "Switch to compact view" crashes on a SQL query with no `rawSql`

**What is the bug?** `CompactSqlMode.switchToBuilder` calls `query.rawSql.trim()` without guarding for `undefined`. Provisioned dashboards, alert/recorded-query definitions, or hand-authored panel JSON can carry `{ editorType: 'sql' }` with **no** `rawSql` field; `migrateCHQuery` returns those unchanged, so clicking **Switch to compact view** throws `Cannot read properties of undefined (reading 'trim')` and the editor crashes.

**How to reproduce**
1. On a single-table datasource, provision/hand-author a query model `{ refId: 'A', editorType: 'sql' }` with no `rawSql`.
2. Open the panel and click **Switch to compact view** without editing the SQL first.
3. **Before:** the editor throws. **After:** it switches to the compact builder normally.

### Related Issues

Closes #

### Environment (if no related issue)

- **ClickHouse version**: any
- **Grafana version**: 11.6+
- **Plugin version**: 4.18.0

---

## Please check that:

- [x] Tests for this change have been added/updated.
- [ ] Documentation has been added/updated (where applicable).

## Special notes for your reviewer

- Bug 1 changes the deliberate "defer until schema loads to avoid transient Map-path SQL" behaviour. The trade-off: on a healthy schema there may now be a one-render window where columns carry Map types before the JSON correction dispatches — but the query isn't executed on toggle (the user hasn't run it yet), and the correction lands before the next run. The upside is that a failed/slow schema fetch no longer permanently breaks the query. The existing `useOtelColumns` "defer dispatch" test was rewritten to encode the new contract, and a recovery test (empty schema → later JSON load → correction) was added.
- **Scope note:** the audit that surfaced these also flagged a suspected "compact trace mode emits `mapKeys()` against JSON columns" bug. On investigation that does **not** reproduce — the compact trace editor renders a trace *search* query (`generateTraceSearchQuery`), which emits no tag columns at all, and trace-ID drill-down queries are already JSON-stamped by `transformQueryResponseWithTraceAndLogLinks`. No change was made for it.

Closes #2031