### PR TITLE
fix(logs): correct and align attribute filters added from the log view

### DIFF
--- a/src/components/queryBuilder/CompactFilterBar.tsx
+++ b/src/components/queryBuilder/CompactFilterBar.tsx
@@ -3,7 +3,7 @@ import { css } from '@emotion/css';
 import { GrafanaTheme2 } from '@grafana/data';
 import { Button, Tooltip, useStyles2 } from '@grafana/ui';
 import { Datasource } from 'data/CHDatasource';
-import { Filter, TableColumn } from 'types/queryBuilder';
+import { Filter, SelectedColumn, TableColumn } from 'types/queryBuilder';
 import { FilterPopover } from './FilterPopover';
 import { FilterTagBar } from './FilterTagBar';
 
@@ -13,6 +13,7 @@ interface CompactFilterBarProps {
   table: string;
   filters: Filter[];
   allColumns: readonly TableColumn[];
+  selectedColumns?: readonly SelectedColumn[];
   onFiltersChange: (filters: Filter[]) => void;
   onToggleAdvanced?: () => void;
   advancedOpen?: boolean;
@@ -44,7 +45,17 @@ const getStyles = (theme: GrafanaTheme2) => ({
 });
 
 export const CompactFilterBar = (props: CompactFilterBarProps) => {
-  const { datasource, database, table, filters, allColumns, onFiltersChange, onToggleAdvanced, advancedOpen } = props;
+  const {
+    datasource,
+    database,
+    table,
+    filters,
+    allColumns,
+    selectedColumns,
+    onFiltersChange,
+    onToggleAdvanced,
+    advancedOpen,
+  } = props;
   const styles = useStyles2(getStyles);
   const [showPopover, setShowPopover] = useState(false);
 
@@ -60,7 +71,7 @@ export const CompactFilterBar = (props: CompactFilterBarProps) => {
     <div data-testid="compact-filter-bar">
       <div className={styles.row}>
         <div className={styles.filters}>
-          <FilterTagBar filters={filters} onRemoveFilter={onRemoveFilter} />
+          <FilterTagBar filters={filters} selectedColumns={selectedColumns} onRemoveFilter={onRemoveFilter} />
           <Button icon="plus" variant="secondary" size="sm" fill="text" onClick={() => setShowPopover(!showPopover)}>
             Add filter
           </Button>

--- a/src/components/queryBuilder/FilterTagBar.test.ts
+++ b/src/components/queryBuilder/FilterTagBar.test.ts
@@ -51,4 +51,15 @@ describe('getFilterDisplayName', () => {
     } as Filter;
     expect(getFilterDisplayName(filter, selectedColumns)).toBe('SeverityText');
   });
+
+  it('resolves trace attribute columns to their names (traces use TraceTags/TraceServiceTags hints)', () => {
+    const traceColumns: SelectedColumn[] = [
+      { name: 'SpanAttributes', hint: ColumnHint.TraceTags },
+      { name: 'ResourceAttributes', hint: ColumnHint.TraceServiceTags },
+    ];
+    const spanFilter = mapKeyFilter({ key: '', hint: ColumnHint.TraceTags, mapKey: 'http.method' });
+    const resourceFilter = mapKeyFilter({ key: '', hint: ColumnHint.TraceServiceTags, mapKey: 'service.name' });
+    expect(getFilterDisplayName(spanFilter, traceColumns)).toBe('SpanAttributes.http.method');
+    expect(getFilterDisplayName(resourceFilter, traceColumns)).toBe('ResourceAttributes.service.name');
+  });
 });

--- a/src/components/queryBuilder/FilterTagBar.test.ts
+++ b/src/components/queryBuilder/FilterTagBar.test.ts
@@ -1,0 +1,54 @@
+import { getFilterDisplayName } from './FilterTagBar';
+import { ColumnHint, Filter, FilterOperator, SelectedColumn } from 'types/queryBuilder';
+
+describe('getFilterDisplayName', () => {
+  const selectedColumns: SelectedColumn[] = [
+    { name: 'LogAttributes', hint: ColumnHint.LogAttributes },
+    { name: 'SeverityText', hint: ColumnHint.LogLevel },
+  ];
+
+  const mapKeyFilter = (overrides: Partial<Filter>): Filter =>
+    ({
+      condition: 'AND',
+      filterType: 'custom',
+      type: 'Map(String, String)',
+      operator: FilterOperator.Equals,
+      value: 'proxy.access',
+      mapKey: 'event.name',
+      ...overrides,
+    }) as Filter;
+
+  it('renders the raw column name for a hinted map-key filter (the log-view "+" path)', () => {
+    const filter = mapKeyFilter({ key: '', hint: ColumnHint.LogAttributes });
+    expect(getFilterDisplayName(filter, selectedColumns)).toBe('LogAttributes.event.name');
+  });
+
+  it('renders the raw column name for a key-based map-key filter (the Add filter path)', () => {
+    const filter = mapKeyFilter({ key: 'LogAttributes' });
+    expect(getFilterDisplayName(filter, selectedColumns)).toBe('LogAttributes.event.name');
+  });
+
+  it('renders the log-view "+" and Add filter representations identically', () => {
+    const hinted = mapKeyFilter({ key: '', hint: ColumnHint.LogAttributes });
+    const keyed = mapKeyFilter({ key: 'LogAttributes' });
+    expect(getFilterDisplayName(hinted, selectedColumns)).toBe(getFilterDisplayName(keyed, selectedColumns));
+  });
+
+  it('falls back to the hint label when no matching column is available', () => {
+    const filter = mapKeyFilter({ key: '', hint: ColumnHint.LogAttributes });
+    expect(getFilterDisplayName(filter, [])).toBe('log attributes.event.name');
+  });
+
+  it('resolves a non-map hinted filter to its column name', () => {
+    const filter = {
+      condition: 'AND',
+      filterType: 'custom',
+      key: '',
+      hint: ColumnHint.LogLevel,
+      type: 'string',
+      operator: FilterOperator.Equals,
+      value: 'info',
+    } as Filter;
+    expect(getFilterDisplayName(filter, selectedColumns)).toBe('SeverityText');
+  });
+});

--- a/src/components/queryBuilder/FilterTagBar.tsx
+++ b/src/components/queryBuilder/FilterTagBar.tsx
@@ -2,10 +2,11 @@ import React from 'react';
 import { css } from '@emotion/css';
 import { GrafanaTheme2 } from '@grafana/data';
 import { Icon, Tooltip, useStyles2 } from '@grafana/ui';
-import { Filter, FilterOperator } from 'types/queryBuilder';
+import { Filter, FilterOperator, SelectedColumn } from 'types/queryBuilder';
 
 interface FilterTagBarProps {
   filters: Filter[];
+  selectedColumns?: readonly SelectedColumn[];
   onRemoveFilter: (index: number) => void;
 }
 
@@ -70,10 +71,14 @@ const getStyles = (theme: GrafanaTheme2) => ({
   `,
 });
 
-const getFilterDisplayName = (filter: Filter): string => {
-  const key = filter.key || (filter.hint ? filter.hint.replace(/_/g, ' ') : '?');
+export const getFilterDisplayName = (filter: Filter, selectedColumns: readonly SelectedColumn[] = []): string => {
+  // Resolve a hinted filter (the log-view "+" stores { key: '', hint }) back to its actual
+  // column name so the chip reads e.g. "LogAttributes.event.name", matching the log viewer
+  // and the Add filter path instead of the friendlier hint label ("log attributes").
+  const hintedColumn = filter.hint ? selectedColumns.find((c) => c.hint === filter.hint) : undefined;
+  const base = filter.key || hintedColumn?.name || (filter.hint ? filter.hint.replace(/_/g, ' ') : '?');
   const mapSuffix = 'mapKey' in filter && filter.mapKey ? `.${filter.mapKey}` : '';
-  return `${key}${mapSuffix}`;
+  return `${base}${mapSuffix}`;
 };
 
 const getFilterDisplayValue = (filter: Filter): string => {
@@ -117,7 +122,7 @@ const getOperatorDisplay = (operator: FilterOperator): string => {
 };
 
 export const FilterTagBar = (props: FilterTagBarProps) => {
-  const { filters, onRemoveFilter } = props;
+  const { filters, selectedColumns, onRemoveFilter } = props;
   const styles = useStyles2(getStyles);
 
   const activeFilters = filters.filter(
@@ -145,7 +150,7 @@ export const FilterTagBar = (props: FilterTagBarProps) => {
           return null;
         }
 
-        const name = getFilterDisplayName(filter);
+        const name = getFilterDisplayName(filter, selectedColumns);
         const operator = getOperatorDisplay(filter.operator);
         const value = getFilterDisplayValue(filter);
 

--- a/src/components/queryBuilder/QueryBuilder.test.tsx
+++ b/src/components/queryBuilder/QueryBuilder.test.tsx
@@ -104,13 +104,22 @@ describe('QueryBuilder', () => {
     expect(result.container.firstChild).not.toBeNull();
   });
 
-  it('shows the raw attribute column name in the compact filter chip for a hinted "+" filter', async () => {
-    const originalGetSignalType = mockDs.getSignalType;
-    const originalIsSingleTableMode = mockDs.isSingleTableMode;
-    // Compact editor renders only when the datasource is single-table with a signal type.
-    mockDs.getSignalType = jest.fn(() => 'logs' as any);
-    mockDs.isSingleTableMode = jest.fn(() => true);
-    try {
+  describe('compact filter chip label', () => {
+    let getSignalTypeSpy: jest.SpyInstance;
+    let isSingleTableModeSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      // Compact editor renders only when the datasource is single-table with a signal type.
+      getSignalTypeSpy = jest.spyOn(mockDs, 'getSignalType').mockReturnValue('logs' as any);
+      isSingleTableModeSpy = jest.spyOn(mockDs, 'isSingleTableMode').mockReturnValue(true);
+    });
+
+    afterEach(() => {
+      getSignalTypeSpy.mockRestore();
+      isSingleTableModeSpy.mockRestore();
+    });
+
+    it('shows the raw attribute column name in the compact filter chip for a hinted "+" filter', async () => {
       render(
         <QueryBuilder
           app={CoreApp.PanelEditor}
@@ -143,15 +152,12 @@ describe('QueryBuilder', () => {
         />
       );
 
-      // The log-view "+" stores { key: '', hint }, so the chip must resolve the hint to
-      // the column name and read "LogAttributes.user.tier" (matching the Add filter path),
-      // not the friendly hint label "log attributes.user.tier".
+      // The log-view "+" stores { key: '', hint }, so the chip must resolve the hint to the
+      // column name and read "LogAttributes.user.tier" (matching the Add filter path), not the
+      // friendly hint label "log attributes.user.tier".
       expect(await screen.findByText('LogAttributes.user.tier')).toBeInTheDocument();
       expect(screen.queryByText('log attributes.user.tier')).not.toBeInTheDocument();
-    } finally {
-      mockDs.getSignalType = originalGetSignalType;
-      mockDs.isSingleTableMode = originalIsSingleTableMode;
-    }
+    });
   });
 
   it('renders TableQueryBuilder when queryType is Table', () => {

--- a/src/components/queryBuilder/QueryBuilder.test.tsx
+++ b/src/components/queryBuilder/QueryBuilder.test.tsx
@@ -3,7 +3,7 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { getCompactFilterColumns, QueryBuilder } from './QueryBuilder';
 import { getDefaultCompactMode } from './CompactModeBar';
 import { Datasource } from 'data/CHDatasource';
-import { BuilderMode, ColumnHint, QueryType, TimeUnit } from 'types/queryBuilder';
+import { BuilderMode, ColumnHint, FilterOperator, QueryType, TimeUnit } from 'types/queryBuilder';
 import { CoreApp } from '@grafana/data';
 
 jest.mock('./views/TableQueryBuilder', () => ({
@@ -102,6 +102,56 @@ describe('QueryBuilder', () => {
       )
     );
     expect(result.container.firstChild).not.toBeNull();
+  });
+
+  it('shows the raw attribute column name in the compact filter chip for a hinted "+" filter', async () => {
+    const originalGetSignalType = mockDs.getSignalType;
+    const originalIsSingleTableMode = mockDs.isSingleTableMode;
+    // Compact editor renders only when the datasource is single-table with a signal type.
+    mockDs.getSignalType = jest.fn(() => 'logs' as any);
+    mockDs.isSingleTableMode = jest.fn(() => true);
+    try {
+      render(
+        <QueryBuilder
+          app={CoreApp.PanelEditor}
+          builderOptions={{
+            queryType: QueryType.Logs,
+            mode: BuilderMode.List,
+            database: 'otel_v2',
+            table: 'otel_logs',
+            columns: [
+              { name: 'Timestamp', hint: ColumnHint.Time },
+              { name: 'Body', hint: ColumnHint.LogMessage },
+              { name: 'LogAttributes', hint: ColumnHint.LogAttributes },
+            ],
+            filters: [
+              {
+                condition: 'AND',
+                filterType: 'custom',
+                key: '',
+                hint: ColumnHint.LogAttributes,
+                mapKey: 'user.tier',
+                type: 'Map(String, String)',
+                operator: FilterOperator.Equals,
+                value: 'basic',
+              } as any,
+            ],
+          }}
+          builderOptionsDispatch={() => {}}
+          datasource={mockDs}
+          generatedSql=""
+        />
+      );
+
+      // The log-view "+" stores { key: '', hint }, so the chip must resolve the hint to
+      // the column name and read "LogAttributes.user.tier" (matching the Add filter path),
+      // not the friendly hint label "log attributes.user.tier".
+      expect(await screen.findByText('LogAttributes.user.tier')).toBeInTheDocument();
+      expect(screen.queryByText('log attributes.user.tier')).not.toBeInTheDocument();
+    } finally {
+      mockDs.getSignalType = originalGetSignalType;
+      mockDs.isSingleTableMode = originalIsSingleTableMode;
+    }
   });
 
   it('renders TableQueryBuilder when queryType is Table', () => {

--- a/src/components/queryBuilder/QueryBuilder.tsx
+++ b/src/components/queryBuilder/QueryBuilder.tsx
@@ -236,6 +236,7 @@ const CompactQueryEditor = (props: CompactQueryEditorProps) => {
         table={activeOptions.table}
         filters={activeOptions.filters || []}
         allColumns={filterColumns}
+        selectedColumns={activeOptions.columns || []}
         onFiltersChange={(filters: Filter[]) => mergeActiveOptions({ filters }, true)}
         onToggleAdvanced={() => setAdvancedOpen(!advancedOpen)}
         advancedOpen={advancedOpen}

--- a/src/data/CHDatasource.test.ts
+++ b/src/data/CHDatasource.test.ts
@@ -1670,7 +1670,7 @@ describe('ClickHouseDatasource', () => {
         expect(result.rawSql).toContain('LogAttributes.`method`');
       });
 
-      it('splits and types a non-selected Map attribute column from the fetched schema cache', () => {
+      it('splits and types a non-selected Map attribute column from the fetched schema cache', async () => {
         const traceQuery: CHBuilderQuery = {
           ...untypedQuery,
           builderOptions: {
@@ -1679,10 +1679,11 @@ describe('ClickHouseDatasource', () => {
             columns: [{ name: 'Timestamp', hint: ColumnHint.Time }],
           },
         };
-        // Prime the schema cache the way getColumnsCached would (key is db\0table).
-        (datasource as any)._columnCache.set((datasource as any).columnCacheKey('default', 'otel_traces'), [
-          { name: 'SpanAttributes', type: 'Map(String, String)' },
-        ]);
+        // Prime the cache through the public path (getColumnsCached -> fetchColumns).
+        jest
+          .spyOn(datasource, 'fetchColumns')
+          .mockResolvedValue([{ name: 'SpanAttributes', type: 'Map(String, String)' }] as any);
+        await datasource.getColumnsCached('default', 'otel_traces');
 
         const result = datasource.modifyQuery(traceQuery, {
           type: 'ADD_FILTER',
@@ -1693,6 +1694,29 @@ describe('ClickHouseDatasource', () => {
         expect(filter.mapKey).toBe('http.method');
         expect(filter.type).toBe('Map(String, String)');
         expect(result.rawSql).toContain("SpanAttributes['http.method']");
+      });
+
+      it('types an aliased attribute column from the schema by its real name, not the alias', async () => {
+        const aliasQuery: CHBuilderQuery = {
+          ...untypedQuery,
+          builderOptions: {
+            ...untypedQuery.builderOptions,
+            columns: [{ name: 'LogAttributes', alias: 'attrs', hint: ColumnHint.LogAttributes }],
+          },
+        };
+        // Selected column is aliased and untyped; the live schema reports it as JSON.
+        jest.spyOn(datasource, 'fetchColumns').mockResolvedValue([{ name: 'LogAttributes', type: 'JSON' }] as any);
+        await datasource.getColumnsCached('default', 'otel_logs');
+
+        const result = datasource.modifyQuery(aliasQuery, {
+          type: 'ADD_FILTER',
+          options: { key: 'attrs.method', value: 'F' },
+        } as any) as CHBuilderQuery;
+
+        const filter = result.builderOptions.filters![0] as any;
+        // Resolved via the real name (LogAttributes) to JSON, so dot access, not the Map default.
+        expect(filter.type).toBe('JSON');
+        expect(result.rawSql).toContain('::Nullable(String)');
       });
     });
 

--- a/src/data/CHDatasource.test.ts
+++ b/src/data/CHDatasource.test.ts
@@ -1609,6 +1609,93 @@ describe('ClickHouseDatasource', () => {
       expect((result as CHBuilderQuery).builderOptions.filters![0].mapKey).toBe('service_name');
     });
 
+    describe('map-key attribute filter type resolution', () => {
+      // Default OTel columns are stored without a type; a query loaded from the
+      // Explore URL keeps them untyped. The attribute filter must still resolve
+      // to Map bracket access, not the JSON dot path (which crashes ClickHouse).
+      const untypedQuery: CHBuilderQuery = {
+        pluginVersion: '',
+        refId: 'A',
+        editorType: EditorType.Builder,
+        rawSql: '',
+        builderOptions: {
+          database: 'default',
+          table: 'otel_logs',
+          queryType: QueryType.Logs,
+          mode: BuilderMode.List,
+          columns: [{ name: 'LogAttributes', hint: ColumnHint.LogAttributes }],
+        },
+      };
+
+      it('ADD_FILTER on an untyped log attribute uses Map bracket access', () => {
+        const result = datasource.modifyQuery(untypedQuery, {
+          type: 'ADD_FILTER',
+          options: { key: 'LogAttributes.method', value: 'F' },
+        } as any) as CHBuilderQuery;
+
+        const filter = result.builderOptions.filters![0] as any;
+        expect(filter.mapKey).toBe('method');
+        expect(filter.type).toBe('Map(String, String)');
+        expect(result.rawSql).toContain("LogAttributes['method']");
+        expect(result.rawSql).not.toContain('LogAttributes.`method`');
+      });
+
+      it('toggleQueryFilter FILTER_FOR on an untyped log attribute uses Map bracket access', () => {
+        const result = datasource.toggleQueryFilter(untypedQuery, {
+          type: 'FILTER_FOR',
+          options: { key: 'LogAttributes.method', value: 'F' },
+        } as any) as CHBuilderQuery;
+
+        const filter = result.builderOptions.filters![0] as any;
+        expect(filter.mapKey).toBe('method');
+        expect(filter.type).toBe('Map(String, String)');
+      });
+
+      it('preserves JSON dot access when the attribute column is a JSON type', () => {
+        const jsonQuery: CHBuilderQuery = {
+          ...untypedQuery,
+          builderOptions: {
+            ...untypedQuery.builderOptions,
+            columns: [{ name: 'LogAttributes', hint: ColumnHint.LogAttributes, type: 'JSON' }],
+          },
+        };
+
+        const result = datasource.modifyQuery(jsonQuery, {
+          type: 'ADD_FILTER',
+          options: { key: 'LogAttributes.method', value: 'F' },
+        } as any) as CHBuilderQuery;
+
+        const filter = result.builderOptions.filters![0] as any;
+        expect(filter.type).toBe('JSON');
+        expect(result.rawSql).toContain('LogAttributes.`method`');
+      });
+
+      it('splits and types a non-selected Map attribute column from the fetched schema cache', () => {
+        const traceQuery: CHBuilderQuery = {
+          ...untypedQuery,
+          builderOptions: {
+            ...untypedQuery.builderOptions,
+            table: 'otel_traces',
+            columns: [{ name: 'Timestamp', hint: ColumnHint.Time }],
+          },
+        };
+        // Prime the schema cache the way getColumnsCached would (key is db\0table).
+        (datasource as any)._columnCache.set((datasource as any).columnCacheKey('default', 'otel_traces'), [
+          { name: 'SpanAttributes', type: 'Map(String, String)' },
+        ]);
+
+        const result = datasource.modifyQuery(traceQuery, {
+          type: 'ADD_FILTER',
+          options: { key: 'SpanAttributes.http.method', value: 'GET' },
+        } as any) as CHBuilderQuery;
+
+        const filter = result.builderOptions.filters![0] as any;
+        expect(filter.mapKey).toBe('http.method');
+        expect(filter.type).toBe('Map(String, String)');
+        expect(result.rawSql).toContain("SpanAttributes['http.method']");
+      });
+    });
+
     describe('ADD_FILTER', () => {
       it('adds an Equals filter for the given field', () => {
         const result = datasource.modifyQuery(query, {
@@ -2005,7 +2092,9 @@ describe('ClickHouseDatasource', () => {
         expect(result.builderOptions.filters![0]).toMatchObject({
           key: 'LogAttributes',
           mapKey: 'foo.bar',
-          type: 'JSON',
+          // LogAttributes is a Map column; an untyped/unselected attribute filter
+          // must resolve to Map bracket access, not the JSON dot path (which crashes).
+          type: 'Map(String, String)',
           operator: FilterOperator.Equals,
           value: 'baz',
         });
@@ -2029,7 +2118,7 @@ describe('ClickHouseDatasource', () => {
           key: '',
           hint: ColumnHint.LogAttributes,
           mapKey: 'log.file.path',
-          type: 'JSON',
+          type: 'Map(String, String)',
           operator: FilterOperator.Equals,
           value: '/var/log/pod.log',
         });

--- a/src/data/CHDatasource.ts
+++ b/src/data/CHDatasource.ts
@@ -80,6 +80,10 @@ const attributeColumnHints = new Set([
 ]);
 const legacyAttributeColumns = new Set(['ResourceAttributes', 'ScopeAttributes', 'LogAttributes']);
 
+// A Map or JSON column can hold OTel attribute map keys; both are treated as attribute
+// columns for map-key splitting and value typing. Shared so the checks stay in sync.
+const isAttributeColumnType = (type?: string): boolean => Boolean(type?.startsWith('Map') || type?.startsWith('JSON'));
+
 // Columns the trace-ID optimization's WITH clause reads from the
 // `<table><suffix>` companion table. The optimization is only safe when the
 // companion actually exposes all of them.
@@ -97,7 +101,7 @@ function getAttributeColumnByDisplayPrefix(
 
   return builderOptions.columns?.find((column) => {
     const isAttributeHint = column.hint ? attributeColumnHints.has(column.hint) : false;
-    const isAttributeType = column.type?.startsWith('Map') || column.type?.startsWith('JSON');
+    const isAttributeType = isAttributeColumnType(column.type);
     if (!isAttributeHint && !isAttributeType) {
       return false;
     }
@@ -132,9 +136,7 @@ function resolveFilterColumn(
     } else if (legacyAttributeColumns.has(columnPrefix)) {
       mapKey = columnName.substring(prefixIndex + 1);
       columnName = columnPrefix;
-    } else if (
-      knownColumns?.some((c) => c.name === columnPrefix && (c.type?.startsWith('Map') || c.type?.startsWith('JSON')))
-    ) {
+    } else if (knownColumns?.some((c) => c.name === columnPrefix && isAttributeColumnType(c.type))) {
       // Split any Map/JSON attribute column detected from the live schema (e.g.
       // traces' SpanAttributes or a non-OTel Map column), even when the selected
       // column carries no type.
@@ -151,10 +153,12 @@ function resolveFilterColumn(
     : undefined;
   const column = lookupByAlias || lookupByName || lookupByLogsAlias;
 
-  // Prefer the selected column's type, but fall back to the live schema type so
-  // map-key filters resolve Map vs JSON authoritatively even when the selected
-  // column is stored without a type (the default OTel columns are).
-  const columnType = column?.type || knownColumns?.find((c) => c.name === columnName)?.type || '';
+  // Prefer the selected column's type, but fall back to the live schema type so map-key
+  // filters resolve Map vs JSON authoritatively even when the selected column is stored
+  // without a type (the default OTel columns are). Look up by the real column name, not
+  // `columnName`, which may be an alias and would miss the schema.
+  const schemaLookupName = column?.name ?? columnName;
+  const columnType = column?.type || knownColumns?.find((c) => c.name === schemaLookupName)?.type || '';
 
   return {
     columnName,

--- a/src/data/CHDatasource.ts
+++ b/src/data/CHDatasource.ts
@@ -107,8 +107,17 @@ function getAttributeColumnByDisplayPrefix(
   });
 }
 
-/** Resolve a filter key to a column in the builder options, handling OTel map key splitting and alias/hint lookup. */
-function resolveFilterColumn(builderOptions: QueryBuilderOptions, key: string): ResolvedColumn {
+/**
+ * Resolve a filter key to a column in the builder options, handling OTel map key
+ * splitting and alias/hint lookup. `knownColumns` (the live table schema, when
+ * available) lets us split and type any Map/JSON attribute column, including ones
+ * the selected-column list stores without a type.
+ */
+function resolveFilterColumn(
+  builderOptions: QueryBuilderOptions,
+  key: string,
+  knownColumns?: readonly TableColumn[]
+): ResolvedColumn {
   let columnName = key;
   let mapKey = '';
 
@@ -123,6 +132,14 @@ function resolveFilterColumn(builderOptions: QueryBuilderOptions, key: string): 
     } else if (legacyAttributeColumns.has(columnPrefix)) {
       mapKey = columnName.substring(prefixIndex + 1);
       columnName = columnPrefix;
+    } else if (
+      knownColumns?.some((c) => c.name === columnPrefix && (c.type?.startsWith('Map') || c.type?.startsWith('JSON')))
+    ) {
+      // Split any Map/JSON attribute column detected from the live schema (e.g.
+      // traces' SpanAttributes or a non-OTel Map column), even when the selected
+      // column carries no type.
+      mapKey = columnName.substring(prefixIndex + 1);
+      columnName = columnPrefix;
     }
   }
 
@@ -134,11 +151,16 @@ function resolveFilterColumn(builderOptions: QueryBuilderOptions, key: string): 
     : undefined;
   const column = lookupByAlias || lookupByName || lookupByLogsAlias;
 
+  // Prefer the selected column's type, but fall back to the live schema type so
+  // map-key filters resolve Map vs JSON authoritatively even when the selected
+  // column is stored without a type (the default OTel columns are).
+  const columnType = column?.type || knownColumns?.find((c) => c.name === columnName)?.type || '';
+
   return {
     columnName,
     mapKey,
     column,
-    columnType: column ? column.type || '' : '',
+    columnType,
     hasMapKey: mapKey !== '',
   };
 }
@@ -150,7 +172,10 @@ function buildFilter(resolved: ResolvedColumn, operator: StringFilter['operator'
     key: resolved.column?.hint ? '' : resolved.columnName,
     hint: resolved.column?.hint || undefined,
     mapKey: resolved.hasMapKey ? resolved.mapKey : undefined,
-    type: resolved.hasMapKey ? (resolved.columnType.startsWith('Map') ? 'Map(String, String)' : 'JSON') : 'string',
+    // Map columns use bracket access (`col['key']`); only genuine JSON columns use
+    // the dot-path branch. Default an unknown-type attribute filter to Map, which
+    // matches the standard OTel schema and avoids emitting invalid `col.key` SQL.
+    type: resolved.hasMapKey ? (resolved.columnType.startsWith('JSON') ? 'JSON' : 'Map(String, String)') : 'string',
     filterType: 'custom',
     operator,
     value,
@@ -164,8 +189,7 @@ function filterMatchesColumn(f: Filter, resolved: ResolvedColumn): boolean {
   // matches on key + type family alone, so a filter stored against one
   // attribute column (e.g. LogAttributes) collides with a different attribute
   // column that happens to share the same map key (e.g. ResourceAttributes).
-  const sameColumn =
-    resolved.column?.hint && f.hint ? f.hint === resolved.column.hint : f.key === resolved.columnName;
+  const sameColumn = resolved.column?.hint && f.hint ? f.hint === resolved.column.hint : f.key === resolved.columnName;
   if (resolved.hasMapKey) {
     return (f.type.startsWith('Map') || f.type.startsWith('JSON')) && f.mapKey === resolved.mapKey && sameColumn;
   }
@@ -616,7 +640,8 @@ export class Datasource
     }
 
     const actionValue = action.options.value;
-    const resolved = resolveFilterColumn(query.builderOptions, columnName);
+    const knownColumns = this.getCachedColumns(query.builderOptions.database, query.builderOptions.table);
+    const resolved = resolveFilterColumn(query.builderOptions, columnName, knownColumns);
 
     let nextFilters: Filter[] = query.builderOptions.filters?.slice() || [];
     if (action.type === 'ADD_FILTER') {
@@ -715,7 +740,8 @@ export class Datasource
       return query;
     }
 
-    const resolved = resolveFilterColumn(query.builderOptions, key);
+    const knownColumns = this.getCachedColumns(query.builderOptions.database, query.builderOptions.table);
+    const resolved = resolveFilterColumn(query.builderOptions, key, knownColumns);
     const targetOperator = filter.type === 'FILTER_FOR' ? FilterOperator.Equals : FilterOperator.NotEquals;
     const oppositeOperator = filter.type === 'FILTER_FOR' ? FilterOperator.NotEquals : FilterOperator.Equals;
 
@@ -1324,8 +1350,27 @@ export class Datasource
    * The cache lives for the lifetime of the datasource instance, which is reset on
    * config save or page reload — short enough that stale schema is not a concern.
    */
+  private columnCacheKey(database: string | undefined, table: string): string {
+    return `${database ?? ''}\0${table}`;
+  }
+
+  /**
+   * Synchronous read of the column cache populated by getColumnsCached. Returns
+   * undefined when the schema for this table has not been fetched yet, so callers
+   * must treat the result as best-effort.
+   */
+  private getCachedColumns(
+    database: string | undefined,
+    table: string | undefined
+  ): readonly TableColumn[] | undefined {
+    if (!table) {
+      return undefined;
+    }
+    return this._columnCache.get(this.columnCacheKey(database, table));
+  }
+
   async getColumnsCached(database: string | undefined, table: string): Promise<TableColumn[]> {
-    const key = `${database ?? ''}\0${table}`;
+    const key = this.columnCacheKey(database, table);
     if (!this._columnCache.has(key)) {
       this._columnCache.set(key, await this.fetchColumns(database, table));
     }

--- a/src/data/sqlGenerator.test.ts
+++ b/src/data/sqlGenerator.test.ts
@@ -49,6 +49,48 @@ describe('SQL Generator', () => {
     expect(sql).toEqual(expectedSqlParts.join(' '));
   });
 
+  it('uses bracket access for a Map map-key filter and dot access for a JSON map-key filter', () => {
+    const mapOpts: QueryBuilderOptions = {
+      database: 'default',
+      table: 'otel_logs',
+      queryType: QueryType.Table,
+      columns: [{ name: 'Body', type: 'String' }],
+      limit: 1000,
+      filters: [
+        {
+          filterType: 'custom',
+          key: 'LogAttributes',
+          mapKey: 'method',
+          type: 'Map(String, String)',
+          condition: 'AND',
+          operator: FilterOperator.Equals,
+          value: 'F',
+        },
+      ],
+      orderBy: [],
+    };
+    const mapSql = generateSql(mapOpts);
+    expect(mapSql).toContain("LogAttributes['method'] = 'F'");
+    expect(mapSql).not.toContain('LogAttributes.`method`');
+
+    const jsonOpts: QueryBuilderOptions = {
+      ...mapOpts,
+      filters: [
+        {
+          filterType: 'custom',
+          key: 'LogAttributes',
+          mapKey: 'method',
+          type: 'JSON',
+          condition: 'AND',
+          operator: FilterOperator.Equals,
+          value: 'F',
+        },
+      ],
+    };
+    const jsonSql = generateSql(jsonOpts);
+    expect(jsonSql).toContain('LogAttributes.`method`');
+  });
+
   it('generates aggregate table query', () => {
     const opts: QueryBuilderOptions = {
       database: 'default',


### PR DESCRIPTION
## Summary

Filtering a log on a `Map` attribute key from the log view had two problems, both of which this PR fixes so the field "+" behaves like the Add filter flow:

1. It generated invalid SQL and crashed the query.
2. The resulting filter chip was labelled inconsistently with the Add filter chip.

### 1. Invalid SQL (crash)

The field filter-for/out buttons emitted dot access on a `Map` column:

```
... AND ( LogAttributes.`user.tier`::Nullable(String) = 'basic' )
```

ClickHouse rejects this with `code: 47, Unknown expression or function identifier ... Maybe you meant: ['LogAttributes.keys']`. A `Map` key needs bracket access:

```
... AND ( LogAttributes['user.tier'] = 'basic' )
```

`buildFilter` set the filter type from the selected column and defaulted to `JSON` when that column had no type. The default OTel columns are stored without a type, and a query loaded from the Explore URL keeps them that way, so an attribute map-key filter fell into the JSON dot-path branch of the SQL generator instead of the `Map` bracket branch. The Add filter editor was unaffected because it reads the type from the full schema; only the field filter-for/out actions (`modifyQuery` / `toggleQueryFilter`) went through the defaulting path.

### 2. Inconsistent chip label

The field "+" stores a hinted column as `{ key: '', hint }` (by design, so the SQL generator resolves the column through the hint), while the Add filter flow stores the raw column name in `key`. `FilterTagBar` rendered the hint verbatim, so the same field showed as `log attributes.event.name` from the "+" and `LogAttributes.event.name` from Add filter. The chip now resolves a hinted filter back to its column name, so both read `LogAttributes.event.name`, matching the log detail panel.

## Changes

- Resolve the real column type from the fetched schema cache in `modifyQuery` and `toggleQueryFilter`, so `Map` vs `JSON` is decided authoritatively even when the selected column has no type. This also lets a non-selected `Map` column (for example a trace `SpanAttributes` key) split and type correctly.
- Default an unknown-type attribute map-key filter to `Map` bracket access instead of `JSON` dot access. Columns that report a `JSON` type still use dot access.
- In `FilterTagBar`, resolve a hinted filter to its column name for display. This is presentation only; the filter key/hint shape, generated SQL, and dedup are unchanged.

## Local verification

Ran a local Grafana with the official plugin and this build side by side against the public demo (`sql-clickhouse.clickhouse.com`, `otel_v2`), filtering on attribute keys from the compact query builder.

**Logs, official plugin (before):** each attribute chip shows the hint label (`log attributes.*`) and the query fails with `code: 47`.

![logs before](https://raw.githubusercontent.com/alex-fedotyev/clickhouse-datasource/fix/logs-map-key-filter-screenshots/pr-screenshots/logs-before.png)

**Logs, this build (after):** `LogAttributes`, `ResourceAttributes`, and `ScopeAttributes` chips all show the raw column name and the query runs (bracket access).

![logs after](https://raw.githubusercontent.com/alex-fedotyev/clickhouse-datasource/fix/logs-map-key-filter-screenshots/pr-screenshots/logs-after.png)

**Traces, this build:** `ResourceAttributes` and `SpanAttributes` attribute filters render the raw column name and run with bracket access, consistent with logs.

![traces after](https://raw.githubusercontent.com/alex-fedotyev/clickhouse-datasource/fix/logs-map-key-filter-screenshots/pr-screenshots/traces-after.png)

## Test plan

- [x] `npx jest src/data/sqlGenerator.test.ts src/data/CHDatasource.test.ts src/components/queryBuilder`
- [x] `npx tsc --noEmit`
- [x] `npx eslint` on the changed files
- [x] `npx prettier --check` on the changed files
- [x] `npm run spellcheck`
- [x] Manual check on the local Grafana build against the demo, logs and traces

Please add the `changelog` label so this surfaces in the next release notes.
