### PR TITLE
ci: add stale issue and PR workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,17 +1,16 @@
 name: 'Close stale issues and PRs'
-
 on:
   schedule:
     - cron: '30 1 * * *'
-  workflow_dispatch:
+
+permissions: {}
 
 jobs:
   stale:
+    runs-on: ubuntu-arm64-small
     permissions:
-      contents: write
       issues: write
       pull-requests: write
-    runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@v10
         with:
@@ -42,5 +41,3 @@ jobs:
           close-pr-message: >
             This pull request has been automatically closed because it has not had any further
             activity in the last 2 weeks. Thank you for your contributions!
-          # Remove the PR head branch when the stale workflow closes the PR (requires contents: write)
-          delete-branch: true


### PR DESCRIPTION
Copies the stale workflow from [grafana/grafana](https://github.com/grafana/grafana/blob/main/.github/workflows/stale.yml) verbatim, as part of a rollout across the standalone data source repos.

What it does:

- Issues inactive for 1 year are labelled `stale`, then closed after a further 30 days of inactivity.
- PRs inactive for 30 days are labelled `stale`, then closed after a further 2 weeks.
- Apply the `no stalebot` label to exempt an issue or PR (issues labelled `type/epic` are also exempt).

**User-facing impact:** community issues and PRs in this repo will start receiving stale warnings and may be auto-closed by the bot.
