### PR TITLE
feat: add optional Row Capacity Hint setting for large query responses

### DIFF
--- a/pkg/plugin/driver.go
+++ b/pkg/plugin/driver.go
@@ -373,7 +373,8 @@ func (h *Clickhouse) Settings(ctx context.Context, config backend.DataSourceInst
 		FillMode: &data.FillMissing{
 			Mode: data.FillModeNull,
 		},
-		ForwardHeaders: settings.ForwardGrafanaHeaders,
+		ForwardHeaders:  settings.ForwardGrafanaHeaders,
+		RowCapacityHint: settings.RowCapacityHint,
 	}
 }
 

--- a/pkg/plugin/settings.go
+++ b/pkg/plugin/settings.go
@@ -49,6 +49,15 @@ type Settings struct {
 	RowLimit       int64 `json:"rowLimit,omitempty"`
 	EnableRowLimit bool  `json:"enableRowLimit,omitempty"`
 
+	// RowCapacityHint is an optional expected row count passed to sqlds as
+	// DriverSettings.RowCapacityHint. sqlds pre-allocates each data.Frame's
+	// fields to this value before scanning, avoiding per-column slice growth on large
+	// results. It is applied to every query, so leave it at 0 (the default,
+	// disabled) unless queries from this datasource reliably return a similar,
+	// large number of rows. A value larger than the typical result wastes
+	// memory.
+	RowCapacityHint int64 `json:"rowCapacityHint,omitempty"`
+
 	// EnableSchemaCache gates the in-process cache that memoizes
 	// system.tables / system.columns / DISTINCT column-value lookups used
 	// by the query builder. Defaults to true.
@@ -249,6 +258,23 @@ func LoadSettings(ctx context.Context, config backend.DataSourceInstanceSettings
 	}
 	if settings.SchemaCacheTTLSeconds <= 0 {
 		settings.SchemaCacheTTLSeconds = 60
+	}
+
+	if raw, ok := jsonData["rowCapacityHint"]; ok && raw != nil {
+		switch v := raw.(type) {
+		case float64:
+			settings.RowCapacityHint = int64(v)
+		case string:
+			if parsed, parseErr := strconv.ParseInt(v, 10, 64); parseErr == nil {
+				settings.RowCapacityHint = parsed
+			} else {
+				backend.Logger.Warn("Failed to parse rowCapacityHint value, defaulting to 0", "error", parseErr)
+			}
+		}
+	}
+	// A negative hint is meaningless; treat it as disabled.
+	if settings.RowCapacityHint < 0 {
+		settings.RowCapacityHint = 0
 	}
 
 	// Set default values

--- a/pkg/plugin/settings_test.go
+++ b/pkg/plugin/settings_test.go
@@ -381,4 +381,29 @@ func TestLoadSettings(t *testing.T) {
 			})
 		}
 	})
+
+	t.Run("should parse rowCapacityHint", func(t *testing.T) {
+		ctx := context.Background()
+		tests := []struct {
+			description string
+			jsonData    string
+			want        int64
+		}{
+			{description: "absent defaults to 0", jsonData: `{"host": "foo", "port": 443}`, want: 0},
+			{description: "numeric value", jsonData: `{"host": "foo", "port": 443, "rowCapacityHint": 50000}`, want: 50000},
+			{description: "string value", jsonData: `{"host": "foo", "port": 443, "rowCapacityHint": "50000"}`, want: 50000},
+			{description: "negative clamps to 0", jsonData: `{"host": "foo", "port": 443, "rowCapacityHint": -1}`, want: 0},
+			{description: "unparseable string defaults to 0", jsonData: `{"host": "foo", "port": 443, "rowCapacityHint": "abc"}`, want: 0},
+		}
+		for _, tc := range tests {
+			t.Run(tc.description, func(t *testing.T) {
+				got, err := LoadSettings(ctx, backend.DataSourceInstanceSettings{
+					JSONData:                []byte(tc.jsonData),
+					DecryptedSecureJSONData: map[string]string{},
+				})
+				assert.NoError(t, err)
+				assert.Equal(t, tc.want, got.RowCapacityHint)
+			})
+		}
+	})
 }

--- a/pkg/plugin/settings_test.go
+++ b/pkg/plugin/settings_test.go
@@ -393,7 +393,7 @@ func TestLoadSettings(t *testing.T) {
 			{description: "numeric value", jsonData: `{"host": "foo", "port": 443, "rowCapacityHint": 50000}`, want: 50000},
 			{description: "string value", jsonData: `{"host": "foo", "port": 443, "rowCapacityHint": "50000"}`, want: 50000},
 			{description: "negative clamps to 0", jsonData: `{"host": "foo", "port": 443, "rowCapacityHint": -1}`, want: 0},
-			{description: "unparseable string defaults to 0", jsonData: `{"host": "foo", "port": 443, "rowCapacityHint": "abc"}`, want: 0},
+			{description: "invalid string defaults to 0", jsonData: `{"host": "foo", "port": 443, "rowCapacityHint": "abc"}`, want: 0},
 		}
 		for _, tc := range tests {
 			t.Run(tc.description, func(t *testing.T) {

--- a/src/components/configEditor/QuerySettingsConfig.test.tsx
+++ b/src/components/configEditor/QuerySettingsConfig.test.tsx
@@ -3,23 +3,31 @@ import { render, fireEvent } from '@testing-library/react';
 import { QuerySettingsConfig } from './QuerySettingsConfig';
 import allLabels from 'labels';
 
+const noop = () => {};
+
+const baseProps = {
+  onConnMaxIdleConnsChange: noop,
+  onConnMaxLifetimeChange: noop,
+  onConnMaxOpenConnsChange: noop,
+  onDialTimeoutChange: noop,
+  onQueryTimeoutChange: noop,
+  onRowCapacityHintChange: noop,
+  onValidateSqlChange: noop,
+  onEnableMapKeysDiscoveryChange: noop,
+};
+
 describe('QuerySettingsConfig', () => {
   it('should render', () => {
     const result = render(
       <QuerySettingsConfig
+        {...baseProps}
         connMaxLifetime={'5'}
         dialTimeout={'5'}
         maxIdleConns={'5'}
         maxOpenConns={'5'}
         queryTimeout={'5'}
+        rowCapacityHint={'5000'}
         validateSql={true}
-        onConnMaxIdleConnsChange={() => {}}
-        onConnMaxLifetimeChange={() => {}}
-        onConnMaxOpenConnsChange={() => {}}
-        onDialTimeoutChange={() => {}}
-        onQueryTimeoutChange={() => {}}
-        onValidateSqlChange={() => {}}
-        onEnableMapKeysDiscoveryChange={() => {}}
       />
     );
     expect(result.container.firstChild).not.toBeNull();
@@ -27,17 +35,7 @@ describe('QuerySettingsConfig', () => {
 
   it('should call onDialTimeout when changed', () => {
     const onDialTimeout = jest.fn();
-    const result = render(
-      <QuerySettingsConfig
-        onConnMaxIdleConnsChange={() => {}}
-        onConnMaxLifetimeChange={() => {}}
-        onConnMaxOpenConnsChange={() => {}}
-        onDialTimeoutChange={onDialTimeout}
-        onQueryTimeoutChange={() => {}}
-        onValidateSqlChange={() => {}}
-        onEnableMapKeysDiscoveryChange={() => {}}
-      />
-    );
+    const result = render(<QuerySettingsConfig {...baseProps} onDialTimeoutChange={onDialTimeout} />);
     expect(result.container.firstChild).not.toBeNull();
 
     const input = result.getByPlaceholderText(allLabels.components.Config.QuerySettingsConfig.dialTimeout.placeholder);
@@ -50,17 +48,7 @@ describe('QuerySettingsConfig', () => {
 
   it('should call onQueryTimeout when changed', () => {
     const onQueryTimeout = jest.fn();
-    const result = render(
-      <QuerySettingsConfig
-        onConnMaxIdleConnsChange={() => {}}
-        onConnMaxLifetimeChange={() => {}}
-        onConnMaxOpenConnsChange={() => {}}
-        onDialTimeoutChange={() => {}}
-        onQueryTimeoutChange={onQueryTimeout}
-        onValidateSqlChange={() => {}}
-        onEnableMapKeysDiscoveryChange={() => {}}
-      />
-    );
+    const result = render(<QuerySettingsConfig {...baseProps} onQueryTimeoutChange={onQueryTimeout} />);
     expect(result.container.firstChild).not.toBeNull();
 
     const input = result.getByPlaceholderText(allLabels.components.Config.QuerySettingsConfig.queryTimeout.placeholder);
@@ -71,19 +59,24 @@ describe('QuerySettingsConfig', () => {
     expect(onQueryTimeout).toHaveBeenCalledWith(expect.any(Object));
   });
 
+  it('should call onRowCapacityHintChange when changed', () => {
+    const onRowCapacityHintChange = jest.fn();
+    const result = render(<QuerySettingsConfig {...baseProps} onRowCapacityHintChange={onRowCapacityHintChange} />);
+    expect(result.container.firstChild).not.toBeNull();
+
+    const input = result.getByPlaceholderText(
+      allLabels.components.Config.QuerySettingsConfig.rowCapacityHint.placeholder
+    );
+    expect(input).toBeInTheDocument();
+    fireEvent.change(input, { target: { value: '50000' } });
+    fireEvent.blur(input);
+    expect(onRowCapacityHintChange).toHaveBeenCalledTimes(1);
+    expect(onRowCapacityHintChange).toHaveBeenCalledWith(expect.any(Object));
+  });
+
   it('should call onValidateSqlChange when changed', () => {
     const onValidateSqlChange = jest.fn();
-    const result = render(
-      <QuerySettingsConfig
-        onConnMaxIdleConnsChange={() => {}}
-        onConnMaxLifetimeChange={() => {}}
-        onConnMaxOpenConnsChange={() => {}}
-        onDialTimeoutChange={() => {}}
-        onQueryTimeoutChange={() => {}}
-        onValidateSqlChange={onValidateSqlChange}
-        onEnableMapKeysDiscoveryChange={() => {}}
-      />
-    );
+    const result = render(<QuerySettingsConfig {...baseProps} onValidateSqlChange={onValidateSqlChange} />);
     expect(result.container.firstChild).not.toBeNull();
 
     // Two switches: validateSql first, enableMapKeysDiscovery second.
@@ -96,15 +89,7 @@ describe('QuerySettingsConfig', () => {
   it('should call onEnableMapKeysDiscoveryChange when changed', () => {
     const onEnableMapKeysDiscoveryChange = jest.fn();
     const result = render(
-      <QuerySettingsConfig
-        onConnMaxIdleConnsChange={() => {}}
-        onConnMaxLifetimeChange={() => {}}
-        onConnMaxOpenConnsChange={() => {}}
-        onDialTimeoutChange={() => {}}
-        onQueryTimeoutChange={() => {}}
-        onValidateSqlChange={() => {}}
-        onEnableMapKeysDiscoveryChange={onEnableMapKeysDiscoveryChange}
-      />
+      <QuerySettingsConfig {...baseProps} onEnableMapKeysDiscoveryChange={onEnableMapKeysDiscoveryChange} />
     );
     const inputs = result.getAllByRole('checkbox');
     fireEvent.click(inputs[1]);
@@ -114,17 +99,7 @@ describe('QuerySettingsConfig', () => {
 
   it('should call onConnMaxIdleConnsChange when changed', () => {
     const onConnMaxIdleConnsChange = jest.fn();
-    const result = render(
-      <QuerySettingsConfig
-        onConnMaxIdleConnsChange={onConnMaxIdleConnsChange}
-        onConnMaxLifetimeChange={() => {}}
-        onConnMaxOpenConnsChange={() => {}}
-        onDialTimeoutChange={() => {}}
-        onQueryTimeoutChange={() => {}}
-        onValidateSqlChange={() => {}}
-        onEnableMapKeysDiscoveryChange={() => {}}
-      />
-    );
+    const result = render(<QuerySettingsConfig {...baseProps} onConnMaxIdleConnsChange={onConnMaxIdleConnsChange} />);
     expect(result.container.firstChild).not.toBeNull();
 
     const input = result.getByPlaceholderText(allLabels.components.Config.QuerySettingsConfig.maxIdleConns.placeholder);
@@ -137,17 +112,7 @@ describe('QuerySettingsConfig', () => {
 
   it('should call onConnMaxLifetimeChange when changed', () => {
     const onConnMaxLifetimeChange = jest.fn();
-    const result = render(
-      <QuerySettingsConfig
-        onConnMaxIdleConnsChange={() => {}}
-        onConnMaxLifetimeChange={onConnMaxLifetimeChange}
-        onConnMaxOpenConnsChange={() => {}}
-        onDialTimeoutChange={() => {}}
-        onQueryTimeoutChange={() => {}}
-        onValidateSqlChange={() => {}}
-        onEnableMapKeysDiscoveryChange={() => {}}
-      />
-    );
+    const result = render(<QuerySettingsConfig {...baseProps} onConnMaxLifetimeChange={onConnMaxLifetimeChange} />);
     expect(result.container.firstChild).not.toBeNull();
 
     const input = result.getByPlaceholderText(
@@ -162,17 +127,7 @@ describe('QuerySettingsConfig', () => {
 
   it('should call onConnMaxOpenConnsChange when changed', () => {
     const onConnMaxOpenConnsChange = jest.fn();
-    const result = render(
-      <QuerySettingsConfig
-        onConnMaxIdleConnsChange={() => {}}
-        onConnMaxLifetimeChange={() => {}}
-        onConnMaxOpenConnsChange={onConnMaxOpenConnsChange}
-        onDialTimeoutChange={() => {}}
-        onQueryTimeoutChange={() => {}}
-        onValidateSqlChange={() => {}}
-        onEnableMapKeysDiscoveryChange={() => {}}
-      />
-    );
+    const result = render(<QuerySettingsConfig {...baseProps} onConnMaxOpenConnsChange={onConnMaxOpenConnsChange} />);
     expect(result.container.firstChild).not.toBeNull();
 
     const input = result.getByPlaceholderText(allLabels.components.Config.QuerySettingsConfig.maxOpenConns.placeholder);

--- a/src/components/configEditor/QuerySettingsConfig.tsx
+++ b/src/components/configEditor/QuerySettingsConfig.tsx
@@ -9,6 +9,7 @@ interface QuerySettingsConfigProps {
   maxIdleConns?: string;
   maxOpenConns?: string;
   queryTimeout?: string;
+  rowCapacityHint?: string;
   validateSql?: boolean;
   enableMapKeysDiscovery?: boolean;
   onConnMaxIdleConnsChange: (e: FormEvent<HTMLInputElement>) => void;
@@ -16,6 +17,7 @@ interface QuerySettingsConfigProps {
   onConnMaxOpenConnsChange: (e: FormEvent<HTMLInputElement>) => void;
   onDialTimeoutChange: (e: FormEvent<HTMLInputElement>) => void;
   onQueryTimeoutChange: (e: FormEvent<HTMLInputElement>) => void;
+  onRowCapacityHintChange: (e: FormEvent<HTMLInputElement>) => void;
   onValidateSqlChange: (e: FormEvent<HTMLInputElement>) => void;
   onEnableMapKeysDiscoveryChange: (e: FormEvent<HTMLInputElement>) => void;
 }
@@ -27,6 +29,7 @@ export const QuerySettingsConfig = (props: QuerySettingsConfigProps) => {
     maxIdleConns,
     maxOpenConns,
     queryTimeout,
+    rowCapacityHint,
     validateSql,
     enableMapKeysDiscovery,
     onConnMaxIdleConnsChange,
@@ -34,6 +37,7 @@ export const QuerySettingsConfig = (props: QuerySettingsConfigProps) => {
     onConnMaxOpenConnsChange,
     onDialTimeoutChange,
     onQueryTimeoutChange,
+    onRowCapacityHintChange,
     onValidateSqlChange,
     onEnableMapKeysDiscoveryChange,
   } = props;
@@ -100,6 +104,19 @@ export const QuerySettingsConfig = (props: QuerySettingsConfigProps) => {
           aria-label={labels.maxOpenConns.label}
           placeholder={labels.maxOpenConns.placeholder}
           type="number"
+        />
+      </Field>
+      <Field label={labels.rowCapacityHint.label} description={labels.rowCapacityHint.tooltip}>
+        <Input
+          name={labels.rowCapacityHint.name}
+          width={40}
+          value={rowCapacityHint || ''}
+          onChange={onRowCapacityHintChange}
+          label={labels.rowCapacityHint.label}
+          aria-label={labels.rowCapacityHint.label}
+          placeholder={labels.rowCapacityHint.placeholder}
+          type="number"
+          min={0}
         />
       </Field>
 

--- a/src/labels.ts
+++ b/src/labels.ts
@@ -161,6 +161,15 @@ export default {
           placeholder: '60',
           tooltip: 'Timeout in seconds for read queries',
         },
+        rowCapacityHint: {
+          label: 'Row Capacity Hint',
+          name: 'rowCapacityHint',
+          placeholder: '0',
+          tooltip:
+            'Expected number of rows per query response. Pre-allocates data frames before scanning to avoid repeated ' +
+            'reallocation on large results. Applied to every query, so leave at 0 (disabled) unless queries reliably ' +
+            'return a similar, large number of rows. A value larger than the typical result wastes memory.',
+        },
         validateSql: {
           label: 'Validate SQL',
           tooltip: 'Validate SQL in the editor.',

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -52,6 +52,15 @@ export interface CHConfig extends DataSourceJsonData {
   enableSecureSocksProxy?: boolean;
   enableRowLimit?: boolean;
 
+  /**
+   * Optional expected row count passed to sqlds as DriverSettings.RowCapacityHint.
+   * sqlds pre-allocates each frame's fields to this value before scanning, avoiding
+   * per-column slice growth on large results. Applied to every query, so leave
+   * unset (0, disabled) unless queries reliably return a similar, large number
+   * of rows. A value larger than the typical result wastes memory.
+   */
+  rowCapacityHint?: string;
+
   hideTableNameInAdhocFilters?: boolean;
 
   /**

--- a/src/views/CHConfigEditor.tsx
+++ b/src/views/CHConfigEditor.tsx
@@ -593,6 +593,7 @@ export const ConfigEditor: React.FC<ConfigEditorProps> = (props) => {
               connMaxLifetime={jsonData.connMaxLifetime}
               maxIdleConns={jsonData.maxIdleConns}
               maxOpenConns={jsonData.maxOpenConns}
+              rowCapacityHint={jsonData.rowCapacityHint}
               validateSql={jsonData.validateSql}
               enableMapKeysDiscovery={jsonData.enableMapKeysDiscovery}
               onDialTimeoutChange={(e) => onUpdateDatasourceJsonDataOption(props, 'dialTimeout')(e)}
@@ -600,6 +601,7 @@ export const ConfigEditor: React.FC<ConfigEditorProps> = (props) => {
               onConnMaxLifetimeChange={(e) => onUpdateDatasourceJsonDataOption(props, 'connMaxLifetime')(e)}
               onConnMaxIdleConnsChange={(e) => onUpdateDatasourceJsonDataOption(props, 'maxIdleConns')(e)}
               onConnMaxOpenConnsChange={(e) => onUpdateDatasourceJsonDataOption(props, 'maxOpenConns')(e)}
+              onRowCapacityHintChange={(e) => onUpdateDatasourceJsonDataOption(props, 'rowCapacityHint')(e)}
               onValidateSqlChange={(e) => onSwitchToggle('validateSql', e.currentTarget.checked)}
               onEnableMapKeysDiscoveryChange={(e) => onSwitchToggle('enableMapKeysDiscovery', e.currentTarget.checked)}
             />
@@ -637,6 +639,7 @@ export const ConfigEditor: React.FC<ConfigEditorProps> = (props) => {
               maxIdleConns={jsonData.maxIdleConns}
               maxOpenConns={jsonData.maxOpenConns}
               queryTimeout={jsonData.queryTimeout}
+              rowCapacityHint={jsonData.rowCapacityHint}
               validateSql={jsonData.validateSql}
               onDialTimeoutChange={(e) => {
                 trackingV1.trackClickhouseConfigV1QuerySettings({ dialTimeout: Number(e.currentTarget.value) });
@@ -645,6 +648,10 @@ export const ConfigEditor: React.FC<ConfigEditorProps> = (props) => {
               onQueryTimeoutChange={(e) => {
                 trackingV1.trackClickhouseConfigV1QuerySettings({ queryTimeout: Number(e.currentTarget.value) });
                 onUpdateDatasourceJsonDataOption(props, 'queryTimeout')(e);
+              }}
+              onRowCapacityHintChange={(e) => {
+                trackingV1.trackClickhouseConfigV1QuerySettings({ rowCapacityHint: Number(e.currentTarget.value) });
+                onUpdateDatasourceJsonDataOption(props, 'rowCapacityHint')(e);
               }}
               onConnMaxLifetimeChange={(e) => {
                 trackingV1.trackClickhouseConfigV1QuerySettings({ connMaxLifetime: Number(e.currentTarget.value) });

--- a/src/views/config-v2/AdditionalSettingsSection.tsx
+++ b/src/views/config-v2/AdditionalSettingsSection.tsx
@@ -189,6 +189,7 @@ export const AdditionalSettingsSection = (props: Props) => {
               maxIdleConns={jsonData.maxIdleConns}
               maxOpenConns={jsonData.maxOpenConns}
               queryTimeout={jsonData.queryTimeout}
+              rowCapacityHint={jsonData.rowCapacityHint}
               validateSql={jsonData.validateSql}
               enableMapKeysDiscovery={jsonData.enableMapKeysDiscovery}
               onDialTimeoutChange={(e) => {
@@ -198,6 +199,10 @@ export const AdditionalSettingsSection = (props: Props) => {
               onQueryTimeoutChange={(e) => {
                 trackClickhouseConfigV2QuerySettings({ queryTimeout: Number(e.currentTarget.value) });
                 onUpdateDatasourceJsonDataOption(props, 'queryTimeout')(e);
+              }}
+              onRowCapacityHintChange={(e) => {
+                trackClickhouseConfigV2QuerySettings({ rowCapacityHint: Number(e.currentTarget.value) });
+                onUpdateDatasourceJsonDataOption(props, 'rowCapacityHint')(e);
               }}
               onConnMaxLifetimeChange={(e) => {
                 trackClickhouseConfigV2QuerySettings({ connMaxLifetime: Number(e.currentTarget.value) });

--- a/src/views/config-v2/AdditionalSettingsSection.tsx
+++ b/src/views/config-v2/AdditionalSettingsSection.tsx
@@ -137,6 +137,7 @@ export const AdditionalSettingsSection = (props: Props) => {
             !!jsonData.maxIdleConns ||
             !!jsonData.maxOpenConns ||
             !!jsonData.queryTimeout ||
+            !!jsonData.rowCapacityHint ||
             !!jsonData.validateSql ||
             jsonData.enableMapKeysDiscovery === false ||
             !isEqual(logs, defaultLogs) ||

--- a/src/views/config-v2/ConfigurationModeSection.tsx
+++ b/src/views/config-v2/ConfigurationModeSection.tsx
@@ -189,6 +189,7 @@ export const ConfigurationModeSection = (props: Props) => {
               connMaxLifetime={jsonData.connMaxLifetime}
               maxIdleConns={jsonData.maxIdleConns}
               maxOpenConns={jsonData.maxOpenConns}
+              rowCapacityHint={jsonData.rowCapacityHint}
               validateSql={jsonData.validateSql}
               enableMapKeysDiscovery={jsonData.enableMapKeysDiscovery}
               onDialTimeoutChange={(e) => {
@@ -198,6 +199,10 @@ export const ConfigurationModeSection = (props: Props) => {
               onQueryTimeoutChange={(e) => {
                 trackClickhouseConfigV2QuerySettings({ queryTimeout: Number(e.currentTarget.value) });
                 onUpdateDatasourceJsonDataOption(props, 'queryTimeout')(e);
+              }}
+              onRowCapacityHintChange={(e) => {
+                trackClickhouseConfigV2QuerySettings({ rowCapacityHint: Number(e.currentTarget.value) });
+                onUpdateDatasourceJsonDataOption(props, 'rowCapacityHint')(e);
               }}
               onConnMaxLifetimeChange={(e) => {
                 trackClickhouseConfigV2QuerySettings({ connMaxLifetime: Number(e.currentTarget.value) });

--- a/src/views/config-v2/tracking.ts
+++ b/src/views/config-v2/tracking.ts
@@ -62,6 +62,7 @@ export const trackClickhouseConfigV2QuerySettings = (props: {
   maxIdleConns?: number;
   maxOpenConns?: number;
   connMaxLifetime?: number;
+  rowCapacityHint?: number;
   validateSql?: boolean;
   enableMapKeysDiscovery?: boolean;
 }) => {

--- a/src/views/trackingV1.ts
+++ b/src/views/trackingV1.ts
@@ -47,6 +47,7 @@ export const trackClickhouseConfigV1QuerySettings = (props: {
   maxIdleConns?: number;
   maxOpenConns?: number;
   connMaxLifetime?: number;
+  rowCapacityHint?: number;
   validateSql?: boolean;
   enableMapKeysDiscovery?: boolean;
 }) => {


### PR DESCRIPTION
## Type of Change

- [x] 🚀 Feature

---

## Feature

### What is this feature?

Adds an optional **Row Capacity Hint** setting to the ClickHouse datasource. It wires the sqlds `DriverSettings.RowCapacityHint` knob (grafana/sqlds#240, released in sqlds v5.3.0) through to the query path. sqlds uses the hint to pre-allocate each `data.Frame`'s fields to the expected row count before scanning rows.

### Why is this feature needed?

Without a hint, sqlds grows each column's slice as rows arrive, which triggers repeated reallocation and copying on large responses. Supplying an expected row count lets the frame fields be allocated once, cutting allocation churn on the hot path for datasources that reliably return large results.

The value is static per datasource and applied to every query, so it is opt-in and defaults to `0` (disabled). Operators who know their workload can set it. A value larger than the typical result would waste memory, so the tooltip calls this out and the default keeps existing behaviour unchanged.

### Who is this feature for?

Operators running dashboards or alerting against ClickHouse datasources whose queries consistently return a large, similar number of rows and who want to reduce backend allocation overhead.

### How to test this feature

1. Open a ClickHouse datasource config page and expand **Query settings**.
2. Confirm a new numeric **Row Capacity Hint** field appears (default empty/0).
3. Set it to a value such as `50000`, save, and run a query. Behaviour is unchanged from the user's perspective; the hint only affects backend frame allocation.
4. Leave it unset to confirm the historical behaviour (no pre-allocation) still applies.

Backend and frontend unit tests cover the settings parsing (number, string, negative-clamped, absent) and the new config field.

---

## Notes

- Based on #2008, which bumps sqlds to v5.3.0 (the release containing grafana/sqlds#240). This PR targets `feat/sqlds-interpolator` and should merge after #2008.
- The field lives in the shared `QuerySettingsConfig` component, so it renders in both the current config editor and the v2 design.

## Please check that:

- [x] Tests for this change have been added/updated.
- [x] The change follows the existing settings-parsing and config-editor patterns.

Closes #2025