### PR TITLE
refactor(macros): expand macros via the sqlds Interpolator extension point

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/docker/go-units v0.5.0
 	github.com/grafana/grafana-plugin-sdk-go v0.292.2
 	github.com/grafana/macropro v1.0.0
-	github.com/grafana/sqlds/v5 v5.2.0
+	github.com/grafana/sqlds/v5 v5.3.0
 	github.com/moby/moby/api v1.55.0
 	github.com/paulmach/orb v0.13.0
 	github.com/shopspring/decimal v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -157,8 +157,8 @@ github.com/grafana/pyroscope-go/godeltaprof v0.1.11 h1:el5LYpXissAiCKZ5/6yjlr6mh
 github.com/grafana/pyroscope-go/godeltaprof v0.1.11/go.mod h1:jl1V8M4cWsXciROCPIDDG7CtjSjT/ECbp6eLVuMxYRI=
 github.com/grafana/schemads v0.2.3 h1:cfneDXyPK5OHqBr2RZlaxjHQNWcSUOX2UKhXLe4MaiE=
 github.com/grafana/schemads v0.2.3/go.mod h1:TX0YfoMxJ8dl1ONXTa+rFk1y3sw1khGwQjB8dKKfzds=
-github.com/grafana/sqlds/v5 v5.2.0 h1:WLhC7z0N2oYM1aKnqttGKwvZ9xopGOH46eZHWY9M8pE=
-github.com/grafana/sqlds/v5 v5.2.0/go.mod h1:VfGgv/j3+0Ttg7gnUIS1+5XmUtLGSlyy0sa3z7s7c/w=
+github.com/grafana/sqlds/v5 v5.3.0 h1:wQoI9x0ACedTwsnD6PWcwMEue836QwLJcTNirAVIw3M=
+github.com/grafana/sqlds/v5 v5.3.0/go.mod h1:8GfxmJ5jiiKx4ztrxAvYaggAzpOEZ1ACXqo9OOhnazI=
 github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.1.0 h1:QGLs/O40yoNK9vmy4rhUGBVyMf1lISBGtXRpsu/Qu/o=
 github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.1.0/go.mod h1:hM2alZsMUni80N33RBe6J0e423LB+odMj7d3EMP9l20=
 github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.3 h1:B+8ClL/kCQkRiU82d9xajRPKYMrB7E0MbtzWVi1K4ns=

--- a/pkg/plugin/datasource.go
+++ b/pkg/plugin/datasource.go
@@ -28,6 +28,9 @@ func (i *clickhouseInstance) Dispose() {
 func NewDatasource(ctx context.Context, settings backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
 	clickhousePlugin := Clickhouse{}
 	ds := sqlds.NewDatasource(&clickhousePlugin)
+	// Replace sqlds's default sqlutil.Interpolate pipeline with the
+	// macropro-backed interpolator; see interpolateMacros in driver.go.
+	ds.Interpolator = interpolateMacros
 	pluginSettings := clickhousePlugin.Settings(ctx, settings)
 	if pluginSettings.ForwardHeaders {
 		ds.EnableMultipleConnections = true

--- a/pkg/plugin/driver.go
+++ b/pkg/plugin/driver.go
@@ -428,11 +428,22 @@ func injectGrafanaUserHeader(ctx context.Context, req *backend.QueryDataRequest)
 // macropro owns macro parsing end-to-end and handlers receive the fully
 // parsed query — including Table and Column, which the previous
 // MutateQueryData pre-expansion never carried. Expansion errors return
-// straight to the query response (classified downstream via
-// backend.DownstreamError inside the handlers) rather than being smuggled
-// through a throwIf() rewrite that failed at execution time.
+// straight to the query response rather than being smuggled through a
+// throwIf() rewrite that failed at execution time.
+//
+// Every error is wrapped as a downstream error: interpolation failures
+// originate from the user's query text (bad macro arguments, missing
+// table/column context, parse errors), never from a plugin bug. Our own
+// handlers already wrap backend.DownstreamError, but macropro's default
+// handlers ($__table, $__column) return plain errors, and sqlds only
+// downstream-classifies bad-argument-count and bracket errors on its own —
+// so without this wrap those would be miscounted as plugin errors.
 func interpolateMacros(_ context.Context, query *sqlutil.Query, _ json.RawMessage) (string, error) {
-	return macros.Interpolate(query.RawSQL, query)
+	sql, err := macros.Interpolate(query.RawSQL, query)
+	if err != nil {
+		return "", backend.DownstreamError(err)
+	}
+	return sql, nil
 }
 
 func preprocessGrafanaSQL(req *backend.QueryDataRequest) *backend.QueryDataRequest {

--- a/pkg/plugin/driver.go
+++ b/pkg/plugin/driver.go
@@ -295,11 +295,12 @@ func (h *Clickhouse) Converters() []sqlutil.Converter {
 	return converters.ClickhouseConverters
 }
 
-// Macros returns an empty macro map. ClickHouse macros are expanded upstream
-// by macropro in MutateQueryData, so by the time sqlds's own Interpolate runs
-// there is nothing left for it to find. The empty map also prevents duplicate
-// expansion via sqlutil.DefaultMacros, since macropro.DefaultMacros is
-// already merged into macros.ClickHouseMacros.
+// Macros returns an empty macro map. ClickHouse macros are expanded by the
+// macropro-backed sqlds.Interpolator installed in NewDatasource, which
+// replaces sqlds's sqlutil.Interpolate pipeline entirely, so this map is
+// never consulted on the query path. macropro.DefaultMacros is already
+// merged into macros.ClickHouseMacros, so nothing is lost by leaving it
+// empty.
 func (h *Clickhouse) Macros() sqlds.Macros {
 	return sqlds.Macros{}
 }
@@ -395,7 +396,6 @@ func (h *Clickhouse) MutateQueryData(
 	injectGrafanaUserHeader(ctx, req)
 
 	req = preprocessGrafanaSQL(req)
-	req = expandMacros(req)
 	return ctx, req
 }
 
@@ -423,93 +423,16 @@ func injectGrafanaUserHeader(ctx context.Context, req *backend.QueryDataRequest)
 	req.SetHTTPHeader("X-Grafana-User", user.Login)
 }
 
-// expandMacros rewrites every query's rawSql with all $__ macros expanded.
-// Running this before sqlds's own query pipeline means macropro owns macro
-// parsing end-to-end; by the time sqlds.Interpolate runs it finds no tokens
-// and becomes a no-op.
-func expandMacros(req *backend.QueryDataRequest) *backend.QueryDataRequest {
-	if req == nil || len(req.Queries) == 0 {
-		return req
-	}
-	queries := make([]backend.DataQuery, 0, len(req.Queries))
-	for _, q := range req.Queries {
-		queries = append(queries, expandMacrosInQuery(q))
-	}
-	return &backend.QueryDataRequest{
-		PluginContext: req.PluginContext,
-		Headers:       req.Headers,
-		Queries:       queries,
-	}
-}
-
-// expandMacrosInQuery expands macros in a single query. When macro
-// expansion fails the rawSql is rewritten to a ClickHouse throwIf() call
-// that surfaces the macro error at execution time: ClickHouse raises an
-// Exception carrying our message, MutateQueryError classifies it as
-// downstream, and the user sees the real reason their query failed
-// instead of a cryptic DB syntax error on the unexpanded macro. We cannot
-// return an error from MutateQueryData directly — sqlds's hook signature
-// forbids it — so the DB round-trip is the only available error channel.
-//
-// The query JSON is decoded once into a map so the rewritten rawSql can
-// be written back while preserving plugin-specific fields (meta.timezone,
-// format, etc.). macropro only needs the raw SQL plus TimeRange/Interval, and
-// the latter come from the backend.DataQuery envelope rather than the JSON
-// body, so a full sqlutil.Query decode is unnecessary. On any (un)marshal
-// failure the original query is returned unchanged.
-func expandMacrosInQuery(q backend.DataQuery) backend.DataQuery {
-	var raw map[string]json.RawMessage
-	if err := json.Unmarshal(q.JSON, &raw); err != nil {
-		return q
-	}
-	var rawSQL string
-	if msg, ok := raw["rawSql"]; ok {
-		if err := json.Unmarshal(msg, &rawSQL); err != nil {
-			return q
-		}
-	}
-	if rawSQL == "" {
-		return q
-	}
-
-	sqq := sqlutil.Query{RawSQL: rawSQL, TimeRange: q.TimeRange, Interval: q.Interval}
-	expanded, err := macros.Interpolate(rawSQL, &sqq)
-	if err != nil {
-		backend.Logger.Error("failed to expand macros", "error", err.Error(), "refId", q.RefID)
-		expanded = macroErrorQuery(err)
-	} else if expanded == rawSQL {
-		return q
-	}
-
-	newRawSQLMsg, err := json.Marshal(expanded)
-	if err != nil {
-		return q
-	}
-	raw["rawSql"] = newRawSQLMsg
-	newJSON, err := json.Marshal(raw)
-	if err != nil {
-		return q
-	}
-	q.JSON = newJSON
-	return q
-}
-
-// macroErrorQuery turns a macro expansion error into a ClickHouse query that
-// fails at execution with the error message attached. ClickHouse's throwIf()
-// raises an Exception carrying the literal string, which is then classified
-// as a downstream error by MutateQueryError and surfaced to the user.
-//
-// sqlds runs sqlutil.Interpolate AFTER MutateQueryData and that function
-// always merges sqlutil.DefaultMacros — meaning any "$__" tokens left in the
-// rewritten rawSql (including inside the throwIf string literal) are
-// re-scanned and may trigger the stock macro handlers, hiding our throwIf
-// behind a "Could not apply macros" error. Strip the "$" prefix to neutralize
-// the scanner while keeping macro names readable.
-func macroErrorQuery(err error) string {
-	msg := strings.ReplaceAll(err.Error(), "$__", "__")
-	// ClickHouse single-quoted string literals escape ' as ''.
-	msg = strings.ReplaceAll(msg, "'", "''")
-	return fmt.Sprintf("SELECT throwIf(1, 'macro expansion failed: %s')", msg)
+// interpolateMacros is the sqlds.Interpolator installed by NewDatasource. It
+// replaces sqlds's default sqlutil.Interpolate pipeline with macropro, so
+// macropro owns macro parsing end-to-end and handlers receive the fully
+// parsed query — including Table and Column, which the previous
+// MutateQueryData pre-expansion never carried. Expansion errors return
+// straight to the query response (classified downstream via
+// backend.DownstreamError inside the handlers) rather than being smuggled
+// through a throwIf() rewrite that failed at execution time.
+func interpolateMacros(_ context.Context, query *sqlutil.Query, _ json.RawMessage) (string, error) {
+	return macros.Interpolate(query.RawSQL, query)
 }
 
 func preprocessGrafanaSQL(req *backend.QueryDataRequest) *backend.QueryDataRequest {

--- a/pkg/plugin/driver_integration_test.go
+++ b/pkg/plugin/driver_integration_test.go
@@ -1391,10 +1391,10 @@ func TestHTTPConnectWithHeaders(t *testing.T) {
 
 // TestQueryDataMacroExpansion exercises the macropro-driven macro pipeline end to
 // end against a live ClickHouse: it goes through NewDatasource → sqlds.SQLDatasource.QueryData
-// rather than calling expandMacrosInQuery directly, so it covers the bits the
-// unit tests cannot — that sqlds with an empty Macros() map round-trips cleanly,
-// that the rewritten rawSql actually executes, and that the throwIf() error path
-// surfaces the real macro error to the caller.
+// rather than calling interpolateMacros directly, so it covers the bits the
+// unit tests cannot — that the macropro-backed sqlds.Interpolator is actually
+// installed, that the expanded rawSql executes, and that a macro error is
+// returned on the query response as a downstream error without touching the DB.
 func TestQueryDataMacroExpansion(t *testing.T) {
 	port := getEnv("CLICKHOUSE_PORT", "9000")
 	host := getEnv("CLICKHOUSE_HOST", "localhost")
@@ -1458,9 +1458,10 @@ func TestQueryDataMacroExpansion(t *testing.T) {
 
 	t.Run("macro expansion failure surfaces a downstream error", func(t *testing.T) {
 		// $__timeFilter() takes one argument; calling it with zero triggers
-		// badArgsErr, which the driver rewrites into SELECT throwIf(...) so
-		// the user sees the real reason rather than a syntax error on the
-		// raw $__ token.
+		// badArgsErr. The interpolator returns the error to sqlds, which
+		// attaches it to the query response before any DB round-trip, so the
+		// user sees the real reason rather than a syntax error on the raw
+		// $__ token.
 		req := &backend.QueryDataRequest{
 			PluginContext: backend.PluginContext{DataSourceInstanceSettings: &settings},
 			Queries: []backend.DataQuery{
@@ -1477,16 +1478,13 @@ func TestQueryDataMacroExpansion(t *testing.T) {
 		require.Contains(t, resp.Responses, "A")
 
 		respErr := resp.Responses["A"].Error
-		require.Error(t, respErr, "expected query to fail at the DB with the macro error")
-		// The macro error message is embedded in the throwIf payload, which
-		// ClickHouse echoes back in the Exception's Message field. The macro
-		// name appears without its $__ prefix because macroErrorQuery scrubs
-		// the prefix to keep sqlutil.DefaultMacros from re-scanning it.
-		assert.Contains(t, respErr.Error(), "macro expansion failed")
+		require.Error(t, respErr, "expected the macro error on the query response")
+		// sqlds wraps interpolator errors as "Could not apply macros: …",
+		// keeping the original macro name and argument-count message intact.
+		assert.Contains(t, respErr.Error(), "Could not apply macros")
 		assert.Contains(t, respErr.Error(), "timeFilter")
-		// MutateQueryError classifies any ClickHouse Exception as downstream,
-		// so the raised throwIf must come back tagged as user input rather
-		// than a plugin bug.
+		// badArgsErr wraps backend.DownstreamError, so sqlds must classify
+		// the failure as user input rather than a plugin bug.
 		assert.Equal(t, backend.ErrorSourceDownstream, resp.Responses["A"].ErrorSource)
 	})
 }

--- a/pkg/plugin/driver_test.go
+++ b/pkg/plugin/driver_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/grafana/grafana-plugin-sdk-go/data/sqlutil"
+	"github.com/grafana/sqlds/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -544,4 +545,36 @@ func TestInterpolateMacros(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "SELECT 1", got)
 	})
+
+	t.Run("returns a downstream error from macropro default handlers", func(t *testing.T) {
+		// macropro's own $__table / $__column handlers return plain errors
+		// with no backend error source, unlike our handlers which wrap
+		// backend.DownstreamError themselves. The interpolator must classify
+		// these downstream too: every interpolation failure originates from
+		// the user's query text, never from a plugin bug.
+		q := &sqlutil.Query{RawSQL: "SELECT * FROM $__table", TimeRange: timeRange}
+		_, err := interpolateMacros(t.Context(), q, nil)
+		require.Error(t, err)
+		assert.True(t, backend.IsDownstreamError(err))
+	})
+}
+
+// TestMissingTableMacroIsDownstream proves the downstream classification
+// survives the full sqlds.QueryData path: the interpolator error must land on
+// the query response with ErrorSourceDownstream, not the plugin default.
+func TestMissingTableMacroIsDownstream(t *testing.T) {
+	ds := sqlds.NewDatasource(&Clickhouse{})
+	ds.Interpolator = interpolateMacros
+
+	resp, err := ds.QueryData(t.Context(), &backend.QueryDataRequest{
+		Queries: []backend.DataQuery{{
+			RefID: "A",
+			JSON:  []byte(`{"rawSql":"SELECT * FROM $__table"}`),
+		}},
+	})
+	require.NoError(t, err)
+
+	got := resp.Responses["A"]
+	require.Error(t, got.Error)
+	assert.Equal(t, backend.ErrorSourceDownstream, got.ErrorSource)
 }

--- a/pkg/plugin/driver_test.go
+++ b/pkg/plugin/driver_test.go
@@ -5,13 +5,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"strings"
 	"testing"
 	"time"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"github.com/grafana/grafana-plugin-sdk-go/data/sqlutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -504,72 +504,44 @@ func TestMutateQueryData_XGrafanaUserForwarding(t *testing.T) {
 	})
 }
 
-func TestExpandMacrosInQuery(t *testing.T) {
+func TestInterpolateMacros(t *testing.T) {
 	from, _ := time.Parse("2006-01-02T15:04:05.000Z", "2014-11-12T11:45:26.371Z")
 	to, _ := time.Parse("2006-01-02T15:04:05.000Z", "2015-11-12T11:45:26.371Z")
+	timeRange := backend.TimeRange{From: from, To: to}
 
-	t.Run("expands macros and preserves sibling JSON fields", func(t *testing.T) {
-		q := backend.DataQuery{
-			RefID:     "A",
-			JSON:      []byte(`{"rawSql":"SELECT $__fromTime","format":1,"meta":{"timezone":"UTC"}}`),
-			TimeRange: backend.TimeRange{From: from, To: to},
-		}
-		out := expandMacrosInQuery(q)
-
-		var body struct {
-			RawSQL string `json:"rawSql"`
-			Format int    `json:"format"`
-			Meta   struct {
-				Timezone string `json:"timezone"`
-			} `json:"meta"`
-		}
-		require.NoError(t, json.Unmarshal(out.JSON, &body))
-		assert.Equal(t, "SELECT toDateTime(1415792726)", body.RawSQL)
-		assert.Equal(t, 1, body.Format)
-		assert.Equal(t, "UTC", body.Meta.Timezone)
+	t.Run("expands macros from the parsed query", func(t *testing.T) {
+		q := &sqlutil.Query{RawSQL: "SELECT $__fromTime", TimeRange: timeRange}
+		got, err := interpolateMacros(t.Context(), q, nil)
+		require.NoError(t, err)
+		assert.Equal(t, "SELECT toDateTime(1415792726)", got)
 	})
 
-	t.Run("rewrites rawSql to throwIf on macro error", func(t *testing.T) {
-		// $__timeFilter with zero args triggers a badArgsErr.
-		q := backend.DataQuery{
-			RefID:     "A",
-			JSON:      []byte(`{"rawSql":"SELECT $__timeFilter()"}`),
-			TimeRange: backend.TimeRange{From: from, To: to},
-		}
-		out := expandMacrosInQuery(q)
-
-		var body struct {
-			RawSQL string `json:"rawSql"`
-		}
-		require.NoError(t, json.Unmarshal(out.JSON, &body))
-		assert.True(t, strings.HasPrefix(body.RawSQL, "SELECT throwIf(1, 'macro expansion failed: "))
-		assert.Contains(t, body.RawSQL, "timeFilter")
-		// $__ tokens leaking into the throwIf payload would be re-expanded by
-		// sqlutil.DefaultMacros downstream and hide the throwIf behind a
-		// "Could not apply macros" error, so the rewrite must scrub them.
-		assert.NotContains(t, body.RawSQL, "$__")
+	t.Run("expands table and column from query context", func(t *testing.T) {
+		// Table/Column only flow into macro handlers now that interpolation
+		// runs on the parsed sqlutil.Query; the old MutateQueryData
+		// pre-expansion never carried them.
+		q := &sqlutil.Query{RawSQL: "SELECT $__column FROM $__table", TimeRange: timeRange, Table: "logs", Column: "ts"}
+		got, err := interpolateMacros(t.Context(), q, nil)
+		require.NoError(t, err)
+		assert.Equal(t, "SELECT ts FROM logs", got)
 	})
 
-	t.Run("escapes single quotes and scrubs $__ in throwIf message", func(t *testing.T) {
-		// ClickHouse string literals escape ' as ''. macroErrorQuery must
-		// double every single quote so a message containing one can't
-		// prematurely close the literal, and strip $__ prefixes so
-		// sqlutil's downstream macro scan doesn't mistake them for macros.
-		got := macroErrorQuery(errors.New("$__timeFilter failed: oh 'no' it broke"))
-		assert.Equal(t, "SELECT throwIf(1, 'macro expansion failed: __timeFilter failed: oh ''no'' it broke')", got)
+	t.Run("returns a downstream error on bad macro arguments", func(t *testing.T) {
+		// $__timeFilter with zero args triggers a badArgsErr. The error goes
+		// back to sqlds, which puts it on the query response; it must be
+		// classified downstream so a user typo isn't counted as a plugin bug.
+		q := &sqlutil.Query{RawSQL: "SELECT $__timeFilter()", TimeRange: timeRange}
+		_, err := interpolateMacros(t.Context(), q, nil)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, sqlutil.ErrorBadArgumentCount)
+		assert.True(t, backend.IsDownstreamError(err))
+		assert.Contains(t, err.Error(), "timeFilter")
 	})
 
-	t.Run("returns query unchanged when there are no macros", func(t *testing.T) {
-		raw := []byte(`{"rawSql":"SELECT 1","format":1}`)
-		q := backend.DataQuery{RefID: "A", JSON: raw}
-		out := expandMacrosInQuery(q)
-		assert.JSONEq(t, string(raw), string(out.JSON))
-	})
-
-	t.Run("returns query unchanged when rawSql is empty", func(t *testing.T) {
-		raw := []byte(`{"rawSql":""}`)
-		q := backend.DataQuery{RefID: "A", JSON: raw}
-		out := expandMacrosInQuery(q)
-		assert.JSONEq(t, string(raw), string(out.JSON))
+	t.Run("returns SQL unchanged when there are no macros", func(t *testing.T) {
+		q := &sqlutil.Query{RawSQL: "SELECT 1", TimeRange: timeRange}
+		got, err := interpolateMacros(t.Context(), q, nil)
+		require.NoError(t, err)
+		assert.Equal(t, "SELECT 1", got)
 	})
 }


### PR DESCRIPTION
## Type of Change

- [x] 🧹 Refactor / Chore

## What is this change?

Follow-up to #1802. sqlds v5.2.0 added a pluggable `Interpolator` extension point (grafana/sqlds#269) that lets a plugin replace the default `sqlutil.Interpolate` pipeline. This PR bumps sqlds to v5.3.0 and installs a macropro-backed `Interpolator`, replacing the `MutateQueryData` pre-expansion workaround that #1802 introduced.

- `NewDatasource` now assigns `ds.Interpolator = interpolateMacros`, a small adapter that calls `macros.Interpolate` on the parsed query.
- The `expandMacros`, `expandMacrosInQuery` and `macroErrorQuery` plumbing in `driver.go` is removed. It only existed because `MutateQueryData` cannot return an error, so macro failures had to be rewritten into a `SELECT throwIf(...)` query that failed at execution time.

Two behaviour improvements fall out of this:

- Macro errors are returned directly on the query response, classified as downstream, without a database round trip. The user-visible message prefix changes from `macro expansion failed:` to sqlds's `Could not apply macros:`.
- `$__table` and `$__column` now expand correctly. The interpolator receives the fully parsed `sqlutil.Query` including `Table` and `Column`, which the old pre-expansion path never carried.

### How to test

1. `docker compose up -d clickhouse-server`
2. `go test -tags=integration ./pkg/plugin/ -run TestQueryDataMacroExpansion -v`

## Please check that:

- [x] Tests for this change have been added/updated.
- [ ] Documentation has been added/updated (where applicable).

## Special notes for your reviewer

The driver's empty `Macros()` map is retained. With a custom `Interpolator` installed sqlds never consults it on the query path, but it remains part of the `sqlds.Driver` interface.

Closes #2026