### PR TITLE
fix(variables): keep query-variable values string-typed so numeric values resolve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Add `1.3.0` OTel schema version to support `opentelemetry-collector-contrib` clickhouseexporter `v0.151.0`+, which removed the `TimestampTime` column from `otel_logs`. The `latest` selector now points to this schema; existing data sources continue to use `1.2.9` until manually updated (#1882)
 
+### Fixes
+
+- Fix dashboard query variables that return numeric or numeric-looking string values (for example `toString(toUnixTimestamp(...))`) failing to resolve with "Couldn't find any field of type string in the results" (#2021)
+
 ## 4.19.0
 
 ### Features

--- a/src/data/CHVariableSupport.test.tsx
+++ b/src/data/CHVariableSupport.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { fireEvent, render, waitFor } from '@testing-library/react';
 import { firstValueFrom } from 'rxjs';
-import { DataQueryRequest, DataQueryResponse } from '@grafana/data';
+import { DataQueryRequest, DataQueryResponse, FieldType } from '@grafana/data';
 import {
   CHVariableQuery,
   CHVariableQueryType,
@@ -279,6 +279,21 @@ describe('VariableQueryEditor', () => {
 });
 
 describe('CHVariableSupport', () => {
+  type RawMetricValue = { text: unknown; value?: unknown };
+  const runWith = async (values: RawMetricValue[]): Promise<DataQueryResponse> => {
+    const datasource = buildDatasource({
+      metricFindQuery: jest.fn(() => Promise.resolve(values)) as unknown as Datasource['metricFindQuery'],
+    });
+    const support = new CHVariableSupport(datasource);
+    const request = {
+      targets: [{ refId: 'v', queryType: 'sql' as CHVariableQueryType, rawSql: 'SELECT x' }],
+      range: { from: new Date(), to: new Date() },
+    };
+    return (await firstValueFrom(
+      support.query(request as unknown as DataQueryRequest<CHVariableQuery>)
+    )) as DataQueryResponse;
+  };
+
   it('returns an empty frame when no rawSql is present', async () => {
     const datasource = buildDatasource();
     const support = new CHVariableSupport(datasource);
@@ -316,8 +331,10 @@ describe('CHVariableSupport', () => {
     const frame = response.data[0];
     expect(frame.fields).toHaveLength(2);
     expect(frame.fields[0].name).toBe('text');
+    expect(frame.fields[0].type).toBe(FieldType.string);
     expect(frame.fields[0].values).toEqual(['foo', 'bar']);
     expect(frame.fields[1].name).toBe('value');
+    expect(frame.fields[1].type).toBe(FieldType.string);
     expect(frame.fields[1].values).toEqual(['foo', 'bar']);
   });
 
@@ -359,6 +376,48 @@ describe('CHVariableSupport', () => {
       expect.objectContaining({ range: expect.any(Object) })
     );
     expect(response.data[0].fields[0].values).toEqual(['foo', 'bar']);
+  });
+
+  it('types numeric-looking string values as string so the variable resolves', async () => {
+    const response = await runWith([{ text: '1783512125' }, { text: '1783511702' }]);
+    const frame = response.data[0];
+    expect(frame.fields[0].type).toBe(FieldType.string);
+    expect(frame.fields[1].type).toBe(FieldType.string);
+    expect(frame.fields[0].values).toEqual(['1783512125', '1783511702']);
+    expect(frame.fields[1].values).toEqual(['1783512125', '1783511702']);
+  });
+
+  it('stringifies numeric values and types them as string', async () => {
+    const response = await runWith([{ text: 200 }, { text: 404 }]);
+    const frame = response.data[0];
+    expect(frame.fields[0].type).toBe(FieldType.string);
+    expect(frame.fields[1].type).toBe(FieldType.string);
+    expect(frame.fields[0].values).toEqual(['200', '404']);
+    expect(frame.fields[1].values).toEqual(['200', '404']);
+  });
+
+  it('keeps ordinary string values string-typed', async () => {
+    const response = await runWith([{ text: 'foo' }, { text: 'bar' }]);
+    const frame = response.data[0];
+    expect(frame.fields[0].type).toBe(FieldType.string);
+    expect(frame.fields[1].type).toBe(FieldType.string);
+    expect(frame.fields[0].values).toEqual(['foo', 'bar']);
+    expect(frame.fields[1].values).toEqual(['foo', 'bar']);
+  });
+
+  it('preserves an explicit value of 0 (nullish fallback, not falsy) and stringifies it', async () => {
+    const response = await runWith([{ text: 'Zero', value: 0 }]);
+    const frame = response.data[0];
+    expect(frame.fields[0].values).toEqual(['Zero']);
+    expect(frame.fields[1].values).toEqual(['0']);
+  });
+
+  it('passes null values through without turning them into the string "null"', async () => {
+    const response = await runWith([{ text: null }]);
+    const frame = response.data[0];
+    expect(frame.fields[0].type).toBe(FieldType.string);
+    expect(frame.fields[0].values).toEqual([null]);
+    expect(frame.fields[1].values).toEqual([null]);
   });
 });
 

--- a/src/data/CHVariableSupport.tsx
+++ b/src/data/CHVariableSupport.tsx
@@ -3,6 +3,7 @@ import {
   CustomVariableSupport,
   DataQueryRequest,
   DataQueryResponse,
+  FieldType,
   MetricFindValue,
   QueryEditorProps,
   toDataFrame,
@@ -233,6 +234,16 @@ export const VariableQueryEditor = (props: EditorProps) => {
 };
 
 /**
+ * Coerce a metric-find value into a string for a template variable option,
+ * preserving null/undefined as null (not the literal string "null"). Variable
+ * options are always strings, so this keeps the emitted DataFrame fields
+ * string-typed whether the query returned numbers or numeric-looking strings.
+ */
+function toVariableString(value: unknown): string | null {
+  return value == null ? null : String(value);
+}
+
+/**
  * CustomVariableSupport binding. Registers the guided editor and runs the
  * resolved `rawSql` through the existing `metricFindQuery` path so all the
  * macro expansion (template variables, time filter, ad-hoc filters) stays in
@@ -261,12 +272,16 @@ export class CHVariableSupport extends CustomVariableSupport<Datasource, CHVaria
       .then((values: MetricFindValue[]) => ({
         // Emit text and value separately so a `SELECT value, label` query
         // substitutes the value while displaying the label. Fall back to text
-        // when the query returns a single column.
+        // when the query returns a single column. Force string typing:
+        // metricFindQuery yields raw column values (numbers, or numeric-looking
+        // strings like toString(toUnixTimestamp(...))), and an untyped
+        // toDataFrame would guess FieldType.number, which makes Grafana's
+        // toMetricFindValues fail to resolve the variable.
         data: [
           toDataFrame({
             fields: [
-              { name: 'text', values: values.map((v) => v.text) },
-              { name: 'value', values: values.map((v) => v.value ?? v.text) },
+              { name: 'text', type: FieldType.string, values: values.map((v) => toVariableString(v.text)) },
+              { name: 'value', type: FieldType.string, values: values.map((v) => toVariableString(v.value ?? v.text)) },
             ],
           }),
         ],


### PR DESCRIPTION
## Summary

Dashboard query variables backed by this datasource stopped resolving in 4.19.0 when the query returns numeric or numeric-looking values. For example:

```sql
SELECT DISTINCT toString(toUnixTimestamp(Timestamp)) FROM otel.generic_logs ...
```

fails with:

```
Couldn't find any field of type string in the results
```

The same happens for a plain numeric column (for example a `StatusCode` variable). It worked on 4.17.

## Root cause

4.19.0 moved variables onto `CustomVariableSupport` (#1868). Grafana now runs the frames returned by `CHVariableSupport.query()` through `@grafana/scenes` `toMetricFindValues`. `query()` rebuilds the frame with `toDataFrame(...)` without setting field types, so `toDataFrame` guesses each field type from its values, and a pure-digit string (or a number) is guessed as `FieldType.number`.

On `@grafana/scenes` before 6.52.8, `toMetricFindValues` accepts only a string-typed field, so an all-numeric result throws "Couldn't find any field of type string in the results" (the reported case). Scenes 6.52.8 (#1338) relaxed this to also accept a numeric `value` field, so on Grafana bundling newer scenes the query resolves; even there, though, the `text`/label field is matched only when it is string-typed, and emitting a numeric field for a ClickHouse `String` column is wrong regardless.

Before 4.19.0 there was no `CustomVariableSupport`; variables went through the legacy `metricFindQuery` path, which consumed the values directly as text, so this never came up.

## Fix

Set `type: FieldType.string` explicitly on the `text` and `value` fields and stringify the values. Template variable options are always strings, so this is lossless, restores the pre-4.19.0 behavior, and emits correctly-typed fields on every Grafana / scenes version (not only those with the older, string-only check). Behavior held constant: the `value` fallback keeps `??` so an explicit `0` is preserved, and null values stay null rather than becoming the string `"null"`.

## Test plan

New unit cases in `CHVariableSupport.test.tsx` covering numeric-looking strings (the reported case), numeric values, ordinary strings, an explicit `value: 0`, and null passthrough, each asserting the emitted fields are `FieldType.string`. The existing shape test also now asserts the field types.

Ran locally on Node 24: `jest src/data/CHVariableSupport.test.tsx`, `tsc --noEmit`, `eslint`, `prettier --check`, and `npm run build`, all green.

<!-- [ui-check: allow] Data/type-only change in the variable resolver (field typing in CHVariableSupport.query). No visual surface, so no screenshots. -->
