### PR TITLE
ci: bump CD go-version to 1.26.4 to match go.mod

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -58,5 +58,5 @@ jobs:
       pull-requests: read
 
     with:
-      go-version: "1.26.3"
+      go-version: "1.26.4"
       golangci-lint-version: "2.10.1"


### PR DESCRIPTION
## Type of Change

- [x] 🐛 Bug Fix

---

## Bug Fix

### What is the bug?

The main-branch CD pipeline (Publish to Dev Catalog and Deploy) fails in the "Test and build backend" step:

```
go: go.mod requires go >= 1.26.4 (running go 1.26.3; GOTOOLCHAIN=local)
```

Failing run: https://github.com/grafana/clickhouse-datasource/actions/runs/28895303322

#1997 bumped the `go` directive in `go.mod` from 1.26.3 to 1.26.4, but `push.yml` still passes `go-version: "1.26.3"` to the CD workflow. That input is required by `data-sources-ci-workflows/cd-dev.yml` and overrides the go.mod-based toolchain resolution, and the runners set `GOTOOLCHAIN=local`, so Go cannot auto-upgrade and `go mod download` exits 1.

The PR-path CI job is unaffected: it calls `plugin-ci-workflows/ci.yml@ci-cd-workflows/v10.1.0` without an explicit `go-version`, so it resolves the toolchain from `go.mod` directly. Only the CD path pins the version, because `cd-dev.yml` makes the input mandatory.

This bumps the pinned version to 1.26.4 to match `go.mod`, the same fix as #1887 for the previous Go bump.

### How to reproduce

1. Merge any PR to `main` (e.g. the 4.19.0 release, #2004).
2. The push-triggered "Plugins - CI" workflow runs the Publish to Dev Catalog job.
3. "Test and build backend" fails at `go mod download` with the version mismatch above.

---

## Please check that:

- [ ] Tests for this change have been added/updated. (N/A — CI configuration only)
- [ ] Documentation has been added/updated (where applicable). (N/A)

## Special notes for your reviewer

This pin will drift again the next time Renovate bumps the `go` directive in `go.mod`. A durable follow-up would be to make `go-version` optional in `data-sources-ci-workflows/cd-dev.yml` and fall back to `go.mod` resolution, the way `plugin-ci-workflows/ci.yml` already does.