### PR TITLE
chore(renovate): group all non-major updates into a single PR

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -63,6 +63,13 @@
       "matchDepTypes": ["devDependencies"],
       "automerge": true,
       "labels": ["automerge-minor"]
+    },
+    {
+      "description": "Batch all non-major updates (minor, patch, pin, digest) into a single PR to reduce rebase/merge churn; major updates stay in separate PRs for individual review",
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "matchPackageNames": ["*"],
+      "groupName": "all non-major dependencies",
+      "groupSlug": "all-non-major"
     }
   ]
 }


### PR DESCRIPTION
## Type of Change

- [ ] 🚀 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [x] 🧹 Refactor / Chore

---

## What this changes

Adds a single catch-all `packageRule` to `.github/renovate.json` that batches **all non-major updates** (`minor`, `patch`, `pin`, `digest`) across every manager (`gomod`, `npm`, `github-actions`) into **one grouped PR** — `all non-major dependencies` — instead of one PR per dependency.

```json
{
  "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
  "matchPackageNames": ["*"],
  "groupName": "all non-major dependencies",
  "groupSlug": "all-non-major"
}
```

## Why

The default one-PR-per-dependency behaviour interacts badly with the repo's branch protection, which requires branches to be **up to date** before merging (`strict_required_status_checks_policy`). With ~60 open Renovate PRs, every merge to `main` puts all the others behind, forcing a serial *rebase → CI → merge* cycle per PR. Grouping non-major updates collapses that churn into a single rebase/CI/merge.

**Major updates are intentionally left as separate PRs** so potentially breaking bumps stay individually reviewable and one bad major can't block the whole batch. Existing rules (Grafana/React/rxjs sync pins, the 3-day devDependency soak, monorepo grouping from the shared presets) are unchanged.

## Rollout note

On its next run, Renovate will supersede the current individual non-major PRs with the grouped branch. With `platformAutomerge` already enabled, the grouped PR still requires human review to merge (it mixes production and dev dependencies, so the automerge-minor-devDep rule won't apply to the whole group).

---

## Please check that:

- [x] Tests for this change have been added/updated. — N/A (Renovate config only; not covered by the plugin test suite)
- [x] Documentation has been added/updated (where applicable). — N/A

## Special notes for your reviewer

- No product code changes; this only affects how Renovate batches dependency PRs.
- If per-ecosystem PRs (one for Go, one for npm, one for Actions) are preferred over a single combined PR, that's a small tweak — happy to adjust.
