### PR TITLE
fix(traces): clear the injected span-link trace ID once the query is edited

### DIFF
--- a/src/data/CHDatasource.ts
+++ b/src/data/CHDatasource.ts
@@ -527,7 +527,9 @@ export class Datasource
       return query;
     }
 
-    const meta = query.builderOptions.meta;
+    // Hand-provisioned models can carry editorType 'builder' without builderOptions,
+    // and the query editor now calls this on every render, so guard the access.
+    const meta = query.builderOptions?.meta;
     if (!meta?.isTraceIdMode) {
       return query;
     }

--- a/src/views/CHQueryEditor.test.tsx
+++ b/src/views/CHQueryEditor.test.tsx
@@ -7,6 +7,7 @@ import { mockDatasource, newMockDatasource } from '__mocks__/datasource';
 import { EditorType } from 'types/sql';
 import { ColumnHint, FilterOperator, QueryType } from 'types/queryBuilder';
 import { pluginVersion } from 'utils/version';
+import { selectors } from 'selectors';
 
 jest.mock('@grafana/ui', () => ({
   ...jest.requireActual<typeof ui>('@grafana/ui'),
@@ -441,5 +442,88 @@ describe('Query Editor', () => {
 
     await waitFor(() => expect(screen.getByText('SeverityText')).toBeInTheDocument());
     expect(screen.getByText('error')).toBeInTheDocument();
+  });
+
+  // Regression guard for the one-shot span-link `query` field (#1889 follow-up):
+  // Grafana core injects a top-level `query` field when a span link is followed.
+  // The editor must fold that trace id into the builder options and never spread
+  // the injected field back out through onChange, otherwise the saved model stays
+  // pinned to the linked trace after the user targets a different trace id.
+  describe('span link one-shot query field', () => {
+    const originalTraceId = 'a55d8be622a816047a902c60adedd776';
+    const linkedTraceId = '4ea6a6e0d0525ed05ecc350d3cdd66b6';
+    const userTraceId = 'c3b5f0a1d2e4968877665544332211ff';
+
+    const spanLinkQuery = () => ({
+      pluginVersion,
+      refId: 'A',
+      editorType: EditorType.Builder as const,
+      rawSql: `SELECT "TraceId" as traceID FROM "otel"."otel_traces" WHERE traceID = '${originalTraceId}'`,
+      builderOptions: {
+        database: 'otel',
+        table: 'otel_traces',
+        queryType: QueryType.Traces,
+        columns: [{ name: 'TraceId', hint: ColumnHint.TraceId }],
+        meta: { isTraceIdMode: true, traceId: originalTraceId },
+      },
+      // Grafana core builds the span-link navigation target as { ...currentQuery, query: linkedTraceId }.
+      query: linkedTraceId,
+    });
+
+    const newTraceDatasource = () => {
+      const datasource = newMockDatasource();
+      datasource.fetchColumns = jest.fn(() => Promise.resolve([]));
+      datasource.fetchDatabases = jest.fn(() => Promise.resolve([]));
+      datasource.fetchTables = jest.fn(() => Promise.resolve([]));
+      jest.spyOn(datasource, 'peekTraceTimestampTable').mockReturnValue(false);
+      jest.spyOn(datasource, 'hasTraceTimestampTable').mockResolvedValue(false);
+      return datasource;
+    };
+
+    it('retargets a freshly injected span-link trace id and strips the one-shot field', async () => {
+      const onChange = jest.fn();
+
+      render(
+        <CHQueryEditor
+          query={spanLinkQuery()}
+          onChange={onChange}
+          onRunQuery={jest.fn()}
+          datasource={newTraceDatasource()}
+        />
+      );
+      await act(async () => {});
+
+      expect(onChange).toHaveBeenCalled();
+      const [propagated] = onChange.mock.calls[onChange.mock.calls.length - 1];
+      expect('query' in propagated).toBe(false);
+      expect(propagated.builderOptions?.meta?.traceId).toEqual(linkedTraceId);
+      expect(propagated.rawSql).toContain(linkedTraceId);
+      expect(propagated.rawSql).not.toContain(originalTraceId);
+    });
+
+    it('follows the user trace id after an edit instead of re-pinning the linked trace', async () => {
+      const onChange = jest.fn();
+
+      render(
+        <CHQueryEditor
+          query={spanLinkQuery()}
+          onChange={onChange}
+          onRunQuery={jest.fn()}
+          datasource={newTraceDatasource()}
+        />
+      );
+      await act(async () => {});
+
+      const traceIdInput = screen.getByTestId(selectors.components.QueryBuilder.TraceIdInput.input);
+      fireEvent.change(traceIdInput, { target: { value: userTraceId } });
+      fireEvent.blur(traceIdInput);
+      await act(async () => {});
+
+      const [propagated] = onChange.mock.calls[onChange.mock.calls.length - 1];
+      expect('query' in propagated).toBe(false);
+      expect(propagated.builderOptions?.meta?.traceId).toEqual(userTraceId);
+      expect(propagated.rawSql).toContain(userTraceId);
+      expect(propagated.rawSql).not.toContain(linkedTraceId);
+    });
   });
 });

--- a/src/views/CHQueryEditor.tsx
+++ b/src/views/CHQueryEditor.tsx
@@ -21,28 +21,49 @@ import { isEqual } from 'lodash';
 export type CHQueryEditorProps = QueryEditorProps<Datasource, CHQuery, CHConfig>;
 
 /**
+ * Grafana core injects a one-shot top-level `query` field into the pane query when a span
+ * link is followed (see Datasource.retargetSpanLinkTrace). The injected value must only
+ * apply until the user next edits the query, so drop it from every change the editor
+ * propagates. Otherwise it survives in the saved model and pins every run to the linked
+ * trace, even after the user targets a different trace id.
+ */
+const removeSpanLinkQueryField = (query: CHQuery): CHQuery => {
+  if (!('query' in query)) {
+    return query;
+  }
+
+  const { query: discardedSpanLinkQuery, ...rest } = query;
+  void discardedSpanLinkQuery;
+  return rest;
+};
+
+/**
  * Top level query editor component
  */
 export const CHQueryEditor = (props: CHQueryEditorProps) => {
-  const { datasource, query: savedQuery, onRunQuery } = props;
-  const query = migrateCHQuery(savedQuery);
+  const { datasource, query: savedQuery, onChange, onRunQuery } = props;
+  // Fold a span-link injected trace id into the builder options before rendering, so the
+  // editor shows the linked trace and the first propagated change keeps targeting it once
+  // removeSpanLinkQueryField drops the one-shot field.
+  const query = datasource.retargetSpanLinkTrace(migrateCHQuery(savedQuery));
+  const handleChange = useCallback((nextQuery: CHQuery) => onChange(removeSpanLinkQueryField(nextQuery)), [onChange]);
   const singleTableMode = datasource.isSingleTableMode();
 
   if (singleTableMode && query.editorType === EditorType.SQL) {
-    return <CompactSqlMode {...props} query={query} />;
+    return <CompactSqlMode {...props} query={query} onChange={handleChange} />;
   }
 
   if (singleTableMode) {
-    return <CHEditorByType {...props} query={query} />;
+    return <CHEditorByType {...props} query={query} onChange={handleChange} />;
   }
 
   return (
     <>
       <InlineFieldRow className={styles.QueryEditor.queryType}>
-        <EditorTypeSwitcher {...props} query={query} datasource={datasource} />
+        <EditorTypeSwitcher {...props} query={query} onChange={handleChange} datasource={datasource} />
         <Button onClick={() => onRunQuery()}>Run Query</Button>
       </InlineFieldRow>
-      <CHEditorByType {...props} query={query} />
+      <CHEditorByType {...props} query={query} onChange={handleChange} />
     </>
   );
 };


### PR DESCRIPTION
## Type of Change

- [x] 🐛 Bug Fix

---

## Bug Fix

### What is the bug?

When a span link ("View Linked Span") is followed in the trace view, Grafana core builds the navigation target as { ...currentQuery, query: linkedTraceId }, and retargetSpanLinkTrace (#1890) regenerates rawSql from that top-level field at query time. Nothing ever cleared the field, and every CHQueryEditor onChange spread it forward into the saved model, so the pane stayed permanently pinned to the linked trace: typing a different trace ID in the builder showed the new ID while the data kept returning the linked trace, and saving persisted the stale field.

### How to reproduce

1. In Explore, run a trace ID query (builder editor, trace ID mode) and open a trace that contains a span link.
2. Follow "View Linked Span" so the pane query becomes { ...currentQuery, query: '<linked trace id>' }. The linked trace loads correctly.
3. In the query builder, enter a different (hex) trace ID and run the query.
4. Observe the trace ID field shows the new ID but the returned spans still belong to the linked trace. Saving the Explore state or panel persists the injected field, so the pin survives reloads.

### Environment (if no related issue)

- **ClickHouse version**: any supported
- **Grafana version**: any supported
- **Plugin version**: 4.19.0 and current main

---

## Please check that:

- [x] Tests for this change have been added/updated.
- [ ] Documentation has been added/updated (where applicable).

## Special notes for your reviewer

The fix has two coupled parts. (1) Strip: removeSpanLinkQueryField drops the injected top-level "query" field from every change the editor propagates. The wrapped handleChange is passed to EditorTypeSwitcher, CHEditorByType and CompactSqlMode, and reaches SqlEditor and the QueryBuilder callbacks through the existing prop spreads, so both SQL typing and builder edits clear it. (2) Fold: CHQueryEditor now runs the saved query through datasource.retargetSpanLinkTrace before rendering. Strip-only would regress #1889 because CHEditorByType's mount-time [builderOptions] effect fires an automatic onChange regenerated from local builder state (still the original trace), which would replace the linked trace on the next run. Folding first means that automatic emission already targets the linked trace, and the model converges with no stray field. The one-line optional chain in retargetSpanLinkTrace (query.builderOptions?.meta) guards hand-provisioned models that carry editorType 'builder' without builderOptions, now that the method runs on every editor render. Verified with tsc, eslint, cspell, and the full jest suite (75 suites, 994 passed), both new tests fail without the fix.

Found by an automated audit of regressions introduced while integrating PRs across the v4.18.0 and v4.19.0 release cycles (range v4.17.0..main). Related PRs: #1890.
