### PR TITLE
fix(config): restore inline required-field validation for host/port on default installs

### DIFF
--- a/src/views/CHConfigEditor.test.tsx
+++ b/src/views/CHConfigEditor.test.tsx
@@ -3,7 +3,7 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { ConfigEditor } from './CHConfigEditor';
 import { mockConfigEditorProps } from '__mocks__/ConfigEditor';
 import '@testing-library/jest-dom';
-import { Protocol } from 'types/config';
+import { CHConfig, Protocol } from 'types/config';
 import allLabels from 'labels';
 
 jest.mock('@grafana/runtime', () => {
@@ -130,6 +130,19 @@ describe('ConfigEditor', () => {
     expect(screen.getByDisplayValue(jsonDataOverrides.customSettings[0].value)).toBeInTheDocument();
     expect(screen.getByText(labels.enableRowLimit.label)).toBeInTheDocument();
     expect(screen.getByTestId(labels.enableRowLimit.testid)).toBeChecked();
+  });
+
+  it('shows the required-field error on an empty host when config validation is not enabled', () => {
+    // On a default install the clickHouseConfigValidation feature toggle is off,
+    // so `validation` is undefined. The required host field must still show an
+    // inline error when empty (structural fallback), as it did in v4.17.0.
+    render(<ConfigEditor {...mockConfigEditorProps({ host: '' } as Partial<CHConfig>)} />);
+    expect(screen.getByText(labels.serverAddress.error)).toBeInTheDocument();
+  });
+
+  it('hides the required-field error once the host is filled (no validation toggle)', () => {
+    render(<ConfigEditor {...mockConfigEditorProps({ host: 'localhost' } as Partial<CHConfig>)} />);
+    expect(screen.queryByText(labels.serverAddress.error)).not.toBeInTheDocument();
   });
 
   it('renders single-table logs configuration', () => {

--- a/src/views/CHConfigEditor.tsx
+++ b/src/views/CHConfigEditor.tsx
@@ -96,6 +96,16 @@ export const ConfigEditor: React.FC<ConfigEditorProps> = (props) => {
 
   const fieldErrors = validation?.getErrors() ?? {};
 
+  // When the clickHouseConfigValidation feature toggle is off (the default),
+  // `validation` is undefined and `fieldErrors` is always empty — which dropped
+  // the inline required-field indicator that shipped in v4.17.0. Fall back to a
+  // structural empty check so the required host/port fields still surface an
+  // inline error on the default install, before Save & Test round-trips.
+  const hostInvalid = validation ? Boolean(fieldErrors.host) : !jsonData.host;
+  const hostError = validation ? fieldErrors.host : jsonData.host ? undefined : labels.serverAddress.error;
+  const portInvalid = validation ? Boolean(fieldErrors.port) : !jsonData.port;
+  const portError = validation ? fieldErrors.port : jsonData.port ? undefined : labels.serverPort.error;
+
   const onPortChange = (port: string) => {
     onOptionsChange({
       ...options,
@@ -294,8 +304,8 @@ export const ConfigEditor: React.FC<ConfigEditorProps> = (props) => {
           required
           label={labels.serverAddress.label}
           description={labels.serverAddress.tooltip}
-          invalid={!!fieldErrors.host}
-          error={fieldErrors.host}
+          invalid={hostInvalid}
+          error={hostError}
         >
           <Input
             name="host"
@@ -312,8 +322,8 @@ export const ConfigEditor: React.FC<ConfigEditorProps> = (props) => {
           required
           label={labels.serverPort.label}
           description={portDescription}
-          invalid={!!fieldErrors.port}
-          error={fieldErrors.port}
+          invalid={portInvalid}
+          error={portError}
         >
           <Input
             name="port"


### PR DESCRIPTION
## Type of Change

- [x] 🐛 Bug Fix

---

## Bug Fix

### What is the bug?

Adding config validation (#1769) changed the required Server address / Port `Field`s from a structural check to feature-toggle-gated `fieldErrors`:

```diff
- invalid={!jsonData.host}   error={labels.serverAddress.error}
+ invalid={!!fieldErrors.host}   error={fieldErrors.host}
```

`fieldErrors` comes from `validation?.getErrors()`, and `validation` is only defined when the **Grafana-core** `clickHouseConfigValidation` feature toggle is enabled. That toggle is not shipped or defaulted-on by this plugin, so on the **default install** (across Grafana 11.6–12.x) `validation` is `undefined`, `fieldErrors` is always `{}`, and the inline "required" indicator for an empty Server address / Port — present in v4.17.0 — no longer appears. The field looks valid until the backend **Save & Test** round-trip fails with a less specific error. (CI/e2e didn't catch this because the dev/e2e environment force-enables the toggle.)

This is a UX regression only — the field still functions and Save & Test still blocks a broken config — but it removes the immediate inline feedback users had before.

### How to reproduce

1. Default Grafana install (no `clickHouseConfigValidation` feature toggle).
2. Open the ClickHouse datasource config, leave **Server address** (or **Port**) empty.
3. **Before:** no inline required error (only the static `*`). **After:** the field shows the inline "Server address required" / "Port is required" error immediately, as in v4.17.0.

### Related Issues

Closes #

### Environment (if no related issue)

- **ClickHouse version**: n/a (config UI)
- **Grafana version**: 11.6–12.x default install (no `clickHouseConfigValidation` toggle)
- **Plugin version**: 4.18.0

---

## Please check that:

- [x] Tests for this change have been added/updated.
- [ ] Documentation has been added/updated (where applicable).

## Special notes for your reviewer

The fix falls back to the structural empty check (`!jsonData.host` / `!jsonData.port`) only when `validation` is unavailable; when the toggle **is** on, `fieldErrors` remains authoritative and behaviour is unchanged. Two tests were added (empty host shows the error; filled host hides it) — these run with the toggle off, which is the default in the test env.

Closes #2028