### PR TITLE
Datasource-enforced settings and read-only mode, not subject to override at query level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ### Features
 
+- **Enforced server-side ClickHouse settings with per-query `readonly=1`**: Operators can now mark individual Custom Settings as "Enforced" in the datasource configuration. When any setting is enforced, the plugin injects the enforced values together with `readonly=1` on every query via the clickhouse-go per-query settings channel — without SQL rewriting and without a persistent ClickHouse session. This makes all queries through this datasource read-only (no INSERT/DDL from Grafana). The mechanism relies on two ClickHouse invariants: (1) `readonly` can only be tightened per query, never loosened; (2) under `readonly=1`, any `SETTINGS`/`SET` clause in user SQL that tries to change a non-whitelisted setting is rejected before the SQL is executed.
+
+  **Recommended combination with ClickHouse row policies**: pair an enforced `custom_visible_tenants='t1,t2'` setting with a server-side row policy such as `CREATE ROW POLICY … USING has(splitByChar(',', getSetting('custom_visible_tenants')), tenant_id) TO ALL`. Because the tenant variable is injected out-of-band and cannot be overridden by the end user's SQL, the row policy filters are tamper-resistant from Grafana's query editor.
+
+  **Important: this is a defence-in-depth layer.** The actual enforcement lives in ClickHouse; the plugin's role is to reliably inject the settings on every query and to surface mis-configuration early via the datasource health check.
+
+  **`CHANGEABLE_IN_READONLY` escape hatch**: ClickHouse operators can mark specific server tunables — such as `max_threads` or `max_memory_usage` — as `<changeable_in_readonly/>` in their settings profile constraints. This lets users still tune those knobs per query from the Grafana query editor without breaking the enforced tenant settings. The enforced tenant settings themselves must **not** be marked `CHANGEABLE_IN_READONLY`, or the guarantee collapses. The datasource health check will surface this mis-configuration with an actionable error message.
+
 - Add `1.3.0` OTel schema version to support `opentelemetry-collector-contrib` clickhouseexporter `v0.151.0`+, which removed the `TimestampTime` column from `otel_logs`. The `latest` selector now points to this schema; existing data sources continue to use `1.2.9` until manually updated (#1882)
 - Auto-detect the OTel logs schema version from the table's columns when the version selector is on `auto (latest)`, removing the manual version pick for the common case. Pinned versions are unchanged (#1900)
 

--- a/config/admin.xml
+++ b/config/admin.xml
@@ -5,6 +5,14 @@
         <default>
             <!-- Allows us to create replicated databases. -->
             <allow_experimental_database_replicated>1</allow_experimental_database_replicated>
+            <constraints>
+                <!-- Allow per-query tuning of max_threads even under readonly=1.
+                     This lets users adjust query parallelism from the Grafana query editor
+                     without breaking enforced tenant settings. -->
+                <max_threads>
+                    <changeable_in_readonly/>
+                </max_threads>
+            </constraints>
         </default>
     </profiles>
     <users>

--- a/config/custom.xml
+++ b/config/custom.xml
@@ -7,5 +7,6 @@
         <console>1</console>
     </logger>
     <timezone>UTC</timezone>
-
+    <!-- Allow custom_* settings so enforced-tenant tests can use custom_visible_tenants. -->
+    <custom_settings_prefixes>custom_</custom_settings_prefixes>
 </clickhouse>

--- a/docs/sources/configure.md
+++ b/docs/sources/configure.md
@@ -191,6 +191,41 @@ You can pass arbitrary ClickHouse `SETTINGS` with every query by adding key-valu
 
 These settings are appended to each query's `SETTINGS` clause. They do not replace any settings that the plugin sets internally (such as `max_execution_time`).
 
+### Enforcing server-side settings (multi-tenancy)
+
+The **Enforced** checkbox on each Custom Setting row enables a tamper-resistant mode: the datasource sends the setting alongside `readonly=1` on every query, so the end user's SQL cannot override it with a `SETTINGS` or `SET` clause.
+
+When any custom setting is marked **Enforced**, the **Enforce read-only on all queries** toggle is automatically enabled. You can also enable that toggle independently to make the datasource fully read-only (SELECT/SHOW only) without any enforced settings.
+
+**How it works (no SQL rewriting, no dedicated DB user):**
+
+The plugin injects the enforced settings and `readonly=1` as per-query settings out-of-band with the SQL — via HTTP query-string parameters or the Native protocol's per-query settings block. ClickHouse enforces two invariants that make this tamper-resistant:
+
+1. `readonly` can only be increased per query; a user's `SETTINGS readonly=0` is rejected once it is already `1`.
+2. Under `readonly=1`, any `SETTINGS foo=…` or `SET foo=…` in the user's SQL that attempts to change a non-whitelisted setting is rejected outright.
+
+**Worked example — row-level multi-tenancy:**
+
+```sql
+-- 1. Create a row policy that reads the enforced setting
+CREATE ROW POLICY tenant_filter ON mydb.events
+  USING has(splitByChar(',', getSetting('custom_visible_tenants')), tenant_id)
+  TO grafana_user;
+
+-- 2. In the datasource config, add a Custom Setting:
+--    setting = custom_visible_tenants
+--    value   = t1,t2          (the tenants this datasource instance may see)
+--    enforced = ✓ (checked)
+```
+
+With `readonly=1` active, the user cannot change `custom_visible_tenants` in their query, so the row policy always filters on the operator-supplied tenant list.
+
+**Important caveats:**
+
+- **Enforced settings must NOT be marked `CHANGEABLE_IN_READONLY` on the ClickHouse server.** If they are, a user can override them even under `readonly=1`, which collapses the enforcement guarantee. The `<changeable_in_readonly/>` server-side tag is intended only for tunables like `max_threads` and `max_memory_usage` that operators want to allow users to tune per query.
+- Enabling this feature makes the datasource **read-only**: INSERT, CREATE, ALTER, and other write statements from Grafana will be rejected by ClickHouse.
+- The connecting DB user must start at `readonly=0` (or `readonly=2`). If the user's server profile already enforces `readonly=1`, the plugin cannot inject the enforced setting values before that restriction takes effect.
+
 ### Logs configuration
 
 The data source includes a dedicated configuration section for log queries. These settings control the default column mappings used by the [logs query builder](/docs/plugins/grafana-clickhouse-datasource/<CLICKHOUSE_PLUGIN_VERSION>/query-editor/#logs-query-builder):

--- a/notes-enforced-settings-plan.md
+++ b/notes-enforced-settings-plan.md
@@ -1,0 +1,263 @@
+# Implementation plan: enforced per-query settings + `readonly=1`
+
+Goal: let operators configure ClickHouse settings (typically a
+`custom_*` tenant variable) that are injected into every query executed
+via the datasource and cannot be overridden by the end user's SQL. The
+enforcement mechanism is per-query `readonly=1` combined with the
+enforced setting values, sent out-of-band with the SQL. No SQL
+rewriting, no per-tenant DB user, no persistent ClickHouse session.
+
+Companion design notes: `notes-enforced-settings.md`.
+
+---
+
+## Phase 0 — Prep
+
+1. Reproduce the mechanism manually against a local ClickHouse:
+   - Verify that `SELECT getSetting('custom_x') SETTINGS custom_x='foo', readonly=1`
+     succeeds and returns `foo`.
+   - Verify `SELECT getSetting('custom_x') SETTINGS custom_x='foo', readonly=1, custom_x='bar'`
+     is rejected (user attempts override).
+   - Verify `SELECT 1 SETTINGS readonly=0` under a `readonly=1` request
+     is rejected.
+   - Verify `SET custom_x='bar'` under `readonly=1` is rejected.
+   - Verify `INSERT`, `CREATE`, `ALTER`, `remote()`, `url()`, `file()`,
+     `s3()` behavior under `readonly=1` on the target ClickHouse
+     version. Document any surprises.
+   - Repeat over both Native and HTTP protocols.
+2. Confirm clickhouse-go v2 API for per-query settings on the version
+   pinned in `go.mod`: `clickhouse.Context(ctx, clickhouse.WithSettings(clickhouse.Settings{...}))`.
+
+Deliverable: a short note captured in the PR description with the
+observed behavior on the CH versions we care about (LTS + latest).
+
+---
+
+## Phase 1 — Config surface
+
+Files: `pkg/plugin/settings.go`, `src/types.ts` (or wherever the
+datasource config types live), `src/views/CHConfigEditor/*` for the UI.
+
+1. Extend `CustomSetting` (backwards compatible):
+   ```go
+   type CustomSetting struct {
+       Setting  string `json:"setting"`
+       Value    string `json:"value"`
+       Enforced bool   `json:"enforced,omitempty"`
+   }
+   ```
+   Alternatively, introduce a second field `EnforcedSettings` and keep
+   `CustomSettings` as-is. Prefer the flag on the existing struct to
+   avoid a second UI list; call this out in the PR description so
+   reviewers can push back if they'd rather split them.
+2. Add a datasource-level toggle `EnforceReadOnly bool
+   \`json:"enforceReadOnly,omitempty"\``. When any `CustomSetting` has
+   `Enforced=true`, force this to `true` on load (with a warning log if
+   it was false). Otherwise it's an operator opt-in that means "force
+   `readonly=1` on every query even without enforced settings" — useful
+   for pure lockdown deployments.
+3. Update `LoadSettings` to parse the new fields (both bool and
+   string shapes, following the existing pattern in this file).
+4. In the config editor UI, add:
+   - A checkbox column next to each Custom Setting row: "Enforced (send
+     as `readonly=1`)".
+   - A standalone "Enforce read-only on all queries" toggle bound to
+     `enforceReadOnly`.
+   - Help text warning that enforced settings must **not** be marked
+     `CHANGEABLE_IN_READONLY` on the ClickHouse server, and that
+     enabling this makes the datasource read-only (no INSERT/DDL from
+     Grafana).
+5. Documentation:
+   - Add a section to `README.md` and/or `docs/` explaining the pattern,
+     the row-policy companion (`getSetting('custom_x')`), the
+     `changeable_in_readonly` footgun, and the operator's option of
+     whitelisting specific tunables (`max_threads`, `max_memory_usage`)
+     as `CHANGEABLE_IN_READONLY` server-side.
+6. Unit test in `settings_test.go` covering parse of both new fields,
+   both JSON shapes.
+
+Deliverable: config-only PR (no runtime behavior change yet) that can
+be reviewed independently.
+
+---
+
+## Phase 2 — Runtime injection
+
+Files: `pkg/plugin/driver.go`.
+
+1. Add a helper on `Settings`:
+   ```go
+   // EnforcedSettings returns the subset of CustomSettings marked
+   // Enforced. Returns nil if empty.
+   func (s Settings) enforcedSettings() clickhouse.Settings { ... }
+
+   func (s Settings) shouldForceReadOnly() bool {
+       return s.EnforceReadOnly || len(s.enforcedSettings()) > 0
+   }
+   ```
+2. At pool creation in `driver.go`, do **not** put enforced settings
+   into `Options.Settings` — they need to be re-applied per query
+   (values may depend on request context in future; and we want
+   `readonly=1` to be the last thing applied, deterministically).
+   Leave the existing pool-level `customSettings` behavior for
+   non-enforced entries.
+3. Introduce a wrapper that attaches enforced settings to the query
+   context. Two candidate integration points:
+   - **Preferred**: inside the sqlds handler path. sqlds calls
+     `DB.QueryContext` under the hood; we need the context passed to
+     that call to carry `clickhouse.WithSettings`. The plugin already
+     implements `MutateQuery(ctx, req) -> (ctx, req)` — extend that to
+     attach the enforced settings to `ctx`. Verify sqlds threads the
+     returned `ctx` all the way to the driver call.
+   - **Fallback**: wrap the `*sql.DB` returned to sqlds so every
+     `QueryContext`/`ExecContext`/`PrepareContext` call unwraps or
+     augments the context. More invasive but robust.
+4. The settings map to attach per query:
+   ```go
+   s := clickhouse.Settings{}
+   for k, v := range settings.enforcedSettings() { s[k] = v }
+   if settings.shouldForceReadOnly() { s["readonly"] = uint8(1) }
+   ctx = clickhouse.Context(ctx, clickhouse.WithSettings(s))
+   ```
+   Ordering note: whether `readonly` goes into the same map as the
+   enforced value is fine — ClickHouse applies the whole map atomically
+   before parsing the SQL. Confirmed in Phase 0.
+5. Keep the existing pool-level `Options.Settings` for
+   non-enforced `customSettings` and `limit`. Enforced settings must not
+   be duplicated pool-side, so they're always re-applied at
+   query-context level (single source of truth).
+6. Do **not** touch `query.RawSQL`. Macro interpolation, comment
+   injection, and `MutateQueryData` remain unchanged.
+7. Error mapping: in the existing `MutateQueryError`, detect
+   ClickHouse's readonly-rejection error code (currently `164
+   READONLY`) and surface a friendlier message like: "This datasource
+   is configured to enforce read-only queries; `SET`/`SETTINGS` clauses
+   that change server settings are not allowed. Contact your
+   administrator." Keep the original error attached.
+
+Deliverable: runtime PR building on Phase 1, with unit tests for the
+context-attachment helper.
+
+---
+
+## Phase 3 — Health check / config validation
+
+Files: `pkg/plugin/datasource.go` (CheckHealth path),
+`pkg/plugin/schema.go` (if reused there).
+
+1. Extend the datasource health check. When enforced settings are
+   configured, additionally probe:
+   - `SELECT getSetting('<enforced_name>')` under the enforced
+     settings map → must succeed and return the configured value.
+   - `SELECT 1 SETTINGS <enforced_name>='__probe_override__'`
+     under the enforced settings map → must **fail** with
+     `READONLY` (or the query result must still show the enforced
+     value, depending on CH version). If it succeeds and returns the
+     override value, the enforced setting is `CHANGEABLE_IN_READONLY`
+     on the server — surface a loud failure in health output.
+   - Query `system.settings_profile_elements` /
+     `system.settings` for the connecting user to verify no
+     conflicting `readonly=1` server-side profile (which would prevent
+     us from setting the enforced value in the first place).
+2. Return actionable messages for the three failure modes (setting
+   missing, setting overridable, connecting user already readonly).
+3. Add integration coverage — see Phase 4.
+
+Deliverable: health-check PR, small.
+
+---
+
+## Phase 4 — Tests
+
+Files: `pkg/plugin/driver_test.go`,
+`pkg/plugin/driver_integration_test.go`,
+`pkg/plugin/settings_test.go`.
+
+1. Unit tests:
+   - `settings_test.go`: JSON parse for new fields, defaulting rules
+     (`Enforced=true` implies `EnforceReadOnly=true` at load), both
+     bool/string encodings.
+   - `driver_test.go`: verify the query context carries the correct
+     `clickhouse.Settings` when enforced settings are configured.
+     Use a fake settings map extraction hook — or add a small exported
+     accessor for tests to read the value out of `ctx`.
+2. Integration tests (opt-in via existing tags; both Native and HTTP):
+   - Positive path: enforced setting is visible via `getSetting` inside
+     the user's SELECT.
+   - Override rejection: a user query with `SETTINGS custom_x='evil'`
+     fails with `READONLY`.
+   - `SET` rejection: multi-statement `SET custom_x='evil'; SELECT ...`
+     fails.
+   - Downgrade rejection: `SETTINGS readonly=0` fails.
+   - Whitelisted tunable: a server-side `CHANGEABLE_IN_READONLY`
+     setting (e.g. `max_threads`) can still be tuned per query
+     (proves we didn't over-restrict).
+   - Health check: probe query behavior across the three failure modes
+     above.
+3. Extend `docker-compose.yml` / test fixtures with a users.xml (or SQL
+   grant script) that:
+   - Creates a test user with a `custom_visible_tenants` setting
+     available.
+   - Marks `max_threads` as `CHANGEABLE_IN_READONLY` for the whitelist
+     test.
+   - Ensures no `CONST` on `custom_visible_tenants` (so the plugin's
+     value takes effect, not a server default).
+
+Deliverable: tests committed alongside their respective phase PRs, not
+in a separate one.
+
+---
+
+## Phase 5 — Observability & rollout
+
+1. Log (info) when enforced settings are being applied to a query, at
+   startup and once per request via existing tracing spans
+   (`clickhouse mutate_query` already exists in `MutateQuery`). Add
+   span attributes:
+   - `clickhouse.enforced_settings.count`
+   - `clickhouse.enforced_readonly` (bool)
+   Avoid logging the enforced *values* at info level — they can encode
+   tenant identity.
+2. CHANGELOG entry describing:
+   - The new feature and the read-only side effect.
+   - The `CHANGEABLE_IN_READONLY` server-side escape hatch for tunables.
+   - Explicit statement that this is a defense-in-depth layer meant to
+     be combined with ClickHouse row policies using
+     `getSetting('custom_x')`.
+3. Feature-flag consideration: since the toggle is per datasource and
+   opt-in, no Grafana feature flag is needed. Consider a boot-time log
+   line summarizing enforced settings at datasource instance creation
+   for auditability.
+4. Migration guidance in docs: current users of the `CONST` /
+   per-tenant-user pattern can migrate by removing the per-tenant users
+   / `CONST` profile and enabling this feature; row policies stay the
+   same.
+
+---
+
+## Order of PRs (suggested)
+
+1. **PR 1 (Phase 1)** — config + docs + settings tests. No runtime
+   effect.
+2. **PR 2 (Phase 2 + Phase 4 unit tests)** — runtime injection and
+   error mapping.
+3. **PR 3 (Phase 3 + Phase 4 integration tests)** — health check,
+   integration coverage, CHANGELOG.
+
+Each PR is independently revertible. Split further if the config UI
+work is large in the frontend.
+
+---
+
+## Out of scope for this plan
+
+- Deriving the enforced value from Grafana user identity (per-request
+  tenant resolution). The interface above accepts static enforced
+  values only. Dynamic values would require an additional resolver
+  hook plumbed into `MutateQuery` — feasible on top of this plan but
+  best done as a follow-up once the static case is proven.
+- Client-side SQL pre-parsing to reject `SETTINGS` / `SET` before the
+  server sees them. Not needed; deliberately omitted to keep the
+  server as the single source of enforcement truth.
+- Session-based (`session_id`) implementation. Not needed; per-query
+  settings are sufficient and work identically across Native and HTTP.

--- a/notes-enforced-settings.md
+++ b/notes-enforced-settings.md
@@ -1,0 +1,273 @@
+# Enforcing ClickHouse server-side settings from the datasource
+
+## Current state
+
+Server-side settings are already configurable but **not enforced**. In
+`pkg/plugin/settings.go` there is a `CustomSettings []CustomSetting` field
+(a list of `{setting, value}` pairs, editable from the datasource config
+UI), which in `driver.go` (lines 198–208, 237) is passed to `clickhouse-go`
+as `clickhouse.Options.Settings`:
+
+```go
+customSettings := make(clickhouse.Settings)
+for _, setting := range settings.CustomSettings {
+    customSettings[setting.Setting] = setting.Value
+}
+...
+opts := &clickhouse.Options{ ..., Settings: customSettings, ... }
+```
+
+Those become **per-request defaults** (HTTP query-string params or the
+Native protocol's per-query settings block). A user's
+`SETTINGS visible_tenants='...'` clause in their SQL — or a `SET`
+statement — will still override them. So today, the datasource cannot
+securely impose a variable a user can't escape.
+
+## Can it be enforced purely from the client side?
+
+**No, not securely.** ClickHouse deliberately keeps that responsibility
+on the server. Any client-only scheme (rejecting queries that contain
+`SETTINGS`/`SET`, wrapping user SQL in a subquery, stripping tokens, etc.)
+is defeatable via comments, string concatenation in query variables,
+macros, multi-statement, alternative clauses like `FORMAT ... SETTINGS`,
+INSERT/CREATE variants, etc. Even if the parsing were airtight, the
+datasource still runs queries as one DB user, so any hardened tenancy
+boundary has to live in the server anyway.
+
+## The right mechanism (server-side, already available)
+
+ClickHouse has exactly the primitives you want:
+
+1. **Settings constraints with `CONST` / `readonly`** — attach a
+   constraint to a user or settings profile so the value cannot be
+   changed by `SET` or a query-level `SETTINGS` clause. Any override
+   attempt is rejected.
+
+   SQL form:
+   ```sql
+   CREATE SETTINGS PROFILE tenant_t1t2
+     SETTINGS custom_visible_tenants = 't1,t2' CONST
+     TO grafana_user_tenant_a;
+   ```
+
+   XML form (`users.xml` / profile config):
+   ```xml
+   <profiles><tenant_t1t2>
+     <constraints>
+       <custom_visible_tenants><readonly/></custom_visible_tenants>
+     </constraints>
+     <custom_visible_tenants>t1,t2</custom_visible_tenants>
+   </tenant_t1t2></profiles>
+   ```
+
+   Custom (user-defined) settings must be prefixed with `custom_` (or
+   another prefix configured via `<custom_settings_prefixes>`).
+
+2. **Row policies that read the setting**, so the constraint actually
+   gates data:
+   ```sql
+   CREATE ROW POLICY tenant_filter ON events
+     USING has(splitByChar(',', getSetting('custom_visible_tenants')), tenant_id)
+     TO ALL;
+   ```
+
+3. Combine this with a per-tenant DB user, and point each Grafana
+   datasource at that user. The datasource's existing **Custom Settings**
+   field can then optionally re-send the same value (harmless — the
+   server will accept a value equal to the CONST one, or you can just
+   omit it because the profile supplies the default).
+
+There is no "dictionary variable" primitive that behaves like a session
+variable; `custom_*` settings + `getSetting()` in row policies / views is
+the idiomatic ClickHouse pattern for this.
+
+## Feasibility of adding stronger support in the plugin
+
+Options, roughly in order of value:
+
+- **Docs only (recommended, minimal work).** Add a section to
+  `README.md` / `docs/` explaining the pattern above and noting that
+  `CustomSettings` provides *defaults*, not enforcement. This is the
+  honest answer and requires no code.
+- **Small UX improvement.** Add a "Server-enforced" hint next to Custom
+  Settings in the config editor UI, and optionally a per-row "readonly"
+  checkbox that, when checked, does two things: (a) sends the setting as
+  usual, and (b) at datasource save time issues a health-check query
+  verifying the setting is `CONST` on the connecting user (e.g.
+  `SELECT readonly FROM system.settings_profile_elements WHERE ...`, or
+  attempt `SET name=<other>` and expect an error). This gives operators
+  a signal that their server config actually enforces what they think it
+  does. Feasible; ~a day of work; no security regression.
+- **Best-effort client blocking.** Reject user queries that contain
+  `SETTINGS`/`SET`/known keywords via a regex or a real SQL pre-parse.
+  Straightforward to implement in `MutateQueryData`/`Interpolate`, but
+  should be advertised as defense-in-depth only, never as a security
+  boundary. Don't ship this without the server-side piece.
+- **Actually enforce client-side.** Not feasible in a way that would
+  survive review as a multi-tenancy control. Don't.
+
+## Bottom line
+
+The datasource already lets you send server-side settings; it does not
+(and realistically cannot) prevent a user from overriding them in SQL.
+For multi-tenant enforcement, configure the setting as `CONST` on a
+ClickHouse settings profile / user and enforce access with row policies
+that read it via `getSetting('custom_visible_tenants')`. On the plugin
+side, the useful addition is documentation plus optionally a config-save
+check that verifies the setting is truly `CONST` on the server.
+
+---
+
+# Follow-up: per-query `readonly=1` to avoid per-tenant DB users
+
+Goal: avoid a dedicated DB user (or `CONST` profile) per tenant. Users
+that can see multiple tenants would otherwise produce a combinatorial
+explosion of profiles.
+
+## The mechanism
+
+ClickHouse's `readonly` values:
+
+- `0` – full access.
+- `1` – SELECT/SHOW only. **`SET` is forbidden and any `SETTINGS ...`
+  clause in a query that tries to change a setting is rejected** (unless
+  that setting is marked `CHANGEABLE_IN_READONLY` on the server).
+- `2` – same write restrictions as `1`, but the user *can* change other
+  settings per query. Not what we want.
+
+Two hard rules that make this safe:
+
+1. From `readonly=1` (or `2`) you cannot go back down. `readonly=0` is
+   always rejected once `readonly>0`.
+2. Under `readonly=1`, any `SETTINGS foo=…` / `SET foo=…` in the user's
+   SQL is rejected outright.
+
+Pattern: on every query, send
+`custom_visible_tenants='t1,t2', readonly=1` as request/query-scope
+settings alongside the user's SQL. When the server parses the user's
+SQL, `readonly` is already `1`, so their inline `SETTINGS` / `SET` are
+refused before they can take effect. `readonly` can only be increased,
+so they can't turn it back off.
+
+No persistent session needed. Works as per-query settings passed
+through `clickhouse-go`'s `Options.Settings` (or
+`clickhouse.WithSettings` on a query context). Pooling is fine, no
+dedicated connection, no per-tenant DB user, no `CONST` profile.
+
+## Datasource change sketch
+
+Small and localized:
+
+1. New config field `EnforcedSettings []{Name, Value}` (or add an
+   `enforced: bool` flag to each `CustomSetting`).
+2. In `driver.go`, per-request (`MutateQueryData` and the direct SQL
+   path), build a settings map that always includes:
+   - each enforced `{name, value}` pair
+   - `"readonly": 1`
+   and pass it via `clickhouse.Context(clickhouse.WithSettings(...))`
+   for that query.
+3. Populate the enforced value per request from wherever the tenant
+   mapping lives (e.g. from a Grafana-forwarded header — the plugin
+   already does header forwarding in `MutateQueryData`).
+
+Row policies on the tables use `getSetting('custom_visible_tenants')`
+exactly as before. No per-tenant users, no combinatorial profile
+explosion.
+
+## Caveats
+
+- **All queries become read-only.** No `INSERT`/DDL through this
+  datasource. Usually fine for dashboards/exploration; make it opt-in.
+- **`max_execution_time`, `max_memory_usage`, etc. in the user's
+  `SETTINGS` clause will start failing.** Users often add these via
+  the query editor. Mitigation is server-side and generic (not per
+  tenant): mark the specific tunables the operator wants to allow with
+  `<changeable_in_readonly/>` in `users.xml` or
+  `ALTER SETTINGS PROFILE default SETTINGS max_threads WRITABLE`. Do
+  this once per cluster; doesn't scale with tenant count.
+- **Do NOT mark the tenant setting `CHANGEABLE_IN_READONLY`.** If any
+  operator does, the guarantee collapses. Call this out prominently in
+  docs; worth a health check.
+- **The connecting DB user must start at `readonly=0`.** If it's
+  already `readonly=1`, the plugin can't set the tenant variable at
+  all. If it's `readonly=2`, we can still set the tenant variable and
+  narrow to `1` in the same settings map — ClickHouse allows
+  increasing restriction.
+- **Table functions.** `remote()`, `url()`, `file()`, `s3()` etc. are
+  already blocked or gated by additional settings under `readonly=1`
+  — good, since `remote()` could otherwise bypass row policies. Verify
+  on the target CH version.
+- **`SETTINGS readonly=2` in a user query.** Increases restriction,
+  allowed, harmless.
+- **Interaction with existing `CustomSettings`.** Same field can carry
+  them; the new twist is also injecting `readonly=1`. Keep the two
+  lists (enforced vs advisory) if you want to distinguish.
+- **Ad-hoc `SET`/`SETTINGS` errors.** Users hitting these will get an
+  error. Add a helpful message in the plugin's error mapper
+  (`MutateQueryError`) so the cause is obvious.
+- **Verify at connection health check.** Run a probe like
+  `SELECT 1 SETTINGS custom_visible_tenants='__probe__'` and expect an
+  error under `readonly=1` — surfaces mis-config early.
+
+## Verdict
+
+Yes — send `<enforced settings>, readonly=1` as per-query settings on
+every query. The two ClickHouse invariants (readonly can only be
+tightened; readonly=1 rejects per-query setting changes) give the
+tamper-resistance we want, without a dedicated user per tenant or a
+`CONST` profile. Cost is ~a small config field + a few lines in
+`driver.go` where the settings map is built, plus documentation about
+the read-only side effects and the `changeable_in_readonly` footgun.
+
+---
+
+## Clarification: no SQL rewriting, no ClickHouse sessions
+
+The scheme does **not** mutate the user's SQL, and does **not** rely on
+ClickHouse "sessions" (`session_id` cookies) or a dedicated pinned
+connection.
+
+### Protocol / session posture today
+
+- The datasource supports **both Native TCP and HTTP** (user-selectable
+  via `Protocol` in `settings.go`). It is not HTTP-only.
+- Neither path uses ClickHouse's `session_id` mechanism. `driver.go`
+  calls `clickhouse.OpenDB(opts)` and lets `database/sql` pool
+  connections; nothing pins a `*sql.Conn` or sends `session_id` /
+  `session_timeout`.
+- `Options.Settings` is set once at pool creation, and clickhouse-go
+  re-sends those settings **per query** on both protocols (query-string
+  params on HTTP; the query-level settings block in the Native
+  handshake for each query).
+
+### Enforced settings ride out-of-band with the SQL
+
+The enforced values (`custom_visible_tenants='…'`, `readonly=1`) go into
+the same per-query settings channel:
+
+- **Native**: extend the settings map on the query context via
+  `clickhouse.Context(ctx, clickhouse.WithSettings(...))`, or extend the
+  pool-level `Options.Settings` for static values.
+- **HTTP**: same map, serialized by clickhouse-go as URL query params on
+  the POST (e.g. `?readonly=1&custom_visible_tenants=t1,t2`). SQL stays
+  in the request body.
+
+The user's `RawSQL` is not edited. `MutateQuery` / `MutateQueryData`
+don't need to touch it. Macro interpolation is unaffected.
+
+### Why this matters
+
+1. No SQL parsing/rewriting fragility — no need to worry about comments,
+   string literals, `FORMAT ... SETTINGS`, trailing `SETTINGS`, multi-
+   statement, etc. ClickHouse itself enforces the boundary once
+   `readonly=1` is active for the query.
+2. The user sees exactly the SQL they typed in Grafana's query inspector
+   and in error messages. The enforced settings appear only in
+   ClickHouse's `system.query_log` under `Settings`.
+3. Works identically over Native and HTTP; no need to add session
+   support to the plugin.
+
+The only user-visible SQL-adjacent change is optional: mapping a
+`readonly`-rejection server error to a clearer message in
+`MutateQueryError`. That's an error-message improvement, not a query
+rewrite.

--- a/pkg/plugin/datasource.go
+++ b/pkg/plugin/datasource.go
@@ -27,7 +27,12 @@ func (i *clickhouseInstance) Dispose() {
 
 func NewDatasource(ctx context.Context, settings backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
 	clickhousePlugin := Clickhouse{}
+	if s, err := LoadSettings(ctx, settings); err == nil {
+		clickhousePlugin.enforceReadOnly = s.EnforceReadOnly
+		clickhousePlugin.enforcedChSettings = buildEnforcedChSettings(s)
+	}
 	ds := sqlds.NewDatasource(&clickhousePlugin)
+
 	// Replace sqlds's default sqlutil.Interpolate pipeline with the
 	// macropro-backed interpolator; see interpolateMacros in driver.go.
 	ds.Interpolator = interpolateMacros

--- a/pkg/plugin/datasource.go
+++ b/pkg/plugin/datasource.go
@@ -2,6 +2,7 @@ package plugin
 
 import (
 	"context"
+	"strings"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/instancemgmt"
@@ -27,11 +28,18 @@ func (i *clickhouseInstance) Dispose() {
 
 func NewDatasource(ctx context.Context, settings backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
 	clickhousePlugin := Clickhouse{}
-	if s, err := LoadSettings(ctx, settings); err == nil {
+	s, settingsErr := LoadSettings(ctx, settings)
+	if settingsErr == nil {
 		clickhousePlugin.enforceReadOnly = s.EnforceReadOnly
 		clickhousePlugin.enforcedChSettings = buildEnforcedChSettings(s)
+		logEnforcedSettingsStartup(s)
 	}
 	ds := sqlds.NewDatasource(&clickhousePlugin)
+
+	// Wire enforced-settings health probes to run after the basic connectivity check.
+	if settingsErr == nil && s.shouldForceReadOnly() {
+		ds.PostCheckHealth = makeEnforcedSettingsHealthCheck(s, settings)
+	}
 
 	// Replace sqlds's default sqlutil.Interpolate pipeline with the
 	// macropro-backed interpolator; see interpolateMacros in driver.go.
@@ -65,4 +73,23 @@ func NewDatasource(ctx context.Context, settings backend.DataSourceInstanceSetti
 		return inst, nil
 	}
 	return &clickhouseInstance{SQLDatasource: sqlInst, schema: schemaProvider}, nil
+}
+
+// logEnforcedSettingsStartup emits a single Info line summarising the enforced-settings
+// configuration at datasource instance creation time. Names only — no values.
+func logEnforcedSettingsStartup(s Settings) {
+	if !s.shouldForceReadOnly() {
+		return
+	}
+	names := make([]string, 0)
+	for _, cs := range s.CustomSettings {
+		if cs.Enforced {
+			names = append(names, cs.Setting)
+		}
+	}
+	backend.Logger.Info("clickhouse datasource: enforced settings active",
+		"enforced_setting_count", len(names),
+		"enforced_setting_names", strings.Join(names, ","),
+		"enforce_readonly", s.EnforceReadOnly,
+	)
 }

--- a/pkg/plugin/driver.go
+++ b/pkg/plugin/driver.go
@@ -555,6 +555,18 @@ func (h *Clickhouse) MutateQuery(ctx context.Context, req backend.DataQuery) (co
 	if len(h.enforcedChSettings) > 0 {
 		ctx = clickhouse.Context(ctx, clickhouse.WithSettings(h.enforcedChSettings))
 		ctx = context.WithValue(ctx, enforcedSettingsCtxKey, h.enforcedChSettings)
+
+		// Record the number of user-configured enforced settings (not counting
+		// readonly=1 itself) and whether read-only enforcement is active.
+		// Values are intentionally omitted — they can encode tenant identity.
+		userSettingCount := len(h.enforcedChSettings)
+		if h.enforceReadOnly {
+			userSettingCount--
+		}
+		span.SetAttributes(
+			attribute.Int("clickhouse.enforced_settings.count", userSettingCount),
+			attribute.Bool("clickhouse.enforced_readonly", h.enforceReadOnly),
+		)
 	}
 
 	comments := make([]string, 0, 4)

--- a/pkg/plugin/driver.go
+++ b/pkg/plugin/driver.go
@@ -40,9 +40,42 @@ type grafanaHeaders struct {
 	RuleUID      string
 }
 
+// enforcedSettingsCtxKeyType is the key type for storing the enforced
+// clickhouse.Settings in the context, used by tests to verify attachment.
+type enforcedSettingsCtxKeyType struct{}
+
+var enforcedSettingsCtxKey = enforcedSettingsCtxKeyType{}
+
 // Clickhouse defines how to connect to a Clickhouse datasource
 type Clickhouse struct {
-	SchemaDatasource *schemas.SchemaDatasource
+	SchemaDatasource   *schemas.SchemaDatasource
+	enforceReadOnly    bool
+	enforcedChSettings clickhouse.Settings // pre-built at instance creation; nil when empty
+}
+
+// buildEnforcedChSettings constructs the clickhouse.Settings map that must be
+// injected on every query when enforced settings or readonly=1 are configured.
+// Returns nil when neither applies. Never mutate the returned map.
+func buildEnforcedChSettings(s Settings) clickhouse.Settings {
+	m := s.enforcedSettings()
+	if !s.shouldForceReadOnly() && len(m) == 0 {
+		return nil
+	}
+	cs := make(clickhouse.Settings, len(m)+1)
+	for k, v := range m {
+		cs[k] = v
+	}
+	if s.shouldForceReadOnly() {
+		cs["readonly"] = uint8(1)
+	}
+	return cs
+}
+
+// enforcedSettingsFromContext returns the enforced clickhouse.Settings stored
+// in ctx by MutateQuery. Returns nil when none were attached. Used by tests.
+func enforcedSettingsFromContext(ctx context.Context) clickhouse.Settings {
+	s, _ := ctx.Value(enforcedSettingsCtxKey).(clickhouse.Settings)
+	return s
 }
 
 // getTLSConfig returns tlsConfig from settings
@@ -198,7 +231,9 @@ func (h *Clickhouse) Connect(
 	customSettings := make(clickhouse.Settings)
 	if settings.CustomSettings != nil {
 		for _, setting := range settings.CustomSettings {
-			customSettings[setting.Setting] = setting.Value
+			if !setting.Enforced {
+				customSettings[setting.Setting] = setting.Value
+			}
 		}
 	}
 
@@ -305,8 +340,18 @@ func (h *Clickhouse) Macros() sqlds.Macros {
 	return sqlds.Macros{}
 }
 
-// MutateQueryError marks ClickHouse errors as downstream errors
+// MutateQueryError marks ClickHouse errors as downstream errors.
+// When EnforceReadOnly is active, READONLY errors (code 164) are rewritten
+// with a friendlier message explaining that readonly=1 is enforced.
 func (h *Clickhouse) MutateQueryError(err error) backend.ErrorWithSource {
+	var ex *clickhouse.Exception
+	if errors.As(err, &ex) && ex.Code == 164 && h.enforceReadOnly {
+		friendly := fmt.Sprintf(
+			"query rejected: this datasource enforces server-side ClickHouse settings and runs queries under readonly=1; "+
+				"SET/SETTINGS clauses that change server settings are not allowed. Original error: %s", err)
+		combined := errors.Join(errors.New(friendly), err)
+		return backend.NewErrorWithSource(combined, backend.ErrorSourceDownstream)
+	}
 	// Check if any error in the error chain (including multi-errors) is a clickhouse.Exception
 	if containsClickHouseException(err) {
 		return backend.NewErrorWithSource(err, backend.ErrorSourceDownstream)
@@ -502,6 +547,15 @@ func (h *Clickhouse) MutateQuery(ctx context.Context, req backend.DataQuery) (co
 	))
 
 	defer span.End()
+
+	// Attach enforced settings (including readonly=1 when configured) to the
+	// query context so the clickhouse-go driver sends them per query, after
+	// the user's SQL is parsed. This means ClickHouse enforces readonly before
+	// it can parse any SETTINGS / SET clauses in the user's SQL.
+	if len(h.enforcedChSettings) > 0 {
+		ctx = clickhouse.Context(ctx, clickhouse.WithSettings(h.enforcedChSettings))
+		ctx = context.WithValue(ctx, enforcedSettingsCtxKey, h.enforcedChSettings)
+	}
 
 	comments := make([]string, 0, 4)
 

--- a/pkg/plugin/driver_test.go
+++ b/pkg/plugin/driver_test.go
@@ -578,3 +578,193 @@ func TestMissingTableMacroIsDownstream(t *testing.T) {
 	require.Error(t, got.Error)
 	assert.Equal(t, backend.ErrorSourceDownstream, got.ErrorSource)
 }
+
+// ---------------------------------------------------------------------------
+// Phase 2: enforced settings helpers
+// ---------------------------------------------------------------------------
+
+func TestEnforcedSettings(t *testing.T) {
+	t.Run("one enforced setting returns it in the map", func(t *testing.T) {
+		s := Settings{
+			CustomSettings: []CustomSetting{
+				{Setting: "custom_tenant", Value: "t1", Enforced: true},
+			},
+			EnforceReadOnly: true,
+		}
+		got := s.enforcedSettings()
+		require.NotNil(t, got)
+		assert.Equal(t, clickhouse.CustomSetting{Value: "t1"}, got["custom_tenant"])
+		assert.Len(t, got, 1)
+	})
+
+	t.Run("non-enforced entries are absent", func(t *testing.T) {
+		s := Settings{
+			CustomSettings: []CustomSetting{
+				{Setting: "advisory", Value: "x", Enforced: false},
+				{Setting: "custom_tenant", Value: "t1", Enforced: true},
+			},
+			EnforceReadOnly: true,
+		}
+		got := s.enforcedSettings()
+		assert.NotContains(t, got, "advisory")
+		assert.Contains(t, got, "custom_tenant")
+	})
+
+	t.Run("no enforced entries returns nil", func(t *testing.T) {
+		s := Settings{
+			CustomSettings: []CustomSetting{
+				{Setting: "advisory", Value: "x"},
+			},
+			EnforceReadOnly: false,
+		}
+		assert.Nil(t, s.enforcedSettings())
+	})
+}
+
+func TestShouldForceReadOnly(t *testing.T) {
+	t.Run("EnforceReadOnly true with no enforced settings", func(t *testing.T) {
+		s := Settings{EnforceReadOnly: true}
+		assert.True(t, s.shouldForceReadOnly())
+		assert.Nil(t, s.enforcedSettings())
+	})
+
+	t.Run("enforced setting auto-enables shouldForceReadOnly", func(t *testing.T) {
+		s := Settings{
+			CustomSettings: []CustomSetting{
+				{Setting: "custom_tenant", Value: "t1", Enforced: true},
+			},
+			EnforceReadOnly: true, // set by Phase 1 load logic
+		}
+		assert.True(t, s.shouldForceReadOnly())
+	})
+
+	t.Run("no enforced settings and EnforceReadOnly false", func(t *testing.T) {
+		s := Settings{}
+		assert.False(t, s.shouldForceReadOnly())
+		assert.Nil(t, s.enforcedSettings())
+	})
+
+	t.Run("non-enforced settings do not trigger shouldForceReadOnly", func(t *testing.T) {
+		s := Settings{
+			CustomSettings: []CustomSetting{
+				{Setting: "advisory", Value: "x", Enforced: false},
+			},
+		}
+		assert.False(t, s.shouldForceReadOnly())
+	})
+}
+
+func TestBuildEnforcedChSettings(t *testing.T) {
+	t.Run("enforced setting + readonly=1 included", func(t *testing.T) {
+		s := Settings{
+			CustomSettings:  []CustomSetting{{Setting: "custom_tenant", Value: "t1", Enforced: true}},
+			EnforceReadOnly: true,
+		}
+		got := buildEnforcedChSettings(s)
+		require.NotNil(t, got)
+		assert.Equal(t, clickhouse.CustomSetting{Value: "t1"}, got["custom_tenant"])
+		assert.Equal(t, uint8(1), got["readonly"])
+	})
+
+	t.Run("EnforceReadOnly only (no custom enforced) includes readonly=1", func(t *testing.T) {
+		s := Settings{EnforceReadOnly: true}
+		got := buildEnforcedChSettings(s)
+		require.NotNil(t, got)
+		assert.Equal(t, uint8(1), got["readonly"])
+		assert.Len(t, got, 1)
+	})
+
+	t.Run("neither flag returns nil", func(t *testing.T) {
+		s := Settings{}
+		assert.Nil(t, buildEnforcedChSettings(s))
+	})
+
+	t.Run("non-enforced settings are absent from the map", func(t *testing.T) {
+		s := Settings{
+			CustomSettings: []CustomSetting{
+				{Setting: "advisory", Value: "x", Enforced: false},
+			},
+			EnforceReadOnly: true,
+		}
+		got := buildEnforcedChSettings(s)
+		assert.NotContains(t, got, "advisory")
+	})
+}
+
+func TestEnforcedSettingsContextAttachment(t *testing.T) {
+	t.Run("MutateQuery attaches enforced settings to context", func(t *testing.T) {
+		s := Settings{
+			CustomSettings:  []CustomSetting{{Setting: "custom_tenant", Value: "t1", Enforced: true}},
+			EnforceReadOnly: true,
+		}
+		h := &Clickhouse{
+			enforceReadOnly:    s.EnforceReadOnly,
+			enforcedChSettings: buildEnforcedChSettings(s),
+		}
+
+		newCtx, _ := h.MutateQuery(t.Context(), backend.DataQuery{JSON: []byte(`{}`)})
+
+		got := enforcedSettingsFromContext(newCtx)
+		require.NotNil(t, got)
+		assert.Equal(t, clickhouse.CustomSetting{Value: "t1"}, got["custom_tenant"])
+		assert.Equal(t, uint8(1), got["readonly"])
+	})
+
+	t.Run("no enforced settings leaves context clean", func(t *testing.T) {
+		h := &Clickhouse{}
+		newCtx, _ := h.MutateQuery(t.Context(), backend.DataQuery{JSON: []byte(`{}`)})
+		assert.Nil(t, enforcedSettingsFromContext(newCtx))
+	})
+}
+
+func TestMutateQueryError_ReadOnly(t *testing.T) {
+	ex164 := &clickhouse.Exception{Code: 164, Message: "cannot execute query in readonly mode"}
+
+	t.Run("code 164 with EnforceReadOnly=true returns friendly DownstreamError", func(t *testing.T) {
+		h := &Clickhouse{enforceReadOnly: true}
+		result := h.MutateQueryError(ex164)
+
+		assert.True(t, backend.IsDownstreamError(result))
+		assert.Contains(t, result.Error(), "query rejected")
+		assert.Contains(t, result.Error(), "readonly=1")
+		assert.Contains(t, result.Error(), ex164.Error())
+
+		// original exception still accessible in chain
+		var got *clickhouse.Exception
+		assert.True(t, errors.As(result, &got))
+		assert.Equal(t, int32(164), got.Code)
+	})
+
+	t.Run("code 164 with EnforceReadOnly=false is NOT rewritten", func(t *testing.T) {
+		h := &Clickhouse{enforceReadOnly: false}
+		result := h.MutateQueryError(ex164)
+
+		assert.True(t, backend.IsDownstreamError(result))
+		assert.Equal(t, ex164.Error(), result.Error())
+	})
+
+	t.Run("non-164 exception is not rewritten", func(t *testing.T) {
+		ex60 := &clickhouse.Exception{Code: 60, Message: "Unknown table"}
+		h := &Clickhouse{enforceReadOnly: true}
+		result := h.MutateQueryError(ex60)
+
+		assert.True(t, backend.IsDownstreamError(result))
+		assert.Equal(t, ex60.Error(), result.Error())
+	})
+
+	t.Run("non-clickhouse error is plugin error", func(t *testing.T) {
+		h := &Clickhouse{enforceReadOnly: true}
+		err := errors.New("connection timeout")
+		result := h.MutateQueryError(err)
+		assert.False(t, backend.IsDownstreamError(result))
+	})
+
+	t.Run("wrapped 164 exception with EnforceReadOnly=true is rewritten", func(t *testing.T) {
+		h := &Clickhouse{enforceReadOnly: true}
+		wrapped := fmt.Errorf("query failed: %w", ex164)
+		result := h.MutateQueryError(wrapped)
+
+		assert.True(t, backend.IsDownstreamError(result))
+		assert.Contains(t, result.Error(), "query rejected")
+	})
+}

--- a/pkg/plugin/enforced_settings_integration_test.go
+++ b/pkg/plugin/enforced_settings_integration_test.go
@@ -1,0 +1,283 @@
+//go:build integration
+// +build integration
+
+package plugin
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	clickhouse_sql "github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// makeEnforcedDSSettings builds a backend.DataSourceInstanceSettings for an enforced
+// setting test. It patches the port based on protocol.
+func makeEnforcedDSSettings(t *testing.T, protocol clickhouse_sql.Protocol, enforcedName, enforcedValue string) backend.DataSourceInstanceSettings {
+	t.Helper()
+	port := getEnv("CLICKHOUSE_PORT", "9000")
+	if protocol == clickhouse_sql.HTTP {
+		port = getEnv("CLICKHOUSE_HTTP_PORT", "8123")
+	}
+	host := getEnv("CLICKHOUSE_HOST", "localhost")
+	username := getEnv("CLICKHOUSE_USERNAME", "default")
+	password := getEnv("CLICKHOUSE_PASSWORD", "")
+	proto := "native"
+	if protocol == clickhouse_sql.HTTP {
+		proto = "http"
+	}
+
+	csJSON, _ := json.Marshal([]map[string]interface{}{
+		{"setting": enforcedName, "value": enforcedValue, "enforced": true},
+	})
+	jsonData := fmt.Sprintf(
+		`{"host":%q,"port":%s,"username":%q,"protocol":%q,"enforceReadOnly":true,"queryTimeout":"10","dialTimeout":"10","customSettings":%s}`,
+		host, port, username, proto, string(csJSON),
+	)
+	secure := map[string]string{}
+	if password != "" {
+		secure["password"] = password
+	}
+	return backend.DataSourceInstanceSettings{
+		JSONData:                []byte(jsonData),
+		DecryptedSecureJSONData: secure,
+	}
+}
+
+// openEnforcedDB creates a *sql.DB via the Clickhouse plugin with the given DS settings.
+func openEnforcedDB(t *testing.T, dsSettings backend.DataSourceInstanceSettings) (*Clickhouse, *sql.DB) {
+	t.Helper()
+	plugin := &Clickhouse{}
+	s, err := LoadSettings(context.Background(), dsSettings)
+	require.NoError(t, err)
+	plugin.enforceReadOnly = s.EnforceReadOnly
+	plugin.enforcedChSettings = buildEnforcedChSettings(s)
+
+	db, err := plugin.Connect(context.Background(), dsSettings, json.RawMessage("{}"))
+	require.NoError(t, err)
+	t.Cleanup(func() { db.Close() })
+	return plugin, db
+}
+
+// enforcedCtx returns a context with the plugin's enforced settings attached —
+// replicating what MutateQuery does on every query.
+func enforcedCtx(ctx context.Context, plugin *Clickhouse) context.Context {
+	if len(plugin.enforcedChSettings) == 0 {
+		return ctx
+	}
+	return clickhouse_sql.Context(ctx, clickhouse_sql.WithSettings(plugin.enforcedChSettings))
+}
+
+func TestEnforcedSettingsE2E(t *testing.T) {
+	for protoName, proto := range Protocols {
+		protoName, proto := protoName, proto
+		t.Run(protoName, func(t *testing.T) {
+			t.Parallel()
+
+			const settingName = "custom_visible_tenants"
+			const settingValue = "t1,t2"
+			dsSettings := makeEnforcedDSSettings(t, proto, settingName, settingValue)
+			plugin, db := openEnforcedDB(t, dsSettings)
+			ctx := context.Background()
+			eCtx := enforcedCtx(ctx, plugin)
+
+			// ── Positive: getSetting returns the enforced value ──────────────────────
+			t.Run("GetSettingReturnsEnforcedValue", func(t *testing.T) {
+				var got string
+				err := db.QueryRowContext(eCtx, "SELECT getSetting('custom_visible_tenants')").Scan(&got)
+				require.NoError(t, err)
+				assert.Equal(t, settingValue, got)
+			})
+
+			// ── Override-rejection: inline SETTINGS override must fail ────────────────
+			t.Run("OverrideRejected", func(t *testing.T) {
+				rows, err := db.QueryContext(eCtx, "SELECT 1 SETTINGS custom_visible_tenants='evil'")
+				if rows != nil {
+					rows.Close()
+				}
+				require.Error(t, err, "inline SETTINGS override should fail under readonly=1")
+				assert.Contains(t, strings.ToLower(err.Error()), "readonly",
+					"expected a READONLY (164) error; got: %v", err)
+			})
+
+			// ── SET rejection ────────────────────────────────────────────────────────
+			t.Run("SetRejected", func(t *testing.T) {
+				rows, err := db.QueryContext(eCtx, "SET custom_visible_tenants='evil'")
+				if rows != nil {
+					rows.Close()
+				}
+				require.Error(t, err, "SET should fail under readonly=1")
+			})
+
+			// ── Downgrade rejection: SETTINGS readonly=0 must fail ───────────────────
+			t.Run("ReadonlyDowngradeRejected", func(t *testing.T) {
+				rows, err := db.QueryContext(eCtx, "SELECT 1 SETTINGS readonly=0")
+				if rows != nil {
+					rows.Close()
+				}
+				require.Error(t, err, "SETTINGS readonly=0 should fail under readonly=1")
+			})
+
+			// ── Row-policy smoke test ─────────────────────────────────────────────────
+			t.Run("RowPolicySmoke", func(t *testing.T) {
+				// Use a direct (admin) connection without enforced settings for DDL.
+				adminConn := setupConnection(t, proto, nil)
+				defer adminConn.Close()
+
+				table := "test_enforced_rp_table_" + protoName
+				policy := "test_enforced_rp_policy_" + protoName
+
+				// Try to create the policy; skip if access_management privileges are denied.
+				_, err := adminConn.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", table))
+				require.NoError(t, err)
+				_, err = adminConn.ExecContext(ctx,
+					fmt.Sprintf("CREATE TABLE %s (tenant_id String, value Int32) ENGINE=MergeTree ORDER BY tenant_id", table))
+				require.NoError(t, err)
+				t.Cleanup(func() {
+					_, _ = adminConn.ExecContext(ctx, fmt.Sprintf("DROP ROW POLICY IF EXISTS %s ON %s", policy, table))
+					_, _ = adminConn.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", table))
+				})
+
+				// Insert rows for tenants t1, t2, t3.
+				for _, row := range []struct {
+					tenant string
+					val    int
+				}{
+					{"t1", 1}, {"t2", 2}, {"t3", 3},
+				} {
+					_, err = adminConn.ExecContext(ctx,
+						fmt.Sprintf("INSERT INTO %s VALUES ('%s', %d)", table, row.tenant, row.val))
+					require.NoError(t, err)
+				}
+
+				// Create row policy that restricts to tenants in the setting.
+				_, err = adminConn.ExecContext(ctx, fmt.Sprintf(
+					"CREATE ROW POLICY IF NOT EXISTS %s ON %s USING has(splitByChar(',', getSetting('custom_visible_tenants')), tenant_id) TO ALL",
+					policy, table,
+				))
+				if err != nil {
+					if strings.Contains(err.Error(), "ACCESS_ENTITY_ALREADY_EXISTS") ||
+						strings.Contains(err.Error(), "Not enough privileges") ||
+						strings.Contains(err.Error(), "ACCESS_DENIED") {
+						t.Skipf("cannot create row policy (privilege denied): %v", err)
+					}
+					require.NoError(t, err, "create row policy")
+				}
+
+				// Query through the enforced-settings plugin connection — should see only t1, t2.
+				rows, err := db.QueryContext(eCtx, fmt.Sprintf("SELECT tenant_id FROM %s ORDER BY tenant_id", table))
+				require.NoError(t, err)
+				defer rows.Close()
+				var tenants []string
+				for rows.Next() {
+					var tid string
+					require.NoError(t, rows.Scan(&tid))
+					tenants = append(tenants, tid)
+				}
+				require.NoError(t, rows.Err())
+
+				assert.Equal(t, []string{"t1", "t2"}, tenants,
+					"row policy should filter to only enforced tenants t1,t2")
+			})
+
+			// ── Whitelist compatibility: max_threads (CHANGEABLE_IN_READONLY) ─────────
+			t.Run("WhitelistedSettingStillWorks", func(t *testing.T) {
+				rows, err := db.QueryContext(eCtx, "SELECT 1 SETTINGS max_threads=1")
+				if err != nil {
+					// This is expected to succeed if admin.xml has the <changeable_in_readonly/>
+					// constraint configured. If the server config is different, skip gracefully.
+					if strings.Contains(err.Error(), "READONLY") || strings.Contains(err.Error(), "164") {
+						t.Skipf("max_threads is not CHANGEABLE_IN_READONLY on this server; skipping whitelist test: %v", err)
+					}
+					require.NoError(t, err, "max_threads per-query override should succeed when marked CHANGEABLE_IN_READONLY")
+				}
+				if rows != nil {
+					rows.Close()
+				}
+			})
+		})
+	}
+}
+
+func TestEnforcedSettingsAbsent(t *testing.T) {
+	// Regression: without EnforceReadOnly, user queries with SETTINGS still work.
+	for protoName, proto := range Protocols {
+		protoName, proto := protoName, proto
+		t.Run(protoName, func(t *testing.T) {
+			t.Parallel()
+
+			port := getEnv("CLICKHOUSE_PORT", "9000")
+			if proto == clickhouse_sql.HTTP {
+				port = getEnv("CLICKHOUSE_HTTP_PORT", "8123")
+			}
+			host := getEnv("CLICKHOUSE_HOST", "localhost")
+			username := getEnv("CLICKHOUSE_USERNAME", "default")
+			password := getEnv("CLICKHOUSE_PASSWORD", "")
+			protoStr := "native"
+			if proto == clickhouse_sql.HTTP {
+				protoStr = "http"
+			}
+
+			jsonData := fmt.Sprintf(
+				`{"host":%q,"port":%s,"username":%q,"protocol":%q,"queryTimeout":"10","dialTimeout":"10"}`,
+				host, port, username, protoStr,
+			)
+			secure := map[string]string{}
+			if password != "" {
+				secure["password"] = password
+			}
+			dsSettings := backend.DataSourceInstanceSettings{
+				JSONData:                []byte(jsonData),
+				DecryptedSecureJSONData: secure,
+			}
+
+			plugin := &Clickhouse{} // enforceReadOnly = false
+			db, err := plugin.Connect(context.Background(), dsSettings, json.RawMessage("{}"))
+			require.NoError(t, err)
+			defer db.Close()
+
+			// Without enforced readonly, users can still tune max_threads per query.
+			rows, err := db.QueryContext(context.Background(), "SELECT 1 SETTINGS max_threads=1")
+			if rows != nil {
+				rows.Close()
+			}
+			assert.NoError(t, err, "non-enforced datasource should allow per-query SETTINGS")
+		})
+	}
+}
+
+func TestEnforcedSettingsHealthCheck(t *testing.T) {
+	// Verify that the health-check probes pass against a real ClickHouse with
+	// custom_visible_tenants enforced.
+	for protoName, proto := range Protocols {
+		protoName, proto := protoName, proto
+		t.Run(protoName, func(t *testing.T) {
+			t.Parallel()
+
+			const settingName = "custom_visible_tenants"
+			const settingValue = "t1,t2"
+			dsSettings := makeEnforcedDSSettings(t, proto, settingName, settingValue)
+
+			s, err := LoadSettings(context.Background(), dsSettings)
+			require.NoError(t, err)
+			require.True(t, s.shouldForceReadOnly())
+
+			// Build a prober backed by a real DB.
+			plugin := &Clickhouse{}
+			db, err := plugin.Connect(context.Background(), dsSettings, json.RawMessage("{}"))
+			require.NoError(t, err)
+			defer db.Close()
+
+			result := runEnforcedHealthProbes(context.Background(), s, sqlDBProber(db))
+			if result != nil {
+				t.Fatalf("expected nil (all probes pass), got: status=%v message=%q", result.Status, result.Message)
+			}
+		})
+	}
+}

--- a/pkg/plugin/health.go
+++ b/pkg/plugin/health.go
@@ -1,0 +1,175 @@
+package plugin
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+)
+
+// dbProber abstracts the two DB operations used by the enforced-settings health probes,
+// allowing the probe logic to be unit-tested without a real ClickHouse connection.
+type dbProber struct {
+	// queryScalar executes query and scans the first column of the first row as a string.
+	queryScalar func(ctx context.Context, query string) (string, error)
+	// execQuery executes query and returns any error (nil = success).
+	execQuery func(ctx context.Context, query string) error
+}
+
+// sqlDBProber builds a dbProber backed by db.
+// Callers supply a context already enriched with clickhouse.Context settings when needed.
+func sqlDBProber(db *sql.DB) dbProber {
+	return dbProber{
+		queryScalar: func(ctx context.Context, query string) (string, error) {
+			var s string
+			return s, db.QueryRowContext(ctx, query).Scan(&s)
+		},
+		execQuery: func(ctx context.Context, query string) error {
+			rows, err := db.QueryContext(ctx, query)
+			if rows != nil {
+				rows.Close()
+			}
+			return err
+		},
+	}
+}
+
+// enforcedProbeTimeout returns the timeout to use for each individual probe.
+// Capped at 30 s so health checks stay responsive.
+func enforcedProbeTimeout(s Settings) time.Duration {
+	qt, err := strconv.Atoi(s.QueryTimeout)
+	if err != nil || qt <= 0 {
+		qt = 30
+	}
+	if qt > 30 {
+		qt = 30
+	}
+	return time.Duration(qt) * time.Second
+}
+
+// runEnforcedHealthProbes runs the three enforced-settings health probes and returns
+// a non-nil StatusError result on the first failure, or nil when all pass.
+//
+// The three probes are:
+//
+//	(c) Startup readonly check — the connecting user must start at readonly=0 so the plugin
+//	    can inject the enforced settings on each query.
+//	(a) Round-trip — getSetting('<name>') under the enforced settings map must return the
+//	    configured value.
+//	(b) Override-rejection — an inline SETTINGS override of each enforced name must fail
+//	    with ClickHouse error 164 (READONLY). Success means the setting is marked
+//	    CHANGEABLE_IN_READONLY, which silently breaks the guarantee.
+//
+// The function is package-level (not a method) so it can be unit-tested with a fake prober.
+func runEnforcedHealthProbes(ctx context.Context, s Settings, p dbProber) *backend.CheckHealthResult {
+	if !s.shouldForceReadOnly() {
+		return nil
+	}
+
+	timeout := enforcedProbeTimeout(s)
+
+	// Probe (c): verify the connecting user starts at readonly=0.
+	cCtx, cCancel := context.WithTimeout(ctx, timeout)
+	defer cCancel()
+	roVal, err := p.queryScalar(cCtx, "SELECT value FROM system.settings WHERE name='readonly'")
+	if err != nil {
+		if !errors.Is(err, sql.ErrNoRows) {
+			backend.Logger.Warn("enforced-settings health: could not query system.settings for readonly", "error", err)
+		}
+		// Best-effort check; the basic connectivity probe already passed.
+	} else if roVal != "0" {
+		return &backend.CheckHealthResult{
+			Status: backend.HealthStatusError,
+			Message: fmt.Sprintf(
+				"Connecting ClickHouse user is already readonly=%s; enforced settings cannot be applied on top. Use a user that starts at readonly=0.",
+				roVal,
+			),
+		}
+	}
+
+	// Build a context that carries the enforced settings for probes (a) and (b).
+	// context.WithTimeout inherits values from its parent, so clickhouse-go sees them.
+	enforcedCtx := clickhouse.Context(ctx, clickhouse.WithSettings(buildEnforcedChSettings(s)))
+
+	for name, cfgValueIface := range s.enforcedSettings() {
+		var cfgValue string
+		if cs, ok := cfgValueIface.(clickhouse.CustomSetting); ok {
+			cfgValue = cs.Value
+		} else {
+			cfgValue = fmt.Sprint(cfgValueIface)
+		}
+
+		// Probe (a): round-trip — getSetting must return the configured value.
+		aCtx, aCancel := context.WithTimeout(enforcedCtx, timeout)
+		got, err := p.queryScalar(aCtx, fmt.Sprintf("SELECT getSetting('%s')", name))
+		aCancel()
+		if err != nil {
+			return &backend.CheckHealthResult{
+				Status: backend.HealthStatusError,
+				Message: fmt.Sprintf(
+					"Enforced setting %q: health probe failed to read back the value via getSetting: %s",
+					name, err,
+				),
+			}
+		}
+		if got != cfgValue {
+			return &backend.CheckHealthResult{
+				Status: backend.HealthStatusError,
+				Message: fmt.Sprintf(
+					"Enforced setting %q: value mismatch — sent %q but getSetting returned %q. "+
+						"Check your ClickHouse settings-constraints profile: if the setting is CONST with a different value, the enforced value is silently ignored.",
+					name, cfgValue, got,
+				),
+			}
+		}
+
+		// Probe (b): override-rejection — an inline SETTINGS override must fail with code 164.
+		bCtx, bCancel := context.WithTimeout(enforcedCtx, timeout)
+		execErr := p.execQuery(bCtx, fmt.Sprintf("SELECT 1 SETTINGS %s = '__grafana_enforced_probe__'", name))
+		bCancel()
+		if execErr == nil {
+			// Override succeeded: the setting is CHANGEABLE_IN_READONLY, breaking the guarantee.
+			return &backend.CheckHealthResult{
+				Status: backend.HealthStatusError,
+				Message: fmt.Sprintf(
+					"Server permits per-query override of enforced setting %q. "+
+						"Check your ClickHouse settings-constraints profile: the setting must not be marked CHANGEABLE_IN_READONLY.",
+					name,
+				),
+			}
+		}
+		// Code 164 (READONLY) is the expected outcome. Any other error is ambiguous —
+		// log a warning but do not fail the health check.
+		var ex *clickhouse.Exception
+		if !errors.As(execErr, &ex) || ex.Code != 164 {
+			backend.Logger.Warn("enforced-settings health: override probe returned unexpected error",
+				"setting", name,
+			)
+		}
+	}
+
+	return nil
+}
+
+// makeEnforcedSettingsHealthCheck returns a sqlds-compatible PostCheckHealth function
+// that opens a short-lived probe connection and runs runEnforcedHealthProbes.
+func makeEnforcedSettingsHealthCheck(s Settings, instanceSettings backend.DataSourceInstanceSettings) func(context.Context, *backend.CheckHealthRequest) *backend.CheckHealthResult {
+	return func(ctx context.Context, req *backend.CheckHealthRequest) *backend.CheckHealthResult {
+		// Use a fresh connection so the probe is independent of the pooled connection
+		// and does not interfere with in-flight queries.
+		plugin := Clickhouse{}
+		db, err := plugin.Connect(ctx, instanceSettings, nil)
+		if err != nil {
+			backend.Logger.Warn("enforced-settings health: could not open probe connection", "error", err)
+			return nil
+		}
+		defer db.Close()
+
+		return runEnforcedHealthProbes(ctx, s, sqlDBProber(db))
+	}
+}

--- a/pkg/plugin/health_test.go
+++ b/pkg/plugin/health_test.go
@@ -1,0 +1,198 @@
+package plugin
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// makeEnforcedTestSettings builds a Settings with one enforced custom setting.
+func makeEnforcedTestSettings(name, value string) Settings {
+	return Settings{
+		EnforceReadOnly: true,
+		QueryTimeout:    "10",
+		CustomSettings: []CustomSetting{
+			{Setting: name, Value: value, Enforced: true},
+		},
+	}
+}
+
+// fakeProber builds a dbProber that uses queryFn and execFn.
+// Either function may call t.Helper() / record calls as needed.
+func fakeProber(queryFn func(ctx context.Context, q string) (string, error), execFn func(ctx context.Context, q string) error) dbProber {
+	return dbProber{
+		queryScalar: queryFn,
+		execQuery:   execFn,
+	}
+}
+
+// sharedFakeProber returns a prober whose behaviour is driven by the supplied map:
+//   - "system.settings" key controls the readonly row scan (probe c)
+//   - "getSetting"      key controls the round-trip value (probe a)
+//   - "exec"            key controls the override-rejection error (probe b)
+//
+// This simplifies the common test cases that only want to exercise one failure mode.
+func sharedFakeProber(
+	roVal string, roErr error,
+	getSettingVal string, getSettingErr error,
+	execErr error,
+) dbProber {
+	return fakeProber(
+		func(_ context.Context, q string) (string, error) {
+			if strings.Contains(q, "system.settings") {
+				return roVal, roErr
+			}
+			return getSettingVal, getSettingErr
+		},
+		func(_ context.Context, _ string) error { return execErr },
+	)
+}
+
+func TestRunEnforcedHealthProbes_HappyPath(t *testing.T) {
+	s := makeEnforcedTestSettings("custom_x", "val1")
+	p := sharedFakeProber("0", nil, "val1", nil, &clickhouse.Exception{Code: 164})
+	result := runEnforcedHealthProbes(context.Background(), s, p)
+	assert.Nil(t, result, "all probes pass → should return nil")
+}
+
+func TestRunEnforcedHealthProbes_NoEnforcedSettings(t *testing.T) {
+	s := Settings{EnforceReadOnly: false, QueryTimeout: "10"}
+	p := sharedFakeProber("0", nil, "anything", nil, fmt.Errorf("should not be called"))
+	result := runEnforcedHealthProbes(context.Background(), s, p)
+	assert.Nil(t, result, "no enforced settings → should short-circuit and return nil")
+}
+
+func TestRunEnforcedHealthProbes_UserAlreadyReadonly(t *testing.T) {
+	s := makeEnforcedTestSettings("custom_x", "val1")
+	// Simulate a user that already has readonly=1 at the server level.
+	p := sharedFakeProber("1", nil, "val1", nil, &clickhouse.Exception{Code: 164})
+	result := runEnforcedHealthProbes(context.Background(), s, p)
+	require.NotNil(t, result)
+	assert.Equal(t, backend.HealthStatusError, result.Status)
+	assert.Contains(t, result.Message, "already readonly=1")
+	assert.Contains(t, result.Message, "readonly=0")
+}
+
+func TestRunEnforcedHealthProbes_UserAlreadyReadonly2(t *testing.T) {
+	s := makeEnforcedTestSettings("custom_x", "val1")
+	p := sharedFakeProber("2", nil, "val1", nil, &clickhouse.Exception{Code: 164})
+	result := runEnforcedHealthProbes(context.Background(), s, p)
+	require.NotNil(t, result)
+	assert.Equal(t, backend.HealthStatusError, result.Status)
+	assert.Contains(t, result.Message, "already readonly=2")
+}
+
+func TestRunEnforcedHealthProbes_ReadonlyQueryError_NonFatal(t *testing.T) {
+	// system.settings query error should not block the health check (best-effort).
+	s := makeEnforcedTestSettings("custom_x", "val1")
+	p := sharedFakeProber("", fmt.Errorf("connection refused"), "val1", nil, &clickhouse.Exception{Code: 164})
+	result := runEnforcedHealthProbes(context.Background(), s, p)
+	// Should still pass since the connection probe already succeeded.
+	assert.Nil(t, result)
+}
+
+func TestRunEnforcedHealthProbes_ErrNoRows_NonFatal(t *testing.T) {
+	// ErrNoRows from system.settings means the readonly setting is absent → default 0.
+	s := makeEnforcedTestSettings("custom_x", "val1")
+	p := sharedFakeProber("", sql.ErrNoRows, "val1", nil, &clickhouse.Exception{Code: 164})
+	result := runEnforcedHealthProbes(context.Background(), s, p)
+	assert.Nil(t, result)
+}
+
+func TestRunEnforcedHealthProbes_ValueMismatch(t *testing.T) {
+	s := makeEnforcedTestSettings("custom_x", "expected_val")
+	// getSetting returns a different value (e.g. a CONST profile overrides it).
+	p := sharedFakeProber("0", nil, "server_forced_val", nil, &clickhouse.Exception{Code: 164})
+	result := runEnforcedHealthProbes(context.Background(), s, p)
+	require.NotNil(t, result)
+	assert.Equal(t, backend.HealthStatusError, result.Status)
+	assert.Contains(t, result.Message, "value mismatch")
+	assert.Contains(t, result.Message, "custom_x")
+}
+
+func TestRunEnforcedHealthProbes_GetSettingError(t *testing.T) {
+	s := makeEnforcedTestSettings("custom_x", "val1")
+	p := sharedFakeProber("0", nil, "", fmt.Errorf("unknown setting"), &clickhouse.Exception{Code: 164})
+	result := runEnforcedHealthProbes(context.Background(), s, p)
+	require.NotNil(t, result)
+	assert.Equal(t, backend.HealthStatusError, result.Status)
+	assert.Contains(t, result.Message, "health probe failed")
+	assert.Contains(t, result.Message, "custom_x")
+}
+
+func TestRunEnforcedHealthProbes_SettingOverridable(t *testing.T) {
+	s := makeEnforcedTestSettings("custom_x", "val1")
+	// Override probe succeeds → setting is CHANGEABLE_IN_READONLY (bad).
+	p := sharedFakeProber("0", nil, "val1", nil, nil)
+	result := runEnforcedHealthProbes(context.Background(), s, p)
+	require.NotNil(t, result)
+	assert.Equal(t, backend.HealthStatusError, result.Status)
+	assert.Contains(t, result.Message, "CHANGEABLE_IN_READONLY")
+	assert.Contains(t, result.Message, "custom_x")
+}
+
+func TestRunEnforcedHealthProbes_UnexpectedExecError_Warning(t *testing.T) {
+	// An override probe returning a non-164 error is ambiguous:
+	// we log a warning but do not fail the health check.
+	s := makeEnforcedTestSettings("custom_x", "val1")
+	p := sharedFakeProber("0", nil, "val1", nil, fmt.Errorf("some other DB error"))
+	result := runEnforcedHealthProbes(context.Background(), s, p)
+	assert.Nil(t, result, "non-164 error from override probe is a warning, not a failure")
+}
+
+func TestRunEnforcedHealthProbes_MultipleSettings_FirstFails(t *testing.T) {
+	s := Settings{
+		EnforceReadOnly: true,
+		QueryTimeout:    "10",
+		CustomSettings: []CustomSetting{
+			{Setting: "custom_a", Value: "v1", Enforced: true},
+			{Setting: "custom_b", Value: "v2", Enforced: true},
+		},
+	}
+	// custom_a will cause a mismatch, custom_b is fine.
+	// We just need to confirm that a failure is returned (not necessarily for custom_a
+	// since map iteration order is random).
+	badVal := map[string]string{"custom_a": "WRONG", "custom_b": "v2"}
+	p := fakeProber(
+		func(_ context.Context, q string) (string, error) {
+			if strings.Contains(q, "system.settings") {
+				return "0", nil
+			}
+			for setting, ret := range badVal {
+				if strings.Contains(q, setting) {
+					return ret, nil
+				}
+			}
+			return "", fmt.Errorf("unexpected query: %s", q)
+		},
+		func(_ context.Context, _ string) error { return &clickhouse.Exception{Code: 164} },
+	)
+	result := runEnforcedHealthProbes(context.Background(), s, p)
+	require.NotNil(t, result, "mismatch on custom_a should produce a failure")
+	assert.Equal(t, backend.HealthStatusError, result.Status)
+}
+
+func TestEnforcedProbeTimeout_Default(t *testing.T) {
+	s := Settings{QueryTimeout: ""}
+	d := enforcedProbeTimeout(s)
+	assert.Equal(t, 30, int(d.Seconds()))
+}
+
+func TestEnforcedProbeTimeout_Capped(t *testing.T) {
+	s := Settings{QueryTimeout: "120"}
+	d := enforcedProbeTimeout(s)
+	assert.Equal(t, 30, int(d.Seconds()), "timeout should be capped at 30 s")
+}
+
+func TestEnforcedProbeTimeout_Short(t *testing.T) {
+	s := Settings{QueryTimeout: "5"}
+	d := enforcedProbeTimeout(s)
+	assert.Equal(t, 5, int(d.Seconds()))
+}

--- a/pkg/plugin/settings.go
+++ b/pkg/plugin/settings.go
@@ -58,6 +58,14 @@ type Settings struct {
 	// memory.
 	RowCapacityHint int64 `json:"rowCapacityHint,omitempty"`
 
+	// EnforceReadOnly forces readonly=1 on every query executed via this datasource,
+	// making it read-only (INSERT/DDL from Grafana will be blocked). It is
+	// automatically set to true when any CustomSetting has Enforced=true. Server
+	// tunables that operators want users to still adjust per query (e.g. max_threads)
+	// should be marked <changeable_in_readonly/> server-side; the enforced tenant
+	// settings must NOT be marked that way.
+	EnforceReadOnly bool `json:"enforceReadOnly,omitempty"`
+
 	// EnableSchemaCache gates the in-process cache that memoizes
 	// system.tables / system.columns / DISTINCT column-value lookups used
 	// by the query builder. Defaults to true.
@@ -69,8 +77,9 @@ type Settings struct {
 }
 
 type CustomSetting struct {
-	Setting string `json:"setting"`
-	Value   string `json:"value"`
+	Setting  string `json:"setting"`
+	Value    string `json:"value"`
+	Enforced bool   `json:"enforced,omitempty"`
 }
 
 const secureHeaderKeyPrefix = "secureHttpHeaders."
@@ -83,6 +92,46 @@ func (settings *Settings) isValid() (err error) {
 		return backend.DownstreamError(ErrorMessageInvalidPort)
 	}
 	return nil
+}
+
+// enforcedSettings returns a clickhouse.Settings map containing only the
+// CustomSettings entries marked Enforced. Returns nil if none are enforced.
+//
+// Values for setting names beginning with "custom_" are wrapped in
+// clickhouse.CustomSetting{Value}. That wrapper is required by clickhouse-go's
+// Native protocol to send user-defined (custom_*) settings; without it the
+// server rejects them with code 115 "Unknown setting". HTTP tolerates plain
+// strings via URL params, but the wrapper is also accepted there, so we always
+// wrap for consistency across protocols.
+func (s Settings) enforcedSettings() clickhouse.Settings {
+	var m clickhouse.Settings
+	for _, cs := range s.CustomSettings {
+		if cs.Enforced {
+			if m == nil {
+				m = make(clickhouse.Settings)
+			}
+			m[cs.Setting] = wrapCustomSettingValue(cs.Setting, cs.Value)
+		}
+	}
+	return m
+}
+
+// wrapCustomSettingValue wraps values for custom_-prefixed settings in
+// clickhouse.CustomSetting so clickhouse-go's Native protocol serializer
+// tags them as user-defined rather than as built-in server settings.
+func wrapCustomSettingValue(name, value string) interface{} {
+	if strings.HasPrefix(name, "custom_") {
+		return clickhouse.CustomSetting{Value: value}
+	}
+	return value
+}
+
+// shouldForceReadOnly reports whether readonly=1 must be injected on every
+// query. Phase 1 auto-enables EnforceReadOnly when any CustomSetting is
+// Enforced, so in practice this is just s.EnforceReadOnly; the len check
+// is kept as defense-in-depth.
+func (s Settings) shouldForceReadOnly() bool {
+	return s.EnforceReadOnly || len(s.enforcedSettings()) > 0
 }
 
 // LoadSettings will read and validate Settings from the DataSourceConfig
@@ -199,10 +248,23 @@ func LoadSettings(ctx context.Context, config backend.DataSourceInstanceSettings
 
 		for i, raw := range customSettingsRaw {
 			rawMap := raw.(map[string]interface{})
-			customSettings[i] = CustomSetting{
+			cs := CustomSetting{
 				Setting: rawMap["setting"].(string),
 				Value:   rawMap["value"].(string),
 			}
+			if rawMap["enforced"] != nil {
+				switch v := rawMap["enforced"].(type) {
+				case bool:
+					cs.Enforced = v
+				case string:
+					if parsed, parseErr := strconv.ParseBool(v); parseErr == nil {
+						cs.Enforced = parsed
+					} else {
+						backend.Logger.Warn("Failed to parse enforced value for custom setting, defaulting to false", "setting", cs.Setting, "error", parseErr)
+					}
+				}
+			}
+			customSettings[i] = cs
 		}
 
 		settings.CustomSettings = customSettings
@@ -226,6 +288,30 @@ func LoadSettings(ctx context.Context, config backend.DataSourceInstanceSettings
 			}
 		} else {
 			settings.EnableRowLimit = jsonData["enableRowLimit"].(bool)
+		}
+	}
+
+	if raw, ok := jsonData["enforceReadOnly"]; ok && raw != nil {
+		switch v := raw.(type) {
+		case bool:
+			settings.EnforceReadOnly = v
+		case string:
+			if parsed, parseErr := strconv.ParseBool(v); parseErr == nil {
+				settings.EnforceReadOnly = parsed
+			} else {
+				backend.Logger.Warn("Failed to parse enforceReadOnly value, defaulting to false", "error", parseErr)
+			}
+		}
+	}
+
+	// If any custom setting is marked enforced, force EnforceReadOnly on.
+	if !settings.EnforceReadOnly {
+		for _, cs := range settings.CustomSettings {
+			if cs.Enforced {
+				settings.EnforceReadOnly = true
+				backend.Logger.Info("enforceReadOnly implicitly enabled because at least one custom setting is marked enforced")
+				break
+			}
 		}
 	}
 

--- a/pkg/plugin/settings_test.go
+++ b/pkg/plugin/settings_test.go
@@ -406,4 +406,114 @@ func TestLoadSettings(t *testing.T) {
 			})
 		}
 	})
+
+	t.Run("should parse enforced flag on custom settings", func(t *testing.T) {
+		ctx := context.Background()
+		tests := []struct {
+			description    string
+			jsonData       string
+			wantEnforced   []bool
+			wantReadOnly   bool
+		}{
+			{
+				description:  "enforced absent defaults to false",
+				jsonData:     `{"host": "foo", "port": 443, "customSettings": [{"setting": "s1", "value": "v1"}]}`,
+				wantEnforced: []bool{false},
+				wantReadOnly: false,
+			},
+			{
+				description:  "enforced as bool true",
+				jsonData:     `{"host": "foo", "port": 443, "customSettings": [{"setting": "s1", "value": "v1", "enforced": true}]}`,
+				wantEnforced: []bool{true},
+				wantReadOnly: true,
+			},
+			{
+				description:  "enforced as bool false",
+				jsonData:     `{"host": "foo", "port": 443, "customSettings": [{"setting": "s1", "value": "v1", "enforced": false}]}`,
+				wantEnforced: []bool{false},
+				wantReadOnly: false,
+			},
+			{
+				description:  `enforced as string "true"`,
+				jsonData:     `{"host": "foo", "port": 443, "customSettings": [{"setting": "s1", "value": "v1", "enforced": "true"}]}`,
+				wantEnforced: []bool{true},
+				wantReadOnly: true,
+			},
+			{
+				description:  `enforced as string "false"`,
+				jsonData:     `{"host": "foo", "port": 443, "customSettings": [{"setting": "s1", "value": "v1", "enforced": "false"}]}`,
+				wantEnforced: []bool{false},
+				wantReadOnly: false,
+			},
+			{
+				description:  "mixed: only one enforced triggers EnforceReadOnly",
+				jsonData:     `{"host": "foo", "port": 443, "customSettings": [{"setting": "s1", "value": "v1", "enforced": true}, {"setting": "s2", "value": "v2"}]}`,
+				wantEnforced: []bool{true, false},
+				wantReadOnly: true,
+			},
+		}
+		for _, tc := range tests {
+			t.Run(tc.description, func(t *testing.T) {
+				got, err := LoadSettings(ctx, backend.DataSourceInstanceSettings{
+					JSONData:                []byte(tc.jsonData),
+					DecryptedSecureJSONData: map[string]string{},
+				})
+				assert.NoError(t, err)
+				assert.Equal(t, tc.wantReadOnly, got.EnforceReadOnly, "EnforceReadOnly mismatch")
+				for i, wantEnforced := range tc.wantEnforced {
+					assert.Equal(t, wantEnforced, got.CustomSettings[i].Enforced, "Enforced mismatch at index %d", i)
+				}
+			})
+		}
+	})
+
+	t.Run("should parse enforceReadOnly at top level", func(t *testing.T) {
+		ctx := context.Background()
+		tests := []struct {
+			description  string
+			jsonData     string
+			wantReadOnly bool
+		}{
+			{
+				description:  "absent defaults to false",
+				jsonData:     `{"host": "foo", "port": 443}`,
+				wantReadOnly: false,
+			},
+			{
+				description:  "bool true",
+				jsonData:     `{"host": "foo", "port": 443, "enforceReadOnly": true}`,
+				wantReadOnly: true,
+			},
+			{
+				description:  "bool false",
+				jsonData:     `{"host": "foo", "port": 443, "enforceReadOnly": false}`,
+				wantReadOnly: false,
+			},
+			{
+				description:  `string "true"`,
+				jsonData:     `{"host": "foo", "port": 443, "enforceReadOnly": "true"}`,
+				wantReadOnly: true,
+			},
+			{
+				description:  `string "false"`,
+				jsonData:     `{"host": "foo", "port": 443, "enforceReadOnly": "false"}`,
+				wantReadOnly: false,
+			},
+			{
+				description:  "enforceReadOnly false + enforced setting true => auto-true",
+				jsonData:     `{"host": "foo", "port": 443, "enforceReadOnly": false, "customSettings": [{"setting": "s1", "value": "v1", "enforced": true}]}`,
+				wantReadOnly: true,
+			},
+		}
+		for _, tc := range tests {
+			t.Run(tc.description, func(t *testing.T) {
+				got, err := LoadSettings(ctx, backend.DataSourceInstanceSettings{
+					JSONData:                []byte(tc.jsonData),
+					DecryptedSecureJSONData: map[string]string{},
+				})
+				assert.NoError(t, err)
+				assert.Equal(t, tc.wantReadOnly, got.EnforceReadOnly, "EnforceReadOnly mismatch")
+			})
+		}
+	})
 }

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -51,6 +51,8 @@ export interface CHConfig extends DataSourceJsonData {
   customSettings?: CHCustomSetting[];
   enableSecureSocksProxy?: boolean;
   enableRowLimit?: boolean;
+  /** Forces readonly=1 on every query, blocking INSERT/DDL. Auto-enabled when any customSetting has enforced=true. */
+  enforceReadOnly?: boolean;
 
   /**
    * Optional expected row count passed to sqlds as DriverSettings.RowCapacityHint.
@@ -105,6 +107,8 @@ export interface CHHttpHeader {
 export interface CHCustomSetting {
   setting: string;
   value: string;
+  /** When true, the setting is sent alongside readonly=1 on every query so the user's SQL cannot override it. */
+  enforced?: boolean;
 }
 
 export interface CHLogsConfig {

--- a/src/views/CHConfigEditor.tsx
+++ b/src/views/CHConfigEditor.tsx
@@ -4,7 +4,7 @@ import {
   onUpdateDatasourceJsonDataOption,
   onUpdateDatasourceSecureJsonDataOption,
 } from '@grafana/data';
-import { RadioButtonGroup, Switch, Input, SecretInput, Button, Field, Alert, Stack } from '@grafana/ui';
+import { RadioButtonGroup, Switch, Input, SecretInput, Button, Field, Alert, Stack, Checkbox, Tooltip } from '@grafana/ui';
 import { CertificationKey } from '../components/ui/CertificationKey';
 import {
   CHConfig,
@@ -136,6 +136,7 @@ export const ConfigEditor: React.FC<ConfigEditorProps> = (props) => {
       | 'enableSecureSocksProxy'
       | 'forwardGrafanaHeaders'
       | 'enableRowLimit'
+      | 'enforceReadOnly'
       | 'hideTableNameInAdhocFilters'
     >,
     value: boolean
@@ -243,6 +244,9 @@ export const ConfigEditor: React.FC<ConfigEditorProps> = (props) => {
   };
 
   const [customSettings, setCustomSettings] = useState(jsonData.customSettings || []);
+
+  // True when at least one custom setting row has enforced=true; drives the enforceReadOnly toggle state.
+  const anyEnforced = customSettings.some((s) => s.enforced);
 
   const hasAdditionalSettings = Boolean(
     window.location.hash || // if trying to link to section on page, open all settings (React breaks this?)
@@ -861,16 +865,30 @@ export const ConfigEditor: React.FC<ConfigEditorProps> = (props) => {
               </Field>
             )}
             <ConfigSubSection title="Custom Settings">
-              {customSettings.map(({ setting, value }, i) => {
+              <Alert title="" severity="info">
+                <ul style={{ margin: 0, paddingLeft: '1.25em' }}>
+                  <li>Enabling read-only enforcement blocks INSERT and DDL queries from Grafana.</li>
+                  <li>
+                    Enforced settings <strong>must NOT</strong> be marked{' '}
+                    <code>CHANGEABLE_IN_READONLY</code> on the ClickHouse server — doing so would let
+                    users override them and break the enforcement guarantee.
+                  </li>
+                  <li>
+                    Use ClickHouse row policies with{' '}
+                    <code>{`getSetting('custom_x')`}</code> to gate data access on enforced settings.
+                  </li>
+                </ul>
+              </Alert>
+              {customSettings.map(({ setting, value, enforced }, i) => {
                 return (
-                  <Stack key={i} direction="row">
+                  <Stack key={i} direction="row" alignItems="flex-end">
                     <Field label={`Setting`} aria-label={`Setting`}>
                       <Input
                         value={setting}
                         placeholder={'Setting'}
                         onChange={(changeEvent: ChangeEvent<HTMLInputElement>) => {
                           let newSettings = customSettings.concat();
-                          newSettings[i] = { setting: changeEvent.target.value, value };
+                          newSettings[i] = { setting: changeEvent.target.value, value, enforced };
                           setCustomSettings(newSettings);
                         }}
                         onBlur={() => {
@@ -885,13 +903,31 @@ export const ConfigEditor: React.FC<ConfigEditorProps> = (props) => {
                         placeholder={'Value'}
                         onChange={(changeEvent: ChangeEvent<HTMLInputElement>) => {
                           let newSettings = customSettings.concat();
-                          newSettings[i] = { setting, value: changeEvent.target.value };
+                          newSettings[i] = { setting, value: changeEvent.target.value, enforced };
                           setCustomSettings(newSettings);
                         }}
                         onBlur={() => {
                           onCustomSettingsChange(customSettings);
                         }}
                       ></Input>
+                    </Field>
+                    <Field
+                      label={
+                        <Tooltip content="Send with readonly=1 so the user's SQL cannot override it.">
+                          <span>Enforced</span>
+                        </Tooltip>
+                      }
+                      aria-label={`Enforced`}
+                    >
+                      <Checkbox
+                        value={enforced || false}
+                        onChange={(changeEvent: ChangeEvent<HTMLInputElement>) => {
+                          let newSettings = customSettings.concat();
+                          newSettings[i] = { setting, value, enforced: changeEvent.target.checked };
+                          setCustomSettings(newSettings);
+                          onCustomSettingsChange(newSettings);
+                        }}
+                      />
                     </Field>
                   </Stack>
                 );
@@ -907,6 +943,34 @@ export const ConfigEditor: React.FC<ConfigEditorProps> = (props) => {
                 Add custom setting
               </Button>
             </ConfigSubSection>
+            <Field
+              label="Enforce read-only on all queries"
+              description={
+                anyEnforced
+                  ? 'Automatically enabled because at least one custom setting is marked Enforced.'
+                  : 'Forces readonly=1 on every query. Blocks INSERT/DDL from Grafana. Enable when you want read-only lockdown without enforced settings.'
+              }
+            >
+              <Tooltip
+                content={
+                  anyEnforced
+                    ? 'Disabled because enforceReadOnly is automatically on when any custom setting is marked Enforced.'
+                    : ''
+                }
+                placement="top"
+              >
+                <Switch
+                  value={anyEnforced || jsonData.enforceReadOnly || false}
+                  disabled={anyEnforced}
+                  onChange={(e) => {
+                    if (!anyEnforced) {
+                      onSwitchToggle('enforceReadOnly', e.currentTarget.checked);
+                    }
+                  }}
+                />
+              </Tooltip>
+            </Field>
+
           </ConfigSection>
         </>
       )}


### PR DESCRIPTION
## Type of Change

- [x] 🚀 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧹 Refactor / Chore

---

> [!NOTE]
> This is an experiment, shared in case others are interested and may benefit. It's marked draft and not currently ready for any sort of serious review beyond a sanity check of the concept.

## Feature

Support enforcing ClickHouse server-side settings and read-only mode on every query run.

### What is this feature?

Enforce ClickHouse server-side settings (e.g. a  `custom_visible_tenants`  variable for multi-tenant row-level security policies) on every query by injecting them plus `readonly=1` out-of-band, so user SQL cannot override them.

### Why is this feature needed?

This allows the data source to be used for soft multi-tenancy with no per-tenant DB-side user or `CONST` profile required. If the Grafana user can edit the datasource they can trivially bypass the restriction, but where Grafana permissions constrain the user's ability to edit the datasource the protection provided is quite strong.

I'm _hoping_ to be able to wire settings values to a HTTP header that's enforced by middleware too, so a datasource can dynamically enforce tenancy based on headers from a reverse proxy or additional attributes injected into a JWT token. This would allow a single datasource to enforce tenancy-visibility (or other useful properties) for all non-Admin grafana users. A working doc [notes-enforced-settings-dynamic-source-plan.md](https://github.com/user-attachments/files/30072732/notes-enforced-settings-dynamic-source-plan.md) outlines an experiment I'm running for that. Edit: A proof of concept branch is at https://github.com/ringerc/clickhouse-datasource-patches/tree/enforced-settings-jwt-binding , implementing header and JWT binding of values into clickhouse datasource enforced headers.

I expect the ability to enforce settings and read-only mode would be useful for other purposes beyond soft-multi-tenancy too.

### Who is this feature for?

Primarily useful for operators of Grafana who use the Organizations feature for soft multi-tenancy access control: One Organization per tenant with per-Organization datasources bound to it.

Without this, a dedicated Clickhouse user needs to be created for each tenant, bound to the settings required for RLS policy enforcement, and its auth credentials added to Grafana.

### How to test this feature

1. Build the plugin from the branch ( `npm ci`  +  `mage build` ).
2. Start ClickHouse with the shipped  [custom.xml](https://github.com/user-attachments/files/30071663/custom.xml)  +  [config.xml](https://github.com/user-attachments/files/30071646/config.xml)  fixtures.
3. Seed an  events  table +  tenant_filter  row policy keyed off  `getSetting('custom_visible_tenants')` ; e.g. push some data with an otel-collector to the standard otel clickhouse schema
4. Run Grafana against the built plugin (dev mode or the repo's compose file).
5. Configure the datasource - add an enforced `custom_visible_tenants` row. Notice the auto-forced Read-only toggle that is enabled when enforced variables are added.
6. Run queries to demonstrate that `SETTINGS` inline will be rejected, the row-security policy is enforced, etc.

(LLM-assisted) detailed test notes at 
[notes-enforced-settings-manual-test.md](https://github.com/user-attachments/files/30071737/notes-enforced-settings-manual-test.md)


## Screenshots / Videos

Pending

## Please check that:

- [x] Tests for this change have been added/updated.
- [ ] Documentation has been added/updated (where applicable).

## Special notes for your reviewer

This is presently a proof of concept draft, heavily LLM-assisted. I'm sharing it so it's visible to others who may have similar needs, but it's marked draft because I don't consider it ready for any meaningful review yet. I need to do my own close review and revision before I can seriously submit anything in good conscience.

Some reference docs:

* [notes-enforced-settings.md](https://github.com/user-attachments/files/30072731/notes-enforced-settings.md)

