### PR TITLE
fix(traces): validate the companion table with the suffix the query uses

### DIFF
--- a/src/data/CHDatasource.test.ts
+++ b/src/data/CHDatasource.test.ts
@@ -2515,6 +2515,30 @@ describe('ClickHouseDatasource', () => {
 
       await expect(ds.hasTraceTimestampTable('default', 'traces')).resolves.toBe(true);
     });
+
+    it('prefers an explicit suffix argument over the configured one', async () => {
+      // A saved query can bake a meta.traceTimestampTableSuffix that differs
+      // from the current datasource config. The check must probe the companion
+      // the generated SQL will reference (the query's suffix), and the two
+      // suffixes must not share a cache entry.
+      const ds = cloneDeep(mockDatasource);
+      ds.settings = {
+        ...ds.settings,
+        jsonData: {
+          ...ds.settings.jsonData,
+          traces: { ...(ds.settings.jsonData.traces || {}), traceTimestampTableSuffix: '_idx_ts' },
+        },
+      };
+      jest.spyOn(ds, 'fetchTables').mockResolvedValue(['traces', 'traces_saved_ts']);
+      const columnsSpy = jest.spyOn(ds, 'fetchColumns').mockResolvedValue(timestampColumns());
+
+      await expect(ds.hasTraceTimestampTable('default', 'traces', '_saved_ts')).resolves.toBe(true);
+      expect(columnsSpy).toHaveBeenCalledWith('default', 'traces_saved_ts');
+
+      // The config-suffix companion does not exist, and the cached result for
+      // the explicit suffix must not leak into this separate check.
+      await expect(ds.hasTraceTimestampTable('default', 'traces')).resolves.toBe(false);
+    });
   });
 
   describe('peekTraceTimestampTable', () => {
@@ -2568,6 +2592,17 @@ describe('ClickHouseDatasource', () => {
       expect(ds.peekTraceTimestampTable('otel', 'otel_traces')).toBeUndefined();
 
       nowSpy.mockRestore();
+    });
+
+    it('keys cached results by the resolved suffix', async () => {
+      const ds = cloneDeep(mockDatasource);
+      jest.spyOn(ds, 'fetchTables').mockResolvedValue(['otel_traces', 'otel_traces_saved_ts']);
+      jest.spyOn(ds, 'fetchColumns').mockResolvedValue(timestampColumns());
+
+      await ds.hasTraceTimestampTable('otel', 'otel_traces', '_saved_ts');
+      expect(ds.peekTraceTimestampTable('otel', 'otel_traces', '_saved_ts')).toBe(true);
+      // The config-suffix check has not run, so it must still read as unknown.
+      expect(ds.peekTraceTimestampTable('otel', 'otel_traces')).toBeUndefined();
     });
   });
 

--- a/src/data/CHDatasource.ts
+++ b/src/data/CHDatasource.ts
@@ -225,8 +225,9 @@ export class Datasource
   private mapColumnsByTable: Map<string, Set<string>> = new Map();
   private static readonly TRACE_TIMESTAMP_TABLE_CACHE_TTL_MS = 30 * 1000;
   // Caches the in-flight or resolved existence check for the `<table>_trace_id_ts`
-  // companion, keyed by `${database}.${table}`. Caching the Promise dedupes concurrent
-  // callers and lets cache hits resolve in a microtask. Entries expire after
+  // companion, keyed by the qualified companion table name (`${database}.${table}${suffix}`)
+  // so checks against different suffixes never share a result. Caching the Promise dedupes
+  // concurrent callers and lets cache hits resolve in a microtask. Entries expire after
   // TRACE_TIMESTAMP_TABLE_CACHE_TTL_MS so a companion table created after the datasource
   // loaded is detected without a page reload.
   private traceTimestampTableCache = new Map<
@@ -998,16 +999,22 @@ export class Datasource
    * with trace_id/start_time/end_time) would produce an UNKNOWN_IDENTIFIER error,
    * so it is rejected here and the query falls back to the plain filter.
    *
+   * The companion name is resolved from the per-query `suffix` when one is
+   * given (saved queries bake it into `meta.traceTimestampTableSuffix`) so the
+   * probe targets the same table the SQL generator will reference; without it
+   * the datasource config suffix applies.
+   *
    * Caches the Promise so concurrent and repeat callers share a single
    * round-trip; on failure, evicts so the next caller retries and meanwhile
    * returns `false` (the safe, unoptimized path).
    */
-  async hasTraceTimestampTable(database: string, table: string): Promise<boolean> {
+  async hasTraceTimestampTable(database: string, table: string, suffix?: string): Promise<boolean> {
     if (!database || !table) {
       return false;
     }
 
-    const key = `${database}.${table}`;
+    const companionTable = table + (suffix || this.getTraceTimestampTableSuffix());
+    const key = `${database}.${companionTable}`;
     const now = Date.now();
 
     let entry = this.traceTimestampTableCache.get(key);
@@ -1015,7 +1022,6 @@ export class Datasource
     if (!entry || entry.expiresAt <= now) {
       const pending = (async () => {
         try {
-          const companionTable = table + this.getTraceTimestampTableSuffix();
           const tables = await this.fetchTables(database);
           if (!tables.includes(companionTable)) {
             return false;
@@ -1049,11 +1055,12 @@ export class Datasource
    * Lets the React hook seed its initial state from a warm cache and skip a
    * false→true render that would briefly clobber a known-good meta value.
    */
-  peekTraceTimestampTable(database: string, table: string): boolean | undefined {
+  peekTraceTimestampTable(database: string, table: string, suffix?: string): boolean | undefined {
     if (!database || !table) {
       return undefined;
     }
-    const entry = this.traceTimestampTableCache.get(`${database}.${table}`);
+    const companionTable = table + (suffix || this.getTraceTimestampTableSuffix());
+    const entry = this.traceTimestampTableCache.get(`${database}.${companionTable}`);
     if (!entry || entry.expiresAt <= Date.now()) {
       return undefined;
     }

--- a/src/data/utils.test.ts
+++ b/src/data/utils.test.ts
@@ -1,4 +1,4 @@
-import { ColumnHint, QueryBuilderOptions, QueryType, TimeUnit } from 'types/queryBuilder';
+import { ColumnHint, QueryBuilderOptions, QueryType, TableColumn, TimeUnit } from 'types/queryBuilder';
 import {
   applyTraceSearchFieldConfig,
   columnLabelToPlaceholder,
@@ -552,6 +552,53 @@ describe('transformQueryResponseWithTraceAndLogLinks', () => {
       expect(traceQuery.rawSql).toContain('trace_start');
       expect(traceQuery.rawSql).toContain('trace_end');
       expect(traceQuery.builderOptions.meta?.hasTraceTimestampTable).toBe(true);
+    });
+
+    it('trace→trace link probes the companion named by the saved query suffix, not the config suffix', async () => {
+      // A saved query baked with meta.traceTimestampTableSuffix: '_saved_ts'
+      // generates SQL against otel_traces_saved_ts. The existence check must
+      // probe that same table: probing the config-suffix companion
+      // (otel_traces_trace_id_ts here, which does not exist) would drop the
+      // optimization, or in the reverse case pass the check and ship SQL
+      // referencing a missing table (UNKNOWN_TABLE).
+      const mockDatasource = newOtelMockDatasource();
+      jest.spyOn(mockDatasource, 'fetchTables').mockResolvedValue(['otel_traces', 'otel_traces_saved_ts']);
+      const companionColumns: TableColumn[] = [
+        { name: 'TraceId', type: 'String', label: 'TraceId', picklistValues: [] },
+        { name: 'Start', type: 'DateTime64(9)', label: 'Start', picklistValues: [] },
+        { name: 'End', type: 'DateTime64(9)', label: 'End', picklistValues: [] },
+      ];
+      jest
+        .spyOn(mockDatasource, 'fetchColumns')
+        .mockImplementation((_database, table) =>
+          Promise.resolve(table === 'otel_traces_saved_ts' ? companionColumns : [])
+        );
+      const otelConfig = otel.getVersion('latest')!;
+      const columns = Array.from(otelConfig.traceColumnMap, ([hint, name]) => ({ name, hint }));
+
+      const builderOptions: Partial<QueryBuilderOptions> = {
+        database: 'otel',
+        table: 'otel_traces',
+        queryType: QueryType.Traces,
+        columns,
+        meta: {
+          otelEnabled: true,
+          otelVersion: 'latest',
+          traceDurationUnit: TimeUnit.Nanoseconds,
+          traceTimestampTableSuffix: '_saved_ts',
+        },
+      };
+
+      const [request, response] = buildTestRequestResponse(builderOptions);
+      const out = await transformQueryResponseWithTraceAndLogLinks(mockDatasource, request, response);
+
+      const links = out?.data[0]?.fields[0]?.config?.links;
+      const viewTraceLink = links?.find((link: any) => link.title === 'View trace');
+      const traceQuery = viewTraceLink?.internal?.query as CHBuilderQuery;
+
+      expect(traceQuery.builderOptions.meta?.hasTraceTimestampTable).toBe(true);
+      expect(traceQuery.builderOptions.meta?.traceTimestampTableSuffix).toBe('_saved_ts');
+      expect(traceQuery.rawSql).toContain('otel_traces_saved_ts');
     });
 
     it('trace→trace link auto-detects JSON tag columns via fetchColumns', async () => {

--- a/src/data/utils.ts
+++ b/src/data/utils.ts
@@ -413,9 +413,12 @@ export const transformQueryResponseWithTraceAndLogLinks = async (
           false) ||
         (!fetchedLiveSchema && !typeKnown && Boolean(originalQuery.builderOptions.meta?.tagsAreJSON));
 
+      // Validate the companion table the generated SQL will reference: the
+      // query's baked suffix wins over the current datasource config suffix.
       const hasTraceTimestampTable = await datasource.hasTraceTimestampTable(
         originalQuery.builderOptions.database || '',
-        originalQuery.builderOptions.table || ''
+        originalQuery.builderOptions.table || '',
+        originalQuery.builderOptions.meta?.traceTimestampTableSuffix
       );
 
       traceIdQuery.builderOptions = {

--- a/src/hooks/useHasTraceTimestampTable.test.ts
+++ b/src/hooks/useHasTraceTimestampTable.test.ts
@@ -14,7 +14,7 @@ describe('useHasTraceTimestampTable', () => {
     // The async check cannot have settled yet, so a `true` on the first render
     // proves the value was seeded synchronously from the cache peek.
     expect(result.current).toBe(true);
-    expect(mockDs.peekTraceTimestampTable).toHaveBeenCalledWith('otel', 'otel_traces');
+    expect(mockDs.peekTraceTimestampTable).toHaveBeenCalledWith('otel', 'otel_traces', undefined);
 
     await act(async () => {}); // flush the pending async check
     expect(result.current).toBe(true);
@@ -49,6 +49,22 @@ describe('useHasTraceTimestampTable', () => {
 
     await act(async () => {});
     expect(result.current).toBe(false);
+  });
+
+  it('passes the per-query suffix through to the peek and the async check', async () => {
+    // A saved query can bake a meta.traceTimestampTableSuffix that differs
+    // from the datasource config suffix. The hook must probe the companion
+    // table the SQL generator will reference, not the config one.
+    const mockDs = {} as Datasource;
+    mockDs.peekTraceTimestampTable = jest.fn(() => undefined);
+    mockDs.hasTraceTimestampTable = jest.fn(() => Promise.resolve(true));
+
+    const { result } = renderHook(() => useHasTraceTimestampTable(mockDs, 'otel', 'otel_traces', '_saved_ts'));
+
+    await act(async () => {});
+    expect(result.current).toBe(true);
+    expect(mockDs.peekTraceTimestampTable).toHaveBeenCalledWith('otel', 'otel_traces', '_saved_ts');
+    expect(mockDs.hasTraceTimestampTable).toHaveBeenCalledWith('otel', 'otel_traces', '_saved_ts');
   });
 
   it('returns false when database or table is empty', async () => {

--- a/src/hooks/useHasTraceTimestampTable.ts
+++ b/src/hooks/useHasTraceTimestampTable.ts
@@ -4,15 +4,20 @@ import { Datasource } from 'data/CHDatasource';
 /**
  * Resolves whether the `<table>_trace_id_ts` companion exists.
  *
+ * Pass the query's `meta.traceTimestampTableSuffix` as `suffix` so the check
+ * probes the same companion table the SQL generator will reference, since a
+ * saved query can carry a suffix that differs from the current datasource
+ * config.
+ *
  * Returns `undefined` while the lookup is still in flight on a cold cache.
  * Callers that mirror this into builder options must treat `undefined` as
  * "don't know yet" and leave the upstream meta value alone — otherwise the
  * transient `false` clobbers the optimized value that the response-transform
  * path bakes into trace ID deep-link queries (see issue #1918).
  */
-export default (datasource: Datasource, database: string, table: string): boolean | undefined => {
+export default (datasource: Datasource, database: string, table: string, suffix?: string): boolean | undefined => {
   const [result, setResult] = useState<boolean | undefined>(() =>
-    datasource.peekTraceTimestampTable(database, table)
+    datasource.peekTraceTimestampTable(database, table, suffix)
   );
 
   useEffect(() => {
@@ -23,7 +28,7 @@ export default (datasource: Datasource, database: string, table: string): boolea
 
     let cancelled = false;
     datasource
-      .hasTraceTimestampTable(database, table)
+      .hasTraceTimestampTable(database, table, suffix)
       .then((v) => {
         if (!cancelled) {
           setResult(v);
@@ -38,7 +43,7 @@ export default (datasource: Datasource, database: string, table: string): boolea
     return () => {
       cancelled = true;
     };
-  }, [datasource, database, table]);
+  }, [datasource, database, table, suffix]);
 
   return result;
 };

--- a/src/views/CHQueryEditor.test.tsx
+++ b/src/views/CHQueryEditor.test.tsx
@@ -152,6 +152,49 @@ describe('Query Editor', () => {
     }
   });
 
+  it('validates the companion table named by the query meta suffix on trace ID deep-links', async () => {
+    // A saved deep-link query can bake a meta.traceTimestampTableSuffix that
+    // differs from the current datasource config suffix. The editor's check
+    // must probe the companion the generated SQL will reference (the query's
+    // suffix), otherwise it validates one table while the emitted SQL joins
+    // against another.
+    const ds = newMockDatasource();
+    jest.spyOn(ds, 'peekTraceTimestampTable').mockReturnValue(undefined);
+    const hasSpy = jest.spyOn(ds, 'hasTraceTimestampTable').mockResolvedValue(true);
+
+    render(
+      <CHQueryEditor
+        query={{
+          pluginVersion,
+          refId: 'Trace ID',
+          editorType: EditorType.Builder,
+          rawSql: '',
+          builderOptions: {
+            database: 'otel',
+            table: 'otel_traces',
+            queryType: QueryType.Traces,
+            columns: [
+              { name: 'Timestamp', hint: ColumnHint.Time },
+              { name: 'TraceId', hint: ColumnHint.TraceId },
+            ],
+            meta: {
+              minimized: true,
+              isTraceIdMode: true,
+              traceId: 'abc',
+              traceTimestampTableSuffix: '_saved_ts',
+            },
+          },
+        }}
+        onChange={jest.fn()}
+        onRunQuery={jest.fn()}
+        datasource={ds}
+      />
+    );
+    await act(async () => {});
+
+    expect(hasSpy).toHaveBeenCalledWith('otel', 'otel_traces', '_saved_ts');
+  });
+
   it('renders compact SQL chrome for single-table datasources', () => {
     const datasource = newMockDatasource();
     datasource.settings.jsonData.configMode = 'single-table';

--- a/src/views/CHQueryEditor.tsx
+++ b/src/views/CHQueryEditor.tsx
@@ -110,7 +110,10 @@ const CHEditorByType = (props: CHQueryEditorProps) => {
   const hasTraceTimestampTable = useHasTraceTimestampTable(
     props.datasource,
     needsTraceTableCheck ? builderOptions.database || '' : '',
-    needsTraceTableCheck ? builderOptions.table || '' : ''
+    needsTraceTableCheck ? builderOptions.table || '' : '',
+    // Probe the companion table the generated SQL will reference: a saved
+    // query's baked suffix wins over the current datasource config suffix.
+    builderOptions.meta?.traceTimestampTableSuffix
   );
 
   useEffect(() => {


### PR DESCRIPTION
## Type of Change

- [x] 🐛 Bug Fix

---

## Bug Fix

### What is the bug?

The trace-ID lookup optimisation is guarded by hasTraceTimestampTable, which validated the companion table named by the datasource config suffix (getTraceTimestampTableSuffix). But the SQL generator (src/data/sqlGenerator.ts, generateTraceIdQuery) and the deep-link transform (src/data/utils.ts) build the companion name from the per-query builderOptions.meta.traceTimestampTableSuffix. When a saved query's baked suffix differs from the current config suffix, the guard validates one table while the emitted SQL references another: the check can pass against the config-suffix table while the generated WITH clause joins a nonexistent meta-suffix table, failing with UNKNOWN_TABLE, or in the reverse case the check fails safe and silently drops the optimisation although the companion the SQL would use exists. Introduced when #1853/#1994 moved the check into the datasource and dropped #1786's meta-suffix preference from the check path.

### How to reproduce

1. Configure a ClickHouse datasource with a traces table and leave the trace timestamp table suffix at the default, then create a logs-to-trace or trace-to-trace deep-link query so meta.traceTimestampTableSuffix: '_trace_id_ts' is baked into the saved query.
2. Change the datasource config suffix to '_idx_ts' and create the companion table `<table>_idx_ts` (with TraceId/Start/End) without a `<table>_trace_id_ts` table.
3. Open the saved deep-link query or click View trace: the guard probes `<table>_idx_ts` (exists, check passes) but the emitted SQL joins `<table>_trace_id_ts`, so the query fails with UNKNOWN_TABLE.
4. Swap which companion table exists to see the fail-safe variant: the guard probes the missing config-suffix table and drops the optimisation even though the table the SQL would reference exists.

### Environment (if no related issue)

- **ClickHouse version**: any supported
- **Grafana version**: any supported
- **Plugin version**: 4.19.0 and current main

---

## Please check that:

- [x] Tests for this change have been added/updated.
- [ ] Documentation has been added/updated (where applicable).

## Special notes for your reviewer

hasTraceTimestampTable/peekTraceTimestampTable gain an optional suffix parameter resolved as suffix || getTraceTimestampTableSuffix(), restoring the meta-suffix preference #1786 used on the editor path before #1853 centralised the check. The #1994 column probe (Start/End/TraceId) is unchanged and runs against the resolved companion. The existence cache key changed from db.table to the qualified companion name (db.table+suffix) so per-suffix results never collide, the cache is private, so no external key shape depends on it. The second branch of the utils.ts transform (fresh query built from config defaults) is deliberately not changed because it bakes the config suffix into meta, so check and generator already resolve the same table there. One known residual: pre-#1786 saved queries with no baked meta suffix still resolve config suffix in the check but the OTel default in the generator, every current creation path bakes a suffix, so this only affects queries saved before May 2026 combined with a custom config suffix. Regression tests: datasource-level suffix preference and cache keying (CHDatasource.test.ts), hook pass-through (useHasTraceTimestampTable.test.ts), editor wiring on deep-links (CHQueryEditor.test.tsx), and an end-to-end transform test where only the meta-suffix companion exists (utils.test.ts), all five fail without the fix.

Found by an automated audit of regressions introduced while integrating PRs across the v4.18.0 and v4.19.0 release cycles (range v4.17.0..main). Related PRs: #1786, #1853, #1994.
