### PR TITLE
fix(adhoc): stop map-key filters colliding across columns; bound free-form Map-key probe

### DIFF
--- a/src/data/CHDatasource.test.ts
+++ b/src/data/CHDatasource.test.ts
@@ -866,7 +866,12 @@ describe('ClickHouseDatasource', () => {
   });
 
   describe('fetchUniqueMapKeys probe (#1843)', () => {
-    it('issues the bare LIMIT probe for free-form tables (no time column known)', async () => {
+    it('bounds the probe to a row-sampled subquery for free-form tables (no time column known)', async () => {
+      // Without a known time column the probe can't prune by partition, so it
+      // reads the map column from a bounded row sample. A bare LIMIT 1000 on
+      // DISTINCT + arrayJoin does NOT bound the scan when the map has fewer than
+      // 1000 distinct keys (the common case) — DISTINCT must read every row
+      // before LIMIT applies, i.e. a full-column scan on huge tables (#5).
       const ds = cloneDeep(mockDatasource);
       const frame = arrayToDataFrame([{ keys: 'a' }, { keys: 'b' }]);
       const spy = jest.spyOn(ds, 'query').mockImplementation(() => of({ data: [frame] }));
@@ -874,7 +879,9 @@ describe('ClickHouseDatasource', () => {
       const result = await ds.fetchUniqueMapKeys('labels', 'db', 'events');
       expect(result).toEqual(['a', 'b']);
       const sql = spy.mock.calls[0][0].targets[0].rawSql!;
-      expect(sql).toBe('SELECT DISTINCT arrayJoin("labels".keys) as keys FROM "db"."events" LIMIT 1000');
+      expect(sql).toBe(
+        'SELECT DISTINCT arrayJoin("labels".keys) as keys FROM (SELECT "labels" FROM "db"."events" LIMIT 100000) LIMIT 1000'
+      );
     });
 
     it('bounds the probe to the configured logs time column when target matches OTel logs table', async () => {
@@ -2596,6 +2603,45 @@ describe('ClickHouseDatasource', () => {
 
       expect(
         datasource.queryHasFilter(queryWithMap, { key: 'ResourceAttributes.service.name', value: 'my-service' })
+      ).toBe(true);
+    });
+
+    it('does not match a map-key filter stored against a different attribute column with the same key', () => {
+      // Two attribute columns share the map key "service.name". A filter stored
+      // against LogAttributes must NOT be reported as present for the sibling
+      // ResourceAttributes.service.name row, otherwise the Log Details "filter
+      // for" button lights up on the wrong column and toggling it drops the
+      // LogAttributes filter.
+      const queryWithTwoMaps: CHBuilderQuery = {
+        ...query,
+        builderOptions: {
+          ...query.builderOptions,
+          columns: [
+            { name: 'ResourceAttributes', hint: ColumnHint.ResourceAttributes, type: 'Map(String, String)' },
+            { name: 'LogAttributes', hint: ColumnHint.LogAttributes, type: 'Map(String, String)' },
+          ],
+          filters: [
+            {
+              condition: 'AND',
+              key: '',
+              hint: ColumnHint.LogAttributes,
+              mapKey: 'service.name',
+              type: 'Map(String, String)',
+              filterType: 'custom',
+              operator: FilterOperator.Equals,
+              value: 'my-service',
+            },
+          ],
+        },
+      };
+
+      // Sibling column with the same key/value: must be reported as NOT filtered.
+      expect(
+        datasource.queryHasFilter(queryWithTwoMaps, { key: 'ResourceAttributes.service.name', value: 'my-service' })
+      ).toBe(false);
+      // The column the filter is actually stored against still matches.
+      expect(
+        datasource.queryHasFilter(queryWithTwoMaps, { key: 'LogAttributes.service.name', value: 'my-service' })
       ).toBe(true);
     });
 

--- a/src/data/CHDatasource.ts
+++ b/src/data/CHDatasource.ts
@@ -85,6 +85,10 @@ const legacyAttributeColumns = new Set(['ResourceAttributes', 'ScopeAttributes',
 // companion actually exposes all of them.
 const TRACE_TIMESTAMP_TABLE_REQUIRED_COLUMNS = ['Start', 'End', 'TraceId'];
 
+// Row cap for the Map-key discovery probe on free-form tables (no known time
+// column to prune by). Bounds the scan to a sample instead of the whole column.
+const MAP_KEY_PROBE_ROW_SAMPLE = 100000;
+
 function getAttributeColumnByDisplayPrefix(
   builderOptions: QueryBuilderOptions,
   columnPrefix: string
@@ -155,13 +159,17 @@ function buildFilter(resolved: ResolvedColumn, operator: StringFilter['operator'
 
 /** Check whether a filter targets the same column as a resolved column reference. */
 function filterMatchesColumn(f: Filter, resolved: ResolvedColumn): boolean {
+  // Compare the owning column the same way in both branches: by hint when both
+  // sides carry one, otherwise by key/name. Without this, a map-key filter
+  // matches on key + type family alone, so a filter stored against one
+  // attribute column (e.g. LogAttributes) collides with a different attribute
+  // column that happens to share the same map key (e.g. ResourceAttributes).
+  const sameColumn =
+    resolved.column?.hint && f.hint ? f.hint === resolved.column.hint : f.key === resolved.columnName;
   if (resolved.hasMapKey) {
-    return (f.type.startsWith('Map') || f.type.startsWith('JSON')) && f.mapKey === resolved.mapKey;
+    return (f.type.startsWith('Map') || f.type.startsWith('JSON')) && f.mapKey === resolved.mapKey && sameColumn;
   }
-  return (
-    f.type === 'string' &&
-    (resolved.column?.hint && f.hint ? f.hint === resolved.column.hint : f.key === resolved.columnName)
-  );
+  return f.type === 'string' && sameColumn;
 }
 
 export class Datasource
@@ -1098,16 +1106,24 @@ export class Datasource
    * When the target matches the configured OTel logs/traces table, the probe
    * is bounded to the last 6 hours via the known time column — on a
    * partitioned-by-day MergeTree this prunes to a handful of parts and avoids
-   * full-column scans (see #1843). For free-form tables the predicate is
-   * omitted because the plugin doesn't know which column is the time column.
+   * full-column scans (see #1843). For free-form tables the time column is
+   * unknown, so the probe instead reads the map column from a bounded row
+   * sample: a bare `LIMIT 1000` does NOT bound `DISTINCT arrayJoin(...)` when
+   * the map has fewer than 1000 distinct keys (the common case for labels),
+   * because DISTINCT must read every row before the limit applies — a
+   * full-column scan on very large tables.
    */
   async fetchUniqueMapKeys(mapColumn: string, db: string, table: string): Promise<string[]> {
     if (!this.isMapKeysDiscoveryEnabled()) {
       return [];
     }
+    const escapedColumn = escapeIdentifier(mapColumn);
+    const tableIdentifier = `${escapeIdentifier(db)}.${escapeIdentifier(table)}`;
     const timeColumn = this.getMapKeyProbeTimeColumn(db, table);
-    const whereClause = timeColumn ? ` WHERE ${escapeIdentifier(timeColumn)} >= now() - INTERVAL 6 HOUR` : '';
-    const rawSql = `SELECT DISTINCT arrayJoin(${escapeIdentifier(mapColumn)}.keys) as keys FROM ${escapeIdentifier(db)}.${escapeIdentifier(table)}${whereClause} LIMIT 1000`;
+    const source = timeColumn
+      ? `${tableIdentifier} WHERE ${escapeIdentifier(timeColumn)} >= now() - INTERVAL 6 HOUR`
+      : `(SELECT ${escapedColumn} FROM ${tableIdentifier} LIMIT ${MAP_KEY_PROBE_ROW_SAMPLE})`;
+    const rawSql = `SELECT DISTINCT arrayJoin(${escapedColumn}.keys) as keys FROM ${source} LIMIT 1000`;
     return this.fetchData(rawSql);
   }
 


### PR DESCRIPTION
## Type of Change

- [x] 🐛 Bug Fix

---

## Bug Fix

Two fixes in the ad-hoc / toggleable-filter path (`src/data/CHDatasource.ts`).

### Bug 1 — map-key filters collide across attribute columns that share a key

**What is the bug?** `filterMatchesColumn`'s map-key branch matched purely on the filter's **type family** (`Map*`/`JSON`) and its `mapKey`, ignoring which column the filter targets — unlike the non-map branch, which compares hint/key. With two OTel attribute columns selected (e.g. `ResourceAttributes` and `LogAttributes`) that share a key such as `service.name`, a filter stored against one column was treated as matching the other:

- `queryHasFilter` lights the Log Details **"Filter for value"** button on the *wrong* attribute row.
- `toggleQueryFilter` / `modifyQuery` find the sibling filter via the same predicate and **remove/replace it**, silently dropping the user's filter and querying the wrong column.

**How to reproduce**
1. OTel logs query selecting both `ResourceAttributes` and `LogAttributes` (both `Map`), where a returned row carries the same key in both maps.
2. Click **Filter for value** on `LogAttributes.<key>`.
3. **Before:** the `ResourceAttributes.<key>` row shows as already-filtered; toggling it drops the `LogAttributes` filter. **After:** each column's filter state is independent.

### Bug 2 — unbounded Map-key discovery probe on free-form tables (perf)

**What is the bug?** `fetchUniqueMapKeys` bounds the probe to a 6-hour window only when `(db, table)` matches the configured OTel logs/traces table. For any other table (e.g. the documented single-table adhoc pattern pointing at `db.big_table` with a `labels Map(...)` column), the bare `LIMIT 1000` does **not** bound `SELECT DISTINCT arrayJoin(col.keys)` — because the map typically has fewer than 1000 distinct keys, `DISTINCT` must read **every row** before the limit can apply, i.e. a **full-column scan** of a multi-billion-row table each time ad-hoc filter keys are populated. This scan did not exist in v4.17.0.

**How to reproduce**
1. Set the adhoc source to `db.big_table` (not the configured OTel logs/traces table) where the table has a `Map` column; leave `enableMapKeysDiscovery` at its default (on).
2. Open a dashboard with ad-hoc filters.
3. **Before:** `SELECT DISTINCT arrayJoin(labels.keys) ... LIMIT 1000` full-scans the `labels` column. **After:** the probe reads the map column from a bounded row sample (`FROM (SELECT labels FROM db.big_table LIMIT 100000)`), capping the rows scanned.

### Related Issues

Closes #

### Environment (if no related issue)

- **ClickHouse version**: any (Map columns; adhoc filters require CH ≥ 22.7)
- **Grafana version**: 11.6+
- **Plugin version**: 4.18.0

---

## Please check that:

- [x] Tests for this change have been added/updated.
- [ ] Documentation has been added/updated (where applicable).

## Special notes for your reviewer

- Bug 2 keeps the existing OTel-table 6h-window behaviour unchanged (it already prunes MergeTree parts); only the free-form path gains a bound. The row sample (`100000`) trades exhaustive key discovery for a bounded scan — consistent with the probe's documented "samples rows … may not include ALL keys" contract, and users can still type a key manually. Happy to tune the constant.
- The existing free-form probe test was updated to assert the bounded form; all other `fetchUniqueMapKeys` and filter tests are unchanged and green.

Closes #2030