### PR TITLE
fix(traces): only apply the trace-ID timestamp optimization when the companion has Start/End/TraceId columns

### DIFF
--- a/src/data/CHDatasource.test.ts
+++ b/src/data/CHDatasource.test.ts
@@ -19,6 +19,7 @@ import {
   OrderByDirection,
   QueryBuilderOptions,
   QueryType,
+  TableColumn,
 } from 'types/queryBuilder';
 import { CHBuilderQuery, CHQuery, CHSqlQuery, EditorType } from 'types/sql';
 import { AdHocFilter } from './adHocFilter';
@@ -2266,6 +2267,14 @@ describe('ClickHouseDatasource', () => {
     });
   });
 
+  // Companion `<table>_trace_id_ts` columns the trace-ID optimization requires.
+  const timestampColumns = () =>
+    [
+      { name: 'TraceId', type: 'String', label: 'TraceId', picklistValues: [] },
+      { name: 'Start', type: 'DateTime64(9)', label: 'Start', picklistValues: [] },
+      { name: 'End', type: 'DateTime64(9)', label: 'End', picklistValues: [] },
+    ] as TableColumn[];
+
   describe('hasTraceTimestampTable', () => {
     it('resolves false when database or table is empty', async () => {
       const ds = cloneDeep(mockDatasource);
@@ -2273,9 +2282,10 @@ describe('ClickHouseDatasource', () => {
       await expect(ds.hasTraceTimestampTable('otel', '')).resolves.toBe(false);
     });
 
-    it('resolves true when the companion table exists', async () => {
+    it('resolves true when the companion table exists with Start/End/TraceId columns', async () => {
       const ds = cloneDeep(mockDatasource);
       jest.spyOn(ds, 'fetchTables').mockResolvedValue(['otel_traces', 'otel_traces_trace_id_ts']);
+      jest.spyOn(ds, 'fetchColumns').mockResolvedValue(timestampColumns());
 
       await expect(ds.hasTraceTimestampTable('otel', 'otel_traces')).resolves.toBe(true);
     });
@@ -2285,6 +2295,23 @@ describe('ClickHouseDatasource', () => {
       jest.spyOn(ds, 'fetchTables').mockResolvedValue(['otel_traces']);
 
       await expect(ds.hasTraceTimestampTable('otel', 'otel_traces')).resolves.toBe(false);
+    });
+
+    it('resolves false when the companion exists but lacks the Start/End/TraceId columns (#6)', async () => {
+      // A non-OTel table can have a companion matching the default suffix whose
+      // columns are named differently (e.g. trace_id/start_time/end_time). The
+      // optimization's WITH clause hardcodes min(Start)/max(End)/TraceId, so
+      // enabling it there produces UNKNOWN_IDENTIFIER instead of loading the
+      // trace. The gate must reject a companion that lacks those columns.
+      const ds = cloneDeep(mockDatasource);
+      jest.spyOn(ds, 'fetchTables').mockResolvedValue(['custom_traces', 'custom_traces_trace_id_ts']);
+      jest.spyOn(ds, 'fetchColumns').mockResolvedValue([
+        { name: 'trace_id', type: 'String', label: 'trace_id', picklistValues: [] },
+        { name: 'start_time', type: 'DateTime64(9)', label: 'start_time', picklistValues: [] },
+        { name: 'end_time', type: 'DateTime64(9)', label: 'end_time', picklistValues: [] },
+      ] as TableColumn[]);
+
+      await expect(ds.hasTraceTimestampTable('default', 'custom_traces')).resolves.toBe(false);
     });
 
     it('does not call fetchTables again once a result is cached', async () => {
@@ -2300,6 +2327,7 @@ describe('ClickHouseDatasource', () => {
     it('dedupes concurrent calls to a single fetchTables', async () => {
       const ds = cloneDeep(mockDatasource);
       const fetchSpy = jest.spyOn(ds, 'fetchTables').mockResolvedValue(['otel_traces', 'otel_traces_trace_id_ts']);
+      jest.spyOn(ds, 'fetchColumns').mockResolvedValue(timestampColumns());
 
       const [a, b] = await Promise.all([
         ds.hasTraceTimestampTable('otel', 'otel_traces'),
@@ -2317,6 +2345,7 @@ describe('ClickHouseDatasource', () => {
         .spyOn(ds, 'fetchTables')
         .mockRejectedValueOnce(new Error('connection refused'))
         .mockResolvedValueOnce(['otel_traces', 'otel_traces_trace_id_ts']);
+      jest.spyOn(ds, 'fetchColumns').mockResolvedValue(timestampColumns());
 
       await expect(ds.hasTraceTimestampTable('otel', 'otel_traces')).resolves.toBe(false);
       await expect(ds.hasTraceTimestampTable('otel', 'otel_traces')).resolves.toBe(true);
@@ -2349,6 +2378,7 @@ describe('ClickHouseDatasource', () => {
         },
       };
       jest.spyOn(ds, 'fetchTables').mockResolvedValue(['traces', 'traces_idx_ts']);
+      jest.spyOn(ds, 'fetchColumns').mockResolvedValue(timestampColumns());
 
       await expect(ds.hasTraceTimestampTable('default', 'traces')).resolves.toBe(true);
     });
@@ -2378,6 +2408,7 @@ describe('ClickHouseDatasource', () => {
     it('returns true once the check resolves true', async () => {
       const ds = cloneDeep(mockDatasource);
       jest.spyOn(ds, 'fetchTables').mockResolvedValue(['otel_traces', 'otel_traces_trace_id_ts']);
+      jest.spyOn(ds, 'fetchColumns').mockResolvedValue(timestampColumns());
 
       await ds.hasTraceTimestampTable('otel', 'otel_traces');
       expect(ds.peekTraceTimestampTable('otel', 'otel_traces')).toBe(true);
@@ -2394,6 +2425,7 @@ describe('ClickHouseDatasource', () => {
     it('returns undefined once the TTL has expired', async () => {
       const ds = cloneDeep(mockDatasource);
       jest.spyOn(ds, 'fetchTables').mockResolvedValue(['otel_traces', 'otel_traces_trace_id_ts']);
+      jest.spyOn(ds, 'fetchColumns').mockResolvedValue(timestampColumns());
       const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(0);
 
       await ds.hasTraceTimestampTable('otel', 'otel_traces');

--- a/src/data/CHDatasource.ts
+++ b/src/data/CHDatasource.ts
@@ -80,6 +80,11 @@ const attributeColumnHints = new Set([
 ]);
 const legacyAttributeColumns = new Set(['ResourceAttributes', 'ScopeAttributes', 'LogAttributes']);
 
+// Columns the trace-ID optimization's WITH clause reads from the
+// `<table><suffix>` companion table. The optimization is only safe when the
+// companion actually exposes all of them.
+const TRACE_TIMESTAMP_TABLE_REQUIRED_COLUMNS = ['Start', 'End', 'TraceId'];
+
 function getAttributeColumnByDisplayPrefix(
   builderOptions: QueryBuilderOptions,
   columnPrefix: string
@@ -948,10 +953,16 @@ export class Datasource
   }
 
   /**
-   * Resolves whether the `<table>_trace_id_ts` companion exists for the given
-   * (database, table). Caches the Promise so concurrent and repeat callers share
-   * a single `SHOW TABLES` round-trip; on failure, evicts so the next caller
-   * retries and meanwhile returns `false` (the safe, unoptimized path).
+   * Resolves whether the `<table>_trace_id_ts` companion is usable for the
+   * trace-ID lookup optimization: it must exist AND expose the Start/End/TraceId
+   * columns that the generated WITH clause hardcodes. A companion that merely
+   * matches the suffix but has differently named columns (e.g. a non-OTel schema
+   * with trace_id/start_time/end_time) would produce an UNKNOWN_IDENTIFIER error,
+   * so it is rejected here and the query falls back to the plain filter.
+   *
+   * Caches the Promise so concurrent and repeat callers share a single
+   * round-trip; on failure, evicts so the next caller retries and meanwhile
+   * returns `false` (the safe, unoptimized path).
    */
   async hasTraceTimestampTable(database: string, table: string): Promise<boolean> {
     if (!database || !table) {
@@ -966,8 +977,14 @@ export class Datasource
     if (!entry || entry.expiresAt <= now) {
       const pending = (async () => {
         try {
+          const companionTable = table + this.getTraceTimestampTableSuffix();
           const tables = await this.fetchTables(database);
-          return tables.includes(table + this.getTraceTimestampTableSuffix());
+          if (!tables.includes(companionTable)) {
+            return false;
+          }
+          const columns = await this.fetchColumns(database, companionTable);
+          const columnNames = new Set(columns.map((c) => c.name));
+          return TRACE_TIMESTAMP_TABLE_REQUIRED_COLUMNS.every((c) => columnNames.has(c));
         } catch {
           this.traceTimestampTableCache.delete(key);
           return false;


### PR DESCRIPTION
## Type of Change

- [x] 🐛 Bug Fix

---

## Bug Fix

### What is the bug?

Since the trace-ID timestamp optimization was decoupled from OTel mode (#1786), it fires for **any** trace-ID query whose `<table><suffix>` companion table exists. `datasource.hasTraceTimestampTable()` only checks **existence** (`SHOW TABLES`), but the generated `WITH` clause hardcodes the companion's schema:

```sql
WITH '<id>' as trace_id,
  (SELECT min(Start) FROM db."<table>_trace_id_ts" WHERE TraceId = trace_id) as trace_start,
  (SELECT max(End) + 1 FROM db."<table>_trace_id_ts" WHERE TraceId = trace_id) as trace_end
SELECT ... WHERE traceID = trace_id AND "<time>" >= trace_start AND "<time>" <= trace_end
```

A non-OTel schema can have a companion table matching the default `_trace_id_ts` suffix (or a user-configured `traceTimestampTableSuffix`) whose columns are named differently — e.g. `trace_id` / `start_time` / `end_time`. The optimization then emits `min(Start)` / `max(End)` / `TraceId` against a table that has no such columns, so ClickHouse rejects it with **`UNKNOWN_IDENTIFIER`** and the trace never loads. Before #1786, the OTel gate meant the optimization didn't fire for these queries and the plain `traceID = '<id>'` lookup succeeded.

### How to reproduce

1. Non-OTel traces datasource (`otelEnabled: false`), e.g. table `default.custom_traces`.
2. A companion table `default.custom_traces_trace_id_ts` exists (default suffix) whose columns are named `trace_id`, `start_time`, `end_time` (not `TraceId`/`Start`/`End`).
3. Follow a trace-ID data link (or run a trace-ID lookup).
4. **Before:** the generated `WITH` clause references `Start`/`End`/`TraceId` → ClickHouse `UNKNOWN_IDENTIFIER` → trace fails to load. **After:** the optimization is skipped and the plain `traceID = '<id>'` query runs.

### Related Issues

Closes #

### Environment (if no related issue)

- **ClickHouse version**: any
- **Grafana version**: 11.6+
- **Plugin version**: 4.18.0

---

## Please check that:

- [x] Tests for this change have been added/updated.
- [ ] Documentation has been added/updated (where applicable).

## Special notes for your reviewer

The fix keeps the #1786 non-OTel optimization working for companions that **do** expose `Start`/`End`/`TraceId` (the OTel-exporter `_trace_id_ts` shape). `hasTraceTimestampTable` now additionally fetches the companion's columns and only returns `true` when all three are present; the result is cached alongside the existence check (same TTL / dedupe). Existing `hasTraceTimestampTable` / `peekTraceTimestampTable` tests were updated to mock `fetchColumns`, and a new test covers the "companion exists but columns don't match" case. Full frontend suite (950 tests) passes.

Closes #2029