### PR TITLE
fix(variables): don't break variable loading when version() returns no rows

### DIFF
--- a/src/data/CHDatasource.test.ts
+++ b/src/data/CHDatasource.test.ts
@@ -127,6 +127,19 @@ describe('ClickHouseDatasource', () => {
 
       expect(querySpy).toHaveBeenCalledWith(expect.objectContaining({ scopedVars }));
     });
+
+    it('does not throw when SELECT version() returns no rows (#1061)', async () => {
+      const instance = cloneDeep(mockDatasource);
+      instance.adHocFiltersStatus = 0; // AdHocFilterStatus.none -> forces the CH version check
+      const metricFrame = toDataFrame({ fields: [{ name: 'field', type: 'string', values: ['a'] }] });
+      jest.spyOn(instance, 'query').mockImplementation((request) =>
+        request.targets[0].rawSql === 'SELECT version()'
+          ? of({ data: [toDataFrame([])] }) // empty version() response (transient / race)
+          : of({ data: [metricFrame] })
+      );
+
+      await expect(instance.metricFindQuery('SELECT 1', {})).resolves.toEqual([{ text: 'a', value: 'a' }]);
+    });
   });
 
   describe('applyTemplateVariables', () => {

--- a/src/data/CHDatasource.ts
+++ b/src/data/CHDatasource.ts
@@ -1774,8 +1774,17 @@ export class Datasource
   private async canUseAdhocFilters(): Promise<AdHocFilterStatus> {
     this.skipAdHocFilter = true;
     const data = await this.fetchData(`SELECT version()`);
+    const versionValue = data[0];
+    if (typeof versionValue !== 'string') {
+      // `SELECT version()` occasionally returns no rows (e.g. a transient/racey
+      // empty response right after Grafana loads). Leaving the status
+      // unresolved lets it be re-checked on the next query instead of throwing
+      // and breaking variable/template loading. See #1061.
+      console.warn('Unable to determine ClickHouse version: empty version() response');
+      return AdHocFilterStatus.none;
+    }
     try {
-      const verString = (data[0] as unknown as string).split('.');
+      const verString = versionValue.split('.');
       const ver = { major: Number.parseInt(verString[0], 10), minor: Number.parseInt(verString[1], 10) };
       return ver.major > this.adHocCHVerReq.major ||
         (ver.major === this.adHocCHVerReq.major && ver.minor >= this.adHocCHVerReq.minor)
@@ -1783,7 +1792,7 @@ export class Datasource
         : AdHocFilterStatus.disabled;
     } catch (err) {
       console.error(`Unable to parse ClickHouse version: ${err}`);
-      throw err;
+      return AdHocFilterStatus.none;
     }
   }
 

--- a/src/data/CHDatasource.ts
+++ b/src/data/CHDatasource.ts
@@ -1776,7 +1776,7 @@ export class Datasource
     const data = await this.fetchData(`SELECT version()`);
     const versionValue = data[0];
     if (typeof versionValue !== 'string') {
-      // `SELECT version()` occasionally returns no rows (e.g. a transient/racey
+      // `SELECT version()` occasionally returns no rows (e.g. a transient
       // empty response right after Grafana loads). Leaving the status
       // unresolved lets it be re-checked on the next query instead of throwing
       // and breaking variable/template loading. See #1061.


### PR DESCRIPTION
## Summary

Fixes a crash where dashboard template variables fail to load with:

> Templating [VARIABLE_NAME] Error updating options: Cannot read properties of undefined (reading 'split')

Closes #1061

## Root cause

`metricFindQuery` calls `canUseAdhocFilters()` to detect whether ClickHouse is >= 22.7. That method runs `SELECT version()` and did:

```ts
const verString = (data[0] as unknown as string).split('.');
```

When `version()` returns an empty response (reported as transient — "works after reloading multiple times"), `data[0]` is `undefined`, `.split` throws, and the `catch` block **rethrew**. The rejection propagated out of `metricFindQuery`, breaking variable loading for the whole dashboard.

## Fix

Guard the empty/unparseable version case: log a warning and return `AdHocFilterStatus.none` instead of throwing. Leaving the status unresolved means it is re-checked on the next query (self-healing for the transient case) rather than permanently disabling ad-hoc filters or crashing variable loading.

## Testing

- New test `does not throw when SELECT version() returns no rows (#1061)` reproduces the crash (red) and passes with the fix (green).
- Full `CHDatasource` suite green (165 passed), `tsc --noEmit` and `eslint` clean.