### PR TITLE
fix(macros): preserve backtick identifiers and dollar-quoted literals

### DIFF
--- a/pkg/macros/macros.go
+++ b/pkg/macros/macros.go
@@ -218,12 +218,19 @@ var ClickHouseMacros = macropro.MergeMacros(
 
 // clickHouseComments is the comment/quote style macropro uses when stripping
 // comments before macro expansion. It keeps the standard -- and /* */
-// stripping (which protects against macros hidden inside comments) but adds
-// BackslashEscape so that ClickHouse's default C-style string escapes (e.g.
-// 'O\'Brien') are handled. Without it, macropro mis-reads a \' as the
-// closing quote, treats the trailing text as a comment, and silently drops any
-// macro that follows — corrupting the emitted SQL with no error.
-const clickHouseComments = macropro.LineComment | macropro.BlockComment | macropro.BackslashEscape
+// stripping (which protects against macros hidden inside comments) and adds
+// the quoting rules ClickHouse supports on top of plain single quotes:
+//   - BackslashEscape for ClickHouse's default C-style string escapes (e.g.
+//     'O\'Brien'), so a \' is not mis-read as the closing quote.
+//   - BacktickQuote for backtick-quoted identifiers (e.g. `it's` or `a--b`),
+//     so quote- and comment-like sequences inside them are not mis-lexed.
+//   - DollarQuote for dollar-quoted string literals (e.g. $tag$a--b$tag$),
+//     so a -- inside them is not treated as a line comment.
+//
+// Without these flags macropro mis-terminates the region, treats the trailing
+// text as a string or comment, and silently drops any macro that follows,
+// corrupting the emitted SQL with no error.
+const clickHouseComments = macropro.LineComment | macropro.BlockComment | macropro.BackslashEscape | macropro.BacktickQuote | macropro.DollarQuote
 
 // Interpolate expands all $__ macros in rawSQL using macropro's parsing engine.
 // Unknown macros are left unchanged; a handler error returns the original query and the error.

--- a/pkg/macros/macros_test.go
+++ b/pkg/macros/macros_test.go
@@ -418,3 +418,54 @@ func TestInterpolateBackslashEscapedStringLiterals(t *testing.T) {
 		})
 	}
 }
+
+// TestInterpolateBacktickAndDollarQuotedRegions guards against macropro's
+// comment-stripping pass mis-lexing ClickHouse backtick-quoted identifiers
+// and dollar-quoted string literals. Without BacktickQuote, an apostrophe
+// inside `it's` opens a phantom string region that swallows the rest of the
+// query, and comment-like sequences inside backticks are stripped. Without
+// DollarQuote, a -- inside $tag$…$tag$ is treated as a line comment. Either
+// way the emitted SQL is silently corrupted and trailing macros are dropped.
+func TestInterpolateBacktickAndDollarQuotedRegions(t *testing.T) {
+	from, _ := time.Parse("2006-01-02T15:04:05.000Z", "2014-11-12T11:45:26.123Z")
+	to, _ := time.Parse("2006-01-02T15:04:05.000Z", "2015-11-12T11:45:26.456Z")
+
+	type test struct {
+		name   string
+		input  string
+		output string
+	}
+
+	tests := []test{
+		{
+			name:   "backtick identifier with apostrophe keeps later literal and macro intact",
+			input:  "SELECT `it's` AS x, msg FROM t WHERE msg = 'a--b' AND $__timeFilter(ts)",
+			output: "SELECT `it's` AS x, msg FROM t WHERE msg = 'a--b' AND ts >= toDateTime(1415792726) AND ts <= toDateTime(1447328726)",
+		},
+		{
+			name:   "backtick identifier containing -- and /* survives verbatim",
+			input:  "SELECT `a--b`, `c/*d` FROM t WHERE $__fromTime",
+			output: "SELECT `a--b`, `c/*d` FROM t WHERE toDateTime(1415792726)",
+		},
+		{
+			name:   "dollar-quoted string containing -- survives with macro expanded",
+			input:  "SELECT $doc$a--b$doc$ AS x FROM t WHERE $__toTime",
+			output: "SELECT $doc$a--b$doc$ AS x FROM t WHERE toDateTime(1447328726)",
+		},
+	}
+
+	for i, tc := range tests {
+		t.Run(fmt.Sprintf("[%d/%d] %s", i+1, len(tests), tc.name), func(t *testing.T) {
+			query := &sqlutil.Query{
+				RawSQL: tc.input,
+				TimeRange: backend.TimeRange{
+					From: from,
+					To:   to,
+				},
+			}
+			interpolatedQuery, err := Interpolate(tc.input, query)
+			require.Nil(t, err)
+			assert.Equal(t, tc.output, interpolatedQuery)
+		})
+	}
+}


### PR DESCRIPTION
## Type of Change

- [x] 🐛 Bug Fix

---

## Bug Fix

### What is the bug?

macropro strips SQL comments before expanding $__ macros, and the comment/quote style passed by the ClickHouse plugin (clickHouseComments in pkg/macros/macros.go) only declared LineComment, BlockComment and BackslashEscape. ClickHouse also supports backtick-quoted identifiers and dollar-quoted string literals, and without the corresponding BacktickQuote and DollarQuote flags macropro mis-lexes those regions: an apostrophe inside a backtick identifier opens a phantom string region, a -- inside a dollar-quoted literal is treated as a line comment, and in both cases the rest of the query (including any macro) is silently blanked out with no error. The corrupted SQL then fails at ClickHouse with a syntax error, or worse, runs with the time filter dropped. Introduced by the macropro migration (#1802) and only partially patched by #1991, which added BackslashEscape alone.

### How to reproduce

1. Create a ClickHouse datasource panel with a SQL query in the SQL editor.
2. Run: `SELECT it's AS x, msg FROM t WHERE msg = 'a--b' AND $__timeFilter(ts)`
3. Before the fix, the interpolated query sent to ClickHouse is truncated to `"SELECT it's AS x, msg FROM t WHERE msg = 'a"` plus padding, with the macro dropped and no interpolation error.
4. Same failure shape with a dollar-quoted literal: `SELECT $doc$a--b$doc$ AS x FROM t WHERE $__toTime` truncates at the --.
5. After the fix, both queries interpolate with the literals intact and the macros expanded (covered by `TestInterpolateBacktickAndDollarQuotedRegions` in pkg/macros/macros_test.go).

### Environment (if no related issue)

- **ClickHouse version**: any supported
- **Grafana version**: any supported
- **Plugin version**: 4.19.0 and current main

---

## Please check that:

- [x] Tests for this change have been added/updated.
- [ ] Documentation has been added/updated (where applicable).

## Special notes for your reviewer

The fix is a one-line flag addition, macropro v1.0.1 already ships both flags (verified via go doc github.com/grafana/macropro). BacktickQuote also treats a doubled backtick as the in-identifier escape, matching ClickHouse. DollarQuote is documented as PostgreSQL-style but ClickHouse's $tag$...$tag$ syntax is identical. BracketQuote was deliberately not added since ClickHouse uses [ ] for arrays, and HashComment was not added since ClickHouse does not support # comments. The new test follows the structure of the adjacent TestInterpolateBackslashEscapedStringLiterals suite added by #1991. User-facing impact: queries using backtick identifiers with quote or comment-like characters, or dollar-quoted strings containing --, were silently corrupted, and now interpolate correctly.

Found by an automated audit of regressions introduced while integrating PRs across the v4.18.0 and v4.19.0 release cycles (range v4.17.0..main). Related PRs: #1802, #1991.
