### PR TITLE
chore(ui): replace legacy gf-form class usage with InlineField/InlineFieldRow

### DIFF
--- a/src/components/SqlEditor.tsx
+++ b/src/components/SqlEditor.tsx
@@ -114,7 +114,7 @@ export const SqlEditor = (props: SqlEditorProps) => {
 
   return (
     <>
-      <InlineFieldRow className={`${styles.Common.formRow} ${styles.QueryEditor.queryType}`}>
+      <InlineFieldRow className={styles.QueryEditor.queryType}>
         <QueryTypeSwitcher queryType={queryType} onChange={(queryType) => saveChanges({ queryType })} sqlEditor />
       </InlineFieldRow>
       <div className={styles.Common.wrapper}>

--- a/src/components/SqlEditor.tsx
+++ b/src/components/SqlEditor.tsx
@@ -1,6 +1,6 @@
 import React, { useRef } from 'react';
 import { QueryEditorProps } from '@grafana/data';
-import { CodeEditor, monacoTypes } from '@grafana/ui';
+import { CodeEditor, InlineFieldRow, monacoTypes } from '@grafana/ui';
 import { Datasource } from 'data/CHDatasource';
 import { registerSQL, Range, Fetcher } from './sqlProvider';
 import { CHConfig } from 'types/config';
@@ -114,9 +114,9 @@ export const SqlEditor = (props: SqlEditorProps) => {
 
   return (
     <>
-      <div className={'gf-form ' + styles.QueryEditor.queryType}>
+      <InlineFieldRow className={`${styles.Common.formRow} ${styles.QueryEditor.queryType}`}>
         <QueryTypeSwitcher queryType={queryType} onChange={(queryType) => saveChanges({ queryType })} sqlEditor />
-      </div>
+      </InlineFieldRow>
       <div className={styles.Common.wrapper}>
         <CodeEditor
           aria-label="SQL Editor"

--- a/src/components/configEditor/HttpHeadersConfig.tsx
+++ b/src/components/configEditor/HttpHeadersConfig.tsx
@@ -72,7 +72,7 @@ export const HttpHeadersConfig = (props: HttpHeadersConfigProps) => {
       <Field label={labels.forwardGrafanaHeaders.label} description={labels.forwardGrafanaHeaders.tooltip}>
         <Switch
           data-testid={selectors.forwardGrafanaHeadersSwitch}
-          className={'gf-form'}
+          className={styles.Common.formRowSwitch}
           value={forwardGrafanaHeaders}
           onChange={(e) => updateForwardGrafanaHeaders(e.currentTarget.checked)}
         />
@@ -155,7 +155,7 @@ const HttpHeaderEditor = (props: HttpHeaderEditorProps) => {
           <Field label={labels.secureLabel}>
             <Switch
               data-testid={selectors.headerSecureSwitch}
-              className="gf-form"
+              className={styles.Common.formRowSwitch}
               value={secure}
               onChange={(e) => setSecure(e.currentTarget.checked)}
               onBlur={() => onUpdate()}

--- a/src/components/configEditor/HttpHeadersConfig.tsx
+++ b/src/components/configEditor/HttpHeadersConfig.tsx
@@ -72,7 +72,6 @@ export const HttpHeadersConfig = (props: HttpHeadersConfigProps) => {
       <Field label={labels.forwardGrafanaHeaders.label} description={labels.forwardGrafanaHeaders.tooltip}>
         <Switch
           data-testid={selectors.forwardGrafanaHeadersSwitch}
-          className={styles.Common.formRowSwitch}
           value={forwardGrafanaHeaders}
           onChange={(e) => updateForwardGrafanaHeaders(e.currentTarget.checked)}
         />
@@ -155,7 +154,6 @@ const HttpHeaderEditor = (props: HttpHeaderEditorProps) => {
           <Field label={labels.secureLabel}>
             <Switch
               data-testid={selectors.headerSecureSwitch}
-              className={styles.Common.formRowSwitch}
               value={secure}
               onChange={(e) => setSecure(e.currentTarget.checked)}
               onBlur={() => onUpdate()}

--- a/src/components/configEditor/LabeledInput.tsx
+++ b/src/components/configEditor/LabeledInput.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { InlineFieldRow, Input, InlineFormLabel } from '@grafana/ui';
-import { styles } from 'styles';
+import { InlineField, Input, InlineFormLabel } from '@grafana/ui';
 
 interface LabeledInputProps {
   label: string;
@@ -15,17 +14,15 @@ export function LabeledInput(props: LabeledInputProps) {
   const { label, tooltip, placeholder, disabled, value, onChange } = props;
 
   return (
-    <InlineFieldRow className={styles.Common.formRow}>
-      <InlineFormLabel width={12} className="query-keyword" tooltip={tooltip || label}>
-        {label}
-      </InlineFormLabel>
-      <Input
-        disabled={disabled}
-        width={30}
-        value={value}
-        onChange={(e) => onChange(e.currentTarget.value)}
-        placeholder={placeholder}
-      />
-    </InlineFieldRow>
+    <InlineField
+      label={
+        <InlineFormLabel width={12} className="query-keyword" tooltip={tooltip || label}>
+          {label}
+        </InlineFormLabel>
+      }
+      disabled={disabled}
+    >
+      <Input width={30} value={value} onChange={(e) => onChange(e.currentTarget.value)} placeholder={placeholder} />
+    </InlineField>
   );
 }

--- a/src/components/configEditor/LabeledInput.tsx
+++ b/src/components/configEditor/LabeledInput.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Input, InlineFormLabel } from '@grafana/ui';
+import { InlineFieldRow, Input, InlineFormLabel } from '@grafana/ui';
+import { styles } from 'styles';
 
 interface LabeledInputProps {
   label: string;
@@ -14,7 +15,7 @@ export function LabeledInput(props: LabeledInputProps) {
   const { label, tooltip, placeholder, disabled, value, onChange } = props;
 
   return (
-    <div className="gf-form">
+    <InlineFieldRow className={styles.Common.formRow}>
       <InlineFormLabel width={12} className="query-keyword" tooltip={tooltip || label}>
         {label}
       </InlineFormLabel>
@@ -25,6 +26,6 @@ export function LabeledInput(props: LabeledInputProps) {
         onChange={(e) => onChange(e.currentTarget.value)}
         placeholder={placeholder}
       />
-    </div>
+    </InlineFieldRow>
   );
 }

--- a/src/components/configEditor/LogsConfig.tsx
+++ b/src/components/configEditor/LogsConfig.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { ConfigSection, ConfigSubSection } from 'components/experimental/ConfigSection';
-import { Input, Field, InlineFormLabel, TagsInput } from '@grafana/ui';
+import { Input, Field, InlineFieldRow, InlineFormLabel, TagsInput } from '@grafana/ui';
+import { styles } from 'styles';
 import { OtelVersionSelect } from 'components/queryBuilder/OtelVersionSelect';
 import { ColumnHint } from 'types/queryBuilder';
 import otel from 'otel';
@@ -152,7 +153,7 @@ export const LogsConfig = (props: LogsConfigProps) => {
           onChange={onSelectContextColumnsChange}
           wide
         />
-        <div className="gf-form">
+        <InlineFieldRow className={styles.Common.formRow}>
           <InlineFormLabel width={12} className="query-keyword" tooltip={labels.contextColumns.columns.tooltip}>
             {labels.contextColumns.columns.label}
           </InlineFormLabel>
@@ -162,7 +163,7 @@ export const LogsConfig = (props: LogsConfigProps) => {
             onChange={onContextColumnsChangeTrimmed}
             width={60}
           />
-        </div>
+        </InlineFieldRow>
       </ConfigSubSection>
     </ConfigSection>
   );

--- a/src/components/configEditor/LogsConfig.tsx
+++ b/src/components/configEditor/LogsConfig.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { ConfigSection, ConfigSubSection } from 'components/experimental/ConfigSection';
-import { Input, Field, InlineFieldRow, InlineFormLabel, TagsInput } from '@grafana/ui';
-import { styles } from 'styles';
+import { Input, Field, InlineField, InlineFormLabel, TagsInput } from '@grafana/ui';
 import { OtelVersionSelect } from 'components/queryBuilder/OtelVersionSelect';
 import { ColumnHint } from 'types/queryBuilder';
 import otel from 'otel';
@@ -153,17 +152,20 @@ export const LogsConfig = (props: LogsConfigProps) => {
           onChange={onSelectContextColumnsChange}
           wide
         />
-        <InlineFieldRow className={styles.Common.formRow}>
-          <InlineFormLabel width={12} className="query-keyword" tooltip={labels.contextColumns.columns.tooltip}>
-            {labels.contextColumns.columns.label}
-          </InlineFormLabel>
+        <InlineField
+          label={
+            <InlineFormLabel width={12} className="query-keyword" tooltip={labels.contextColumns.columns.tooltip}>
+              {labels.contextColumns.columns.label}
+            </InlineFormLabel>
+          }
+        >
           <TagsInput
             placeholder={labels.contextColumns.columns.placeholder}
             tags={contextColumns || []}
             onChange={onContextColumnsChangeTrimmed}
             width={60}
           />
-        </InlineFieldRow>
+        </InlineField>
       </ConfigSubSection>
     </ConfigSection>
   );

--- a/src/components/configEditor/QuerySettingsConfig.tsx
+++ b/src/components/configEditor/QuerySettingsConfig.tsx
@@ -2,6 +2,7 @@ import React, { FormEvent } from 'react';
 import { Switch, Input, Field } from '@grafana/ui';
 import { ConfigSection } from 'components/experimental/ConfigSection';
 import allLabels from 'labels';
+import { styles } from 'styles';
 
 interface QuerySettingsConfigProps {
   connMaxLifetime?: string;
@@ -104,12 +105,17 @@ export const QuerySettingsConfig = (props: QuerySettingsConfigProps) => {
       </Field>
 
       <Field label={labels.validateSql.label} description={labels.validateSql.tooltip}>
-        <Switch className="gf-form" value={validateSql || false} onChange={onValidateSqlChange} role="checkbox" />
+        <Switch
+          className={styles.Common.formRowSwitch}
+          value={validateSql || false}
+          onChange={onValidateSqlChange}
+          role="checkbox"
+        />
       </Field>
 
       <Field label={labels.enableMapKeysDiscovery.label} description={labels.enableMapKeysDiscovery.tooltip}>
         <Switch
-          className="gf-form"
+          className={styles.Common.formRowSwitch}
           value={enableMapKeysDiscovery ?? true}
           onChange={onEnableMapKeysDiscoveryChange}
           role="checkbox"

--- a/src/components/configEditor/QuerySettingsConfig.tsx
+++ b/src/components/configEditor/QuerySettingsConfig.tsx
@@ -2,7 +2,6 @@ import React, { FormEvent } from 'react';
 import { Switch, Input, Field } from '@grafana/ui';
 import { ConfigSection } from 'components/experimental/ConfigSection';
 import allLabels from 'labels';
-import { styles } from 'styles';
 
 interface QuerySettingsConfigProps {
   connMaxLifetime?: string;
@@ -106,7 +105,6 @@ export const QuerySettingsConfig = (props: QuerySettingsConfigProps) => {
 
       <Field label={labels.validateSql.label} description={labels.validateSql.tooltip}>
         <Switch
-          className={styles.Common.formRowSwitch}
           value={validateSql || false}
           onChange={onValidateSqlChange}
           role="checkbox"
@@ -115,7 +113,6 @@ export const QuerySettingsConfig = (props: QuerySettingsConfigProps) => {
 
       <Field label={labels.enableMapKeysDiscovery.label} description={labels.enableMapKeysDiscovery.tooltip}>
         <Switch
-          className={styles.Common.formRowSwitch}
           value={enableMapKeysDiscovery ?? true}
           onChange={onEnableMapKeysDiscoveryChange}
           role="checkbox"

--- a/src/components/queryBuilder/AggregateEditor.tsx
+++ b/src/components/queryBuilder/AggregateEditor.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { SelectableValue } from '@grafana/data';
-import { InlineFieldRow, InlineFormLabel, Select, Button, Input, Stack } from '@grafana/ui';
+import { InlineField, InlineFormLabel, Select, Button, Input, Stack } from '@grafana/ui';
 import { AggregateColumn, AggregateType, TableColumn } from 'types/queryBuilder';
 import labels from 'labels';
 import { selectors } from 'selectors';
@@ -138,12 +138,11 @@ export const AggregateEditor = (props: AggregateEditorProps) => {
       {aggregates.map((aggregate, index) => {
         const key = `${index}-${aggregate.column}-${aggregate.aggregateType}-${aggregate.alias}`;
         return (
-          <InlineFieldRow
-            className={styles.Common.formRow}
+          <InlineField
+            label={index === 0 ? fieldLabel : fieldSpacer}
             key={key}
             data-testid={selectors.components.QueryBuilder.AggregateEditor.itemWrapper}
           >
-            {index === 0 ? fieldLabel : fieldSpacer}
             <Aggregate
               columnOptions={columnOptions}
               index={index}
@@ -151,12 +150,11 @@ export const AggregateEditor = (props: AggregateEditorProps) => {
               updateAggregate={updateAggregate}
               removeAggregate={removeAggregate}
             />
-          </InlineFieldRow>
+          </InlineField>
         );
       })}
 
-      <InlineFieldRow className={styles.Common.formRow}>
-        {aggregates.length === 0 ? fieldLabel : fieldSpacer}
+      <InlineField label={aggregates.length === 0 ? fieldLabel : fieldSpacer}>
         <Button
           data-testid={selectors.components.QueryBuilder.AggregateEditor.addButton}
           icon="plus-circle"
@@ -167,7 +165,7 @@ export const AggregateEditor = (props: AggregateEditorProps) => {
         >
           {addLabel}
         </Button>
-      </InlineFieldRow>
+      </InlineField>
     </>
   );
 };

--- a/src/components/queryBuilder/AggregateEditor.tsx
+++ b/src/components/queryBuilder/AggregateEditor.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { SelectableValue } from '@grafana/data';
-import { InlineFormLabel, Select, Button, Input, Stack } from '@grafana/ui';
+import { InlineFieldRow, InlineFormLabel, Select, Button, Input, Stack } from '@grafana/ui';
 import { AggregateColumn, AggregateType, TableColumn } from 'types/queryBuilder';
 import labels from 'labels';
 import { selectors } from 'selectors';
@@ -138,8 +138,8 @@ export const AggregateEditor = (props: AggregateEditorProps) => {
       {aggregates.map((aggregate, index) => {
         const key = `${index}-${aggregate.column}-${aggregate.aggregateType}-${aggregate.alias}`;
         return (
-          <div
-            className="gf-form"
+          <InlineFieldRow
+            className={styles.Common.formRow}
             key={key}
             data-testid={selectors.components.QueryBuilder.AggregateEditor.itemWrapper}
           >
@@ -151,11 +151,11 @@ export const AggregateEditor = (props: AggregateEditorProps) => {
               updateAggregate={updateAggregate}
               removeAggregate={removeAggregate}
             />
-          </div>
+          </InlineFieldRow>
         );
       })}
 
-      <div className="gf-form">
+      <InlineFieldRow className={styles.Common.formRow}>
         {aggregates.length === 0 ? fieldLabel : fieldSpacer}
         <Button
           data-testid={selectors.components.QueryBuilder.AggregateEditor.addButton}
@@ -167,7 +167,7 @@ export const AggregateEditor = (props: AggregateEditorProps) => {
         >
           {addLabel}
         </Button>
-      </div>
+      </InlineFieldRow>
     </>
   );
 };

--- a/src/components/queryBuilder/ColumnSelect.tsx
+++ b/src/components/queryBuilder/ColumnSelect.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { SelectableValue } from '@grafana/data';
-import { InlineFormLabel, Select } from '@grafana/ui';
+import { InlineFieldRow, InlineFormLabel, Select } from '@grafana/ui';
 import { ColumnHint, SelectedColumn, TableColumn } from 'types/queryBuilder';
 import { styles } from 'styles';
 
@@ -71,7 +71,7 @@ export const ColumnSelect = (props: ColumnSelectProps) => {
   const labelStyle = 'query-keyword ' + (inline ? styles.QueryEditor.inlineField : '');
 
   return (
-    <div className="gf-form">
+    <InlineFieldRow className={styles.Common.formRow}>
       <InlineFormLabel width={wide ? 12 : 8} className={labelStyle} tooltip={tooltip}>
         {label}
       </InlineFormLabel>
@@ -87,6 +87,6 @@ export const ColumnSelect = (props: ColumnSelectProps) => {
         isClearable={clearable === undefined || clearable}
         allowCustomValue
       />
-    </div>
+    </InlineFieldRow>
   );
 };

--- a/src/components/queryBuilder/ColumnSelect.tsx
+++ b/src/components/queryBuilder/ColumnSelect.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { SelectableValue } from '@grafana/data';
-import { InlineFieldRow, InlineFormLabel, Select } from '@grafana/ui';
+import { InlineField, InlineFormLabel, Select } from '@grafana/ui';
 import { ColumnHint, SelectedColumn, TableColumn } from 'types/queryBuilder';
 import { styles } from 'styles';
 
@@ -71,13 +71,16 @@ export const ColumnSelect = (props: ColumnSelectProps) => {
   const labelStyle = 'query-keyword ' + (inline ? styles.QueryEditor.inlineField : '');
 
   return (
-    <InlineFieldRow className={styles.Common.formRow}>
-      <InlineFormLabel width={wide ? 12 : 8} className={labelStyle} tooltip={tooltip}>
-        {label}
-      </InlineFormLabel>
+    <InlineField
+      label={
+        <InlineFormLabel width={wide ? 12 : 8} className={labelStyle} tooltip={tooltip}>
+          {label}
+        </InlineFormLabel>
+      }
+      disabled={disabled}
+      invalid={invalid || staleOption}
+    >
       <Select<string | undefined>
-        disabled={disabled}
-        invalid={invalid || staleOption}
         options={columns}
         value={selectedColumnName}
         placeholder={selectedColumnName || undefined}
@@ -87,6 +90,6 @@ export const ColumnSelect = (props: ColumnSelectProps) => {
         isClearable={clearable === undefined || clearable}
         allowCustomValue
       />
-    </InlineFieldRow>
+    </InlineField>
   );
 };

--- a/src/components/queryBuilder/ColumnsEditor.tsx
+++ b/src/components/queryBuilder/ColumnsEditor.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { InlineFieldRow, InlineFormLabel, MultiSelect } from '@grafana/ui';
+import { InlineField, InlineFormLabel, MultiSelect } from '@grafana/ui';
 import { SelectableValue } from '@grafana/data';
 import { TableColumn, SelectedColumn } from 'types/queryBuilder';
 import labels from 'labels';
@@ -79,10 +79,14 @@ export const ColumnsEditor = (props: ColumnsEditorProps) => {
   };
 
   return (
-    <InlineFieldRow className={styles.Common.formRow}>
-      <InlineFormLabel width={8} className="query-keyword" tooltip={tooltip}>
-        {label}
-      </InlineFormLabel>
+    <InlineField
+      label={
+        <InlineFormLabel width={8} className="query-keyword" tooltip={tooltip}>
+          {label}
+        </InlineFormLabel>
+      }
+      grow
+    >
       <div
         data-testid={selectors.components.QueryBuilder.ColumnsEditor.multiSelectWrapper}
         className={styles.Common.selectWrapper}
@@ -99,6 +103,6 @@ export const ColumnsEditor = (props: ColumnsEditorProps) => {
           menuPlacement={'bottom'}
         />
       </div>
-    </InlineFieldRow>
+    </InlineField>
   );
 };

--- a/src/components/queryBuilder/ColumnsEditor.tsx
+++ b/src/components/queryBuilder/ColumnsEditor.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { InlineFormLabel, MultiSelect } from '@grafana/ui';
+import { InlineFieldRow, InlineFormLabel, MultiSelect } from '@grafana/ui';
 import { SelectableValue } from '@grafana/data';
 import { TableColumn, SelectedColumn } from 'types/queryBuilder';
 import labels from 'labels';
@@ -79,7 +79,7 @@ export const ColumnsEditor = (props: ColumnsEditorProps) => {
   };
 
   return (
-    <div className="gf-form">
+    <InlineFieldRow className={styles.Common.formRow}>
       <InlineFormLabel width={8} className="query-keyword" tooltip={tooltip}>
         {label}
       </InlineFormLabel>
@@ -99,6 +99,6 @@ export const ColumnsEditor = (props: ColumnsEditorProps) => {
           menuPlacement={'bottom'}
         />
       </div>
-    </div>
+    </InlineFieldRow>
   );
 };

--- a/src/components/queryBuilder/DatabaseTableSelect.test.tsx
+++ b/src/components/queryBuilder/DatabaseTableSelect.test.tsx
@@ -139,6 +139,6 @@ describe('DatabaseTableSelect', () => {
       )
     );
     expect(result.container.firstChild).not.toBeNull();
-    expect(result.container.firstChild?.childNodes).toHaveLength(2 * 2); // 2 components with a fragment of 2 components
+    expect(result.container.firstChild?.childNodes).toHaveLength(2); // 2 InlineFields (database + table)
   });
 });

--- a/src/components/queryBuilder/DatabaseTableSelect.tsx
+++ b/src/components/queryBuilder/DatabaseTableSelect.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { InlineFieldRow, InlineFormLabel, Select } from '@grafana/ui';
+import { InlineField, InlineFieldRow, InlineFormLabel, Select } from '@grafana/ui';
 import { Datasource } from '../../data/CHDatasource';
 import labels from 'labels';
 import { styles } from '../../styles';
@@ -34,10 +34,13 @@ export const DatabaseSelect = (props: DatabaseSelectProps) => {
   }, [datasource, database, onDatabaseChange]);
 
   return (
-    <>
-      <InlineFormLabel width={8} className="query-keyword" tooltip={tooltip}>
-        {label}
-      </InlineFormLabel>
+    <InlineField
+      label={
+        <InlineFormLabel width={8} className="query-keyword" tooltip={tooltip}>
+          {label}
+        </InlineFormLabel>
+      }
+    >
       <Select
         className={`width-15 ${styles.Common.inlineSelect}`}
         options={options}
@@ -46,7 +49,7 @@ export const DatabaseSelect = (props: DatabaseSelectProps) => {
         menuPlacement={'bottom'}
         allowCustomValue
       ></Select>
-    </>
+    </InlineField>
   );
 };
 
@@ -78,10 +81,13 @@ export const TableSelect = (props: TableSelectProps) => {
   }, [database, table, tables, datasource, onTableChange]);
 
   return (
-    <>
-      <InlineFormLabel width={8} className="query-keyword" tooltip={tooltip}>
-        {label}
-      </InlineFormLabel>
+    <InlineField
+      label={
+        <InlineFormLabel width={8} className="query-keyword" tooltip={tooltip}>
+          {label}
+        </InlineFormLabel>
+      }
+    >
       <Select
         className={`width-15 ${styles.Common.inlineSelect}`}
         options={options}
@@ -90,7 +96,7 @@ export const TableSelect = (props: TableSelectProps) => {
         menuPlacement={'bottom'}
         allowCustomValue
       ></Select>
-    </>
+    </InlineField>
   );
 };
 
@@ -106,7 +112,7 @@ export const DatabaseTableSelect = (props: DatabaseTableSelectProps) => {
   const { datasource, database, onDatabaseChange, table, onTableChange } = props;
 
   return (
-    <InlineFieldRow className={styles.Common.formRow}>
+    <InlineFieldRow>
       <DatabaseSelect datasource={datasource} database={database} onDatabaseChange={onDatabaseChange} />
       <TableSelect datasource={datasource} database={database} table={table} onTableChange={onTableChange} />
     </InlineFieldRow>

--- a/src/components/queryBuilder/DatabaseTableSelect.tsx
+++ b/src/components/queryBuilder/DatabaseTableSelect.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { InlineFormLabel, Select } from '@grafana/ui';
+import { InlineFieldRow, InlineFormLabel, Select } from '@grafana/ui';
 import { Datasource } from '../../data/CHDatasource';
 import labels from 'labels';
 import { styles } from '../../styles';
@@ -106,9 +106,9 @@ export const DatabaseTableSelect = (props: DatabaseTableSelectProps) => {
   const { datasource, database, onDatabaseChange, table, onTableChange } = props;
 
   return (
-    <div className="gf-form">
+    <InlineFieldRow className={styles.Common.formRow}>
       <DatabaseSelect datasource={datasource} database={database} onDatabaseChange={onDatabaseChange} />
       <TableSelect datasource={datasource} database={database} table={table} onTableChange={onTableChange} />
-    </div>
+    </InlineFieldRow>
   );
 };

--- a/src/components/queryBuilder/DurationUnitSelect.tsx
+++ b/src/components/queryBuilder/DurationUnitSelect.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { TimeUnit } from 'types/queryBuilder';
 import allLabels from 'labels';
-import { InlineFormLabel, Select } from '@grafana/ui';
+import { InlineFieldRow, InlineFormLabel, Select } from '@grafana/ui';
 import { SelectableValue } from '@grafana/data';
 import { styles } from 'styles';
 
@@ -24,7 +24,7 @@ export const DurationUnitSelect = (props: DurationUnitSelectProps) => {
   const { label, tooltip } = allLabels.components.TraceQueryBuilder.columns.durationUnit;
 
   return (
-    <div className="gf-form">
+    <InlineFieldRow className={styles.Common.formRow}>
       <InlineFormLabel
         width={12}
         className={`query-keyword ${inline ? styles.QueryEditor.inlineField : ''}`}
@@ -40,6 +40,6 @@ export const DurationUnitSelect = (props: DurationUnitSelectProps) => {
         width={inline ? 25 : 30}
         menuPlacement={'bottom'}
       />
-    </div>
+    </InlineFieldRow>
   );
 };

--- a/src/components/queryBuilder/DurationUnitSelect.tsx
+++ b/src/components/queryBuilder/DurationUnitSelect.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { TimeUnit } from 'types/queryBuilder';
 import allLabels from 'labels';
-import { InlineFieldRow, InlineFormLabel, Select } from '@grafana/ui';
+import { InlineField, InlineFormLabel, Select } from '@grafana/ui';
 import { SelectableValue } from '@grafana/data';
 import { styles } from 'styles';
 
@@ -24,22 +24,25 @@ export const DurationUnitSelect = (props: DurationUnitSelectProps) => {
   const { label, tooltip } = allLabels.components.TraceQueryBuilder.columns.durationUnit;
 
   return (
-    <InlineFieldRow className={styles.Common.formRow}>
-      <InlineFormLabel
-        width={12}
-        className={`query-keyword ${inline ? styles.QueryEditor.inlineField : ''}`}
-        tooltip={tooltip}
-      >
-        {label}
-      </InlineFormLabel>
+    <InlineField
+      label={
+        <InlineFormLabel
+          width={12}
+          className={`query-keyword ${inline ? styles.QueryEditor.inlineField : ''}`}
+          tooltip={tooltip}
+        >
+          {label}
+        </InlineFormLabel>
+      }
+      disabled={disabled}
+    >
       <Select<TimeUnit>
-        disabled={disabled}
         options={durationUnitOptions as Array<SelectableValue<TimeUnit>>}
         value={unit}
         onChange={(v) => onChange(v.value!)}
         width={inline ? 25 : 30}
         menuPlacement={'bottom'}
       />
-    </InlineFieldRow>
+    </InlineField>
   );
 };

--- a/src/components/queryBuilder/EditorTypeSwitcher.tsx
+++ b/src/components/queryBuilder/EditorTypeSwitcher.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { SelectableValue } from '@grafana/data';
-import { RadioButtonGroup, ConfirmModal, InlineFormLabel } from '@grafana/ui';
+import { RadioButtonGroup, ConfirmModal, InlineField, InlineFormLabel } from '@grafana/ui';
 import { getQueryOptionsFromSql } from '../queryBuilder/utils';
 import { generateSql } from 'data/sqlGenerator';
 import labels from 'labels';
@@ -86,10 +86,15 @@ export const EditorTypeSwitcher = (props: CHEditorTypeSwitcherProps) => {
   };
   return (
     <span>
-      <InlineFormLabel width={8} className="query-keyword" tooltip={tooltip}>
-        {label}
-      </InlineFormLabel>
-      <RadioButtonGroup options={options} value={editorType} onChange={(e) => onEditorTypeChange(e)} />
+      <InlineField
+        label={
+          <InlineFormLabel width={8} className="query-keyword" tooltip={tooltip}>
+            {label}
+          </InlineFormLabel>
+        }
+      >
+        <RadioButtonGroup options={options} value={editorType} onChange={(e) => onEditorTypeChange(e)} />
+      </InlineField>
       <ConfirmModal
         isOpen={confirmModalState}
         title={switcher.title}

--- a/src/components/queryBuilder/FilterEditor.tsx
+++ b/src/components/queryBuilder/FilterEditor.tsx
@@ -4,7 +4,7 @@ import {
   Button,
   Combobox,
   ComboboxOption,
-  InlineFieldRow,
+  InlineField,
   InlineFormLabel,
   Input,
   MultiCombobox,
@@ -395,10 +395,13 @@ export const FiltersEditor = (props: {
   return (
     <>
       {filters.length === 0 && (
-        <InlineFieldRow className={styles.Common.formRow}>
-          <InlineFormLabel width={8} className="query-keyword" tooltip={tooltip}>
-            {label}
-          </InlineFormLabel>
+        <InlineField
+          label={
+            <InlineFormLabel width={8} className="query-keyword" tooltip={tooltip}>
+              {label}
+            </InlineFormLabel>
+          }
+        >
           <Button
             data-testid="query-builder-filters-add-button"
             icon="plus-circle"
@@ -409,18 +412,23 @@ export const FiltersEditor = (props: {
           >
             {addLabel}
           </Button>
-        </InlineFieldRow>
+        </InlineField>
       )}
       {filters.map((filter, index) => {
         return (
-          <InlineFieldRow className={styles.Common.formRow} key={index}>
-            {index === 0 ? (
-              <InlineFormLabel width={8} className="query-keyword" tooltip={tooltip}>
-                {label}
-              </InlineFormLabel>
-            ) : (
-              <div className={`width-8 ${styles.Common.firstLabel}`}></div>
-            )}
+          <InlineField
+            key={index}
+            label={
+              index === 0 ? (
+                <InlineFormLabel width={8} className="query-keyword" tooltip={tooltip}>
+                  {label}
+                </InlineFormLabel>
+              ) : (
+                <div className={`width-8 ${styles.Common.firstLabel}`}></div>
+              )
+            }
+            shrink
+          >
             <FilterEditor
               allColumns={fieldsList}
               filter={filter}
@@ -431,12 +439,11 @@ export const FiltersEditor = (props: {
               database={database}
               table={table}
             />
-          </InlineFieldRow>
+          </InlineField>
         );
       })}
       {filters.length !== 0 && (
-        <InlineFieldRow className={styles.Common.formRow}>
-          <div className={`width-8 ${styles.Common.firstLabel}`}></div>
+        <InlineField label={<div className={`width-8 ${styles.Common.firstLabel}`}></div>}>
           <Button
             data-testid="query-builder-filters-inline-add-button"
             icon="plus-circle"
@@ -447,7 +454,7 @@ export const FiltersEditor = (props: {
           >
             {addLabel}
           </Button>
-        </InlineFieldRow>
+        </InlineField>
       )}
     </>
   );

--- a/src/components/queryBuilder/FilterEditor.tsx
+++ b/src/components/queryBuilder/FilterEditor.tsx
@@ -4,6 +4,7 @@ import {
   Button,
   Combobox,
   ComboboxOption,
+  InlineFieldRow,
   InlineFormLabel,
   Input,
   MultiCombobox,
@@ -394,7 +395,7 @@ export const FiltersEditor = (props: {
   return (
     <>
       {filters.length === 0 && (
-        <div className="gf-form">
+        <InlineFieldRow className={styles.Common.formRow}>
           <InlineFormLabel width={8} className="query-keyword" tooltip={tooltip}>
             {label}
           </InlineFormLabel>
@@ -408,11 +409,11 @@ export const FiltersEditor = (props: {
           >
             {addLabel}
           </Button>
-        </div>
+        </InlineFieldRow>
       )}
       {filters.map((filter, index) => {
         return (
-          <div className="gf-form" key={index}>
+          <InlineFieldRow className={styles.Common.formRow} key={index}>
             {index === 0 ? (
               <InlineFormLabel width={8} className="query-keyword" tooltip={tooltip}>
                 {label}
@@ -430,11 +431,11 @@ export const FiltersEditor = (props: {
               database={database}
               table={table}
             />
-          </div>
+          </InlineFieldRow>
         );
       })}
       {filters.length !== 0 && (
-        <div className="gf-form">
+        <InlineFieldRow className={styles.Common.formRow}>
           <div className={`width-8 ${styles.Common.firstLabel}`}></div>
           <Button
             data-testid="query-builder-filters-inline-add-button"
@@ -446,7 +447,7 @@ export const FiltersEditor = (props: {
           >
             {addLabel}
           </Button>
-        </div>
+        </InlineFieldRow>
       )}
     </>
   );

--- a/src/components/queryBuilder/GroupByEditor.tsx
+++ b/src/components/queryBuilder/GroupByEditor.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { InlineFieldRow, InlineFormLabel, MultiSelect } from '@grafana/ui';
+import { InlineField, InlineFormLabel, MultiSelect } from '@grafana/ui';
 import { SelectableValue } from '@grafana/data';
 import { TableColumn } from 'types/queryBuilder';
 import labels from 'labels';
@@ -24,10 +24,14 @@ export const GroupByEditor = (props: GroupByEditorProps) => {
   };
 
   return (
-    <InlineFieldRow className={styles.Common.formRow}>
-      <InlineFormLabel width={8} className="query-keyword" tooltip={tooltip}>
-        {label}
-      </InlineFormLabel>
+    <InlineField
+      label={
+        <InlineFormLabel width={8} className="query-keyword" tooltip={tooltip}>
+          {label}
+        </InlineFormLabel>
+      }
+      grow
+    >
       <div
         data-testid={selectors.components.QueryBuilder.GroupByEditor.multiSelectWrapper}
         className={styles.Common.selectWrapper}
@@ -43,6 +47,6 @@ export const GroupByEditor = (props: GroupByEditorProps) => {
           menuPlacement={'bottom'}
         />
       </div>
-    </InlineFieldRow>
+    </InlineField>
   );
 };

--- a/src/components/queryBuilder/GroupByEditor.tsx
+++ b/src/components/queryBuilder/GroupByEditor.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { InlineFormLabel, MultiSelect } from '@grafana/ui';
+import { InlineFieldRow, InlineFormLabel, MultiSelect } from '@grafana/ui';
 import { SelectableValue } from '@grafana/data';
 import { TableColumn } from 'types/queryBuilder';
 import labels from 'labels';
@@ -24,7 +24,7 @@ export const GroupByEditor = (props: GroupByEditorProps) => {
   };
 
   return (
-    <div className="gf-form">
+    <InlineFieldRow className={styles.Common.formRow}>
       <InlineFormLabel width={8} className="query-keyword" tooltip={tooltip}>
         {label}
       </InlineFormLabel>
@@ -43,6 +43,6 @@ export const GroupByEditor = (props: GroupByEditorProps) => {
           menuPlacement={'bottom'}
         />
       </div>
-    </div>
+    </InlineFieldRow>
   );
 };

--- a/src/components/queryBuilder/LimitEditor.tsx
+++ b/src/components/queryBuilder/LimitEditor.tsx
@@ -1,7 +1,8 @@
 import React, { useState } from 'react';
-import { InlineFormLabel, Input } from '@grafana/ui';
+import { InlineFieldRow, InlineFormLabel, Input } from '@grafana/ui';
 import labels from 'labels';
 import { selectors } from 'selectors';
+import { styles } from 'styles';
 
 interface LimitEditorProps {
   limit: number;
@@ -13,7 +14,7 @@ export const LimitEditor = (props: LimitEditorProps) => {
   const { label, tooltip } = labels.components.LimitEditor;
 
   return (
-    <div className="gf-form">
+    <InlineFieldRow className={styles.Common.formRow}>
       <InlineFormLabel width={8} className="query-keyword" tooltip={tooltip}>
         {label}
       </InlineFormLabel>
@@ -26,6 +27,6 @@ export const LimitEditor = (props: LimitEditorProps) => {
         onChange={(e) => setLimit(e.currentTarget.valueAsNumber)}
         onBlur={() => props.onLimitChange(limit)}
       />
-    </div>
+    </InlineFieldRow>
   );
 };

--- a/src/components/queryBuilder/LimitEditor.tsx
+++ b/src/components/queryBuilder/LimitEditor.tsx
@@ -1,8 +1,7 @@
 import React, { useState } from 'react';
-import { InlineFieldRow, InlineFormLabel, Input } from '@grafana/ui';
+import { InlineField, InlineFormLabel, Input } from '@grafana/ui';
 import labels from 'labels';
 import { selectors } from 'selectors';
-import { styles } from 'styles';
 
 interface LimitEditorProps {
   limit: number;
@@ -14,10 +13,13 @@ export const LimitEditor = (props: LimitEditorProps) => {
   const { label, tooltip } = labels.components.LimitEditor;
 
   return (
-    <InlineFieldRow className={styles.Common.formRow}>
-      <InlineFormLabel width={8} className="query-keyword" tooltip={tooltip}>
-        {label}
-      </InlineFormLabel>
+    <InlineField
+      label={
+        <InlineFormLabel width={8} className="query-keyword" tooltip={tooltip}>
+          {label}
+        </InlineFormLabel>
+      }
+    >
       <Input
         data-testid={selectors.components.QueryBuilder.LimitEditor.input}
         width={10}
@@ -27,6 +29,6 @@ export const LimitEditor = (props: LimitEditorProps) => {
         onChange={(e) => setLimit(e.currentTarget.valueAsNumber)}
         onBlur={() => props.onLimitChange(limit)}
       />
-    </InlineFieldRow>
+    </InlineField>
   );
 };

--- a/src/components/queryBuilder/ModeSwitch.tsx
+++ b/src/components/queryBuilder/ModeSwitch.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { RadioButtonGroup, InlineFormLabel } from '@grafana/ui';
+import { RadioButtonGroup, InlineFieldRow, InlineFormLabel } from '@grafana/ui';
+import { styles } from 'styles';
 
 export interface ModeSwitchProps {
   labelA: string;
@@ -28,11 +29,11 @@ export const ModeSwitch = (props: ModeSwitchProps) => {
   ];
 
   return (
-    <div className="gf-form">
+    <InlineFieldRow className={styles.Common.formRow}>
       <InlineFormLabel width={8} className="query-keyword" tooltip={tooltip}>
         {label}
       </InlineFormLabel>
       <RadioButtonGroup<boolean> options={options} value={value} onChange={(v) => onChange(v)} />
-    </div>
+    </InlineFieldRow>
   );
 };

--- a/src/components/queryBuilder/ModeSwitch.tsx
+++ b/src/components/queryBuilder/ModeSwitch.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { RadioButtonGroup, InlineFieldRow, InlineFormLabel } from '@grafana/ui';
-import { styles } from 'styles';
+import { RadioButtonGroup, InlineField, InlineFormLabel } from '@grafana/ui';
 
 export interface ModeSwitchProps {
   labelA: string;
@@ -29,11 +28,14 @@ export const ModeSwitch = (props: ModeSwitchProps) => {
   ];
 
   return (
-    <InlineFieldRow className={styles.Common.formRow}>
-      <InlineFormLabel width={8} className="query-keyword" tooltip={tooltip}>
-        {label}
-      </InlineFormLabel>
+    <InlineField
+      label={
+        <InlineFormLabel width={8} className="query-keyword" tooltip={tooltip}>
+          {label}
+        </InlineFormLabel>
+      }
+    >
       <RadioButtonGroup<boolean> options={options} value={value} onChange={(v) => onChange(v)} />
-    </InlineFieldRow>
+    </InlineField>
   );
 };

--- a/src/components/queryBuilder/OrderByEditor.tsx
+++ b/src/components/queryBuilder/OrderByEditor.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { SelectableValue } from '@grafana/data';
-import { Button, InlineFieldRow, InlineFormLabel, Select } from '@grafana/ui';
+import { Button, InlineField, InlineFormLabel, Select, Stack } from '@grafana/ui';
 import { OrderBy, OrderByDirection, QueryBuilderOptions, TableColumn } from 'types/queryBuilder';
 import allLabels from 'labels';
 import { styles } from 'styles';
@@ -23,7 +23,7 @@ const OrderByItem = (props: OrderByItemProps) => {
   const { columnOptions, index, orderByItem, updateOrderByItem, removeOrderByItem } = props;
 
   return (
-    <>
+    <Stack direction="row" wrap="wrap" alignItems="flex-start" justifyContent="flex-start" gap={0}>
       <Select
         disabled={Boolean(orderByItem.hint)}
         placeholder={orderByItem.hint ? allLabels.types.ColumnHint[orderByItem.hint] : undefined}
@@ -52,7 +52,7 @@ const OrderByItem = (props: OrderByItemProps) => {
         onClick={() => removeOrderByItem(index)}
         aria-label="order-by-remove-item"
       />
-    </>
+    </Stack>
   );
 };
 
@@ -102,8 +102,11 @@ export const OrderByEditor = (props: OrderByEditorProps) => {
       {orderBy.map((orderByItem, index) => {
         const key = `${index}-${orderByItem.name}-${orderByItem.hint || ''}-${orderByItem.dir}`;
         return (
-          <InlineFieldRow className={styles.Common.formRow} key={key} data-testid="query-builder-orderby-item-wrapper">
-            {index === 0 ? fieldLabel : fieldSpacer}
+          <InlineField
+            label={index === 0 ? fieldLabel : fieldSpacer}
+            key={key}
+            data-testid="query-builder-orderby-item-wrapper"
+          >
             <OrderByItem
               columnOptions={orderByOptions}
               index={index}
@@ -111,12 +114,11 @@ export const OrderByEditor = (props: OrderByEditorProps) => {
               updateOrderByItem={updateOrderByItem}
               removeOrderByItem={removeOrderByItem}
             />
-          </InlineFieldRow>
+          </InlineField>
         );
       })}
 
-      <InlineFieldRow className={styles.Common.formRow}>
-        {orderBy.length === 0 ? fieldLabel : fieldSpacer}
+      <InlineField label={orderBy.length === 0 ? fieldLabel : fieldSpacer}>
         <Button
           data-testid="query-builder-orderby-add-button"
           icon="plus-circle"
@@ -127,7 +129,7 @@ export const OrderByEditor = (props: OrderByEditorProps) => {
         >
           {addLabel}
         </Button>
-      </InlineFieldRow>
+      </InlineField>
     </>
   );
 };

--- a/src/components/queryBuilder/OrderByEditor.tsx
+++ b/src/components/queryBuilder/OrderByEditor.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { SelectableValue } from '@grafana/data';
-import { Button, InlineFormLabel, Select } from '@grafana/ui';
+import { Button, InlineFieldRow, InlineFormLabel, Select } from '@grafana/ui';
 import { OrderBy, OrderByDirection, QueryBuilderOptions, TableColumn } from 'types/queryBuilder';
 import allLabels from 'labels';
 import { styles } from 'styles';
@@ -102,7 +102,7 @@ export const OrderByEditor = (props: OrderByEditorProps) => {
       {orderBy.map((orderByItem, index) => {
         const key = `${index}-${orderByItem.name}-${orderByItem.hint || ''}-${orderByItem.dir}`;
         return (
-          <div className="gf-form" key={key} data-testid="query-builder-orderby-item-wrapper">
+          <InlineFieldRow className={styles.Common.formRow} key={key} data-testid="query-builder-orderby-item-wrapper">
             {index === 0 ? fieldLabel : fieldSpacer}
             <OrderByItem
               columnOptions={orderByOptions}
@@ -111,11 +111,11 @@ export const OrderByEditor = (props: OrderByEditorProps) => {
               updateOrderByItem={updateOrderByItem}
               removeOrderByItem={removeOrderByItem}
             />
-          </div>
+          </InlineFieldRow>
         );
       })}
 
-      <div className="gf-form">
+      <InlineFieldRow className={styles.Common.formRow}>
         {orderBy.length === 0 ? fieldLabel : fieldSpacer}
         <Button
           data-testid="query-builder-orderby-add-button"
@@ -127,7 +127,7 @@ export const OrderByEditor = (props: OrderByEditorProps) => {
         >
           {addLabel}
         </Button>
-      </div>
+      </InlineFieldRow>
     </>
   );
 };

--- a/src/components/queryBuilder/OtelVersionSelect.tsx
+++ b/src/components/queryBuilder/OtelVersionSelect.tsx
@@ -1,9 +1,8 @@
 import React, { useEffect } from 'react';
 import { SelectableValue } from '@grafana/data';
-import { InlineFieldRow, InlineFormLabel, Select, Switch as GrafanaSwitch, useTheme } from '@grafana/ui';
+import { InlineField, InlineFieldRow, InlineFormLabel, Select, Switch as GrafanaSwitch, useTheme } from '@grafana/ui';
 import otel from 'otel';
 import selectors from 'labels';
-import { styles } from 'styles';
 
 interface OtelVersionSelectProps {
   enabled: boolean;
@@ -37,18 +36,22 @@ export const OtelVersionSelect = (props: OtelVersionSelectProps) => {
   };
 
   return (
-    <InlineFieldRow className={styles.Common.formRow}>
-      <InlineFormLabel width={wide ? 12 : 8} className="query-keyword" tooltip={tooltip}>
-        {label}
-      </InlineFormLabel>
-      <div style={switchContainerStyle}>
-        <GrafanaSwitch
-          className={styles.Common.formRowSwitch}
-          value={enabled}
-          onChange={(e) => onEnabledChange(e.currentTarget.checked)}
-          role="checkbox"
-        />
-      </div>
+    <InlineFieldRow>
+      <InlineField
+        label={
+          <InlineFormLabel width={wide ? 12 : 8} className="query-keyword" tooltip={tooltip}>
+            {label}
+          </InlineFormLabel>
+        }
+      >
+        <div style={switchContainerStyle}>
+          <GrafanaSwitch
+            value={enabled}
+            onChange={(e) => onEnabledChange(e.currentTarget.checked)}
+            role="checkbox"
+          />
+        </div>
+      </InlineField>
       <Select
         disabled={!enabled}
         options={options}

--- a/src/components/queryBuilder/OtelVersionSelect.tsx
+++ b/src/components/queryBuilder/OtelVersionSelect.tsx
@@ -1,8 +1,9 @@
 import React, { useEffect } from 'react';
 import { SelectableValue } from '@grafana/data';
-import { InlineFormLabel, Select, Switch as GrafanaSwitch, useTheme } from '@grafana/ui';
+import { InlineFieldRow, InlineFormLabel, Select, Switch as GrafanaSwitch, useTheme } from '@grafana/ui';
 import otel from 'otel';
 import selectors from 'labels';
+import { styles } from 'styles';
 
 interface OtelVersionSelectProps {
   enabled: boolean;
@@ -36,13 +37,13 @@ export const OtelVersionSelect = (props: OtelVersionSelectProps) => {
   };
 
   return (
-    <div className="gf-form">
+    <InlineFieldRow className={styles.Common.formRow}>
       <InlineFormLabel width={wide ? 12 : 8} className="query-keyword" tooltip={tooltip}>
         {label}
       </InlineFormLabel>
       <div style={switchContainerStyle}>
         <GrafanaSwitch
-          className="gf-form"
+          className={styles.Common.formRowSwitch}
           value={enabled}
           onChange={(e) => onEnabledChange(e.currentTarget.checked)}
           role="checkbox"
@@ -56,6 +57,6 @@ export const OtelVersionSelect = (props: OtelVersionSelectProps) => {
         value={selectedVersion}
         menuPlacement={'bottom'}
       />
-    </div>
+    </InlineFieldRow>
   );
 };

--- a/src/components/queryBuilder/QueryBuilder.tsx
+++ b/src/components/queryBuilder/QueryBuilder.tsx
@@ -86,7 +86,7 @@ export const QueryBuilder = (props: QueryBuilderProps) => {
 
   return (
     <div data-testid="query-editor-section-builder">
-      <InlineFieldRow className={`${styles.Common.formRow} ${styles.QueryEditor.queryType}`}>
+      <InlineFieldRow className={styles.QueryEditor.queryType}>
         <DatabaseTableSelect
           datasource={datasource}
           database={builderOptions.database}
@@ -95,7 +95,7 @@ export const QueryBuilder = (props: QueryBuilderProps) => {
           onTableChange={onTableChange}
         />
       </InlineFieldRow>
-      <InlineFieldRow className={`${styles.Common.formRow} ${styles.QueryEditor.queryType}`}>
+      <InlineFieldRow className={styles.QueryEditor.queryType}>
         <QueryTypeSwitcher queryType={builderOptions.queryType} onChange={onQueryTypeChange} />
       </InlineFieldRow>
 

--- a/src/components/queryBuilder/QueryBuilder.tsx
+++ b/src/components/queryBuilder/QueryBuilder.tsx
@@ -27,7 +27,7 @@ import {
   setTable,
 } from 'hooks/useBuilderOptionsState';
 import TraceIdInput from './TraceIdInput';
-import { Alert, Button, Stack } from '@grafana/ui';
+import { Alert, Button, InlineFieldRow, Stack } from '@grafana/ui';
 import { Components as allSelectors } from 'selectors';
 import allLabels from 'labels';
 import { buildCompactQueryDefaults, isDefaultOrMismatchedCompactQuery } from './compactQueryDefaults';
@@ -86,7 +86,7 @@ export const QueryBuilder = (props: QueryBuilderProps) => {
 
   return (
     <div data-testid="query-editor-section-builder">
-      <div className={'gf-form ' + styles.QueryEditor.queryType}>
+      <InlineFieldRow className={`${styles.Common.formRow} ${styles.QueryEditor.queryType}`}>
         <DatabaseTableSelect
           datasource={datasource}
           database={builderOptions.database}
@@ -94,10 +94,10 @@ export const QueryBuilder = (props: QueryBuilderProps) => {
           table={builderOptions.table}
           onTableChange={onTableChange}
         />
-      </div>
-      <div className={'gf-form ' + styles.QueryEditor.queryType}>
+      </InlineFieldRow>
+      <InlineFieldRow className={`${styles.Common.formRow} ${styles.QueryEditor.queryType}`}>
         <QueryTypeSwitcher queryType={builderOptions.queryType} onChange={onQueryTypeChange} />
-      </div>
+      </InlineFieldRow>
 
       {builderOptions.queryType === QueryType.Table && (
         <TableQueryBuilder

--- a/src/components/queryBuilder/QueryTypeSwitcher.tsx
+++ b/src/components/queryBuilder/QueryTypeSwitcher.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { RadioButtonGroup, InlineFormLabel } from '@grafana/ui';
+import { RadioButtonGroup, InlineField, InlineFormLabel } from '@grafana/ui';
 import labels from 'labels';
 import { QueryType } from 'types/queryBuilder';
 
@@ -36,11 +36,14 @@ export const QueryTypeSwitcher = (props: QueryTypeSwitcherProps) => {
   const { label, tooltip, sqlTooltip } = labels.components.QueryTypeSwitcher;
 
   return (
-    <span>
-      <InlineFormLabel width={8} className="query-keyword" tooltip={sqlEditor ? sqlTooltip : tooltip}>
-        {label}
-      </InlineFormLabel>
+    <InlineField
+      label={
+        <InlineFormLabel width={8} className="query-keyword" tooltip={sqlEditor ? sqlTooltip : tooltip}>
+          {label}
+        </InlineFormLabel>
+      }
+    >
       <RadioButtonGroup options={options} value={queryType} onChange={onChange} />
-    </span>
+    </InlineField>
   );
 };

--- a/src/components/queryBuilder/SqlPreview.tsx
+++ b/src/components/queryBuilder/SqlPreview.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import { css } from '@emotion/css';
 import { GrafanaTheme2 } from '@grafana/data';
-import { Button, Icon, InlineFieldRow, InlineFormLabel, useStyles2 } from '@grafana/ui';
-import { styles as sharedStyles } from 'styles';
+import { Button, Icon, InlineField, InlineFormLabel, useStyles2 } from '@grafana/ui';
 import labels from 'labels';
 
 interface SqlPreviewProps {
@@ -89,11 +88,15 @@ export const SqlPreview = (props: SqlPreviewProps) => {
   }
 
   return (
-    <InlineFieldRow className={sharedStyles.Common.formRow}>
-      <InlineFormLabel width={8} className="query-keyword" tooltip={tooltip}>
-        {label}
-      </InlineFormLabel>
+    <InlineField
+      label={
+        <InlineFormLabel width={8} className="query-keyword" tooltip={tooltip}>
+          {label}
+        </InlineFormLabel>
+      }
+      shrink
+    >
       <pre>{sql}</pre>
-    </InlineFieldRow>
+    </InlineField>
   );
 };

--- a/src/components/queryBuilder/SqlPreview.tsx
+++ b/src/components/queryBuilder/SqlPreview.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { css } from '@emotion/css';
 import { GrafanaTheme2 } from '@grafana/data';
-import { Button, Icon, InlineFormLabel, useStyles2 } from '@grafana/ui';
+import { Button, Icon, InlineFieldRow, InlineFormLabel, useStyles2 } from '@grafana/ui';
+import { styles as sharedStyles } from 'styles';
 import labels from 'labels';
 
 interface SqlPreviewProps {
@@ -88,11 +89,11 @@ export const SqlPreview = (props: SqlPreviewProps) => {
   }
 
   return (
-    <div className="gf-form">
+    <InlineFieldRow className={sharedStyles.Common.formRow}>
       <InlineFormLabel width={8} className="query-keyword" tooltip={tooltip}>
         {label}
       </InlineFormLabel>
       <pre>{sql}</pre>
-    </div>
+    </InlineFieldRow>
   );
 };

--- a/src/components/queryBuilder/Switch.tsx
+++ b/src/components/queryBuilder/Switch.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { InlineFormLabel, Switch as GrafanaSwitch, useTheme } from '@grafana/ui';
+import { InlineFieldRow, InlineFormLabel, Switch as GrafanaSwitch, useTheme } from '@grafana/ui';
 import { styles } from 'styles';
 
 interface SwitchProps {
@@ -26,19 +26,19 @@ export const Switch = (props: SwitchProps) => {
   const labelStyle = 'query-keyword ' + (inline ? styles.QueryEditor.inlineField : '');
 
   return (
-    <div className="gf-form">
+    <InlineFieldRow className={styles.Common.formRow}>
       <InlineFormLabel width={wide ? 12 : 8} className={labelStyle} tooltip={tooltip}>
         {label}
       </InlineFormLabel>
       <div style={switchContainerStyle}>
         <GrafanaSwitch
           disabled={disabled}
-          className="gf-form"
+          className={styles.Common.formRowSwitch}
           value={value}
           onChange={(e) => onChange(e.currentTarget.checked)}
           aria-label={label}
         />
       </div>
-    </div>
+    </InlineFieldRow>
   );
 };

--- a/src/components/queryBuilder/Switch.tsx
+++ b/src/components/queryBuilder/Switch.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { InlineFieldRow, InlineFormLabel, Switch as GrafanaSwitch, useTheme } from '@grafana/ui';
+import { InlineField, InlineFormLabel, Switch as GrafanaSwitch, useTheme } from '@grafana/ui';
 import { styles } from 'styles';
 
 interface SwitchProps {
@@ -26,19 +26,21 @@ export const Switch = (props: SwitchProps) => {
   const labelStyle = 'query-keyword ' + (inline ? styles.QueryEditor.inlineField : '');
 
   return (
-    <InlineFieldRow className={styles.Common.formRow}>
-      <InlineFormLabel width={wide ? 12 : 8} className={labelStyle} tooltip={tooltip}>
-        {label}
-      </InlineFormLabel>
+    <InlineField
+      label={
+        <InlineFormLabel width={wide ? 12 : 8} className={labelStyle} tooltip={tooltip}>
+          {label}
+        </InlineFormLabel>
+      }
+    >
       <div style={switchContainerStyle}>
         <GrafanaSwitch
           disabled={disabled}
-          className={styles.Common.formRowSwitch}
           value={value}
           onChange={(e) => onChange(e.currentTarget.checked)}
           aria-label={label}
         />
       </div>
-    </InlineFieldRow>
+    </InlineField>
   );
 };

--- a/src/components/queryBuilder/TraceIdInput.tsx
+++ b/src/components/queryBuilder/TraceIdInput.tsx
@@ -1,8 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import allLabels from 'labels';
-import { InlineFieldRow, InlineFormLabel, Input } from '@grafana/ui';
+import { InlineField, InlineFormLabel, Input } from '@grafana/ui';
 import { selectors } from 'selectors';
-import { styles } from 'styles';
 
 interface TraceIdInputProps {
   traceId: string;
@@ -20,20 +19,23 @@ const TraceIdInput = (props: TraceIdInputProps) => {
   }, [traceId]);
 
   return (
-    <InlineFieldRow className={styles.Common.formRow}>
-      <InlineFormLabel width={8} className="query-keyword" tooltip={tooltip}>
-        {label}
-      </InlineFormLabel>
+    <InlineField
+      label={
+        <InlineFormLabel width={8} className="query-keyword" tooltip={tooltip}>
+          {label}
+        </InlineFormLabel>
+      }
+      disabled={disabled}
+    >
       <Input
         data-testid={selectors.components.QueryBuilder.TraceIdInput.input}
         width={40}
         value={inputId}
-        disabled={disabled}
         type="string"
         onChange={(e) => setInputId(e.currentTarget.value)}
         onBlur={() => onChange(inputId)}
       />
-    </InlineFieldRow>
+    </InlineField>
   );
 };
 

--- a/src/components/queryBuilder/TraceIdInput.tsx
+++ b/src/components/queryBuilder/TraceIdInput.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import allLabels from 'labels';
-import { InlineFormLabel, Input } from '@grafana/ui';
+import { InlineFieldRow, InlineFormLabel, Input } from '@grafana/ui';
 import { selectors } from 'selectors';
+import { styles } from 'styles';
 
 interface TraceIdInputProps {
   traceId: string;
@@ -19,7 +20,7 @@ const TraceIdInput = (props: TraceIdInputProps) => {
   }, [traceId]);
 
   return (
-    <div className="gf-form">
+    <InlineFieldRow className={styles.Common.formRow}>
       <InlineFormLabel width={8} className="query-keyword" tooltip={tooltip}>
         {label}
       </InlineFormLabel>
@@ -32,7 +33,7 @@ const TraceIdInput = (props: TraceIdInputProps) => {
         onChange={(e) => setInputId(e.currentTarget.value)}
         onBlur={() => onChange(inputId)}
       />
-    </div>
+    </InlineFieldRow>
   );
 };
 

--- a/src/components/queryBuilder/views/LogsQueryBuilder.tsx
+++ b/src/components/queryBuilder/views/LogsQueryBuilder.tsx
@@ -12,7 +12,7 @@ import { getColumnByHint } from 'data/sqlGenerator';
 import { columnFilterDateTime, columnFilterString } from 'data/columnFilters';
 import { Datasource } from 'data/CHDatasource';
 import { useBuilderOptionChanges } from 'hooks/useBuilderOptionChanges';
-import { Alert, Button, InlineFieldRow, InlineFormLabel, Input, Stack } from '@grafana/ui';
+import { Alert, Button, InlineField, InlineFieldRow, InlineFormLabel, Input, Stack } from '@grafana/ui';
 import useColumns from 'hooks/useColumns';
 import { BuilderOptionsReducerAction, setOptions, setOtelEnabled, setOtelVersion } from 'hooks/useBuilderOptionsState';
 import useIsNewQuery from 'hooks/useIsNewQuery';
@@ -158,7 +158,7 @@ export const LogsQueryBuilder = (props: LogsQueryBuilderProps) => {
         selectedColumns={builderState.selectedColumns}
         onSelectedColumnsChange={onOptionChange('selectedColumns')}
       />
-      <InlineFieldRow className={styles.Common.formRow}>
+      <InlineFieldRow>
         <ColumnSelect
           disabled={builderState.otelEnabled}
           allColumns={allColumns}
@@ -183,7 +183,7 @@ export const LogsQueryBuilder = (props: LogsQueryBuilderProps) => {
           inline
         />
       </InlineFieldRow>
-      <InlineFieldRow className={styles.Common.formRow}>
+      <InlineFieldRow>
         <ColumnSelect
           disabled={builderState.otelEnabled}
           allColumns={allColumns}
@@ -230,17 +230,23 @@ const LogMessageLikeInput = (props: LogMessageLikeInputProps) => {
   }, [logMessageLike]);
 
   return (
-    <InlineFieldRow className={styles.Common.formRow}>
-      <InlineFormLabel width={8} className="query-keyword" tooltip={tooltip}>
-        {label}
-      </InlineFormLabel>
-      <Input
-        width={200}
-        value={input}
-        type="string"
-        onChange={(e) => setInput(e.currentTarget.value)}
-        onBlur={() => onChange(input)}
-      />
+    <InlineFieldRow>
+      <InlineField
+        label={
+          <InlineFormLabel width={8} className="query-keyword" tooltip={tooltip}>
+            {label}
+          </InlineFormLabel>
+        }
+        shrink
+      >
+        <Input
+          width={200}
+          value={input}
+          type="string"
+          onChange={(e) => setInput(e.currentTarget.value)}
+          onBlur={() => onChange(input)}
+        />
+      </InlineField>
       {logMessageLike && (
         <Button
           data-testid={allSelectors.QueryBuilder.LogsQueryBuilder.LogMessageLikeInput.input}

--- a/src/components/queryBuilder/views/LogsQueryBuilder.tsx
+++ b/src/components/queryBuilder/views/LogsQueryBuilder.tsx
@@ -12,7 +12,7 @@ import { getColumnByHint } from 'data/sqlGenerator';
 import { columnFilterDateTime, columnFilterString } from 'data/columnFilters';
 import { Datasource } from 'data/CHDatasource';
 import { useBuilderOptionChanges } from 'hooks/useBuilderOptionChanges';
-import { Alert, Button, InlineFormLabel, Input, Stack } from '@grafana/ui';
+import { Alert, Button, InlineFieldRow, InlineFormLabel, Input, Stack } from '@grafana/ui';
 import useColumns from 'hooks/useColumns';
 import { BuilderOptionsReducerAction, setOptions, setOtelEnabled, setOtelVersion } from 'hooks/useBuilderOptionsState';
 import useIsNewQuery from 'hooks/useIsNewQuery';
@@ -158,7 +158,7 @@ export const LogsQueryBuilder = (props: LogsQueryBuilderProps) => {
         selectedColumns={builderState.selectedColumns}
         onSelectedColumnsChange={onOptionChange('selectedColumns')}
       />
-      <div className="gf-form">
+      <InlineFieldRow className={styles.Common.formRow}>
         <ColumnSelect
           disabled={builderState.otelEnabled}
           allColumns={allColumns}
@@ -182,8 +182,8 @@ export const LogsQueryBuilder = (props: LogsQueryBuilderProps) => {
           tooltip={labels.logLevelColumn.tooltip}
           inline
         />
-      </div>
-      <div className="gf-form">
+      </InlineFieldRow>
+      <InlineFieldRow className={styles.Common.formRow}>
         <ColumnSelect
           disabled={builderState.otelEnabled}
           allColumns={allColumns}
@@ -195,7 +195,7 @@ export const LogsQueryBuilder = (props: LogsQueryBuilderProps) => {
           label={labels.logMessageColumn.label}
           tooltip={labels.logMessageColumn.tooltip}
         />
-      </div>
+      </InlineFieldRow>
       <OrderByEditor
         orderByOptions={getOrderByOptions(builderOptions, allColumns)}
         orderBy={builderState.orderBy}
@@ -230,7 +230,7 @@ const LogMessageLikeInput = (props: LogMessageLikeInputProps) => {
   }, [logMessageLike]);
 
   return (
-    <div className="gf-form">
+    <InlineFieldRow className={styles.Common.formRow}>
       <InlineFormLabel width={8} className="query-keyword" tooltip={tooltip}>
         {label}
       </InlineFormLabel>
@@ -253,6 +253,6 @@ const LogMessageLikeInput = (props: LogMessageLikeInputProps) => {
           {clearButton}
         </Button>
       )}
-    </div>
+    </InlineFieldRow>
   );
 };

--- a/src/components/queryBuilder/views/TraceQueryBuilder.tsx
+++ b/src/components/queryBuilder/views/TraceQueryBuilder.tsx
@@ -7,7 +7,8 @@ import { FiltersEditor } from '../FilterEditor';
 import allLabels from 'labels';
 import { ModeSwitch } from '../ModeSwitch';
 import { getColumnByHint } from 'data/sqlGenerator';
-import { Alert, Collapse, Stack } from '@grafana/ui';
+import { Alert, Collapse, InlineFieldRow, Stack } from '@grafana/ui';
+import { styles } from 'styles';
 import { DurationUnitSelect } from 'components/queryBuilder/DurationUnitSelect';
 import { Datasource } from 'data/CHDatasource';
 import { useBuilderOptionChanges } from 'hooks/useBuilderOptionChanges';
@@ -208,7 +209,7 @@ export const TraceQueryBuilder = (props: TraceQueryBuilderProps) => {
           onVersionChange={(v) => builderOptionsDispatch(setOtelVersion(v))}
           wide
         />
-        <div className="gf-form">
+        <InlineFieldRow className={styles.Common.formRow}>
           <ColumnSelect
             disabled={builderState.otelEnabled}
             allColumns={allColumns}
@@ -232,8 +233,8 @@ export const TraceQueryBuilder = (props: TraceQueryBuilderProps) => {
             wide
             inline
           />
-        </div>
-        <div className="gf-form">
+        </InlineFieldRow>
+        <InlineFieldRow className={styles.Common.formRow}>
           <ColumnSelect
             disabled={builderState.otelEnabled}
             allColumns={allColumns}
@@ -257,8 +258,8 @@ export const TraceQueryBuilder = (props: TraceQueryBuilderProps) => {
             wide
             inline
           />
-        </div>
-        <div className="gf-form">
+        </InlineFieldRow>
+        <InlineFieldRow className={styles.Common.formRow}>
           <ColumnSelect
             disabled={builderState.otelEnabled}
             allColumns={allColumns}
@@ -282,8 +283,8 @@ export const TraceQueryBuilder = (props: TraceQueryBuilderProps) => {
             wide
             inline
           />
-        </div>
-        <div className="gf-form">
+        </InlineFieldRow>
+        <InlineFieldRow className={styles.Common.formRow}>
           <ColumnSelect
             disabled={builderState.otelEnabled}
             allColumns={allColumns}
@@ -301,8 +302,8 @@ export const TraceQueryBuilder = (props: TraceQueryBuilderProps) => {
             onChange={onOptionChange('durationUnit')}
             inline
           />
-        </div>
-        <div className="gf-form">
+        </InlineFieldRow>
+        <InlineFieldRow className={styles.Common.formRow}>
           <ColumnSelect
             disabled={builderState.otelEnabled}
             allColumns={allColumns}
@@ -326,8 +327,8 @@ export const TraceQueryBuilder = (props: TraceQueryBuilderProps) => {
             wide
             inline
           />
-        </div>
-        <div className="gf-form">
+        </InlineFieldRow>
+        <InlineFieldRow className={styles.Common.formRow}>
           <ColumnSelect
             disabled={builderState.otelEnabled}
             allColumns={allColumns}
@@ -351,8 +352,8 @@ export const TraceQueryBuilder = (props: TraceQueryBuilderProps) => {
             wide
             inline
           />
-        </div>
-        <div className="gf-form">
+        </InlineFieldRow>
+        <InlineFieldRow className={styles.Common.formRow}>
           <ColumnSelect
             disabled={builderState.otelEnabled}
             allColumns={allColumns}
@@ -376,8 +377,8 @@ export const TraceQueryBuilder = (props: TraceQueryBuilderProps) => {
             wide
             inline
           />
-        </div>
-        <div className="gf-form">
+        </InlineFieldRow>
+        <InlineFieldRow className={styles.Common.formRow}>
           <ColumnSelect
             disabled={builderState.otelEnabled}
             allColumns={allColumns}
@@ -401,8 +402,8 @@ export const TraceQueryBuilder = (props: TraceQueryBuilderProps) => {
             wide
             inline
           />
-        </div>
-        <div className="gf-form">
+        </InlineFieldRow>
+        <InlineFieldRow className={styles.Common.formRow}>
           <Switch
             disabled={builderState.otelEnabled}
             label={labels.columns.flattenNested.label}
@@ -411,8 +412,8 @@ export const TraceQueryBuilder = (props: TraceQueryBuilderProps) => {
             onChange={onOptionChange('flattenNested')}
             wide
           />
-        </div>
-        <div className="gf-form">
+        </InlineFieldRow>
+        <InlineFieldRow className={styles.Common.formRow}>
           <LabeledInput
             disabled={builderState.otelEnabled}
             label={labels.columns.eventsPrefix.label}
@@ -420,8 +421,8 @@ export const TraceQueryBuilder = (props: TraceQueryBuilderProps) => {
             value={builderState.traceEventsColumnPrefix || ''}
             onChange={onOptionChange('traceEventsColumnPrefix')}
           />
-        </div>
-        <div className="gf-form">
+        </InlineFieldRow>
+        <InlineFieldRow className={styles.Common.formRow}>
           <LabeledInput
             disabled={builderState.otelEnabled}
             label={labels.columns.linksPrefix.label}
@@ -429,7 +430,7 @@ export const TraceQueryBuilder = (props: TraceQueryBuilderProps) => {
             value={builderState.traceLinksColumnPrefix || ''}
             onChange={onOptionChange('traceLinksColumnPrefix')}
           />
-        </div>
+        </InlineFieldRow>
       </Collapse>
       <Collapse label={labels.filtersSection} isOpen={isFiltersOpen} onToggle={setFiltersOpen}>
         <OrderByEditor

--- a/src/components/queryBuilder/views/TraceQueryBuilder.tsx
+++ b/src/components/queryBuilder/views/TraceQueryBuilder.tsx
@@ -8,7 +8,6 @@ import allLabels from 'labels';
 import { ModeSwitch } from '../ModeSwitch';
 import { getColumnByHint } from 'data/sqlGenerator';
 import { Alert, Collapse, InlineFieldRow, Stack } from '@grafana/ui';
-import { styles } from 'styles';
 import { DurationUnitSelect } from 'components/queryBuilder/DurationUnitSelect';
 import { Datasource } from 'data/CHDatasource';
 import { useBuilderOptionChanges } from 'hooks/useBuilderOptionChanges';
@@ -209,7 +208,7 @@ export const TraceQueryBuilder = (props: TraceQueryBuilderProps) => {
           onVersionChange={(v) => builderOptionsDispatch(setOtelVersion(v))}
           wide
         />
-        <InlineFieldRow className={styles.Common.formRow}>
+        <InlineFieldRow>
           <ColumnSelect
             disabled={builderState.otelEnabled}
             allColumns={allColumns}
@@ -234,7 +233,7 @@ export const TraceQueryBuilder = (props: TraceQueryBuilderProps) => {
             inline
           />
         </InlineFieldRow>
-        <InlineFieldRow className={styles.Common.formRow}>
+        <InlineFieldRow>
           <ColumnSelect
             disabled={builderState.otelEnabled}
             allColumns={allColumns}
@@ -259,7 +258,7 @@ export const TraceQueryBuilder = (props: TraceQueryBuilderProps) => {
             inline
           />
         </InlineFieldRow>
-        <InlineFieldRow className={styles.Common.formRow}>
+        <InlineFieldRow>
           <ColumnSelect
             disabled={builderState.otelEnabled}
             allColumns={allColumns}
@@ -284,7 +283,7 @@ export const TraceQueryBuilder = (props: TraceQueryBuilderProps) => {
             inline
           />
         </InlineFieldRow>
-        <InlineFieldRow className={styles.Common.formRow}>
+        <InlineFieldRow>
           <ColumnSelect
             disabled={builderState.otelEnabled}
             allColumns={allColumns}
@@ -303,7 +302,7 @@ export const TraceQueryBuilder = (props: TraceQueryBuilderProps) => {
             inline
           />
         </InlineFieldRow>
-        <InlineFieldRow className={styles.Common.formRow}>
+        <InlineFieldRow>
           <ColumnSelect
             disabled={builderState.otelEnabled}
             allColumns={allColumns}
@@ -328,7 +327,7 @@ export const TraceQueryBuilder = (props: TraceQueryBuilderProps) => {
             inline
           />
         </InlineFieldRow>
-        <InlineFieldRow className={styles.Common.formRow}>
+        <InlineFieldRow>
           <ColumnSelect
             disabled={builderState.otelEnabled}
             allColumns={allColumns}
@@ -353,7 +352,7 @@ export const TraceQueryBuilder = (props: TraceQueryBuilderProps) => {
             inline
           />
         </InlineFieldRow>
-        <InlineFieldRow className={styles.Common.formRow}>
+        <InlineFieldRow>
           <ColumnSelect
             disabled={builderState.otelEnabled}
             allColumns={allColumns}
@@ -378,7 +377,7 @@ export const TraceQueryBuilder = (props: TraceQueryBuilderProps) => {
             inline
           />
         </InlineFieldRow>
-        <InlineFieldRow className={styles.Common.formRow}>
+        <InlineFieldRow>
           <ColumnSelect
             disabled={builderState.otelEnabled}
             allColumns={allColumns}
@@ -403,7 +402,7 @@ export const TraceQueryBuilder = (props: TraceQueryBuilderProps) => {
             inline
           />
         </InlineFieldRow>
-        <InlineFieldRow className={styles.Common.formRow}>
+        <InlineFieldRow>
           <Switch
             disabled={builderState.otelEnabled}
             label={labels.columns.flattenNested.label}
@@ -413,7 +412,7 @@ export const TraceQueryBuilder = (props: TraceQueryBuilderProps) => {
             wide
           />
         </InlineFieldRow>
-        <InlineFieldRow className={styles.Common.formRow}>
+        <InlineFieldRow>
           <LabeledInput
             disabled={builderState.otelEnabled}
             label={labels.columns.eventsPrefix.label}
@@ -422,7 +421,7 @@ export const TraceQueryBuilder = (props: TraceQueryBuilderProps) => {
             onChange={onOptionChange('traceEventsColumnPrefix')}
           />
         </InlineFieldRow>
-        <InlineFieldRow className={styles.Common.formRow}>
+        <InlineFieldRow>
           <LabeledInput
             disabled={builderState.otelEnabled}
             label={labels.columns.linksPrefix.label}

--- a/src/data/CHAnnotationSupport.tsx
+++ b/src/data/CHAnnotationSupport.tsx
@@ -1,8 +1,7 @@
 import React, { useCallback, useMemo } from 'react';
 import { AnnotationQuery, AnnotationSupport, GrafanaTheme2, QueryEditorProps } from '@grafana/data';
-import { InlineFieldRow, InlineFormLabel, Select, TextArea, useStyles2 } from '@grafana/ui';
+import { Box, InlineField, InlineFormLabel, Select, Text, TextArea, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
-import { styles as sharedStyles } from 'styles';
 import { Datasource } from './CHDatasource';
 import { escapeIdentifier, getTableIdentifier } from './sqlGenerator';
 import { CHQuery, CHSqlQuery, EditorType } from 'types/sql';
@@ -264,17 +263,21 @@ const AnnotationQueryEditor = (props: AnnotationEditorProps) => {
 
   return (
     <div>
-      <InlineFieldRow className={sharedStyles.Common.formRow} style={{ marginBottom: 8 }}>
-        <InlineFormLabel width={10} tooltip="Select an annotation preset or write custom SQL">
-          Annotation Type
-        </InlineFormLabel>
+      <InlineField
+        label={
+          <InlineFormLabel width={10} tooltip="Select an annotation preset or write custom SQL">
+            Annotation Type
+          </InlineFormLabel>
+        }
+        style={{ marginBottom: 8 }}
+      >
         <Select
           width={40}
           options={PRESET_OPTIONS}
           value={preset}
           onChange={(v) => onPresetChange(v.value || 'custom')}
         />
-      </InlineFieldRow>
+      </InlineField>
 
       {preset === 'change_detection' && (
         <>
@@ -287,40 +290,45 @@ const AnnotationQueryEditor = (props: AnnotationEditorProps) => {
           />
 
           {cd.column && (
-            <InlineFieldRow className={sharedStyles.Common.formRow} style={{ marginBottom: 4 }}>
-              <InlineFormLabel
-                width={10}
-                tooltip="Group changes by this column. Each unique value is tracked independently."
-              >
-                Group By
-              </InlineFormLabel>
+            <InlineField
+              label={
+                <InlineFormLabel
+                  width={10}
+                  tooltip="Group changes by this column. Each unique value is tracked independently."
+                >
+                  Group By
+                </InlineFormLabel>
+              }
+            >
               <Select
                 width={30}
                 options={groupByOptions}
                 value={cd.groupBy || 'ServiceName'}
                 onChange={(v) => updateChangeDetection({ groupBy: v.value || 'ServiceName' })}
               />
-            </InlineFieldRow>
+            </InlineField>
           )}
         </>
       )}
 
-      <InlineFieldRow className={sharedStyles.Common.formRow} style={{ marginBottom: 4 }}>
-        <InlineFormLabel width={10}>SQL Query</InlineFormLabel>
-        <TextArea
-          className={styles.sqlInput}
-          rows={8}
-          value={anno.target?.rawSql || ''}
-          onChange={onSqlChange}
-          placeholder="SELECT Timestamp AS time, Body AS text, ServiceName AS tags FROM otel_logs WHERE $__timeFilter(Timestamp)"
-        />
-      </InlineFieldRow>
-
-      <div className={styles.helpText}>
-        {preset === 'change_detection'
-          ? 'Annotations appear when the watched value changes per group, including rollbacks.'
-          : 'Return columns: time (required), text, title, tags. Standard Grafana annotation mapping.'}
-      </div>
+      <InlineField label={<InlineFormLabel width={10}>SQL Query</InlineFormLabel>} grow shrink>
+        <Box>
+          <TextArea
+            className={styles.sqlInput}
+            rows={8}
+            value={anno.target?.rawSql || ''}
+            onChange={onSqlChange}
+            placeholder="SELECT Timestamp AS time, Body AS text, ServiceName AS tags FROM otel_logs WHERE $__timeFilter(Timestamp)"
+          />
+          <Box marginTop={0.5} marginBottom={1}>
+            <Text color="secondary" variant="bodySmall">
+              {preset === 'change_detection'
+                ? 'Annotations appear when the watched value changes per group, including rollbacks.'
+                : 'Return columns: time (required), text, title, tags. Standard Grafana annotation mapping.'}
+            </Text>
+          </Box>
+        </Box>
+      </InlineField>
     </div>
   );
 };
@@ -329,12 +337,6 @@ const getStyles = (theme: GrafanaTheme2) => ({
   sqlInput: css({
     fontFamily: theme.typography.fontFamilyMonospace,
     fontSize: theme.typography.bodySmall.fontSize,
-  }),
-  helpText: css({
-    color: theme.colors.text.secondary,
-    fontSize: theme.typography.bodySmall.fontSize,
-    marginLeft: 88,
-    marginBottom: theme.spacing(1),
   }),
 });
 

--- a/src/data/CHAnnotationSupport.tsx
+++ b/src/data/CHAnnotationSupport.tsx
@@ -1,7 +1,8 @@
 import React, { useCallback, useMemo } from 'react';
 import { AnnotationQuery, AnnotationSupport, GrafanaTheme2, QueryEditorProps } from '@grafana/data';
-import { InlineFormLabel, Select, TextArea, useStyles2 } from '@grafana/ui';
+import { InlineFieldRow, InlineFormLabel, Select, TextArea, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
+import { styles as sharedStyles } from 'styles';
 import { Datasource } from './CHDatasource';
 import { escapeIdentifier, getTableIdentifier } from './sqlGenerator';
 import { CHQuery, CHSqlQuery, EditorType } from 'types/sql';
@@ -263,7 +264,7 @@ const AnnotationQueryEditor = (props: AnnotationEditorProps) => {
 
   return (
     <div>
-      <div className="gf-form" style={{ marginBottom: 8 }}>
+      <InlineFieldRow className={sharedStyles.Common.formRow} style={{ marginBottom: 8 }}>
         <InlineFormLabel width={10} tooltip="Select an annotation preset or write custom SQL">
           Annotation Type
         </InlineFormLabel>
@@ -273,7 +274,7 @@ const AnnotationQueryEditor = (props: AnnotationEditorProps) => {
           value={preset}
           onChange={(v) => onPresetChange(v.value || 'custom')}
         />
-      </div>
+      </InlineFieldRow>
 
       {preset === 'change_detection' && (
         <>
@@ -286,7 +287,7 @@ const AnnotationQueryEditor = (props: AnnotationEditorProps) => {
           />
 
           {cd.column && (
-            <div className="gf-form" style={{ marginBottom: 4 }}>
+            <InlineFieldRow className={sharedStyles.Common.formRow} style={{ marginBottom: 4 }}>
               <InlineFormLabel
                 width={10}
                 tooltip="Group changes by this column. Each unique value is tracked independently."
@@ -299,12 +300,12 @@ const AnnotationQueryEditor = (props: AnnotationEditorProps) => {
                 value={cd.groupBy || 'ServiceName'}
                 onChange={(v) => updateChangeDetection({ groupBy: v.value || 'ServiceName' })}
               />
-            </div>
+            </InlineFieldRow>
           )}
         </>
       )}
 
-      <div className="gf-form" style={{ marginBottom: 4 }}>
+      <InlineFieldRow className={sharedStyles.Common.formRow} style={{ marginBottom: 4 }}>
         <InlineFormLabel width={10}>SQL Query</InlineFormLabel>
         <TextArea
           className={styles.sqlInput}
@@ -313,7 +314,7 @@ const AnnotationQueryEditor = (props: AnnotationEditorProps) => {
           onChange={onSqlChange}
           placeholder="SELECT Timestamp AS time, Body AS text, ServiceName AS tags FROM otel_logs WHERE $__timeFilter(Timestamp)"
         />
-      </div>
+      </InlineFieldRow>
 
       <div className={styles.helpText}>
         {preset === 'change_detection'

--- a/src/data/CHVariableSupport.tsx
+++ b/src/data/CHVariableSupport.tsx
@@ -7,7 +7,8 @@ import {
   QueryEditorProps,
   toDataFrame,
 } from '@grafana/data';
-import { InlineFormLabel, Select, TextArea } from '@grafana/ui';
+import { InlineFieldRow, InlineFormLabel, Select, TextArea } from '@grafana/ui';
+import { styles } from 'styles';
 import { Observable, from, of } from 'rxjs';
 import { SchemaPicker, SchemaPickerLevel, SchemaPickerValue } from 'components/queryBuilder/SchemaPicker';
 import { CHConfig } from 'types/config';
@@ -178,7 +179,7 @@ export const VariableQueryEditor = (props: EditorProps) => {
 
   return (
     <div>
-      <div className="gf-form">
+      <InlineFieldRow className={styles.Common.formRow}>
         <InlineFormLabel
           width={10}
           className="query-keyword"
@@ -193,7 +194,7 @@ export const VariableQueryEditor = (props: EditorProps) => {
           onChange={(v) => onTypeChange((v.value as CHVariableQueryType) || 'sql')}
           aria-label="Variable type"
         />
-      </div>
+      </InlineFieldRow>
 
       {pickerLevel && (
         <SchemaPicker
@@ -204,7 +205,7 @@ export const VariableQueryEditor = (props: EditorProps) => {
         />
       )}
 
-      <div className="gf-form">
+      <InlineFieldRow className={styles.Common.formRow}>
         <InlineFormLabel
           width={10}
           className="query-keyword"
@@ -219,7 +220,7 @@ export const VariableQueryEditor = (props: EditorProps) => {
           placeholder="SELECT DISTINCT column FROM database.table"
           aria-label="SQL Query"
         />
-      </div>
+      </InlineFieldRow>
     </div>
   );
 };

--- a/src/data/CHVariableSupport.tsx
+++ b/src/data/CHVariableSupport.tsx
@@ -7,8 +7,7 @@ import {
   QueryEditorProps,
   toDataFrame,
 } from '@grafana/data';
-import { InlineFieldRow, InlineFormLabel, Select, TextArea } from '@grafana/ui';
-import { styles } from 'styles';
+import { InlineField, InlineFormLabel, Select, TextArea } from '@grafana/ui';
 import { Observable, from, of } from 'rxjs';
 import { SchemaPicker, SchemaPickerLevel, SchemaPickerValue } from 'components/queryBuilder/SchemaPicker';
 import { CHConfig } from 'types/config';
@@ -179,14 +178,17 @@ export const VariableQueryEditor = (props: EditorProps) => {
 
   return (
     <div>
-      <InlineFieldRow className={styles.Common.formRow}>
-        <InlineFormLabel
-          width={10}
-          className="query-keyword"
-          tooltip="Pick a guided variable type, or keep Custom SQL to write your own query."
-        >
-          Variable type
-        </InlineFormLabel>
+      <InlineField
+        label={
+          <InlineFormLabel
+            width={10}
+            className="query-keyword"
+            tooltip="Pick a guided variable type, or keep Custom SQL to write your own query."
+          >
+            Variable type
+          </InlineFormLabel>
+        }
+      >
         <Select
           width={40}
           options={VARIABLE_TYPE_OPTIONS}
@@ -194,7 +196,7 @@ export const VariableQueryEditor = (props: EditorProps) => {
           onChange={(v) => onTypeChange((v.value as CHVariableQueryType) || 'sql')}
           aria-label="Variable type"
         />
-      </InlineFieldRow>
+      </InlineField>
 
       {pickerLevel && (
         <SchemaPicker
@@ -205,14 +207,19 @@ export const VariableQueryEditor = (props: EditorProps) => {
         />
       )}
 
-      <InlineFieldRow className={styles.Common.formRow}>
-        <InlineFormLabel
-          width={10}
-          className="query-keyword"
-          tooltip="Generated SQL. You can edit it; the runtime variable resolver uses this exact query."
-        >
-          SQL Query
-        </InlineFormLabel>
+      <InlineField
+        label={
+          <InlineFormLabel
+            width={10}
+            className="query-keyword"
+            tooltip="Generated SQL. You can edit it; the runtime variable resolver uses this exact query."
+          >
+            SQL Query
+          </InlineFormLabel>
+        }
+        grow
+        shrink
+      >
         <TextArea
           rows={3}
           value={safeQuery.rawSql || ''}
@@ -220,7 +227,7 @@ export const VariableQueryEditor = (props: EditorProps) => {
           placeholder="SELECT DISTINCT column FROM database.table"
           aria-label="SQL Query"
         />
-      </InlineFieldRow>
+      </InlineField>
     </div>
   );
 };

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -2,6 +2,34 @@ import { css } from '@emotion/css';
 
 export const styles = {
   Common: {
+    // Replicates the layout of the removed `.gf-form` global class
+    // (grafana/grafana#65513) so rows keep their exact look without it.
+    // Applied on top of InlineFieldRow, whose only conflicting property is
+    // flex-wrap; `&&` doubles specificity so these values always win.
+    formRow: css`
+      label: form-row;
+      && {
+        display: flex;
+        flex-direction: row;
+        flex-wrap: nowrap;
+        align-items: flex-start;
+        text-align: left;
+        position: relative;
+        margin-bottom: 4px;
+      }
+    `,
+    // Same replacement for the grafana-ui Switch controls that carried the
+    // gf-form class. Switch puts the className on its inner <input>, whose own
+    // `position: absolute` used to win the cascade against gf-form — so this
+    // variant omits `position` (and the specificity boost) to keep that intact.
+    formRowSwitch: css`
+      label: form-row-switch;
+      display: flex;
+      flex-direction: row;
+      align-items: flex-start;
+      text-align: left;
+      margin-bottom: 4px;
+    `,
     check: css`
       margin-top: 5px;
     `,

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -2,34 +2,6 @@ import { css } from '@emotion/css';
 
 export const styles = {
   Common: {
-    // Replicates the layout of the removed `.gf-form` global class
-    // (grafana/grafana#65513) so rows keep their exact look without it.
-    // Applied on top of InlineFieldRow, whose only conflicting property is
-    // flex-wrap; `&&` doubles specificity so these values always win.
-    formRow: css`
-      label: form-row;
-      && {
-        display: flex;
-        flex-direction: row;
-        flex-wrap: nowrap;
-        align-items: flex-start;
-        text-align: left;
-        position: relative;
-        margin-bottom: 4px;
-      }
-    `,
-    // Same replacement for the grafana-ui Switch controls that carried the
-    // gf-form class. Switch puts the className on its inner <input>, whose own
-    // `position: absolute` used to win the cascade against gf-form — so this
-    // variant omits `position` (and the specificity boost) to keep that intact.
-    formRowSwitch: css`
-      label: form-row-switch;
-      display: flex;
-      flex-direction: row;
-      align-items: flex-start;
-      text-align: left;
-      margin-bottom: 4px;
-    `,
     check: css`
       margin-top: 5px;
     `,

--- a/src/views/CHConfigEditor.test.tsx
+++ b/src/views/CHConfigEditor.test.tsx
@@ -206,7 +206,7 @@ describe('ConfigEditor', () => {
     const showLogLinksLabel = screen.getByText(
       allLabels.components.Config.LogsConfig.traceIdCorrelation.showLogLinks.label
     );
-    const showLogLinksInput = showLogLinksLabel.closest('.gf-form')?.querySelector('input');
+    const showLogLinksInput = showLogLinksLabel.closest('[class*="form-row"]')?.querySelector('input');
 
     expect(showLogLinksInput).toBeChecked();
     fireEvent.click(showLogLinksInput!);

--- a/src/views/CHConfigEditor.test.tsx
+++ b/src/views/CHConfigEditor.test.tsx
@@ -206,7 +206,9 @@ describe('ConfigEditor', () => {
     const showLogLinksLabel = screen.getByText(
       allLabels.components.Config.LogsConfig.traceIdCorrelation.showLogLinks.label
     );
-    const showLogLinksInput = showLogLinksLabel.closest('[class*="form-row"]')?.querySelector('input');
+    // The switch is a grafana-ui InlineField: its container div is the direct
+    // parent of the label, with the input in a sibling child container.
+    const showLogLinksInput = showLogLinksLabel.closest('div')?.querySelector('input');
 
     expect(showLogLinksInput).toBeChecked();
     fireEvent.click(showLogLinksInput!);

--- a/src/views/CHConfigEditor.tsx
+++ b/src/views/CHConfigEditor.tsx
@@ -5,6 +5,7 @@ import {
   onUpdateDatasourceSecureJsonDataOption,
 } from '@grafana/data';
 import { RadioButtonGroup, Switch, Input, SecretInput, Button, Field, Alert, Stack } from '@grafana/ui';
+import { styles } from 'styles';
 import { CertificationKey } from '../components/ui/CertificationKey';
 import {
   CHConfig,
@@ -352,7 +353,7 @@ export const ConfigEditor: React.FC<ConfigEditorProps> = (props) => {
         <Field label={labels.secure.label} description={labels.secure.tooltip}>
           <Switch
             id="secure"
-            className="gf-form"
+            className={styles.Common.formRowSwitch}
             value={jsonData.secure || false}
             onChange={(e) => {
               trackingV1.trackClickhouseConfigV1SecureConnectionToggleClicked({
@@ -394,7 +395,7 @@ export const ConfigEditor: React.FC<ConfigEditorProps> = (props) => {
       <ConfigSection title="TLS / SSL Settings">
         <Field label={labels.tlsSkipVerify.label} description={labels.tlsSkipVerify.tooltip}>
           <Switch
-            className="gf-form"
+            className={styles.Common.formRowSwitch}
             value={jsonData.tlsSkipVerify || false}
             onChange={(e) => {
               trackingV1.trackClickhouseConfigV1SkipTLSVerifyToggleClicked({
@@ -406,7 +407,7 @@ export const ConfigEditor: React.FC<ConfigEditorProps> = (props) => {
         </Field>
         <Field label={labels.tlsClientAuth.label} description={labels.tlsClientAuth.tooltip}>
           <Switch
-            className="gf-form"
+            className={styles.Common.formRowSwitch}
             value={jsonData.tlsAuth || false}
             onChange={(e) => {
               trackingV1.trackClickhouseConfigV1TLSClientAuthToggleClicked({
@@ -418,7 +419,7 @@ export const ConfigEditor: React.FC<ConfigEditorProps> = (props) => {
         </Field>
         <Field label={labels.tlsAuthWithCACert.label} description={labels.tlsAuthWithCACert.tooltip}>
           <Switch
-            className="gf-form"
+            className={styles.Common.formRowSwitch}
             value={jsonData.tlsAuthWithCACert || false}
             onChange={(e) => {
               trackingV1.trackClickhouseConfigV1WithCACertToggleClicked({ caCertToggle: e.currentTarget.checked });
@@ -829,7 +830,7 @@ export const ConfigEditor: React.FC<ConfigEditorProps> = (props) => {
             <Divider />
             <Field label={labels.enableRowLimit.label} description={labels.enableRowLimit.tooltip}>
               <Switch
-                className="gf-form"
+                className={styles.Common.formRowSwitch}
                 value={jsonData.enableRowLimit || false}
                 data-testid={labels.enableRowLimit.testid}
                 onChange={(e) => {
@@ -843,7 +844,7 @@ export const ConfigEditor: React.FC<ConfigEditorProps> = (props) => {
               description={labels.hideTableNameInAdhocFilters.tooltip}
             >
               <Switch
-                className="gf-form"
+                className={styles.Common.formRowSwitch}
                 value={jsonData.hideTableNameInAdhocFilters || false}
                 data-testid={labels.hideTableNameInAdhocFilters.testid}
                 onChange={(e) => {
@@ -854,7 +855,7 @@ export const ConfigEditor: React.FC<ConfigEditorProps> = (props) => {
             {config.secureSocksDSProxyEnabled && versionGte(config.buildInfo.version, '10.0.0') && (
               <Field label={labels.secureSocksProxy.label} description={labels.secureSocksProxy.tooltip}>
                 <Switch
-                  className="gf-form"
+                  className={styles.Common.formRowSwitch}
                   value={jsonData.enableSecureSocksProxy || false}
                   onChange={(e) => onSwitchToggle('enableSecureSocksProxy', e.currentTarget.checked)}
                 />

--- a/src/views/CHConfigEditor.tsx
+++ b/src/views/CHConfigEditor.tsx
@@ -5,7 +5,6 @@ import {
   onUpdateDatasourceSecureJsonDataOption,
 } from '@grafana/data';
 import { RadioButtonGroup, Switch, Input, SecretInput, Button, Field, Alert, Stack } from '@grafana/ui';
-import { styles } from 'styles';
 import { CertificationKey } from '../components/ui/CertificationKey';
 import {
   CHConfig,
@@ -353,7 +352,6 @@ export const ConfigEditor: React.FC<ConfigEditorProps> = (props) => {
         <Field label={labels.secure.label} description={labels.secure.tooltip}>
           <Switch
             id="secure"
-            className={styles.Common.formRowSwitch}
             value={jsonData.secure || false}
             onChange={(e) => {
               trackingV1.trackClickhouseConfigV1SecureConnectionToggleClicked({
@@ -395,7 +393,6 @@ export const ConfigEditor: React.FC<ConfigEditorProps> = (props) => {
       <ConfigSection title="TLS / SSL Settings">
         <Field label={labels.tlsSkipVerify.label} description={labels.tlsSkipVerify.tooltip}>
           <Switch
-            className={styles.Common.formRowSwitch}
             value={jsonData.tlsSkipVerify || false}
             onChange={(e) => {
               trackingV1.trackClickhouseConfigV1SkipTLSVerifyToggleClicked({
@@ -407,7 +404,6 @@ export const ConfigEditor: React.FC<ConfigEditorProps> = (props) => {
         </Field>
         <Field label={labels.tlsClientAuth.label} description={labels.tlsClientAuth.tooltip}>
           <Switch
-            className={styles.Common.formRowSwitch}
             value={jsonData.tlsAuth || false}
             onChange={(e) => {
               trackingV1.trackClickhouseConfigV1TLSClientAuthToggleClicked({
@@ -419,7 +415,6 @@ export const ConfigEditor: React.FC<ConfigEditorProps> = (props) => {
         </Field>
         <Field label={labels.tlsAuthWithCACert.label} description={labels.tlsAuthWithCACert.tooltip}>
           <Switch
-            className={styles.Common.formRowSwitch}
             value={jsonData.tlsAuthWithCACert || false}
             onChange={(e) => {
               trackingV1.trackClickhouseConfigV1WithCACertToggleClicked({ caCertToggle: e.currentTarget.checked });
@@ -830,7 +825,6 @@ export const ConfigEditor: React.FC<ConfigEditorProps> = (props) => {
             <Divider />
             <Field label={labels.enableRowLimit.label} description={labels.enableRowLimit.tooltip}>
               <Switch
-                className={styles.Common.formRowSwitch}
                 value={jsonData.enableRowLimit || false}
                 data-testid={labels.enableRowLimit.testid}
                 onChange={(e) => {
@@ -844,7 +838,6 @@ export const ConfigEditor: React.FC<ConfigEditorProps> = (props) => {
               description={labels.hideTableNameInAdhocFilters.tooltip}
             >
               <Switch
-                className={styles.Common.formRowSwitch}
                 value={jsonData.hideTableNameInAdhocFilters || false}
                 data-testid={labels.hideTableNameInAdhocFilters.testid}
                 onChange={(e) => {
@@ -855,7 +848,6 @@ export const ConfigEditor: React.FC<ConfigEditorProps> = (props) => {
             {config.secureSocksDSProxyEnabled && versionGte(config.buildInfo.version, '10.0.0') && (
               <Field label={labels.secureSocksProxy.label} description={labels.secureSocksProxy.tooltip}>
                 <Switch
-                  className={styles.Common.formRowSwitch}
                   value={jsonData.enableSecureSocksProxy || false}
                   onChange={(e) => onSwitchToggle('enableSecureSocksProxy', e.currentTarget.checked)}
                 />

--- a/src/views/CHQueryEditor.tsx
+++ b/src/views/CHQueryEditor.tsx
@@ -3,7 +3,7 @@ import { QueryEditorProps } from '@grafana/data';
 import { Datasource } from 'data/CHDatasource';
 import { EditorTypeSwitcher } from 'components/queryBuilder/EditorTypeSwitcher';
 import { styles } from 'styles';
-import { Button, ConfirmModal, Stack } from '@grafana/ui';
+import { Button, ConfirmModal, InlineFieldRow, Stack } from '@grafana/ui';
 import { CHBuilderQuery, CHQuery, EditorType } from 'types/sql';
 import { CHConfig } from 'types/config';
 import { QueryBuilder } from 'components/queryBuilder/QueryBuilder';
@@ -38,10 +38,10 @@ export const CHQueryEditor = (props: CHQueryEditorProps) => {
 
   return (
     <>
-      <div className={'gf-form ' + styles.QueryEditor.queryType}>
+      <InlineFieldRow className={`${styles.Common.formRow} ${styles.QueryEditor.queryType}`}>
         <EditorTypeSwitcher {...props} query={query} datasource={datasource} />
         <Button onClick={() => onRunQuery()}>Run Query</Button>
-      </div>
+      </InlineFieldRow>
       <CHEditorByType {...props} query={query} />
     </>
   );

--- a/src/views/CHQueryEditor.tsx
+++ b/src/views/CHQueryEditor.tsx
@@ -38,7 +38,7 @@ export const CHQueryEditor = (props: CHQueryEditorProps) => {
 
   return (
     <>
-      <InlineFieldRow className={`${styles.Common.formRow} ${styles.QueryEditor.queryType}`}>
+      <InlineFieldRow className={styles.QueryEditor.queryType}>
         <EditorTypeSwitcher {...props} query={query} datasource={datasource} />
         <Button onClick={() => onRunQuery()}>Run Query</Button>
       </InlineFieldRow>

--- a/tests/e2e/annotations.spec.ts
+++ b/tests/e2e/annotations.spec.ts
@@ -16,13 +16,13 @@ const sqlBox = (page: Page) => page.getByPlaceholder(/SELECT Timestamp AS time/)
 // Two field shapes appear in this editor. The SchemaPicker fields (Database,
 // Table, Watch Column, Map Key) expose the label as the combobox's accessible
 // name. The editor's own Select rows (Annotation Type, Group By) render an
-// InlineFormLabel inside a form row (emotion class labelled `form-row`, the
-// plugin's replacement for the removed .gf-form global) with no accessible
-// name on the control. Match either shape so one helper covers both.
+// InlineFormLabel inside a grafana-ui InlineField with no accessible name on
+// the control — the InlineField container is the label's direct parent, so
+// anchor on the label. Match either shape so one helper covers both.
 const comboFor = (page: Page, label: string) =>
   page
     .getByRole('combobox', { name: label })
-    .or(page.locator('[class*="form-row"]', { hasText: label }).getByRole('combobox'))
+    .or(page.locator('label', { hasText: label }).locator('xpath=..').getByRole('combobox'))
     .first();
 
 async function selectFromCombo(page: Page, label: string, optionText: string) {

--- a/tests/e2e/annotations.spec.ts
+++ b/tests/e2e/annotations.spec.ts
@@ -16,12 +16,13 @@ const sqlBox = (page: Page) => page.getByPlaceholder(/SELECT Timestamp AS time/)
 // Two field shapes appear in this editor. The SchemaPicker fields (Database,
 // Table, Watch Column, Map Key) expose the label as the combobox's accessible
 // name. The editor's own Select rows (Annotation Type, Group By) render an
-// InlineFormLabel inside a .gf-form row with no accessible name on the control.
-// Match either shape so one helper covers both.
+// InlineFormLabel inside a form row (emotion class labelled `form-row`, the
+// plugin's replacement for the removed .gf-form global) with no accessible
+// name on the control. Match either shape so one helper covers both.
 const comboFor = (page: Page, label: string) =>
   page
     .getByRole('combobox', { name: label })
-    .or(page.locator('.gf-form', { hasText: label }).getByRole('combobox'))
+    .or(page.locator('[class*="form-row"]', { hasText: label }).getByRole('combobox'))
     .first();
 
 async function selectFromCombo(page: Page, label: string, optionText: string) {

--- a/tests/e2e/columnAutodetect.spec.ts
+++ b/tests/e2e/columnAutodetect.spec.ts
@@ -64,7 +64,7 @@ async function switchToBuilderMode(page: Page, queryType?: QueryType) {
  * is scoped inside page.getByRole('listbox').
  */
 async function selectFromCombobox(page: Page, label: string, value: string) {
-  const row = page.locator('div.gf-form', {
+  const row = page.locator('div[class*="form-row"]', {
     has: page.locator('label.query-keyword', { hasText: new RegExp(`^${label}$`) }),
   });
 
@@ -87,14 +87,15 @@ async function selectFromCombobox(page: Page, label: string, value: string) {
 }
 
 /**
- * Returns the innermost row (`div.gf-form`) that contains a specific
- * column-role label. The builder nests `div.gf-form` wrappers, so the
+ * Returns the innermost form row (emotion class labelled `form-row`, the
+ * plugin's replacement for the removed .gf-form global) that contains a
+ * specific column-role label. The builder nests row wrappers, so the
  * `has:` locator matches both the outer grouping and the inner row — we
  * use `.last()` to pick the innermost, which is the single-field row.
  */
 function columnRow(page: Page, label: string): Locator {
   return page
-    .locator('div.gf-form', {
+    .locator('div[class*="form-row"]', {
       has: page.locator('label.query-keyword', { hasText: new RegExp(`^${label}$`) }),
     })
     .last();

--- a/tests/e2e/columnAutodetect.spec.ts
+++ b/tests/e2e/columnAutodetect.spec.ts
@@ -64,9 +64,11 @@ async function switchToBuilderMode(page: Page, queryType?: QueryType) {
  * is scoped inside page.getByRole('listbox').
  */
 async function selectFromCombobox(page: Page, label: string, value: string) {
-  const row = page.locator('div[class*="form-row"]', {
-    has: page.locator('label.query-keyword', { hasText: new RegExp(`^${label}$`) }),
-  });
+  // The builder renders each field as a grafana-ui InlineField whose container
+  // div is the direct parent of the InlineFormLabel, so anchor on the label.
+  const row = page
+    .locator('label.query-keyword', { hasText: new RegExp(`^${label}$`) })
+    .locator('xpath=..');
 
   // Race: either the field auto-populates to `value` within a short window, or
   // we need to open the listbox and click the option ourselves. `isVisible()`
@@ -87,18 +89,12 @@ async function selectFromCombobox(page: Page, label: string, value: string) {
 }
 
 /**
- * Returns the innermost form row (emotion class labelled `form-row`, the
- * plugin's replacement for the removed .gf-form global) that contains a
- * specific column-role label. The builder nests row wrappers, so the
- * `has:` locator matches both the outer grouping and the inner row — we
- * use `.last()` to pick the innermost, which is the single-field row.
+ * Returns the single-field row that contains a specific column-role label.
+ * Each field is a grafana-ui InlineField whose container div is the direct
+ * parent of the InlineFormLabel, so the label's parent IS the field row.
  */
 function columnRow(page: Page, label: string): Locator {
-  return page
-    .locator('div[class*="form-row"]', {
-      has: page.locator('label.query-keyword', { hasText: new RegExp(`^${label}$`) }),
-    })
-    .last();
+  return page.locator('label.query-keyword', { hasText: new RegExp(`^${label}$`) }).locator('xpath=..');
 }
 
 test.describe('Column auto-detection (Layer 2)', () => {


### PR DESCRIPTION
## Type of Change

- [x] 🧹 Refactor / Chore

---

## What is this change?

Grafana core is removing the legacy `.gf-form` global styles (grafana/grafana#65513; the SASS was already migrated to emotion globals in grafana/grafana#91632 and the class is deprecated with a lint rule upstream). This plugin used `gf-form` in 57 places across the query builder, config editor, variable editor, and annotation editor — once the global class disappears from core, every one of those rows would silently lose its layout.

The change lands as two commits so the second can be reverted independently:

**Commit 1 — pixel-identical removal.** Every `<div className="gf-form">` becomes `@grafana/ui`'s `InlineFieldRow` plus a small local class replicating the exact `.gf-form` ruleset, so rendering is provably unchanged (screenshot pixel diffs and DOM-geometry captures across 8 editor surfaces: identical).

**Commit 2 — idiomatic `InlineField` composition.** Relaxes strict parity and removes the shim classes entirely:

- Label + control pairs (`ColumnSelect`, `LimitEditor`, the editor/query-type switchers, `DatabaseSelect`/`TableSelect`, config, variable and annotation editors, …) become `InlineField`, keeping the existing `InlineFormLabel` as the `label` node so the `query-keyword` styling is unchanged. `disabled`/`invalid` move onto `InlineField` since it clones them onto its child.
- Multi-field rows become bare `InlineFieldRow`; list rows (order by, aggregates, filters) become `InlineField` with the label/spacer as the label node. `shrink`/`grow` are set where the old flex rows let children shrink or stretch (SQL preview, filter rows, SQL textareas).
- The `gf-form` classNames on grafana-ui `Switch` controls are deleted outright — they land on the invisible absolutely-positioned `<input>` and never had a visual effect (verified by geometry capture).
- Annotation editor: the "Return columns…" help text moves inside the SQL Query field (`Box` + `Text`) so it sits under the editor, aligned with its left edge.
- Unit and Playwright selectors anchor on the label's parent (the `InlineField` container) instead of the removed class.

## Visual verification

Before/after captures from a local Grafana 12.2.0 + ClickHouse docker stack at a fixed 1680px viewport, driving Explore with identical URL-serialized queries; pixel diffs plus DOM-geometry dumps (bounding rects + computed styles of every affected row):

- **Commit 1**: pixel-identical everywhere (only diffs: spinner, live log data, nav sidebar, focus rings).
- **Commit 2**: rows keep their exact 36px rhythm with a one-time −4px vertical shift (the old outer wrapper's bottom margin) and ≤8px horizontal shifts from `InlineField`'s 4px right margin; offset-compensated diffs are ≤0.05%. SQL editor byte-identical; variable editor 0.015%. One traces filter row's remove button wraps ~10px earlier (same wrap semantics, threshold moved).

## Please check that:

- [x] Tests for this change have been added/updated.
- [ ] Documentation has been added/updated (where applicable).

## Special notes for your reviewer

- `npx tsc --noEmit`, `npm run lint` (0 errors), full jest suite (73 suites / 955 tests) and cspell pass on both commits.
- The two Playwright specs that used `.gf-form` locators (`annotations.spec.ts`, `columnAutodetect.spec.ts`) were updated in the same PR so e2e keeps working once the DOM class is gone.
- If the small visual deltas from commit 2 turn out to matter, revert just that commit to fall back to the pixel-identical shim version.

## Follow-up

The remaining modernization step is adopting `EditorRow`/`EditorFieldGroup`/`EditorField` from `@grafana/plugin-ui` (the currently recommended query-editor kit upstream — see the migration guide referenced by the `DataSourceHttpSettings` deprecation in grafana/grafana#100583), which would also retire `InlineFormLabel` and the `query-keyword` styling. Labels-above-inputs layout — a deliberate redesign to be scoped and reviewed on its own.

Closes #2027