### PR TITLE
feat(otel): auto-detect logs schema version from table columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - Add `1.3.0` OTel schema version to support `opentelemetry-collector-contrib` clickhouseexporter `v0.151.0`+, which removed the `TimestampTime` column from `otel_logs`. The `latest` selector now points to this schema; existing data sources continue to use `1.2.9` until manually updated (#1882)
+- Auto-detect the OTel logs schema version from the table's columns when the version selector is on `auto (latest)`, removing the manual version pick for the common case. Pinned versions are unchanged (#1900)
 
 ### Fixes
 

--- a/docs/sources/configure.md
+++ b/docs/sources/configure.md
@@ -228,13 +228,13 @@ When **Configuration mode** is set to **Single source** and **Signal type** is s
 
 The plugin ships built-in column maps for the OpenTelemetry ClickHouse exporter's default schemas. Pick the version that matches the exporter that wrote your data:
 
-- **`latest`** — always tracks the newest schema below. Recommended for new data sources.
+- **`auto (latest)`** — detects the logs schema version from the table's columns when building a query: tables with a `TimestampTime` column use the `1.2.9` map, tables without it use the `1.3.0` map. Recommended, and the default. Pin a specific version below to override the detection.
 - **`1.3.0`** — `opentelemetry-collector-contrib` clickhouseexporter `v0.151.0` and later. The `otel_logs` table partitions and orders directly on `Timestamp`. The `TimestampTime` column was removed in [PR #47720](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/47720), so the **Filter Time column** is left blank.
 - **`1.2.9`** — `opentelemetry-collector-contrib` clickhouseexporter `v0.150.x` and earlier. The `otel_logs` table includes a `TimestampTime DateTime` column used for partition-based filtering.
 
-The trace tables (`otel_traces`, `otel_traces_trace_id_ts`) and metric tables are unchanged across these versions; only the `otel_logs` schema changed.
+The trace tables (`otel_traces`, `otel_traces_trace_id_ts`) and metric tables are unchanged across these versions; only the `otel_logs` schema changed. Detection therefore only applies to logs, and traces always use the selected version's map.
 
-If queries fail with an `Unknown identifier 'TimestampTime'` error after upgrading the exporter, switch the schema version to `1.3.0` (or `latest`).
+If queries fail with an `Unknown identifier 'TimestampTime'` error after upgrading the exporter, leave the version on `auto (latest)` and rebuild the query, or pin the schema version to `1.3.0`.
 
 ### Private data source connect
 

--- a/src/components/queryBuilder/views/logsQueryBuilderHooks.test.ts
+++ b/src/components/queryBuilder/views/logsQueryBuilderHooks.test.ts
@@ -183,6 +183,85 @@ describe('useOtelColumns', () => {
     expect(builderOptionsDispatch).toHaveBeenCalledWith(expect.objectContaining(setOptions(expectedOptions)));
   });
 
+  it('should apply the 1.29.0 column map when version is "latest" and the table has TimestampTime', async () => {
+    jest.spyOn(mockDatasource, 'shouldSelectLogContextColumns').mockReturnValue(false);
+    const builderOptionsDispatch = jest.fn();
+    const allColumns: readonly TableColumn[] = [
+      { name: 'TimestampTime', type: 'DateTime', picklistValues: [] },
+      { name: 'LogAttributes', type: 'Map(String, String)', picklistValues: [] },
+    ];
+
+    let otelEnabled = false;
+    const hook = renderHook(
+      (enabled) => useOtelColumns(mockDatasource, allColumns, enabled, 'latest', builderOptionsDispatch),
+      { initialProps: otelEnabled }
+    );
+    otelEnabled = true;
+    hook.rerender(otelEnabled);
+
+    const columns: SelectedColumn[] = [];
+    otel.getVersion('1.29.0')!.logColumnMap.forEach((v, k) => {
+      columns.push({ name: v, hint: k, type: allColumns.find((c) => c.name === v)?.type });
+    });
+    const expectedOptions = { columns };
+
+    expect(builderOptionsDispatch).toHaveBeenCalledTimes(1);
+    expect(builderOptionsDispatch).toHaveBeenCalledWith(expect.objectContaining(setOptions(expectedOptions)));
+  });
+
+  it('should apply the 1.30.0 column map when version is "latest" and the table has no TimestampTime', async () => {
+    jest.spyOn(mockDatasource, 'shouldSelectLogContextColumns').mockReturnValue(false);
+    const builderOptionsDispatch = jest.fn();
+    const allColumns: readonly TableColumn[] = [
+      { name: 'Timestamp', type: 'DateTime64(9)', picklistValues: [] },
+      { name: 'LogAttributes', type: 'Map(String, String)', picklistValues: [] },
+    ];
+
+    let otelEnabled = false;
+    const hook = renderHook(
+      (enabled) => useOtelColumns(mockDatasource, allColumns, enabled, 'latest', builderOptionsDispatch),
+      { initialProps: otelEnabled }
+    );
+    otelEnabled = true;
+    hook.rerender(otelEnabled);
+
+    const columns: SelectedColumn[] = [];
+    otel.getVersion('1.30.0')!.logColumnMap.forEach((v, k) => {
+      columns.push({ name: v, hint: k, type: allColumns.find((c) => c.name === v)?.type });
+    });
+    const expectedOptions = { columns };
+
+    expect(builderOptionsDispatch).toHaveBeenCalledTimes(1);
+    expect(builderOptionsDispatch).toHaveBeenCalledWith(expect.objectContaining(setOptions(expectedOptions)));
+  });
+
+  it('should honour a pinned version even when detection would disagree', async () => {
+    jest.spyOn(mockDatasource, 'shouldSelectLogContextColumns').mockReturnValue(false);
+    const builderOptionsDispatch = jest.fn();
+    // Table still has TimestampTime, but the user pinned 1.30.0 explicitly.
+    const allColumns: readonly TableColumn[] = [
+      { name: 'TimestampTime', type: 'DateTime', picklistValues: [] },
+      { name: 'LogAttributes', type: 'Map(String, String)', picklistValues: [] },
+    ];
+
+    let otelEnabled = false;
+    const hook = renderHook(
+      (enabled) => useOtelColumns(mockDatasource, allColumns, enabled, '1.30.0', builderOptionsDispatch),
+      { initialProps: otelEnabled }
+    );
+    otelEnabled = true;
+    hook.rerender(otelEnabled);
+
+    const columns: SelectedColumn[] = [];
+    otel.getVersion('1.30.0')!.logColumnMap.forEach((v, k) => {
+      columns.push({ name: v, hint: k, type: allColumns.find((c) => c.name === v)?.type });
+    });
+    const expectedOptions = { columns };
+
+    expect(builderOptionsDispatch).toHaveBeenCalledTimes(1);
+    expect(builderOptionsDispatch).toHaveBeenCalledWith(expect.objectContaining(setOptions(expectedOptions)));
+  });
+
   it('should not call builderOptionsDispatch after OTEL columns are set', async () => {
     jest.spyOn(mockDatasource, 'shouldSelectLogContextColumns').mockReturnValue(false);
     const builderOptionsDispatch = jest.fn();

--- a/src/components/queryBuilder/views/logsQueryBuilderHooks.ts
+++ b/src/components/queryBuilder/views/logsQueryBuilderHooks.ts
@@ -90,7 +90,15 @@ export const useOtelColumns = (
       return;
     }
 
-    const otelConfig = otel.getVersion(otelVersion);
+    let otelConfig = otel.getVersion(otelVersion);
+    // The "latest" alias resolves against the actual table instead of a fixed
+    // schema: pre-v0.151.0 collector tables keep their TimestampTime column,
+    // newer ones don't, and both exist in the wild (see #1900). allColumns is
+    // already fetched for the builder, so detection costs no extra round-trip.
+    // Pinned versions (1.29.0, 1.30.0, ...) are honoured as-is.
+    if (otelConfig?.version === 'latest') {
+      otelConfig = otel.detectLogsVersion(allColumns.map((c) => c.name));
+    }
     const logColumnMap = otelConfig?.logColumnMap;
     if (!logColumnMap) {
       return;

--- a/src/labels.ts
+++ b/src/labels.ts
@@ -401,7 +401,8 @@ export default {
     },
     OtelVersionSelect: {
       label: 'Use OTel',
-      tooltip: 'Enables Open Telemetry schema versioning',
+      tooltip:
+        'Enables Open Telemetry schema versioning. The auto option matches the logs schema version to the table columns. Pick a specific version to override.',
     },
     LimitEditor: {
       label: 'Limit',

--- a/src/otel.test.ts
+++ b/src/otel.test.ts
@@ -1,4 +1,11 @@
-import otel, { defaultLogsTable, defaultTraceTable, getLatestVersion, getVersion, versions } from 'otel';
+import otel, {
+  defaultLogsTable,
+  defaultTraceTable,
+  detectLogsVersion,
+  getLatestVersion,
+  getVersion,
+  versions,
+} from 'otel';
 import { ColumnHint } from 'types/queryBuilder';
 
 describe('otel versions', () => {
@@ -61,6 +68,24 @@ describe('otel trace schema (unchanged in v0.151.0)', () => {
     expect(Array.from(v130.traceColumnMap.entries())).toEqual(Array.from(v129.traceColumnMap.entries()));
     expect(v130.traceTable).toBe(v129.traceTable);
     expect(v130.traceTable).toBe(defaultTraceTable);
+  });
+});
+
+describe('detectLogsVersion', () => {
+  it('picks the 1.29.0 schema when the table has a TimestampTime column', () => {
+    const detected = detectLogsVersion(['Timestamp', 'TimestampTime', 'Body', 'SeverityText']);
+    expect(detected.version).toBe('1.29.0');
+    expect(detected.logColumnMap.get(ColumnHint.FilterTime)).toBe('TimestampTime');
+  });
+
+  it('picks the 1.30.0 schema when the table has no TimestampTime column', () => {
+    const detected = detectLogsVersion(['Timestamp', 'Body', 'SeverityText']);
+    expect(detected.version).toBe('1.30.0');
+    expect(detected.logColumnMap.has(ColumnHint.FilterTime)).toBe(false);
+  });
+
+  it('falls back to the 1.30.0 schema for an empty column list', () => {
+    expect(detectLogsVersion([]).version).toBe('1.30.0');
   });
 });
 

--- a/src/otel.ts
+++ b/src/otel.ts
@@ -83,13 +83,27 @@ const otel130: OtelVersion = {
 };
 
 export const versions: readonly OtelVersion[] = [
-  // When selected, will always keep OTEL config up to date as new versions are added
-  { ...otel130, name: `latest (${otel130.name})`, version: 'latest' },
+  // When selected, the log schema version is detected from the table's columns
+  // (see detectLogsVersion). The static map here is the fallback for paths that
+  // can't inspect the table, and always tracks the newest schema.
+  { ...otel130, name: 'auto (latest)', version: 'latest' },
   otel130,
   otel129,
 ];
 
 export const getLatestVersion = (): OtelVersion => versions[0];
+
+/**
+ * Picks the log schema version that matches an actual table's columns.
+ * The collector's migration is non-destructive, so both schema generations
+ * coexist in the wild: tables created before clickhouseexporter v0.151.0 keep
+ * their TimestampTime column, tables created after don't have it.
+ * TimestampTime is the only column that distinguishes the two, so its
+ * presence is the whole probe. Callers that pin an explicit version bypass
+ * this entirely.
+ */
+export const detectLogsVersion = (columnNames: readonly string[]): OtelVersion =>
+  columnNames.includes('TimestampTime') ? otel129 : otel130;
 export const getVersion = (version: string | undefined): OtelVersion | undefined => {
   if (!version) {
     return;
@@ -101,6 +115,7 @@ export const getVersion = (version: string | undefined): OtelVersion | undefined
 export default {
   traceTimestampTableSuffix,
   versions,
+  detectLogsVersion,
   getLatestVersion,
   getVersion,
 };


### PR DESCRIPTION
## Type of Change

- [x] 🚀 Feature

---

## Feature

### What is this feature?

The `latest` OTel schema version entry (now labelled `auto (latest)`) resolves the logs schema against the actual table instead of a fixed map. When the query builder applies OTel column mappings, it checks the table's columns: tables with a `TimestampTime` column get the `1.2.9` map, tables without it get the `1.3.0` map. Pinned versions (`1.2.9`, `1.3.0`) bypass detection entirely and behave exactly as before.

Because the persisted `otelVersion` value is still `latest`, existing data sources pick up detection with no migration or manual step.

### Why is this feature needed?

`opentelemetry-collector-contrib`'s `clickhouseexporter` removed `TimestampTime` from `otel_logs` in v0.151.0, and #1899 added versioned column maps with a manual selector. The exporter migration is non-destructive, so both schema generations coexist in the wild, and users have no easy way to know which generation their tables were created with. Detection removes the version-selection step for the common case, and future exporter schema bumps become a code-only change in the plugin.

Closes #1900

### Who is this feature for?

Anyone querying OTel logs tables written by the ClickHouse exporter, particularly clusters that predate the v0.151.0 upgrade and mixed fleets where old and new tables coexist.

### How to test this feature

1. Create two logs tables, one with a `TimestampTime` column (pre-v0.151.0 layout, see `1.2.9` in `src/otel.ts`) and one without (v0.151.0+ layout, see `tests/e2e/fixtures/otel_logs_v0151.sql`).
2. In a logs query, enable **Use OTel** with the version on `auto (latest)` and point it at each table in turn.
3. The old table gets the `1.2.9` mapping (Filter Time is `TimestampTime`), the new table gets the `1.3.0` mapping (no `TimestampTime` reference in the generated SQL).
4. Pin the version to `1.3.0` against the old table and confirm the pinned map is used instead of the detected one.

---

## Please check that:

- [x] Tests for this change have been added/updated.
- [x] Documentation has been added/updated (where applicable).

## Special notes for your reviewer

The issue proposed probing `system.columns` at health-check or config-save time with a cached result on the data source instance. This implementation detects at query-build time instead: `useOtelColumns` already receives the table's full column list (fetched and cached for the builder), so detection costs no extra round-trip and covers every path that applies the log column map. Paths that cannot inspect the table (config editor display, trace-to-logs link defaults) fall back to the static latest map, which is safe because the maps only differ in the optional `FilterTime` entry and the SQL generator already falls back to `Time` when `FilterTime` is unmapped (#1899).

Detection is logs-only, matching the issue scope. The trace tables are identical across both schema generations.
