### PR TITLE
ci: derive ClickHouse integration test matrix from the upstream support table

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -13,20 +13,36 @@ on:
     - cron: '0 9 1 * *'
 
 jobs:
+  versions:
+    name: Get supported ClickHouse versions
+    permissions: {}
+    runs-on: ubuntu-latest
+    outputs:
+      versions: ${{ steps.parse.outputs.versions }}
+    steps:
+      - name: Parse supported versions from the ClickHouse security policy
+        id: parse
+        run: |
+          versions=$(curl -sSf --retry 3 https://raw.githubusercontent.com/ClickHouse/ClickHouse/master/SECURITY.md \
+            | sed -nE 's/^\| ([0-9]+\.[0-9]+) \| ✔️ \|$/\1/p' \
+            | sort -t. -k1,1n -k2,2n \
+            | jq -R . | jq -sc '. + ["latest"]')
+          if [ "$versions" = '["latest"]' ]; then
+            echo 'No supported versions found in SECURITY.md, the table format may have changed' >&2
+            exit 1
+          fi
+          echo "Testing against ClickHouse versions: $versions"
+          echo "versions=$versions" >> "$GITHUB_OUTPUT"
+
   run:
+    needs: versions
     permissions:
       contents: read
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true
       matrix:
-        clickhouse:
-          - 24.8
-          - 25.3
-          - 25.5
-          - 25.6
-          - 25.7
-          - latest
+        clickhouse: ${{ fromJSON(needs.versions.outputs.versions) }}
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7


### PR DESCRIPTION
## Type of Change

- [x] 🧹 Refactor / Chore

## What is this change?

The integration test workflow currently hardcodes the ClickHouse versions it tests against (24.8, 25.3, 25.5, 25.6, 25.7, latest). That list had drifted well behind upstream, none of those pinned versions still receives security updates.

This change adds a `versions` job that fetches the [ClickHouse security policy](https://github.com/ClickHouse/ClickHouse/blob/master/SECURITY.md#security-change-log-and-support) on every run and parses the support table, taking every version marked ✔️ plus the `latest` tag. The result feeds the test job's matrix via `fromJSON`, so the workflow always tests exactly the set of upstream-supported releases without manual bumps.

As of today that resolves to `25.8`, `26.3`, `26.4`, `26.5`, `26.6`, and `latest`.

If the fetch fails or the table format changes so that no versions parse, the job fails loudly rather than silently testing `latest` only. The parsed matrix values are constrained to `X.Y` numeric strings by the extraction pattern, so no untrusted upstream content can reach the matrix expression.

## Please check that:

- [x] Tests for this change have been added/updated. (CI workflow change, verified by the run on this PR)
- [x] Documentation has been added/updated (where applicable). (n/a)

## Special notes for your reviewer

The `versions` job runs with an empty permissions block since it only performs an outbound fetch. Sorting is numeric on major then minor, with `latest` appended last.
