### PR TITLE
feat(driver): support comma-separated hosts for load-balancing and failover

### DIFF
--- a/pkg/plugin/driver.go
+++ b/pkg/plugin/driver.go
@@ -45,12 +45,52 @@ type Clickhouse struct {
 	SchemaDatasource *schemas.SchemaDatasource
 }
 
+// buildConnectionAddresses turns the configured host setting into the list of
+// "host:port" addresses passed to clickhouse-go, which natively load-balances
+// and fails over across multiple entries. Host may be a single value or a
+// comma-separated list (see #279); each entry may carry its own "host:port",
+// otherwise the shared port is appended. Empty entries and surrounding
+// whitespace are ignored.
+func buildConnectionAddresses(host string, port int64) []string {
+	parts := strings.Split(host, ",")
+	addrs := make([]string, 0, len(parts))
+	for _, part := range parts {
+		p := strings.TrimSpace(part)
+		if p == "" {
+			continue
+		}
+		// If the entry already includes a port (host:port or [ipv6]:port),
+		// keep it verbatim; otherwise append the shared port.
+		if _, _, err := net.SplitHostPort(p); err == nil {
+			addrs = append(addrs, p)
+		} else {
+			addrs = append(addrs, fmt.Sprintf("%s:%d", p, port))
+		}
+	}
+	return addrs
+}
+
+// firstHost returns the first host in a possibly comma-separated host setting,
+// used as the TLS ServerName for SNI/verification.
+func firstHost(host string) string {
+	for _, part := range strings.Split(host, ",") {
+		if p := strings.TrimSpace(part); p != "" {
+			// Strip an optional port so ServerName is a bare hostname.
+			if h, _, err := net.SplitHostPort(p); err == nil {
+				return h
+			}
+			return p
+		}
+	}
+	return host
+}
+
 // getTLSConfig returns tlsConfig from settings
 // logic reused from https://github.com/grafana/grafana/blob/615c153b3a2e4d80cff263e67424af6edb992211/pkg/models/datasource_cache.go#L211
 func getTLSConfig(settings Settings) (*tls.Config, error) {
 	tlsConfig := &tls.Config{
 		InsecureSkipVerify: settings.InsecureSkipVerify,
-		ServerName:         settings.Host,
+		ServerName:         firstHost(settings.Host),
 	}
 	if settings.TlsClientAuth || settings.TlsAuthWithCACert {
 		if settings.TlsAuthWithCACert && len(settings.TlsCACert) > 0 {
@@ -217,7 +257,7 @@ func (h *Clickhouse) Connect(
 	}
 
 	opts := &clickhouse.Options{
-		Addr: []string{fmt.Sprintf("%s:%d", settings.Host, settings.Port)},
+		Addr: buildConnectionAddresses(settings.Host, settings.Port),
 		Auth: clickhouse.Auth{
 			Database: settings.DefaultDatabase,
 			Password: settings.Password,

--- a/pkg/plugin/driver.go
+++ b/pkg/plugin/driver.go
@@ -45,52 +45,37 @@ type Clickhouse struct {
 	SchemaDatasource *schemas.SchemaDatasource
 }
 
-// buildConnectionAddresses turns the configured host setting into the list of
-// "host:port" addresses passed to clickhouse-go, which natively load-balances
-// and fails over across multiple entries. Host may be a single value or a
-// comma-separated list (see #279); each entry may carry its own "host:port",
-// otherwise the shared port is appended. Empty entries and surrounding
-// whitespace are ignored.
-func buildConnectionAddresses(host string, port int64) []string {
-	parts := strings.Split(host, ",")
-	addrs := make([]string, 0, len(parts))
-	for _, part := range parts {
-		p := strings.TrimSpace(part)
-		if p == "" {
-			continue
+// connectionAddresses returns the "host:port" addresses passed to
+// clickhouse-go, which natively load-balances and fails over across multiple
+// entries (see #279). Settings.Hosts takes precedence when set; otherwise the
+// single Host/Port pair is used. A node without its own port falls back to the
+// shared port.
+func connectionAddresses(settings Settings) []string {
+	if len(settings.Hosts) == 0 {
+		return []string{fmt.Sprintf("%s:%d", settings.Host, settings.Port)}
+	}
+
+	addrs := make([]string, 0, len(settings.Hosts))
+	for _, host := range settings.Hosts {
+		port := host.Port
+		if port == 0 {
+			port = settings.Port
 		}
-		// If the entry already includes a port (host:port or [ipv6]:port),
-		// keep it verbatim; otherwise append the shared port.
-		if _, _, err := net.SplitHostPort(p); err == nil {
-			addrs = append(addrs, p)
-		} else {
-			addrs = append(addrs, fmt.Sprintf("%s:%d", p, port))
-		}
+		addrs = append(addrs, fmt.Sprintf("%s:%d", host.Host, port))
 	}
 	return addrs
-}
-
-// firstHost returns the first host in a possibly comma-separated host setting,
-// used as the TLS ServerName for SNI/verification.
-func firstHost(host string) string {
-	for _, part := range strings.Split(host, ",") {
-		if p := strings.TrimSpace(part); p != "" {
-			// Strip an optional port so ServerName is a bare hostname.
-			if h, _, err := net.SplitHostPort(p); err == nil {
-				return h
-			}
-			return p
-		}
-	}
-	return host
 }
 
 // getTLSConfig returns tlsConfig from settings
 // logic reused from https://github.com/grafana/grafana/blob/615c153b3a2e4d80cff263e67424af6edb992211/pkg/models/datasource_cache.go#L211
 func getTLSConfig(settings Settings) (*tls.Config, error) {
+	// ServerName is deliberately left unset. clickhouse-go hands this one
+	// tls.Config to every address it dials, so a name pinned here would be sent
+	// for all nodes and fail verification on every host but the one it names.
+	// Left empty, crypto/tls infers the name per connection from the address
+	// being dialled, which is correct for both a single host and a list.
 	tlsConfig := &tls.Config{
 		InsecureSkipVerify: settings.InsecureSkipVerify,
-		ServerName:         firstHost(settings.Host),
 	}
 	if settings.TlsClientAuth || settings.TlsAuthWithCACert {
 		if settings.TlsAuthWithCACert && len(settings.TlsCACert) > 0 {
@@ -257,7 +242,7 @@ func (h *Clickhouse) Connect(
 	}
 
 	opts := &clickhouse.Options{
-		Addr: buildConnectionAddresses(settings.Host, settings.Port),
+		Addr: connectionAddresses(settings),
 		Auth: clickhouse.Auth{
 			Database: settings.DefaultDatabase,
 			Password: settings.Password,

--- a/pkg/plugin/driver.go
+++ b/pkg/plugin/driver.go
@@ -42,12 +42,52 @@ type grafanaHeaders struct {
 // Clickhouse defines how to connect to a Clickhouse datasource
 type Clickhouse struct{}
 
+// buildConnectionAddresses turns the configured host setting into the list of
+// "host:port" addresses passed to clickhouse-go, which natively load-balances
+// and fails over across multiple entries. Host may be a single value or a
+// comma-separated list (see #279); each entry may carry its own "host:port",
+// otherwise the shared port is appended. Empty entries and surrounding
+// whitespace are ignored.
+func buildConnectionAddresses(host string, port int64) []string {
+	parts := strings.Split(host, ",")
+	addrs := make([]string, 0, len(parts))
+	for _, part := range parts {
+		p := strings.TrimSpace(part)
+		if p == "" {
+			continue
+		}
+		// If the entry already includes a port (host:port or [ipv6]:port),
+		// keep it verbatim; otherwise append the shared port.
+		if _, _, err := net.SplitHostPort(p); err == nil {
+			addrs = append(addrs, p)
+		} else {
+			addrs = append(addrs, fmt.Sprintf("%s:%d", p, port))
+		}
+	}
+	return addrs
+}
+
+// firstHost returns the first host in a possibly comma-separated host setting,
+// used as the TLS ServerName for SNI/verification.
+func firstHost(host string) string {
+	for _, part := range strings.Split(host, ",") {
+		if p := strings.TrimSpace(part); p != "" {
+			// Strip an optional port so ServerName is a bare hostname.
+			if h, _, err := net.SplitHostPort(p); err == nil {
+				return h
+			}
+			return p
+		}
+	}
+	return host
+}
+
 // getTLSConfig returns tlsConfig from settings
 // logic reused from https://github.com/grafana/grafana/blob/615c153b3a2e4d80cff263e67424af6edb992211/pkg/models/datasource_cache.go#L211
 func getTLSConfig(settings Settings) (*tls.Config, error) {
 	tlsConfig := &tls.Config{
 		InsecureSkipVerify: settings.InsecureSkipVerify,
-		ServerName:         settings.Host,
+		ServerName:         firstHost(settings.Host),
 	}
 	if settings.TlsClientAuth || settings.TlsAuthWithCACert {
 		if settings.TlsAuthWithCACert && len(settings.TlsCACert) > 0 {
@@ -294,7 +334,7 @@ func buildClickHouseOptions(ctx context.Context, settings Settings, message json
 	auth, getJWT := resolveJWTAuth(settings, httpHeaders)
 
 	opts := &clickhouse.Options{
-		Addr: []string{fmt.Sprintf("%s:%d", settings.Host, settings.Port)},
+		Addr: buildConnectionAddresses(settings.Host, settings.Port),
 		Auth: auth,
 		ClientInfo: clickhouse.ClientInfo{
 			Products: getClientInfoProducts(ctx),

--- a/pkg/plugin/driver.go
+++ b/pkg/plugin/driver.go
@@ -42,14 +42,22 @@ type grafanaHeaders struct {
 // Clickhouse defines how to connect to a Clickhouse datasource
 type Clickhouse struct{}
 
+// hostPort builds a dialable "host:port" address. A bare IPv6 literal has to
+// be bracketed or net.Dial rejects it ("too many colons in address"); hosts is
+// a hand-edited provisioning field, so the brackets may or may not already be
+// there and a second pair would be just as broken.
+func hostPort(host string, port int64) string {
+	host = strings.TrimSuffix(strings.TrimPrefix(host, "["), "]")
+	return net.JoinHostPort(host, strconv.FormatInt(port, 10))
+}
+
 // connectionAddresses returns the "host:port" addresses passed to
-// clickhouse-go, which natively load-balances and fails over across multiple
-// entries (see #279). Settings.Hosts takes precedence when set; otherwise the
-// single Host/Port pair is used. A node without its own port falls back to the
-// shared port.
+// clickhouse-go, which fails over across every entry (see #279).
+// Settings.Hosts takes precedence when set; otherwise the single Host/Port
+// pair is used. A node without its own port falls back to the shared port.
 func connectionAddresses(settings Settings) []string {
 	if len(settings.Hosts) == 0 {
-		return []string{fmt.Sprintf("%s:%d", settings.Host, settings.Port)}
+		return []string{hostPort(settings.Host, settings.Port)}
 	}
 
 	addrs := make([]string, 0, len(settings.Hosts))
@@ -58,7 +66,7 @@ func connectionAddresses(settings Settings) []string {
 		if port == 0 {
 			port = settings.Port
 		}
-		addrs = append(addrs, fmt.Sprintf("%s:%d", host.Host, port))
+		addrs = append(addrs, hostPort(host.Host, port))
 	}
 	return addrs
 }
@@ -69,8 +77,11 @@ func getTLSConfig(settings Settings) (*tls.Config, error) {
 	// ServerName is deliberately left unset. clickhouse-go hands this one
 	// tls.Config to every address it dials, so a name pinned here would be sent
 	// for all nodes and fail verification on every host but the one it names.
-	// Left empty, crypto/tls infers the name per connection from the address
-	// being dialled, which is correct for both a single host and a list.
+	// Left empty, the name is inferred per connection from the address being
+	// dialled: tls.DialWithDialer for the native protocol and net/http for
+	// HTTP both do this. tls.Client does not, which is why proxyDialContext
+	// below sets ServerName itself for the PDC path — a new dial path has to
+	// make the same arrangement rather than assume crypto/tls covers it.
 	tlsConfig := &tls.Config{
 		InsecureSkipVerify: settings.InsecureSkipVerify,
 	}
@@ -318,8 +329,10 @@ func buildClickHouseOptions(ctx context.Context, settings Settings, message json
 
 	auth, getJWT := resolveJWTAuth(settings, httpHeaders)
 
+	addrs := connectionAddresses(settings)
+
 	opts := &clickhouse.Options{
-		Addr: connectionAddresses(settings),
+		Addr: addrs,
 		Auth: auth,
 		ClientInfo: clickhouse.ClientInfo{
 			Products: getClientInfoProducts(ctx),
@@ -335,6 +348,16 @@ func buildClickHouseOptions(ctx context.Context, settings Settings, message json
 		ReadTimeout: time.Duration(qt) * time.Second,
 		Settings:    customSettings,
 		TLS:         tlsConfig,
+	}
+
+	// clickhouse-go leaves ConnOpenStrategy at ConnOpenInOrder, which dials the
+	// second node only once the first is unreachable — failover, but not the
+	// load balancing #279 also asks for. Spread new pooled connections across
+	// the nodes instead. Single-host setups keep the default: with one address
+	// the two strategies are identical, and not setting it keeps the option
+	// exactly as it was for every existing datasource.
+	if len(addrs) > 1 {
+		opts.ConnOpenStrategy = clickhouse.ConnOpenRoundRobin
 	}
 
 	// dialCtx is used to create a connection to PDC, if it is enabled above

--- a/pkg/plugin/driver.go
+++ b/pkg/plugin/driver.go
@@ -42,52 +42,37 @@ type grafanaHeaders struct {
 // Clickhouse defines how to connect to a Clickhouse datasource
 type Clickhouse struct{}
 
-// buildConnectionAddresses turns the configured host setting into the list of
-// "host:port" addresses passed to clickhouse-go, which natively load-balances
-// and fails over across multiple entries. Host may be a single value or a
-// comma-separated list (see #279); each entry may carry its own "host:port",
-// otherwise the shared port is appended. Empty entries and surrounding
-// whitespace are ignored.
-func buildConnectionAddresses(host string, port int64) []string {
-	parts := strings.Split(host, ",")
-	addrs := make([]string, 0, len(parts))
-	for _, part := range parts {
-		p := strings.TrimSpace(part)
-		if p == "" {
-			continue
+// connectionAddresses returns the "host:port" addresses passed to
+// clickhouse-go, which natively load-balances and fails over across multiple
+// entries (see #279). Settings.Hosts takes precedence when set; otherwise the
+// single Host/Port pair is used. A node without its own port falls back to the
+// shared port.
+func connectionAddresses(settings Settings) []string {
+	if len(settings.Hosts) == 0 {
+		return []string{fmt.Sprintf("%s:%d", settings.Host, settings.Port)}
+	}
+
+	addrs := make([]string, 0, len(settings.Hosts))
+	for _, host := range settings.Hosts {
+		port := host.Port
+		if port == 0 {
+			port = settings.Port
 		}
-		// If the entry already includes a port (host:port or [ipv6]:port),
-		// keep it verbatim; otherwise append the shared port.
-		if _, _, err := net.SplitHostPort(p); err == nil {
-			addrs = append(addrs, p)
-		} else {
-			addrs = append(addrs, fmt.Sprintf("%s:%d", p, port))
-		}
+		addrs = append(addrs, fmt.Sprintf("%s:%d", host.Host, port))
 	}
 	return addrs
-}
-
-// firstHost returns the first host in a possibly comma-separated host setting,
-// used as the TLS ServerName for SNI/verification.
-func firstHost(host string) string {
-	for _, part := range strings.Split(host, ",") {
-		if p := strings.TrimSpace(part); p != "" {
-			// Strip an optional port so ServerName is a bare hostname.
-			if h, _, err := net.SplitHostPort(p); err == nil {
-				return h
-			}
-			return p
-		}
-	}
-	return host
 }
 
 // getTLSConfig returns tlsConfig from settings
 // logic reused from https://github.com/grafana/grafana/blob/615c153b3a2e4d80cff263e67424af6edb992211/pkg/models/datasource_cache.go#L211
 func getTLSConfig(settings Settings) (*tls.Config, error) {
+	// ServerName is deliberately left unset. clickhouse-go hands this one
+	// tls.Config to every address it dials, so a name pinned here would be sent
+	// for all nodes and fail verification on every host but the one it names.
+	// Left empty, crypto/tls infers the name per connection from the address
+	// being dialled, which is correct for both a single host and a list.
 	tlsConfig := &tls.Config{
 		InsecureSkipVerify: settings.InsecureSkipVerify,
-		ServerName:         firstHost(settings.Host),
 	}
 	if settings.TlsClientAuth || settings.TlsAuthWithCACert {
 		if settings.TlsAuthWithCACert && len(settings.TlsCACert) > 0 {
@@ -334,7 +319,7 @@ func buildClickHouseOptions(ctx context.Context, settings Settings, message json
 	auth, getJWT := resolveJWTAuth(settings, httpHeaders)
 
 	opts := &clickhouse.Options{
-		Addr: buildConnectionAddresses(settings.Host, settings.Port),
+		Addr: connectionAddresses(settings),
 		Auth: auth,
 		ClientInfo: clickhouse.ClientInfo{
 			Products: getClientInfoProducts(ctx),

--- a/pkg/plugin/driver_test.go
+++ b/pkg/plugin/driver_test.go
@@ -832,3 +832,56 @@ func TestMissingTableMacroIsDownstream(t *testing.T) {
 	require.Error(t, got.Error)
 	assert.Equal(t, backend.ErrorSourceDownstream, got.ErrorSource)
 }
+
+func TestBuildConnectionAddresses(t *testing.T) {
+	tests := []struct {
+		name     string
+		host     string
+		port     int64
+		expected []string
+	}{
+		{
+			name:     "single host uses shared port",
+			host:     "localhost",
+			port:     9000,
+			expected: []string{"localhost:9000"},
+		},
+		{
+			name:     "comma-separated hosts share port",
+			host:     "ch1,ch2,ch3",
+			port:     9000,
+			expected: []string{"ch1:9000", "ch2:9000", "ch3:9000"},
+		},
+		{
+			name:     "whitespace around hosts is trimmed",
+			host:     " ch1 , ch2 ",
+			port:     9000,
+			expected: []string{"ch1:9000", "ch2:9000"},
+		},
+		{
+			name:     "per-host port overrides shared port",
+			host:     "ch1:9001,ch2",
+			port:     9000,
+			expected: []string{"ch1:9001", "ch2:9000"},
+		},
+		{
+			name:     "empty entries are skipped",
+			host:     "ch1,,ch2,",
+			port:     9000,
+			expected: []string{"ch1:9000", "ch2:9000"},
+		},
+		{
+			name:     "bracketed IPv6 with port is preserved",
+			host:     "[::1]:9000,ch2",
+			port:     9440,
+			expected: []string{"[::1]:9000", "ch2:9440"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildConnectionAddresses(tt.host, tt.port)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}

--- a/pkg/plugin/driver_test.go
+++ b/pkg/plugin/driver_test.go
@@ -589,55 +589,73 @@ func TestMissingTableMacroIsDownstream(t *testing.T) {
 	assert.Equal(t, backend.ErrorSourceDownstream, got.ErrorSource)
 }
 
-func TestBuildConnectionAddresses(t *testing.T) {
+func TestConnectionAddresses(t *testing.T) {
 	tests := []struct {
 		name     string
-		host     string
-		port     int64
+		settings Settings
 		expected []string
 	}{
 		{
-			name:     "single host uses shared port",
-			host:     "localhost",
-			port:     9000,
+			name:     "single host falls back to Host/Port",
+			settings: Settings{Host: "localhost", Port: 9000},
 			expected: []string{"localhost:9000"},
 		},
 		{
-			name:     "comma-separated hosts share port",
-			host:     "ch1,ch2,ch3",
-			port:     9000,
+			name: "hosts share the top-level port",
+			settings: Settings{
+				Port:  9000,
+				Hosts: []HostAddress{{Host: "ch1"}, {Host: "ch2"}, {Host: "ch3"}},
+			},
 			expected: []string{"ch1:9000", "ch2:9000", "ch3:9000"},
 		},
 		{
-			name:     "whitespace around hosts is trimmed",
-			host:     " ch1 , ch2 ",
-			port:     9000,
-			expected: []string{"ch1:9000", "ch2:9000"},
-		},
-		{
-			name:     "per-host port overrides shared port",
-			host:     "ch1:9001,ch2",
-			port:     9000,
+			name: "per-host port overrides the shared port",
+			settings: Settings{
+				Port:  9000,
+				Hosts: []HostAddress{{Host: "ch1", Port: 9001}, {Host: "ch2"}},
+			},
 			expected: []string{"ch1:9001", "ch2:9000"},
 		},
 		{
-			name:     "empty entries are skipped",
-			host:     "ch1,,ch2,",
-			port:     9000,
-			expected: []string{"ch1:9000", "ch2:9000"},
+			name: "hosts take precedence over Host/Port",
+			settings: Settings{
+				Host:  "legacy",
+				Port:  9000,
+				Hosts: []HostAddress{{Host: "ch1", Port: 9440}},
+			},
+			expected: []string{"ch1:9440"},
 		},
 		{
-			name:     "bracketed IPv6 with port is preserved",
-			host:     "[::1]:9000,ch2",
-			port:     9440,
+			name: "IPv6 hosts are bracketed by the caller",
+			settings: Settings{
+				Port:  9440,
+				Hosts: []HostAddress{{Host: "[::1]", Port: 9000}, {Host: "ch2"}},
+			},
 			expected: []string{"[::1]:9000", "ch2:9440"},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := buildConnectionAddresses(tt.host, tt.port)
+			got := connectionAddresses(tt.settings)
 			assert.Equal(t, tt.expected, got)
 		})
 	}
+}
+
+// The TLS config is handed to clickhouse-go once and reused for every address
+// it dials, so pinning ServerName would break verification on all but one host.
+// crypto/tls infers the name per connection from the address instead.
+func TestGetTLSConfigLeavesServerNameUnset(t *testing.T) {
+	tlsConfig, err := getTLSConfig(Settings{
+		Host: "ch1",
+		Port: 9000,
+		Hosts: []HostAddress{
+			{Host: "ch1"},
+			{Host: "ch2"},
+		},
+	})
+
+	require.NoError(t, err)
+	assert.Empty(t, tlsConfig.ServerName)
 }

--- a/pkg/plugin/driver_test.go
+++ b/pkg/plugin/driver_test.go
@@ -328,10 +328,10 @@ func TestMutateQueryData(t *testing.T) {
 	h := &Clickhouse{}
 
 	tests := []struct {
-		name   string
+		name    string
 		headers map[string]string
-		want   grafanaHeaders
-		stored bool
+		want    grafanaHeaders
+		stored  bool
 	}{
 		{
 			name: "all headers",
@@ -587,4 +587,57 @@ func TestMissingTableMacroIsDownstream(t *testing.T) {
 	got := resp.Responses["A"]
 	require.Error(t, got.Error)
 	assert.Equal(t, backend.ErrorSourceDownstream, got.ErrorSource)
+}
+
+func TestBuildConnectionAddresses(t *testing.T) {
+	tests := []struct {
+		name     string
+		host     string
+		port     int64
+		expected []string
+	}{
+		{
+			name:     "single host uses shared port",
+			host:     "localhost",
+			port:     9000,
+			expected: []string{"localhost:9000"},
+		},
+		{
+			name:     "comma-separated hosts share port",
+			host:     "ch1,ch2,ch3",
+			port:     9000,
+			expected: []string{"ch1:9000", "ch2:9000", "ch3:9000"},
+		},
+		{
+			name:     "whitespace around hosts is trimmed",
+			host:     " ch1 , ch2 ",
+			port:     9000,
+			expected: []string{"ch1:9000", "ch2:9000"},
+		},
+		{
+			name:     "per-host port overrides shared port",
+			host:     "ch1:9001,ch2",
+			port:     9000,
+			expected: []string{"ch1:9001", "ch2:9000"},
+		},
+		{
+			name:     "empty entries are skipped",
+			host:     "ch1,,ch2,",
+			port:     9000,
+			expected: []string{"ch1:9000", "ch2:9000"},
+		},
+		{
+			name:     "bracketed IPv6 with port is preserved",
+			host:     "[::1]:9000,ch2",
+			port:     9440,
+			expected: []string{"[::1]:9000", "ch2:9440"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildConnectionAddresses(tt.host, tt.port)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
 }

--- a/pkg/plugin/driver_test.go
+++ b/pkg/plugin/driver_test.go
@@ -833,55 +833,73 @@ func TestMissingTableMacroIsDownstream(t *testing.T) {
 	assert.Equal(t, backend.ErrorSourceDownstream, got.ErrorSource)
 }
 
-func TestBuildConnectionAddresses(t *testing.T) {
+func TestConnectionAddresses(t *testing.T) {
 	tests := []struct {
 		name     string
-		host     string
-		port     int64
+		settings Settings
 		expected []string
 	}{
 		{
-			name:     "single host uses shared port",
-			host:     "localhost",
-			port:     9000,
+			name:     "single host falls back to Host/Port",
+			settings: Settings{Host: "localhost", Port: 9000},
 			expected: []string{"localhost:9000"},
 		},
 		{
-			name:     "comma-separated hosts share port",
-			host:     "ch1,ch2,ch3",
-			port:     9000,
+			name: "hosts share the top-level port",
+			settings: Settings{
+				Port:  9000,
+				Hosts: []HostAddress{{Host: "ch1"}, {Host: "ch2"}, {Host: "ch3"}},
+			},
 			expected: []string{"ch1:9000", "ch2:9000", "ch3:9000"},
 		},
 		{
-			name:     "whitespace around hosts is trimmed",
-			host:     " ch1 , ch2 ",
-			port:     9000,
-			expected: []string{"ch1:9000", "ch2:9000"},
-		},
-		{
-			name:     "per-host port overrides shared port",
-			host:     "ch1:9001,ch2",
-			port:     9000,
+			name: "per-host port overrides the shared port",
+			settings: Settings{
+				Port:  9000,
+				Hosts: []HostAddress{{Host: "ch1", Port: 9001}, {Host: "ch2"}},
+			},
 			expected: []string{"ch1:9001", "ch2:9000"},
 		},
 		{
-			name:     "empty entries are skipped",
-			host:     "ch1,,ch2,",
-			port:     9000,
-			expected: []string{"ch1:9000", "ch2:9000"},
+			name: "hosts take precedence over Host/Port",
+			settings: Settings{
+				Host:  "legacy",
+				Port:  9000,
+				Hosts: []HostAddress{{Host: "ch1", Port: 9440}},
+			},
+			expected: []string{"ch1:9440"},
 		},
 		{
-			name:     "bracketed IPv6 with port is preserved",
-			host:     "[::1]:9000,ch2",
-			port:     9440,
+			name: "IPv6 hosts are bracketed by the caller",
+			settings: Settings{
+				Port:  9440,
+				Hosts: []HostAddress{{Host: "[::1]", Port: 9000}, {Host: "ch2"}},
+			},
 			expected: []string{"[::1]:9000", "ch2:9440"},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := buildConnectionAddresses(tt.host, tt.port)
+			got := connectionAddresses(tt.settings)
 			assert.Equal(t, tt.expected, got)
 		})
 	}
+}
+
+// The TLS config is handed to clickhouse-go once and reused for every address
+// it dials, so pinning ServerName would break verification on all but one host.
+// crypto/tls infers the name per connection from the address instead.
+func TestGetTLSConfigLeavesServerNameUnset(t *testing.T) {
+	tlsConfig, err := getTLSConfig(Settings{
+		Host: "ch1",
+		Port: 9000,
+		Hosts: []HostAddress{
+			{Host: "ch1"},
+			{Host: "ch2"},
+		},
+	})
+
+	require.NoError(t, err)
+	assert.Empty(t, tlsConfig.ServerName)
 }

--- a/pkg/plugin/driver_test.go
+++ b/pkg/plugin/driver_test.go
@@ -870,12 +870,28 @@ func TestConnectionAddresses(t *testing.T) {
 			expected: []string{"ch1:9440"},
 		},
 		{
-			name: "IPv6 hosts are bracketed by the caller",
+			// hosts is hand-edited, so an IPv6 literal arrives with or without
+			// brackets depending on who wrote it. Both have to dial: bare is
+			// what net.Dial rejects, doubled brackets would be just as broken.
+			name: "bare IPv6 hosts are bracketed",
+			settings: Settings{
+				Port:  9440,
+				Hosts: []HostAddress{{Host: "2001:db8::1", Port: 9000}, {Host: "ch2"}},
+			},
+			expected: []string{"[2001:db8::1]:9000", "ch2:9440"},
+		},
+		{
+			name: "already-bracketed IPv6 hosts are left alone",
 			settings: Settings{
 				Port:  9440,
 				Hosts: []HostAddress{{Host: "[::1]", Port: 9000}, {Host: "ch2"}},
 			},
 			expected: []string{"[::1]:9000", "ch2:9440"},
+		},
+		{
+			name:     "a bare IPv6 Host/Port pair is bracketed too",
+			settings: Settings{Host: "::1", Port: 9000},
+			expected: []string{"[::1]:9000"},
 		},
 	}
 
@@ -885,6 +901,46 @@ func TestConnectionAddresses(t *testing.T) {
 			assert.Equal(t, tt.expected, got)
 		})
 	}
+}
+
+// connectionAddresses is only useful if what it returns reaches the driver, so
+// assert the wiring, not just the helper: a regression that collapsed Addr back
+// to a single address would leave TestConnectionAddresses green.
+func TestBuildClickHouseOptionsMultiHost(t *testing.T) {
+	settings := Settings{
+		Port:         9000,
+		Protocol:     "native",
+		Hosts:        []HostAddress{{Host: "ch1"}, {Host: "ch2", Port: 9001}},
+		DialTimeout:  "5",
+		QueryTimeout: "30",
+	}
+
+	opts, err := buildClickHouseOptions(t.Context(), settings, nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"ch1:9000", "ch2:9001"}, opts.Addr)
+	// ConnOpenInOrder (the zero value) would send every new pooled connection
+	// to ch1 until it goes down — failover, not the load balancing #279 asks
+	// for.
+	assert.Equal(t, clickhouse.ConnOpenRoundRobin, opts.ConnOpenStrategy)
+}
+
+func TestBuildClickHouseOptionsSingleHostKeepsDefaultStrategy(t *testing.T) {
+	settings := Settings{
+		Host:         "ch1",
+		Port:         9000,
+		Protocol:     "native",
+		DialTimeout:  "5",
+		QueryTimeout: "30",
+	}
+
+	opts, err := buildClickHouseOptions(t.Context(), settings, nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"ch1:9000"}, opts.Addr)
+	// With one address the strategies are indistinguishable; leaving the option
+	// untouched keeps existing datasources byte-identical.
+	assert.Equal(t, clickhouse.ConnOpenInOrder, opts.ConnOpenStrategy)
 }
 
 // The TLS config is handed to clickhouse-go once and reused for every address

--- a/pkg/plugin/settings.go
+++ b/pkg/plugin/settings.go
@@ -17,11 +17,16 @@ import (
 
 // Settings - data loaded from grafana settings database
 type Settings struct {
-	Host     string `json:"host,omitempty"`
-	Port     int64  `json:"port,omitempty"`
-	Protocol string `json:"protocol"`
-	Secure   bool   `json:"secure,omitempty"`
-	Path     string `json:"path,omitempty"`
+	// Hosts is the optional list of nodes to connect to. When non-empty it takes
+	// precedence over Host/Port, which stay supported for existing data sources.
+	// clickhouse-go load-balances and fails over across the entries. A node
+	// without its own Port falls back to the shared Port.
+	Hosts    []HostAddress `json:"hosts,omitempty"`
+	Host     string        `json:"host,omitempty"`
+	Port     int64         `json:"port,omitempty"`
+	Protocol string        `json:"protocol"`
+	Secure   bool          `json:"secure,omitempty"`
+	Path     string        `json:"path,omitempty"`
 
 	InsecureSkipVerify bool `json:"tlsSkipVerify,omitempty"`
 	TlsClientAuth      bool `json:"tlsAuth,omitempty"`
@@ -68,6 +73,12 @@ type Settings struct {
 	SchemaCacheTTLSeconds int `json:"schemaCacheTTLSeconds,omitempty"`
 }
 
+// HostAddress is a single node in Settings.Hosts.
+type HostAddress struct {
+	Host string `json:"host"`
+	Port int64  `json:"port,omitempty"`
+}
+
 type CustomSetting struct {
 	Setting string `json:"setting"`
 	Value   string `json:"value"`
@@ -76,6 +87,17 @@ type CustomSetting struct {
 const secureHeaderKeyPrefix = "secureHttpHeaders."
 
 func (settings *Settings) isValid() (err error) {
+	if len(settings.Hosts) > 0 {
+		for _, host := range settings.Hosts {
+			if host.Host == "" {
+				return backend.DownstreamError(ErrorMessageInvalidHost)
+			}
+			if host.Port == 0 && settings.Port == 0 {
+				return backend.DownstreamError(ErrorMessageInvalidPort)
+			}
+		}
+		return nil
+	}
 	if settings.Host == "" {
 		return backend.DownstreamError(ErrorMessageInvalidHost)
 	}
@@ -83,6 +105,63 @@ func (settings *Settings) isValid() (err error) {
 		return backend.DownstreamError(ErrorMessageInvalidPort)
 	}
 	return nil
+}
+
+// parsePort reads a port that may arrive as a JSON number or a string.
+func parsePort(value interface{}) (int64, error) {
+	switch port := value.(type) {
+	case string:
+		parsed, err := strconv.ParseInt(port, 0, 64)
+		if err != nil {
+			return 0, fmt.Errorf("could not parse port value: %w", err)
+		}
+		return parsed, nil
+	case float64:
+		return int64(port), nil
+	default:
+		return 0, fmt.Errorf("could not parse port value: unexpected type %T", value)
+	}
+}
+
+// parseHosts deserializes the "hosts" field. Entries without a host name are
+// skipped so a trailing blank row in the UI does not become an empty address.
+func parseHosts(value interface{}) ([]HostAddress, error) {
+	entries, ok := value.([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("could not parse hosts value: expected a list, got %T", value)
+	}
+
+	hosts := make([]HostAddress, 0, len(entries))
+	for _, entry := range entries {
+		fields, ok := entry.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("could not parse hosts value: expected a list of objects, got %T", entry)
+		}
+
+		var host HostAddress
+		if fields["host"] != nil {
+			name, ok := fields["host"].(string)
+			if !ok {
+				return nil, fmt.Errorf("could not parse hosts value: host must be a string, got %T", fields["host"])
+			}
+			host.Host = strings.TrimSpace(name)
+		}
+		if host.Host == "" {
+			continue
+		}
+
+		if fields["port"] != nil {
+			port, err := parsePort(fields["port"])
+			if err != nil {
+				return nil, err
+			}
+			host.Port = port
+		}
+
+		hosts = append(hosts, host)
+	}
+
+	return hosts, nil
 }
 
 // LoadSettings will read and validate Settings from the DataSourceConfig
@@ -101,13 +180,19 @@ func LoadSettings(ctx context.Context, config backend.DataSourceInstanceSettings
 	}
 
 	if jsonData["port"] != nil {
-		if port, ok := jsonData["port"].(string); ok {
-			settings.Port, err = strconv.ParseInt(port, 0, 64)
-			if err != nil {
-				return settings, backend.DownstreamError(fmt.Errorf("could not parse port value: %w", err))
-			}
-		} else {
-			settings.Port = int64(jsonData["port"].(float64))
+		settings.Port, err = parsePort(jsonData["port"])
+		if err != nil {
+			return settings, backend.DownstreamError(err)
+		}
+	}
+
+	// Hosts supersedes Host/Port when set, in the same way Host supersedes the
+	// deprecated "server" above. Existing single-host configs keep working
+	// untouched, so no migration is needed.
+	if jsonData["hosts"] != nil {
+		settings.Hosts, err = parseHosts(jsonData["hosts"])
+		if err != nil {
+			return settings, backend.DownstreamError(err)
 		}
 	}
 	if jsonData["protocol"] != nil {

--- a/pkg/plugin/settings.go
+++ b/pkg/plugin/settings.go
@@ -17,11 +17,16 @@ import (
 
 // Settings - data loaded from grafana settings database
 type Settings struct {
-	Host     string `json:"host,omitempty"`
-	Port     int64  `json:"port,omitempty"`
-	Protocol string `json:"protocol"`
-	Secure   bool   `json:"secure,omitempty"`
-	Path     string `json:"path,omitempty"`
+	// Hosts is the optional list of nodes to connect to. When non-empty it takes
+	// precedence over Host/Port, which stay supported for existing data sources.
+	// clickhouse-go load-balances and fails over across the entries. A node
+	// without its own Port falls back to the shared Port.
+	Hosts    []HostAddress `json:"hosts,omitempty"`
+	Host     string        `json:"host,omitempty"`
+	Port     int64         `json:"port,omitempty"`
+	Protocol string        `json:"protocol"`
+	Secure   bool          `json:"secure,omitempty"`
+	Path     string        `json:"path,omitempty"`
 
 	InsecureSkipVerify bool `json:"tlsSkipVerify,omitempty"`
 	TlsClientAuth      bool `json:"tlsAuth,omitempty"`
@@ -77,6 +82,12 @@ type Settings struct {
 	SchemaCacheTTLSeconds int `json:"schemaCacheTTLSeconds,omitempty"`
 }
 
+// HostAddress is a single node in Settings.Hosts.
+type HostAddress struct {
+	Host string `json:"host"`
+	Port int64  `json:"port,omitempty"`
+}
+
 type CustomSetting struct {
 	Setting string `json:"setting"`
 	Value   string `json:"value"`
@@ -85,6 +96,17 @@ type CustomSetting struct {
 const secureHeaderKeyPrefix = "secureHttpHeaders."
 
 func (settings *Settings) isValid() (err error) {
+	if len(settings.Hosts) > 0 {
+		for _, host := range settings.Hosts {
+			if host.Host == "" {
+				return backend.DownstreamError(ErrorMessageInvalidHost)
+			}
+			if host.Port == 0 && settings.Port == 0 {
+				return backend.DownstreamError(ErrorMessageInvalidPort)
+			}
+		}
+		return nil
+	}
 	if settings.Host == "" {
 		return backend.DownstreamError(ErrorMessageInvalidHost)
 	}
@@ -92,6 +114,63 @@ func (settings *Settings) isValid() (err error) {
 		return backend.DownstreamError(ErrorMessageInvalidPort)
 	}
 	return nil
+}
+
+// parsePort reads a port that may arrive as a JSON number or a string.
+func parsePort(value interface{}) (int64, error) {
+	switch port := value.(type) {
+	case string:
+		parsed, err := strconv.ParseInt(port, 0, 64)
+		if err != nil {
+			return 0, fmt.Errorf("could not parse port value: %w", err)
+		}
+		return parsed, nil
+	case float64:
+		return int64(port), nil
+	default:
+		return 0, fmt.Errorf("could not parse port value: unexpected type %T", value)
+	}
+}
+
+// parseHosts deserializes the "hosts" field. Entries without a host name are
+// skipped so a trailing blank row in the UI does not become an empty address.
+func parseHosts(value interface{}) ([]HostAddress, error) {
+	entries, ok := value.([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("could not parse hosts value: expected a list, got %T", value)
+	}
+
+	hosts := make([]HostAddress, 0, len(entries))
+	for _, entry := range entries {
+		fields, ok := entry.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("could not parse hosts value: expected a list of objects, got %T", entry)
+		}
+
+		var host HostAddress
+		if fields["host"] != nil {
+			name, ok := fields["host"].(string)
+			if !ok {
+				return nil, fmt.Errorf("could not parse hosts value: host must be a string, got %T", fields["host"])
+			}
+			host.Host = strings.TrimSpace(name)
+		}
+		if host.Host == "" {
+			continue
+		}
+
+		if fields["port"] != nil {
+			port, err := parsePort(fields["port"])
+			if err != nil {
+				return nil, err
+			}
+			host.Port = port
+		}
+
+		hosts = append(hosts, host)
+	}
+
+	return hosts, nil
 }
 
 // LoadSettings will read and validate Settings from the DataSourceConfig
@@ -110,13 +189,19 @@ func LoadSettings(ctx context.Context, config backend.DataSourceInstanceSettings
 	}
 
 	if jsonData["port"] != nil {
-		if port, ok := jsonData["port"].(string); ok {
-			settings.Port, err = strconv.ParseInt(port, 0, 64)
-			if err != nil {
-				return settings, backend.DownstreamError(fmt.Errorf("could not parse port value: %w", err))
-			}
-		} else {
-			settings.Port = int64(jsonData["port"].(float64))
+		settings.Port, err = parsePort(jsonData["port"])
+		if err != nil {
+			return settings, backend.DownstreamError(err)
+		}
+	}
+
+	// Hosts supersedes Host/Port when set, in the same way Host supersedes the
+	// deprecated "server" above. Existing single-host configs keep working
+	// untouched, so no migration is needed.
+	if jsonData["hosts"] != nil {
+		settings.Hosts, err = parseHosts(jsonData["hosts"])
+		if err != nil {
+			return settings, backend.DownstreamError(err)
 		}
 	}
 	if jsonData["protocol"] != nil {

--- a/pkg/plugin/settings.go
+++ b/pkg/plugin/settings.go
@@ -56,9 +56,9 @@ type Settings struct {
 	// they fall back to the configured username/password (service account).
 	// Health checks and schema introspection always fall back regardless of
 	// this setting, since no user token is ever available for them.
-	OAuthPassThruAllowFallback bool `json:"oauthPassThruAllowFallback,omitempty"`
-	CustomSettings        []CustomSetting   `json:"customSettings"`
-	ProxyOptions          *proxy.Options
+	OAuthPassThruAllowFallback bool            `json:"oauthPassThruAllowFallback,omitempty"`
+	CustomSettings             []CustomSetting `json:"customSettings"`
+	ProxyOptions               *proxy.Options
 
 	RowLimit       int64 `json:"rowLimit,omitempty"`
 	EnableRowLimit bool  `json:"enableRowLimit,omitempty"`
@@ -118,22 +118,31 @@ func (settings *Settings) isValid() (err error) {
 
 // parsePort reads a port that may arrive as a JSON number or a string.
 func parsePort(value interface{}) (int64, error) {
-	switch port := value.(type) {
+	var port int64
+	switch v := value.(type) {
 	case string:
-		parsed, err := strconv.ParseInt(port, 0, 64)
+		parsed, err := strconv.ParseInt(strings.TrimSpace(v), 0, 64)
 		if err != nil {
 			return 0, fmt.Errorf("could not parse port value: %w", err)
 		}
-		return parsed, nil
+		port = parsed
 	case float64:
-		return int64(port), nil
+		port = int64(v)
 	default:
 		return 0, fmt.Errorf("could not parse port value: unexpected type %T", value)
 	}
+	// A port outside the TCP range can only fail at dial time, with an error
+	// that points at the network rather than at the config that caused it.
+	if port < 1 || port > 65535 {
+		return 0, fmt.Errorf("could not parse port value: %d is out of range (1-65535)", port)
+	}
+	return port, nil
 }
 
-// parseHosts deserializes the "hosts" field. Entries without a host name are
-// skipped so a trailing blank row in the UI does not become an empty address.
+// parseHosts deserializes the "hosts" field. An entry without a usable host
+// name is an error rather than a skip: this field is hand-edited in
+// provisioning, so a dropped entry is a typo silently costing a node, not a
+// blank row from a form.
 func parseHosts(value interface{}) ([]HostAddress, error) {
 	entries, ok := value.([]interface{})
 	if !ok {
@@ -141,7 +150,7 @@ func parseHosts(value interface{}) ([]HostAddress, error) {
 	}
 
 	hosts := make([]HostAddress, 0, len(entries))
-	for _, entry := range entries {
+	for i, entry := range entries {
 		fields, ok := entry.(map[string]interface{})
 		if !ok {
 			return nil, fmt.Errorf("could not parse hosts value: expected a list of objects, got %T", entry)
@@ -156,7 +165,7 @@ func parseHosts(value interface{}) ([]HostAddress, error) {
 			host.Host = strings.TrimSpace(name)
 		}
 		if host.Host == "" {
-			continue
+			return nil, fmt.Errorf("could not parse hosts value: entry %d has no host", i)
 		}
 
 		if fields["port"] != nil {

--- a/pkg/plugin/settings_test.go
+++ b/pkg/plugin/settings_test.go
@@ -407,3 +407,74 @@ func TestLoadSettings(t *testing.T) {
 		}
 	})
 }
+
+func TestLoadSettingsHosts(t *testing.T) {
+	t.Run("parses hosts with per-node and shared ports", func(t *testing.T) {
+		settings, err := LoadSettings(context.Background(), backend.DataSourceInstanceSettings{
+			JSONData:                []byte(`{"port": 9000, "hosts": [{"host": "ch1"}, {"host": "ch2", "port": 9440}]}`),
+			DecryptedSecureJSONData: map[string]string{},
+		})
+
+		assert.Nil(t, err)
+		assert.Equal(t, []HostAddress{{Host: "ch1"}, {Host: "ch2", Port: 9440}}, settings.Hosts)
+	})
+
+	t.Run("accepts a port given as a string", func(t *testing.T) {
+		settings, err := LoadSettings(context.Background(), backend.DataSourceInstanceSettings{
+			JSONData:                []byte(`{"port": 9000, "hosts": [{"host": "ch1", "port": "9440"}]}`),
+			DecryptedSecureJSONData: map[string]string{},
+		})
+
+		assert.Nil(t, err)
+		assert.Equal(t, []HostAddress{{Host: "ch1", Port: 9440}}, settings.Hosts)
+	})
+
+	t.Run("trims whitespace and skips entries without a host", func(t *testing.T) {
+		settings, err := LoadSettings(context.Background(), backend.DataSourceInstanceSettings{
+			JSONData:                []byte(`{"port": 9000, "hosts": [{"host": "  ch1  "}, {"host": "   "}, {"port": 9440}]}`),
+			DecryptedSecureJSONData: map[string]string{},
+		})
+
+		assert.Nil(t, err)
+		assert.Equal(t, []HostAddress{{Host: "ch1"}}, settings.Hosts)
+	})
+
+	t.Run("existing host/port configs keep working untouched", func(t *testing.T) {
+		settings, err := LoadSettings(context.Background(), backend.DataSourceInstanceSettings{
+			JSONData:                []byte(`{"host": "ch1", "port": 9000}`),
+			DecryptedSecureJSONData: map[string]string{},
+		})
+
+		assert.Nil(t, err)
+		assert.Empty(t, settings.Hosts)
+		assert.Equal(t, "ch1", settings.Host)
+		assert.Equal(t, int64(9000), settings.Port)
+	})
+
+	t.Run("hosts alone satisfy validation without host/port", func(t *testing.T) {
+		_, err := LoadSettings(context.Background(), backend.DataSourceInstanceSettings{
+			JSONData:                []byte(`{"hosts": [{"host": "ch1", "port": 9000}]}`),
+			DecryptedSecureJSONData: map[string]string{},
+		})
+
+		assert.Nil(t, err)
+	})
+
+	t.Run("a host without any port is rejected", func(t *testing.T) {
+		_, err := LoadSettings(context.Background(), backend.DataSourceInstanceSettings{
+			JSONData:                []byte(`{"hosts": [{"host": "ch1"}]}`),
+			DecryptedSecureJSONData: map[string]string{},
+		})
+
+		assert.NotNil(t, err)
+	})
+
+	t.Run("a malformed hosts value is reported, not panicked on", func(t *testing.T) {
+		_, err := LoadSettings(context.Background(), backend.DataSourceInstanceSettings{
+			JSONData:                []byte(`{"port": 9000, "hosts": "ch1,ch2"}`),
+			DecryptedSecureJSONData: map[string]string{},
+		})
+
+		assert.NotNil(t, err)
+	})
+}

--- a/pkg/plugin/settings_test.go
+++ b/pkg/plugin/settings_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend/proxy"
 	sdkconfig "github.com/grafana/grafana-plugin-sdk-go/config"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestLoadSettings(t *testing.T) {
@@ -491,14 +492,59 @@ func TestLoadSettingsHosts(t *testing.T) {
 		assert.Equal(t, []HostAddress{{Host: "ch1", Port: 9440}}, settings.Hosts)
 	})
 
-	t.Run("trims whitespace and skips entries without a host", func(t *testing.T) {
+	t.Run("trims whitespace around a host name", func(t *testing.T) {
 		settings, err := LoadSettings(context.Background(), backend.DataSourceInstanceSettings{
-			JSONData:                []byte(`{"port": 9000, "hosts": [{"host": "  ch1  "}, {"host": "   "}, {"port": 9440}]}`),
+			JSONData:                []byte(`{"port": 9000, "hosts": [{"host": "  ch1  "}]}`),
 			DecryptedSecureJSONData: map[string]string{},
 		})
 
 		assert.Nil(t, err)
 		assert.Equal(t, []HostAddress{{Host: "ch1"}}, settings.Hosts)
+	})
+
+	// hosts is hand-edited in provisioning, so an entry with no usable host is
+	// a typo that would otherwise cost a node silently: validation still
+	// passes, Save & test is green, and the operator believes they have one
+	// more node than they do.
+	t.Run("an entry without a usable host is rejected, not skipped", func(t *testing.T) {
+		for name, hosts := range map[string]string{
+			"blank host":       `[{"host": "ch1"}, {"host": "   "}]`,
+			"host key missing": `[{"host": "ch1"}, {"port": 9440}]`,
+			"misspelled key":   `[{"host": "ch1"}, {"hostname": "ch2"}]`,
+		} {
+			t.Run(name, func(t *testing.T) {
+				_, err := LoadSettings(context.Background(), backend.DataSourceInstanceSettings{
+					JSONData:                []byte(`{"port": 9000, "hosts": ` + hosts + `}`),
+					DecryptedSecureJSONData: map[string]string{},
+				})
+
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "entry 1 has no host")
+			})
+		}
+	})
+
+	t.Run("a port outside the TCP range is rejected", func(t *testing.T) {
+		for _, port := range []string{"70000", "-1", "0"} {
+			t.Run(port, func(t *testing.T) {
+				_, err := LoadSettings(context.Background(), backend.DataSourceInstanceSettings{
+					JSONData:                []byte(`{"hosts": [{"host": "ch1", "port": ` + port + `}]}`),
+					DecryptedSecureJSONData: map[string]string{},
+				})
+
+				require.Error(t, err)
+			})
+		}
+	})
+
+	t.Run("a port given as a padded string is accepted", func(t *testing.T) {
+		settings, err := LoadSettings(context.Background(), backend.DataSourceInstanceSettings{
+			JSONData:                []byte(`{"hosts": [{"host": "ch1", "port": " 9440 "}]}`),
+			DecryptedSecureJSONData: map[string]string{},
+		})
+
+		assert.Nil(t, err)
+		assert.Equal(t, []HostAddress{{Host: "ch1", Port: 9440}}, settings.Hosts)
 	})
 
 	t.Run("existing host/port configs keep working untouched", func(t *testing.T) {

--- a/pkg/plugin/settings_test.go
+++ b/pkg/plugin/settings_test.go
@@ -114,17 +114,17 @@ func TestLoadSettings(t *testing.T) {
 					},
 				},
 				wantSettings: Settings{
-					Host:               "test",
-					Port:               443,
-					Path:               "custom-path",
-					InsecureSkipVerify: true,
-					TlsClientAuth:      true,
-					TlsAuthWithCACert:  true,
-					ConnMaxLifetime:    "5",
-					DialTimeout:        "10",
-					MaxIdleConns:       "25",
-					MaxOpenConns:       "50",
-					QueryTimeout:       "60",
+					Host:                  "test",
+					Port:                  443,
+					Path:                  "custom-path",
+					InsecureSkipVerify:    true,
+					TlsClientAuth:         true,
+					TlsAuthWithCACert:     true,
+					ConnMaxLifetime:       "5",
+					DialTimeout:           "10",
+					MaxIdleConns:          "25",
+					MaxOpenConns:          "50",
+					QueryTimeout:          "60",
 					ProxyOptions:          nil,
 					EnableRowLimit:        true,
 					RowLimit:              1000000,
@@ -143,12 +143,12 @@ func TestLoadSettings(t *testing.T) {
 					},
 				},
 				wantSettings: Settings{
-					Host:            "test",
-					Port:            443,
-					ConnMaxLifetime: "5",
-					DialTimeout:     "10",
-					MaxIdleConns:    "25",
-					MaxOpenConns:    "50",
+					Host:                  "test",
+					Port:                  443,
+					ConnMaxLifetime:       "5",
+					DialTimeout:           "10",
+					MaxIdleConns:          "25",
+					MaxOpenConns:          "50",
 					QueryTimeout:          "60",
 					RowLimit:              1000000,
 					EnableRowLimit:        true,
@@ -234,12 +234,12 @@ func TestLoadSettings(t *testing.T) {
 					},
 				},
 				wantSettings: Settings{
-					Host:            "test",
-					Port:            443,
-					ConnMaxLifetime: "5",
-					DialTimeout:     "15",
-					MaxIdleConns:    "25",
-					MaxOpenConns:    "50",
+					Host:                  "test",
+					Port:                  443,
+					ConnMaxLifetime:       "5",
+					DialTimeout:           "15",
+					MaxIdleConns:          "25",
+					MaxOpenConns:          "50",
 					QueryTimeout:          "120",
 					EnableRowLimit:        false,
 					EnableSchemaCache:     true,
@@ -257,12 +257,12 @@ func TestLoadSettings(t *testing.T) {
 					},
 				},
 				wantSettings: Settings{
-					Host:            "test",
-					Port:            443,
-					ConnMaxLifetime: "5",
-					DialTimeout:     "25",
-					MaxIdleConns:    "25",
-					MaxOpenConns:    "50",
+					Host:                  "test",
+					Port:                  443,
+					ConnMaxLifetime:       "5",
+					DialTimeout:           "25",
+					MaxIdleConns:          "25",
+					MaxOpenConns:          "50",
 					QueryTimeout:          "60",
 					EnableRowLimit:        false,
 					EnableSchemaCache:     true,
@@ -280,12 +280,12 @@ func TestLoadSettings(t *testing.T) {
 					},
 				},
 				wantSettings: Settings{
-					Host:            "test",
-					Port:            443,
-					ConnMaxLifetime: "5",
-					DialTimeout:     "10",
-					MaxIdleConns:    "25",
-					MaxOpenConns:    "50",
+					Host:                  "test",
+					Port:                  443,
+					ConnMaxLifetime:       "5",
+					DialTimeout:           "10",
+					MaxIdleConns:          "25",
+					MaxOpenConns:          "50",
 					QueryTimeout:          "60",
 					EnableRowLimit:        false,
 					EnableSchemaCache:     true,
@@ -467,5 +467,76 @@ func TestLoadSettingsOAuthPassThruAllowFallback(t *testing.T) {
 		})
 		assert.NoError(t, err)
 		assert.False(t, settings.OAuthPassThruAllowFallback)
+	})
+}
+
+func TestLoadSettingsHosts(t *testing.T) {
+	t.Run("parses hosts with per-node and shared ports", func(t *testing.T) {
+		settings, err := LoadSettings(context.Background(), backend.DataSourceInstanceSettings{
+			JSONData:                []byte(`{"port": 9000, "hosts": [{"host": "ch1"}, {"host": "ch2", "port": 9440}]}`),
+			DecryptedSecureJSONData: map[string]string{},
+		})
+
+		assert.Nil(t, err)
+		assert.Equal(t, []HostAddress{{Host: "ch1"}, {Host: "ch2", Port: 9440}}, settings.Hosts)
+	})
+
+	t.Run("accepts a port given as a string", func(t *testing.T) {
+		settings, err := LoadSettings(context.Background(), backend.DataSourceInstanceSettings{
+			JSONData:                []byte(`{"port": 9000, "hosts": [{"host": "ch1", "port": "9440"}]}`),
+			DecryptedSecureJSONData: map[string]string{},
+		})
+
+		assert.Nil(t, err)
+		assert.Equal(t, []HostAddress{{Host: "ch1", Port: 9440}}, settings.Hosts)
+	})
+
+	t.Run("trims whitespace and skips entries without a host", func(t *testing.T) {
+		settings, err := LoadSettings(context.Background(), backend.DataSourceInstanceSettings{
+			JSONData:                []byte(`{"port": 9000, "hosts": [{"host": "  ch1  "}, {"host": "   "}, {"port": 9440}]}`),
+			DecryptedSecureJSONData: map[string]string{},
+		})
+
+		assert.Nil(t, err)
+		assert.Equal(t, []HostAddress{{Host: "ch1"}}, settings.Hosts)
+	})
+
+	t.Run("existing host/port configs keep working untouched", func(t *testing.T) {
+		settings, err := LoadSettings(context.Background(), backend.DataSourceInstanceSettings{
+			JSONData:                []byte(`{"host": "ch1", "port": 9000}`),
+			DecryptedSecureJSONData: map[string]string{},
+		})
+
+		assert.Nil(t, err)
+		assert.Empty(t, settings.Hosts)
+		assert.Equal(t, "ch1", settings.Host)
+		assert.Equal(t, int64(9000), settings.Port)
+	})
+
+	t.Run("hosts alone satisfy validation without host/port", func(t *testing.T) {
+		_, err := LoadSettings(context.Background(), backend.DataSourceInstanceSettings{
+			JSONData:                []byte(`{"hosts": [{"host": "ch1", "port": 9000}]}`),
+			DecryptedSecureJSONData: map[string]string{},
+		})
+
+		assert.Nil(t, err)
+	})
+
+	t.Run("a host without any port is rejected", func(t *testing.T) {
+		_, err := LoadSettings(context.Background(), backend.DataSourceInstanceSettings{
+			JSONData:                []byte(`{"hosts": [{"host": "ch1"}]}`),
+			DecryptedSecureJSONData: map[string]string{},
+		})
+
+		assert.NotNil(t, err)
+	})
+
+	t.Run("a malformed hosts value is reported, not panicked on", func(t *testing.T) {
+		_, err := LoadSettings(context.Background(), backend.DataSourceInstanceSettings{
+			JSONData:                []byte(`{"port": 9000, "hosts": "ch1,ch2"}`),
+			DecryptedSecureJSONData: map[string]string{},
+		})
+
+		assert.NotNil(t, err)
 	})
 }


### PR DESCRIPTION
## Summary

Adds support for configuring multiple ClickHouse hosts as a comma-separated list in the datasource `host` setting, enabling clickhouse-go's native load-balancing and failover across nodes.

Closes #279

## Details

`clickhouse-go` load-balances and fails over across every entry in `Options.Addr`, and its own DSN parser already treats the host as a comma-separated list (`clickhouse_options.go`: `o.Addr = append(o.Addr, strings.Split(dsn.Host, ",")...)`). This plugin builds `Options` directly rather than via a DSN, so it previously collapsed the host into a single `host:port` address. This change mirrors the driver's convention:

- `host` is split on commas into multiple `host:port` addresses.
- Each entry may carry its own port (`ch1:9001,ch2`); entries without one use the shared port field.
- Empty entries and surrounding whitespace are ignored.
- TLS `ServerName` now uses the first host so SNI/verification keeps working when a list is configured.

The default `ConnOpenStrategy` (round-robin + failover) requires no extra configuration.

## Testing

- New table-driven unit test `TestBuildConnectionAddresses` covers single host, comma lists, whitespace trimming, per-host port override, empty-entry skipping, and bracketed IPv6.
- Full backend suite green (`go test ./pkg/...`), `go vet` and `go build` clean.