### PR TITLE
Release 4.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## 4.19.0
+
+### Features
+
+- Compact query mode for single-table data sources (#1841)
+- Pre-built OpenTelemetry dashboards for logs, traces, and per-service deep dives (#1869)
+- Guided variable editor with column values and Map-key support (#1868)
+- Preset-driven annotation editor with change detection (#1922)
+- SchemaPicker for cascading schema navigation in the query builder (#1828)
+- Group OTel attributes in log details (#1829)
+- Native type support for SimpleAggregateFunction numeric/bool/date columns (#1928)
+- Implement DataSourceWithToggleableQueryFiltersSupport interface (#1824)
+
+### Fixes
+
+- Ad-hoc: stop Map-key filters colliding across columns; bound free-form Map-key probe (#1993)
+- Traces: recover OTel columns on schema-fetch failure and guard compact SQL switch (#1992)
+- Traces: only apply the trace-ID timestamp optimization when the companion has Start/End/TraceId columns (#1994)
+- Traces: prevent crash when running Traces queries on older Grafana (#1937)
+- Traces: preserve trace-ID link optimization on cold cache (#1919)
+- Traces: prevent crash on raw-SQL queries with a trace_id column (#1920)
+- Macros: preserve macros in queries with backslash-escaped string literals (#1991)
+- Config: restore inline required-field validation for host/port on default installs (#1995)
+- Render SimpleAggregateFunction string columns correctly (#1927)
+- Fix datasource variable refs in Data Analysis dashboard (#1896)
+
+### Refactors
+
+- Config: migrate the ClickHouse config page design to OpenFeature (#1921)
+- Macros: adopt grafana/macropro as the macro engine (#1802)
+
 ## 4.18.0
 
 ### Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clickhouse-datasource",
-  "version": "4.18.0",
+  "version": "4.19.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clickhouse-datasource",
-      "version": "4.18.0",
+      "version": "4.19.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/css": "11.13.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clickhouse-datasource",
-  "version": "4.18.0",
+  "version": "4.19.0",
   "description": "Clickhouse Datasource",
   "engines": {
     "node": ">=24",


### PR DESCRIPTION
### Features

- Compact query mode for single-table data sources (#1841)
- Pre-built OpenTelemetry dashboards for logs, traces, and per-service deep dives (#1869)
- Guided variable editor with column values and Map-key support (#1868)
- Preset-driven annotation editor with change detection (#1922)
- SchemaPicker for cascading schema navigation in the query builder (#1828)
- Group OTel attributes in log details (#1829)
- Native type support for SimpleAggregateFunction numeric/bool/date columns (#1928)
- Implement DataSourceWithToggleableQueryFiltersSupport interface (#1824)

### Fixes

- Ad-hoc: stop Map-key filters colliding across columns; bound free-form Map-key probe (#1993)
- Traces: recover OTel columns on schema-fetch failure and guard compact SQL switch (#1992)
- Traces: only apply the trace-ID timestamp optimization when the companion has Start/End/TraceId columns (#1994)
- Traces: prevent crash when running Traces queries on older Grafana (#1937)
- Traces: preserve trace-ID link optimization on cold cache (#1919)
- Traces: prevent crash on raw-SQL queries with a trace_id column (#1920)
- Macros: preserve macros in queries with backslash-escaped string literals (#1991)
- Config: restore inline required-field validation for host/port on default installs (#1995)
- Render SimpleAggregateFunction string columns correctly (#1927)
- Fix datasource variable refs in Data Analysis dashboard (#1896)

### Refactors

- Config: migrate the ClickHouse config page design to OpenFeature (#1921)
- Macros: adopt grafana/macropro as the macro engine (#1802)