### PR TITLE
fix(macros): expand macros nested inside another macro's arguments

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/ClickHouse/clickhouse-go/v2 v2.47.0
 	github.com/docker/go-units v0.5.0
 	github.com/grafana/grafana-plugin-sdk-go v0.292.2
-	github.com/grafana/macropro v1.0.0
+	github.com/grafana/macropro v1.0.1-0.20260716172249-a6e57b732fd3
 	github.com/grafana/sqlds/v5 v5.3.0
 	github.com/moby/moby/api v1.55.0
 	github.com/paulmach/orb v0.13.0

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/ClickHouse/clickhouse-go/v2 v2.47.0
 	github.com/docker/go-units v0.5.0
 	github.com/grafana/grafana-plugin-sdk-go v0.292.2
-	github.com/grafana/macropro v1.0.1-0.20260716172249-a6e57b732fd3
+	github.com/grafana/macropro v1.0.1
 	github.com/grafana/sqlds/v5 v5.3.0
 	github.com/moby/moby/api v1.55.0
 	github.com/paulmach/orb v0.13.0

--- a/go.sum
+++ b/go.sum
@@ -149,8 +149,8 @@ github.com/grafana/dataplane/sdata v0.0.9 h1:AGL1LZnCUG4MnQtnWpBPbQ8ZpptaZs14w6k
 github.com/grafana/dataplane/sdata v0.0.9/go.mod h1:Jvs5ddpGmn6vcxT7tCTWAZ1mgi4sbcdFt9utQx5uMAU=
 github.com/grafana/grafana-plugin-sdk-go v0.292.2 h1:6xrNZpe905vzX1pY33Fyet7Oxw5xULcAHm2b8dvNZNY=
 github.com/grafana/grafana-plugin-sdk-go v0.292.2/go.mod h1:MPviZeixuZDc5T3f62FBCCPSOJ51/JocZH5+ZiQ1DmM=
-github.com/grafana/macropro v1.0.1-0.20260716172249-a6e57b732fd3 h1:MF1GtitF6jopvGFV7LG1f9DN4Yi+ypH4VngsnXp4kCc=
-github.com/grafana/macropro v1.0.1-0.20260716172249-a6e57b732fd3/go.mod h1:ID2n/OCKz4v4sqj+ckSNT7S9aRabod7G6Eg5S+sS4LU=
+github.com/grafana/macropro v1.0.1 h1:Z3Pv9TE1vt3A9rOSQ/H8fxna7hm0csA/pD4l6C4Gcmc=
+github.com/grafana/macropro v1.0.1/go.mod h1:ID2n/OCKz4v4sqj+ckSNT7S9aRabod7G6Eg5S+sS4LU=
 github.com/grafana/otel-profiling-go v0.6.0 h1:W7lOZaJj4IJISXMcM1UBk3fJF3tzF2OD6MJBJaQp1H8=
 github.com/grafana/otel-profiling-go v0.6.0/go.mod h1:cqLIDgNXlnzknJ0WLiEe+JPjZk2MZ4ftMdqRJRWj1ZM=
 github.com/grafana/pyroscope-go/godeltaprof v0.1.11 h1:el5LYpXissAiCKZ5/6yjlr6mhYVV6Cp5lahTocxraXM=

--- a/go.sum
+++ b/go.sum
@@ -149,8 +149,8 @@ github.com/grafana/dataplane/sdata v0.0.9 h1:AGL1LZnCUG4MnQtnWpBPbQ8ZpptaZs14w6k
 github.com/grafana/dataplane/sdata v0.0.9/go.mod h1:Jvs5ddpGmn6vcxT7tCTWAZ1mgi4sbcdFt9utQx5uMAU=
 github.com/grafana/grafana-plugin-sdk-go v0.292.2 h1:6xrNZpe905vzX1pY33Fyet7Oxw5xULcAHm2b8dvNZNY=
 github.com/grafana/grafana-plugin-sdk-go v0.292.2/go.mod h1:MPviZeixuZDc5T3f62FBCCPSOJ51/JocZH5+ZiQ1DmM=
-github.com/grafana/macropro v1.0.0 h1:R4/CgSgRrNQXpqk1JCHolg1/8Fz5g5CVW/C86AMz9Zw=
-github.com/grafana/macropro v1.0.0/go.mod h1:ID2n/OCKz4v4sqj+ckSNT7S9aRabod7G6Eg5S+sS4LU=
+github.com/grafana/macropro v1.0.1-0.20260716172249-a6e57b732fd3 h1:MF1GtitF6jopvGFV7LG1f9DN4Yi+ypH4VngsnXp4kCc=
+github.com/grafana/macropro v1.0.1-0.20260716172249-a6e57b732fd3/go.mod h1:ID2n/OCKz4v4sqj+ckSNT7S9aRabod7G6Eg5S+sS4LU=
 github.com/grafana/otel-profiling-go v0.6.0 h1:W7lOZaJj4IJISXMcM1UBk3fJF3tzF2OD6MJBJaQp1H8=
 github.com/grafana/otel-profiling-go v0.6.0/go.mod h1:cqLIDgNXlnzknJ0WLiEe+JPjZk2MZ4ftMdqRJRWj1ZM=
 github.com/grafana/pyroscope-go/godeltaprof v0.1.11 h1:el5LYpXissAiCKZ5/6yjlr6mhYVV6Cp5lahTocxraXM=

--- a/pkg/macros/macros_test.go
+++ b/pkg/macros/macros_test.go
@@ -318,6 +318,57 @@ func TestInterpolate(t *testing.T) {
 	}
 }
 
+// TestInterpolateNestedMacros guards against the regression introduced by the
+// macropro migration, where a macro passed as an argument to another macro
+// stopped expanding. The inner token reached ClickHouse verbatim and every
+// such query failed with UNKNOWN_IDENTIFIER at runtime, with no error at
+// build time. Nested macros must expand innermost-first, restoring the
+// behaviour these query shapes had before the migration.
+func TestInterpolateNestedMacros(t *testing.T) {
+	from, _ := time.Parse("2006-01-02T15:04:05.000Z", "2014-11-12T11:45:26.123Z")
+	to, _ := time.Parse("2006-01-02T15:04:05.000Z", "2015-11-12T11:45:26.456Z")
+
+	type test struct {
+		name   string
+		input  string
+		output string
+	}
+
+	tests := []test{
+		{
+			name:   "macro as sole argument of another macro (#2038 repro)",
+			input:  "SELECT $__timeInterval($__fromTime) AS from_time",
+			output: "SELECT toStartOfInterval(toDateTime(toDateTime(1415792726)), INTERVAL 60 second) AS from_time",
+		},
+		{
+			name:   "millisecond variants nest the same way",
+			input:  "SELECT $__timeInterval_ms($__fromTime_ms)",
+			output: "SELECT toStartOfInterval(toDateTime64(fromUnixTimestamp64Milli(1415792726123), 3), INTERVAL 60000 millisecond)",
+		},
+		{
+			name:   "macro nested inside a larger argument expression",
+			input:  "select * from foo where $__timeFilter(coalesce(closed_at, $__toTime))",
+			output: "select * from foo where coalesce(closed_at, toDateTime(1447328726)) >= toDateTime(1415792726) AND coalesce(closed_at, toDateTime(1447328726)) <= toDateTime(1447328726)",
+		},
+	}
+
+	for i, tc := range tests {
+		t.Run(fmt.Sprintf("[%d/%d] %s", i+1, len(tests), tc.name), func(t *testing.T) {
+			query := &sqlutil.Query{
+				RawSQL:   tc.input,
+				Interval: time.Minute,
+				TimeRange: backend.TimeRange{
+					From: from,
+					To:   to,
+				},
+			}
+			interpolatedQuery, err := Interpolate(tc.input, query)
+			require.Nil(t, err)
+			assert.Equal(t, tc.output, interpolatedQuery)
+		})
+	}
+}
+
 // TestInterpolateBackslashEscapedStringLiterals guards against macropro's
 // comment-stripping pass mis-terminating a ClickHouse string literal at a
 // backslash-escaped quote (\'), which would let a following -- or /* token be

--- a/pkg/macros/macros_test.go
+++ b/pkg/macros/macros_test.go
@@ -323,7 +323,7 @@ func TestInterpolate(t *testing.T) {
 // stopped expanding. The inner token reached ClickHouse verbatim and every
 // such query failed with UNKNOWN_IDENTIFIER at runtime, with no error at
 // build time. Nested macros must expand innermost-first, restoring the
-// behaviour these query shapes had before the migration.
+// behavior these query shapes had before the migration.
 func TestInterpolateNestedMacros(t *testing.T) {
 	from, _ := time.Parse("2006-01-02T15:04:05.000Z", "2014-11-12T11:45:26.123Z")
 	to, _ := time.Parse("2006-01-02T15:04:05.000Z", "2015-11-12T11:45:26.456Z")

--- a/pkg/plugin/driver_integration_test.go
+++ b/pkg/plugin/driver_integration_test.go
@@ -1456,6 +1456,36 @@ func TestQueryDataMacroExpansion(t *testing.T) {
 		assert.EqualValues(t, to.Unix(), gotTo)
 	})
 
+	t.Run("nested macro expands before execution", func(t *testing.T) {
+		// Regression guard: $__timeInterval($__fromTime) must expand the
+		// inner macro too. After the macropro migration it reached ClickHouse
+		// verbatim and the query failed with UNKNOWN_IDENTIFIER. The window
+		// starts exactly on a minute boundary, so flooring it to the interval
+		// start is the identity and the value round-trips.
+		req := &backend.QueryDataRequest{
+			PluginContext: backend.PluginContext{DataSourceInstanceSettings: &settings},
+			Queries: []backend.DataQuery{
+				{
+					RefID:     "A",
+					TimeRange: timeRange,
+					Interval:  time.Minute,
+					JSON:      []byte(`{"rawSql":"SELECT toUnixTimestamp($__timeInterval($__fromTime)) AS f"}`),
+				},
+			},
+		}
+
+		resp, err := ds.QueryData(ctx, req)
+		require.NoError(t, err)
+		require.Contains(t, resp.Responses, "A")
+		require.NoError(t, resp.Responses["A"].Error, "nested-macro query should run cleanly")
+
+		frames := resp.Responses["A"].Frames
+		require.Len(t, frames, 1)
+		require.Equal(t, 1, len(frames[0].Fields))
+		gotFrom, _ := frames[0].Fields[0].ConcreteAt(0)
+		assert.EqualValues(t, from.Unix(), gotFrom)
+	})
+
 	t.Run("macro expansion failure surfaces a downstream error", func(t *testing.T) {
 		// $__timeFilter() takes one argument; calling it with zero triggers
 		// badArgsErr. The interpolator returns the error to sqlds, which

--- a/pkg/plugin/driver_test.go
+++ b/pkg/plugin/driver_test.go
@@ -527,6 +527,16 @@ func TestInterpolateMacros(t *testing.T) {
 		assert.Equal(t, "SELECT ts FROM logs", got)
 	})
 
+	t.Run("expands macros nested in another macro's arguments", func(t *testing.T) {
+		// Regression guard: after the macropro migration the inner macro was
+		// left verbatim ($__timeInterval($__fromTime) → toDateTime($__fromTime))
+		// and the query failed at runtime with UNKNOWN_IDENTIFIER.
+		q := &sqlutil.Query{RawSQL: "SELECT $__timeInterval($__fromTime) AS from_time", TimeRange: timeRange, Interval: time.Minute}
+		got, err := interpolateMacros(t.Context(), q, nil)
+		require.NoError(t, err)
+		assert.Equal(t, "SELECT toStartOfInterval(toDateTime(toDateTime(1415792726)), INTERVAL 60 second) AS from_time", got)
+	})
+
 	t.Run("returns a downstream error on bad macro arguments", func(t *testing.T) {
 		// $__timeFilter with zero args triggers a badArgsErr. The error goes
 		// back to sqlds, which puts it on the query response; it must be


### PR DESCRIPTION
## Type of Change

- [x] 🐛 Bug Fix

---

## Bug Fix

### What is the bug?

As of 4.19.0, a macro passed as an argument to another macro no longer expands. `SELECT $__timeInterval($__fromTime)` reaches ClickHouse as `toStartOfInterval(toDateTime($__fromTime), INTERVAL 60 second)` and fails at runtime with `UNKNOWN_IDENTIFIER` (HTTP 404). This regressed in the macropro migration (#1802): the new engine's single forward scan skipped the outer call's argument text entirely, where the previous sqlutil engine expanded each macro in sequential passes and handled nesting incidentally.

The fix lives in the engine (grafana/macropro#20), which now expands nested macros innermost first before the outer handler runs. This PR picks up that fix and adds regression coverage in the plugin.

### How to reproduce

1. Run plugin 4.19.0 against any ClickHouse instance.
2. Create a query `SELECT $__timeInterval($__fromTime) AS from_time`.
3. The query fails with `DB::Exception: Unknown expression or function identifier '$__fromTime'`.

### Related Issues

Closes #2038

---

## What's in this PR

- Bumps `github.com/grafana/macropro` to pick up the nested-expansion fix.
- Regression tests at three levels:
  - `pkg/macros`: table tests for the exact #2038 query shape, the millisecond variants, and a macro nested inside a larger argument expression.
  - `pkg/plugin`: driver-level `interpolateMacros` test through the sqlds interpolator path.
  - Integration: executes the nested query end to end against a live ClickHouse and asserts the round-tripped value.

---

## Please check that:

- [x] Tests for this change have been added/updated.
- [ ] Documentation has been added/updated (where applicable).

## Special notes for your reviewer

grafana/macropro#20 merged and shipped in macropro v1.0.1, which go.mod now pins. The earlier draft state used a pseudo-version of the fix commit while the release was pending.

