### PR TITLE
fix(traces): stop trace-ID lookup aliases shadowing table columns

### DIFF
--- a/src/data/sqlGenerator.test.ts
+++ b/src/data/sqlGenerator.test.ts
@@ -541,8 +541,8 @@ describe('SQL Generator', () => {
     };
 
     const expectedSqlParts = [
-      `WITH 'abcdefg' as trace_id, (SELECT min(Start) FROM "default"."otel_traces_trace_id_ts" WHERE TraceId = trace_id) as trace_start,`,
-      `(SELECT max(End) + 1 FROM "default"."otel_traces_trace_id_ts" WHERE TraceId = trace_id) as trace_end`,
+      `WITH 'abcdefg' as __gf_trace_id, (SELECT min(Start) FROM "default"."otel_traces_trace_id_ts" WHERE TraceId = __gf_trace_id) as __gf_trace_start,`,
+      `(SELECT max(End) + 1 FROM "default"."otel_traces_trace_id_ts" WHERE TraceId = __gf_trace_id) as __gf_trace_end`,
       'SELECT "TraceId" as traceID, "SpanId" as spanID, "ParentSpanId" as parentSpanID,',
       '"ServiceName" as serviceName, "SpanName" as operationName, multiply(toUnixTimestamp64Nano("Timestamp"), 0.000001) as startTime,',
       'multiply("Duration", 0.000001) as duration,',
@@ -557,7 +557,7 @@ describe('SQL Generator', () => {
       '"InstrumentationLibraryName" as instrumentationLibraryName,',
       '"InstrumentationLibraryVersion" as instrumentationLibraryVersion,',
       '"TraceState" as traceState',
-      `FROM "default"."otel_traces" WHERE traceID = trace_id AND "Timestamp" >= trace_start AND "Timestamp" <= trace_end`,
+      `FROM "default"."otel_traces" WHERE traceID = __gf_trace_id AND "Timestamp" >= __gf_trace_start AND "Timestamp" <= __gf_trace_end`,
     ];
 
     const sql = generateSql(opts);
@@ -604,8 +604,8 @@ describe('SQL Generator', () => {
     };
 
     const expectedSqlParts = [
-      `WITH 'abcdefg' as trace_id, (SELECT min(Start) FROM "default"."otel_traces_trace_id_ts" WHERE TraceId = trace_id) as trace_start,`,
-      `(SELECT max(End) + 1 FROM "default"."otel_traces_trace_id_ts" WHERE TraceId = trace_id) as trace_end`,
+      `WITH 'abcdefg' as __gf_trace_id, (SELECT min(Start) FROM "default"."otel_traces_trace_id_ts" WHERE TraceId = __gf_trace_id) as __gf_trace_start,`,
+      `(SELECT max(End) + 1 FROM "default"."otel_traces_trace_id_ts" WHERE TraceId = __gf_trace_id) as __gf_trace_end`,
       'SELECT "TraceId" as traceID, "SpanId" as spanID, "ParentSpanId" as parentSpanID,',
       '"ServiceName" as serviceName, "SpanName" as operationName, multiply(toUnixTimestamp64Nano("Timestamp"), 0.000001) as startTime,',
       'multiply("Duration", 0.000001) as duration,',
@@ -620,7 +620,7 @@ describe('SQL Generator', () => {
       '"InstrumentationLibraryName" as instrumentationLibraryName,',
       '"InstrumentationLibraryVersion" as instrumentationLibraryVersion,',
       '"TraceState" as traceState',
-      `FROM "default"."otel_traces" WHERE traceID = trace_id AND "Timestamp" >= trace_start AND "Timestamp" <= trace_end`,
+      `FROM "default"."otel_traces" WHERE traceID = __gf_trace_id AND "Timestamp" >= __gf_trace_start AND "Timestamp" <= __gf_trace_end`,
     ];
 
     const sql = generateSql(opts);
@@ -658,8 +658,8 @@ describe('SQL Generator', () => {
       orderBy: [],
     };
     const expectedSqlParts = [
-      `WITH 'abcdefg' as trace_id, (SELECT min(Start) FROM "default"."otel_traces_trace_id_ts" WHERE TraceId = trace_id) as trace_start,`,
-      `(SELECT max(End) + 1 FROM "default"."otel_traces_trace_id_ts" WHERE TraceId = trace_id) as trace_end`,
+      `WITH 'abcdefg' as __gf_trace_id, (SELECT min(Start) FROM "default"."otel_traces_trace_id_ts" WHERE TraceId = __gf_trace_id) as __gf_trace_start,`,
+      `(SELECT max(End) + 1 FROM "default"."otel_traces_trace_id_ts" WHERE TraceId = __gf_trace_id) as __gf_trace_end`,
       'SELECT "TraceId" as traceID, "SpanId" as spanID, "ParentSpanId" as parentSpanID,',
       '"ServiceName" as serviceName, "SpanName" as operationName, multiply(toUnixTimestamp64Nano("Timestamp"), 0.000001) as startTime,',
       'multiply("Duration", 0.000001) as duration,',
@@ -667,7 +667,7 @@ describe('SQL Generator', () => {
       `mapKeys("SpanAttributes")) as tags,`,
       `arrayMap(key -> map('key', key, 'value',"ResourceAttributes"[key]), mapKeys("ResourceAttributes")) as serviceTags,`,
       `if("StatusCode" IN ('Error', 'STATUS_CODE_ERROR'), 2, 0) as statusCode`,
-      `FROM "default"."otel_traces" WHERE traceID = trace_id AND "Timestamp" >= trace_start AND "Timestamp" <= trace_end`,
+      `FROM "default"."otel_traces" WHERE traceID = __gf_trace_id AND "Timestamp" >= __gf_trace_start AND "Timestamp" <= __gf_trace_end`,
     ];
 
     const sql = generateSql(opts);
@@ -777,8 +777,8 @@ describe('SQL Generator', () => {
       orderBy: [],
     };
     const expectedSqlParts = [
-      `WITH 'abcdefg' as trace_id, (SELECT min(Start) FROM "default"."custom_traces_trace_id_ts" WHERE TraceId = trace_id) as trace_start,`,
-      `(SELECT max(End) + 1 FROM "default"."custom_traces_trace_id_ts" WHERE TraceId = trace_id) as trace_end`,
+      `WITH 'abcdefg' as __gf_trace_id, (SELECT min(Start) FROM "default"."custom_traces_trace_id_ts" WHERE TraceId = __gf_trace_id) as __gf_trace_start,`,
+      `(SELECT max(End) + 1 FROM "default"."custom_traces_trace_id_ts" WHERE TraceId = __gf_trace_id) as __gf_trace_end`,
       'SELECT "TraceId" as traceID, "SpanId" as spanID, "ParentSpanId" as parentSpanID,',
       '"ServiceName" as serviceName, "SpanName" as operationName, multiply(toUnixTimestamp64Nano("Timestamp"), 0.000001) as startTime,',
       'multiply("Duration", 0.000001) as duration,',
@@ -786,7 +786,7 @@ describe('SQL Generator', () => {
       `mapKeys("SpanAttributes")) as tags,`,
       `arrayMap(key -> map('key', key, 'value',"ResourceAttributes"[key]), mapKeys("ResourceAttributes")) as serviceTags,`,
       `if("StatusCode" IN ('Error', 'STATUS_CODE_ERROR'), 2, 0) as statusCode`,
-      `FROM "default"."custom_traces" WHERE traceID = trace_id AND "Timestamp" >= trace_start AND "Timestamp" <= trace_end`,
+      `FROM "default"."custom_traces" WHERE traceID = __gf_trace_id AND "Timestamp" >= __gf_trace_start AND "Timestamp" <= __gf_trace_end`,
     ];
 
     const sql = generateSql(opts);
@@ -828,8 +828,47 @@ describe('SQL Generator', () => {
 
     expect(sql).toContain('FROM "default"."custom_traces_ts_index"');
     expect(sql).not.toContain('custom_traces_trace_id_ts');
-    expect(sql).toContain(`WITH 'abcdefg' as trace_id`);
-    expect(sql).toContain('"Timestamp" >= trace_start');
+    expect(sql).toContain(`WITH 'abcdefg' as __gf_trace_id`);
+    expect(sql).toContain('"Timestamp" >= __gf_trace_start');
+  });
+
+  // Regression guard: the WITH aliases must never collide with physical columns
+  // on the main traces table. A bare `trace_id` alias is shadowed by a physical
+  // `trace_id` column, so `WHERE traceID = trace_id` becomes a tautology and
+  // every span in the time window is returned mislabelled with the searched ID.
+  it('does not emit WITH aliases that can be shadowed by main-table columns named trace_id/trace_start/trace_end', () => {
+    const opts: QueryBuilderOptions = {
+      database: 'default',
+      table: 'custom_traces',
+      queryType: QueryType.Traces,
+      columns: [
+        { name: 'trace_id', type: 'String', hint: ColumnHint.TraceId },
+        { name: 'span_id', type: 'String', hint: ColumnHint.TraceSpanId },
+        { name: 'trace_start', type: 'DateTime64(9)', hint: ColumnHint.Time },
+        { name: 'duration', type: 'Int64', hint: ColumnHint.TraceDurationTime },
+      ],
+      filters: [],
+      meta: {
+        minimized: true,
+        otelEnabled: false,
+        otelVersion: undefined,
+        traceDurationUnit: TimeUnit.Nanoseconds,
+        isTraceIdMode: true,
+        traceId: 'abcdefg',
+        hasTraceTimestampTable: true,
+      },
+      limit: 1000,
+      orderBy: [],
+    };
+    const sql = generateSql(opts);
+
+    expect(sql).not.toMatch(/\bas trace_id\b/i);
+    expect(sql).not.toMatch(/\bas trace_start\b/i);
+    expect(sql).not.toMatch(/\bas trace_end\b/i);
+    expect(sql).toContain(`WITH 'abcdefg' as __gf_trace_id`);
+    expect(sql).toContain('WHERE traceID = __gf_trace_id');
+    expect(sql).toContain('"trace_start" >= __gf_trace_start');
+    expect(sql).toContain('"trace_start" <= __gf_trace_end');
   });
 
   it('generates trace search query', () => {

--- a/src/data/sqlGenerator.ts
+++ b/src/data/sqlGenerator.ts
@@ -281,10 +281,14 @@ const generateTraceIdQuery = (options: QueryBuilderOptions): string => {
     const traceIdValue = options.meta!.traceId;
     const suffix = options.meta?.traceTimestampTableSuffix || otel.traceTimestampTableSuffix;
     const timestampTable = getTableIdentifier(database, table + suffix);
+    // The WITH aliases are prefixed so they cannot collide with physical columns
+    // on the main traces table. A bare `trace_id` alias shadows a physical
+    // `trace_id` column, turning `WHERE traceID = trace_id` into a tautology
+    // that returns every span in the time window.
     queryParts.push('WITH');
-    queryParts.push(`'${traceIdValue}' as trace_id,`);
-    queryParts.push(`(SELECT min(Start) FROM ${timestampTable} WHERE TraceId = trace_id) as trace_start,`);
-    queryParts.push(`(SELECT max(End) + 1 FROM ${timestampTable} WHERE TraceId = trace_id) as trace_end`);
+    queryParts.push(`'${traceIdValue}' as __gf_trace_id,`);
+    queryParts.push(`(SELECT min(Start) FROM ${timestampTable} WHERE TraceId = __gf_trace_id) as __gf_trace_start,`);
+    queryParts.push(`(SELECT max(End) + 1 FROM ${timestampTable} WHERE TraceId = __gf_trace_id) as __gf_trace_end`);
   }
 
   queryParts.push('SELECT');
@@ -299,11 +303,11 @@ const generateTraceIdQuery = (options: QueryBuilderOptions): string => {
   }
 
   if (applyTraceIdOptimization) {
-    queryParts.push('traceID = trace_id');
+    queryParts.push('traceID = __gf_trace_id');
     queryParts.push('AND');
-    queryParts.push(`${escapeIdentifier(traceStartTime.name)} >= trace_start`);
+    queryParts.push(`${escapeIdentifier(traceStartTime.name)} >= __gf_trace_start`);
     queryParts.push('AND');
-    queryParts.push(`${escapeIdentifier(traceStartTime.name)} <= trace_end`);
+    queryParts.push(`${escapeIdentifier(traceStartTime.name)} <= __gf_trace_end`);
   } else if (hasTraceIdFilter) {
     const traceId = options.meta!.traceId;
     queryParts.push(`traceID = '${traceId}'`);

--- a/src/data/utils.test.ts
+++ b/src/data/utils.test.ts
@@ -549,8 +549,8 @@ describe('transformQueryResponseWithTraceAndLogLinks', () => {
       const traceQuery = viewTraceLink?.internal?.query as CHBuilderQuery;
 
       expect(traceQuery.rawSql).toContain('otel_traces_trace_id_ts');
-      expect(traceQuery.rawSql).toContain('trace_start');
-      expect(traceQuery.rawSql).toContain('trace_end');
+      expect(traceQuery.rawSql).toContain('__gf_trace_start');
+      expect(traceQuery.rawSql).toContain('__gf_trace_end');
       expect(traceQuery.builderOptions.meta?.hasTraceTimestampTable).toBe(true);
     });
 
@@ -642,8 +642,8 @@ describe('transformQueryResponseWithTraceAndLogLinks', () => {
       expect(traceQuery.builderOptions.meta?.otelEnabled).toBe(true);
       expect(traceQuery.builderOptions.meta?.hasTraceTimestampTable).toBe(true);
       expect(traceQuery.rawSql).toContain('otel_traces_trace_id_ts');
-      expect(traceQuery.rawSql).toContain('trace_start');
-      expect(traceQuery.rawSql).toContain('trace_end');
+      expect(traceQuery.rawSql).toContain('__gf_trace_start');
+      expect(traceQuery.rawSql).toContain('__gf_trace_end');
     });
 
     it('sets format on the trace ID link query so Grafana picks the trace panel', async () => {

--- a/src/views/CHQueryEditor.test.tsx
+++ b/src/views/CHQueryEditor.test.tsx
@@ -98,11 +98,11 @@ describe('Query Editor', () => {
     jest.spyOn(ds, 'hasTraceTimestampTable').mockResolvedValue(true);
 
     const optimizedSql =
-      `WITH 'abc' as trace_id, ` +
-      `(SELECT min(Start) FROM "otel"."otel_traces_trace_id_ts" WHERE TraceId = trace_id) as trace_start, ` +
-      `(SELECT max(End) + 1 FROM "otel"."otel_traces_trace_id_ts" WHERE TraceId = trace_id) as trace_end ` +
+      `WITH 'abc' as __gf_trace_id, ` +
+      `(SELECT min(Start) FROM "otel"."otel_traces_trace_id_ts" WHERE TraceId = __gf_trace_id) as __gf_trace_start, ` +
+      `(SELECT max(End) + 1 FROM "otel"."otel_traces_trace_id_ts" WHERE TraceId = __gf_trace_id) as __gf_trace_end ` +
       `SELECT "TraceId" as traceID FROM "otel"."otel_traces" ` +
-      `WHERE traceID = trace_id AND "Timestamp" >= trace_start AND "Timestamp" <= trace_end`;
+      `WHERE traceID = __gf_trace_id AND "Timestamp" >= __gf_trace_start AND "Timestamp" <= __gf_trace_end`;
 
     const onChange = jest.fn();
     render(

--- a/tests/benchmarks/trace-id-query.sh
+++ b/tests/benchmarks/trace-id-query.sh
@@ -129,13 +129,13 @@ SLOW_SQL="SELECT /* ${SLOW_TAG} */ * FROM ${CH_DB}.bench_traces WHERE TraceId = 
 # Optimized: the exact shape generateTraceIdQuery() emits today when
 # applyTraceIdOptimization fires.
 FAST_SQL="WITH /* ${FAST_TAG} */
-  '${TARGET_TRACE_ID}' AS trace_id,
-  (SELECT min(Start) FROM ${CH_DB}.bench_traces_trace_id_ts WHERE TraceId = trace_id) AS trace_start,
-  (SELECT max(End) + 1 FROM ${CH_DB}.bench_traces_trace_id_ts WHERE TraceId = trace_id) AS trace_end
+  '${TARGET_TRACE_ID}' AS __gf_trace_id,
+  (SELECT min(Start) FROM ${CH_DB}.bench_traces_trace_id_ts WHERE TraceId = __gf_trace_id) AS __gf_trace_start,
+  (SELECT max(End) + 1 FROM ${CH_DB}.bench_traces_trace_id_ts WHERE TraceId = __gf_trace_id) AS __gf_trace_end
 SELECT * FROM ${CH_DB}.bench_traces
-WHERE TraceId = trace_id
-  AND Timestamp >= trace_start
-  AND Timestamp <= trace_end
+WHERE TraceId = __gf_trace_id
+  AND Timestamp >= __gf_trace_start
+  AND Timestamp <= __gf_trace_end
 FORMAT Null"
 
 run_sql "SET use_query_cache = 0; ${SLOW_SQL};"

--- a/tests/e2e/traceTimestampTable.spec.ts
+++ b/tests/e2e/traceTimestampTable.spec.ts
@@ -5,7 +5,7 @@ import { Page } from '@playwright/test';
 // regression guard. The tests exercise the two SQL shapes the plugin
 // generates against real ClickHouse:
 //
-//   Optimized  – WITH trace_id / trace_start / trace_end + Timestamp bounds
+//   Optimized  – WITH __gf_trace_id / __gf_trace_start / __gf_trace_end + Timestamp bounds
 //   Fallback   – plain WHERE traceID = '<id>'
 //
 // Fixture: tests/e2e/fixtures/trace_id_ts.sql creates
@@ -35,14 +35,14 @@ const TRACE_B_SPAN_COUNT = 1;
 // SQL the plugin generates with hasTraceTimestampTable: true
 function optimizedSql(traceId: string): string {
   return [
-    `WITH '${traceId}' as trace_id,`,
-    `(SELECT min(Start) FROM "e2e_test"."trace_ts_spans_trace_id_ts" WHERE TraceId = trace_id) as trace_start,`,
-    `(SELECT max(End) + 1 FROM "e2e_test"."trace_ts_spans_trace_id_ts" WHERE TraceId = trace_id) as trace_end`,
+    `WITH '${traceId}' as __gf_trace_id,`,
+    `(SELECT min(Start) FROM "e2e_test"."trace_ts_spans_trace_id_ts" WHERE TraceId = __gf_trace_id) as __gf_trace_start,`,
+    `(SELECT max(End) + 1 FROM "e2e_test"."trace_ts_spans_trace_id_ts" WHERE TraceId = __gf_trace_id) as __gf_trace_end`,
     `SELECT "TraceId" as traceID, "SpanId" as spanID`,
     `FROM "e2e_test"."trace_ts_spans"`,
-    `WHERE traceID = trace_id`,
-    `AND "Timestamp" >= trace_start`,
-    `AND "Timestamp" <= trace_end`,
+    `WHERE traceID = __gf_trace_id`,
+    `AND "Timestamp" >= __gf_trace_start`,
+    `AND "Timestamp" <= __gf_trace_end`,
   ].join(' ');
 }
 


### PR DESCRIPTION
## Type of Change

- [x] 🐛 Bug Fix

---

## Bug Fix

### What is the bug?

The companion-table optimisation in generateTraceIdQuery emits "WITH '<id>' as trace_id, ... as trace_start, ... as trace_end" and then filters with "WHERE traceID = trace_id AND <time> >= trace_start AND <time> <= trace_end". If the main traces table has physical columns named trace_id, trace_start or trace_end (common on non-OTel schemas, and the column heuristics from #1791 auto-map a trace_id column), the bare identifier in the WHERE clause resolves against the physical column instead of the WITH alias. "traceID = trace_id" then compares the trace ID column with itself, a tautology, so every span in the queried time window is returned and mislabelled with the searched trace ID. Introduced when #1786/#1853/#1994 decoupled the optimisation from OTel naming without guarding against main-table column names. Reproduced empirically on ClickHouse 24.8.

### How to reproduce

1. Create a traces table whose trace ID column is physically named trace_id (and optionally a time column named trace_start), plus a companion <table>_trace_id_ts table so the optimisation activates.
2. Configure a trace query on that table with the column hints mapped to those columns (the auto-mapping heuristics will map trace_id automatically) and let the datasource detect the companion table (hasTraceTimestampTable: true).
3. Open a single trace by ID (trace ID mode), for example via a View trace link.
4. Before the fix, the generated SQL contains "WHERE traceID = trace_id", which ClickHouse resolves to the physical trace_id column, so the trace view shows every span in the time window instead of only the requested trace. After the fix the aliases are __gf_-prefixed and only the requested trace's spans are returned.

### Environment (if no related issue)

- **ClickHouse version**: any supported
- **Grafana version**: any supported
- **Plugin version**: 4.19.0 and current main

---

## Please check that:

- [x] Tests for this change have been added/updated.
- [ ] Documentation has been added/updated (where applicable).

## Special notes for your reviewer

The renamed aliases (__gf_trace_id, __gf_trace_start, __gf_trace_end) only exist inside SQL that is generated per execution and never persisted in saved queries, so the rename is safe with no migration concerns. The __gf_ prefix is new in this repo (no existing prefix convention was found) and is intended to be obviously Grafana-generated and vanishingly unlikely to collide with user schemas. Beyond the generator, the change updates every place that asserts or mirrors the exact generated SQL: sqlGenerator.test.ts (three exact toEqual assertions plus two toContain assertions), utils.test.ts (trace link rawSql assertions, tightened from bare substrings to the prefixed names), CHQueryEditor.test.tsx (the #1918 cold-cache fixture rawSql), tests/e2e/traceTimestampTable.spec.ts (the optimised SQL shape the e2e suite replays against real ClickHouse), and tests/benchmarks/trace-id-query.sh (whose comment claims to be the exact shape generateTraceIdQuery emits). The new regression test in sqlGenerator.test.ts builds a table with physical trace_id/trace_start columns and asserts no bare "as trace_id/as trace_start/as trace_end" alias is emitted. It was verified to fail against the unfixed generator. The three cspell complaints in tests/benchmarks/trace-id-query.sh (Prereqs, dockerised, ZSTD) are pre-existing on HEAD and not on changed lines.

Found by an automated audit of regressions introduced while integrating PRs across the v4.18.0 and v4.19.0 release cycles (range v4.17.0..main). Related PRs: #1786, #1853, #1994, #1791.
