### PR TITLE
fix(queryBuilder): support JSON attribute columns in the compact filter popover

### DIFF
--- a/src/components/queryBuilder/FilterPopover.test.tsx
+++ b/src/components/queryBuilder/FilterPopover.test.tsx
@@ -1,5 +1,47 @@
-import { FilterOperator } from 'types/queryBuilder';
-import { getFilterValueKind, getOperatorOptions, toFilterValueOption } from './FilterPopover';
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Datasource } from 'data/CHDatasource';
+import { FilterOperator, TableColumn } from 'types/queryBuilder';
+import { FilterPopover, getFilterValueKind, getOperatorOptions, toFilterValueOption } from './FilterPopover';
+
+const createMockDatasource = (): Datasource => {
+  const datasource = {} as Datasource;
+  datasource.fetchUniqueMapKeys = jest.fn(() => Promise.resolve(['mapKey']));
+  datasource.fetchUniqueJSONPaths = jest.fn(() => Promise.resolve(['service.name', 'http.status_code']));
+  datasource.fetchDistinctValues = jest.fn(() => Promise.resolve([]));
+  datasource.fetchDistinctMapValues = jest.fn(() => Promise.resolve([]));
+  return datasource;
+};
+
+const allColumns: TableColumn[] = [
+  { name: 'Body', type: 'String', picklistValues: [] },
+  { name: 'LogAttributes', type: 'JSON', picklistValues: [] },
+  { name: 'ResourceAttributes', type: 'Map(String, String)', picklistValues: [] },
+];
+
+const renderPopover = (overrides?: { onAddFilter?: jest.Mock; onClose?: jest.Mock; columns?: TableColumn[] }) => {
+  const datasource = createMockDatasource();
+  render(
+    <FilterPopover
+      datasource={datasource}
+      database="default"
+      table="otel_logs"
+      allColumns={overrides?.columns || allColumns}
+      onAddFilter={overrides?.onAddFilter || jest.fn()}
+      onClose={overrides?.onClose || jest.fn()}
+    />
+  );
+  return datasource;
+};
+
+// Typing highlights the first (exact) match, so a plain Enter selects it. The
+// options list uses virtual scrolling and does not render in jsdom, so
+// clicking an option is not possible here.
+const selectColumn = async (columnName: string) => {
+  await userEvent.type(screen.getAllByRole('combobox')[0], columnName);
+  await userEvent.keyboard('{Enter}');
+};
 
 describe('FilterPopover', () => {
   it('infers number filter kind from ClickHouse numeric types', () => {
@@ -14,6 +56,11 @@ describe('FilterPopover', () => {
     expect(getFilterValueKind('LowCardinality(String)')).toBe('string');
     expect(getFilterValueKind('DateTime64(9)')).toBe('string');
     expect(getFilterValueKind('Map(String, String)')).toBe('string');
+  });
+
+  it('treats JSON columns as string filters since JSON paths are cast to Nullable(String)', () => {
+    expect(getFilterValueKind('JSON')).toBe('string');
+    expect(getFilterValueKind('JSON(max_dynamic_paths=100)')).toBe('string');
   });
 
   it('returns type-specific operator options', () => {
@@ -43,5 +90,88 @@ describe('FilterPopover', () => {
       { label: 'error', value: 'error' },
       { label: 'true', value: 'true' },
     ]);
+  });
+
+  it('shows a path input and probes JSON paths when a JSON column is selected', async () => {
+    const datasource = renderPopover();
+
+    await selectColumn('LogAttributes');
+
+    await waitFor(() =>
+      expect(datasource.fetchUniqueJSONPaths).toHaveBeenCalledWith('LogAttributes', 'default', 'otel_logs', undefined)
+    );
+    expect(screen.getByText('JSON path')).toBeInTheDocument();
+    expect(datasource.fetchUniqueMapKeys).not.toHaveBeenCalled();
+  });
+
+  it('probes JSON paths via the sibling keys column when one exists', async () => {
+    const columns: TableColumn[] = [
+      ...allColumns,
+      { name: 'LogAttributesKeys', type: 'Array(String)', picklistValues: [] },
+    ];
+    const datasource = renderPopover({ columns });
+
+    await selectColumn('LogAttributes');
+
+    await waitFor(() =>
+      expect(datasource.fetchUniqueJSONPaths).toHaveBeenCalledWith(
+        'LogAttributes',
+        'default',
+        'otel_logs',
+        'LogAttributesKeys'
+      )
+    );
+  });
+
+  it('still probes map keys when a Map column is selected', async () => {
+    const datasource = renderPopover();
+
+    await selectColumn('ResourceAttributes');
+
+    await waitFor(() =>
+      expect(datasource.fetchUniqueMapKeys).toHaveBeenCalledWith('ResourceAttributes', 'default', 'otel_logs')
+    );
+    expect(screen.getByText('Map key')).toBeInTheDocument();
+    expect(datasource.fetchUniqueJSONPaths).not.toHaveBeenCalled();
+  });
+
+  it('disables Add for a JSON column until a path is set', async () => {
+    renderPopover();
+
+    await selectColumn('LogAttributes');
+
+    expect(screen.getByRole('button', { name: 'Add' })).toBeDisabled();
+
+    await userEvent.type(screen.getAllByRole('combobox')[1], 'service.name');
+    await userEvent.keyboard('{Enter}');
+
+    expect(screen.getByRole('button', { name: 'Add' })).toBeEnabled();
+  });
+
+  it('adds a JSON filter with the selected path as mapKey and the real column type', async () => {
+    const onAddFilter = jest.fn();
+    const onClose = jest.fn();
+    renderPopover({ onAddFilter, onClose });
+
+    await selectColumn('LogAttributes');
+
+    await userEvent.type(screen.getAllByRole('combobox')[1], 'service.name');
+    await userEvent.keyboard('{Enter}');
+
+    await userEvent.type(screen.getAllByRole('combobox')[3], 'grafana');
+    await userEvent.keyboard('{Enter}');
+
+    await userEvent.click(screen.getByRole('button', { name: 'Add' }));
+
+    expect(onAddFilter).toHaveBeenCalledWith({
+      filterType: 'custom',
+      key: 'LogAttributes',
+      type: 'JSON',
+      operator: FilterOperator.Like,
+      condition: 'AND',
+      mapKey: 'service.name',
+      value: 'grafana',
+    });
+    expect(onClose).toHaveBeenCalled();
   });
 });

--- a/src/components/queryBuilder/FilterPopover.tsx
+++ b/src/components/queryBuilder/FilterPopover.tsx
@@ -53,6 +53,12 @@ const getMapValueType = (type: string): string => {
 };
 
 export const getFilterValueKind = (type = ''): FilterValueKind => {
+  // JSON path filters are cast to Nullable(String) by the SQL generator, so
+  // string operators always apply regardless of any parameters in the type.
+  if (type.startsWith('JSON')) {
+    return 'string';
+  }
+
   const valueType = getMapValueType(type);
 
   return utils.isNumberType(valueType) ? 'number' : 'string';
@@ -110,20 +116,25 @@ export const FilterPopover = (props: FilterPopoverProps) => {
 
   const selectedColDef = allColumns.find((column) => column.name === selectedColumn);
   const isMapColumn = selectedColDef?.type?.startsWith('Map(') || false;
+  const isJSONColumn = selectedColDef?.type?.startsWith('JSON') || false;
+  const isKeyedColumn = isMapColumn || isJSONColumn;
+  const jsonKeysColumn = isJSONColumn
+    ? allColumns.find((column) => column.name === `${selectedColumn}Keys`)?.name
+    : undefined;
   const filterKind = getFilterValueKind(selectedColDef?.type);
   const currentOperatorOptions = useMemo(() => getOperatorOptions(filterKind), [filterKind]);
 
   useEffect(() => {
-    if (isMapColumn && selectedColumn && database && table) {
-      datasource
-        .fetchUniqueMapKeys(selectedColumn, database, table)
-        .then(setMapKeys)
-        .catch(() => setMapKeys([]));
+    if ((isMapColumn || isJSONColumn) && selectedColumn && database && table) {
+      const fetchKeys = isMapColumn
+        ? datasource.fetchUniqueMapKeys(selectedColumn, database, table)
+        : datasource.fetchUniqueJSONPaths(selectedColumn, database, table, jsonKeysColumn);
+      fetchKeys.then(setMapKeys).catch(() => setMapKeys([]));
     } else {
       setMapKeys([]);
       setSelectedMapKey('');
     }
-  }, [datasource, database, table, selectedColumn, isMapColumn]);
+  }, [datasource, database, table, selectedColumn, isMapColumn, isJSONColumn, jsonKeysColumn]);
 
   const columnOptions: Array<ComboboxOption<string>> = allColumns.map((column) => ({
     label: column.label || column.name,
@@ -140,7 +151,7 @@ export const FilterPopover = (props: FilterPopoverProps) => {
         const values =
           isMapColumn && selectedMapKey
             ? await datasource.fetchDistinctMapValues(selectedColumn, selectedMapKey, database, table)
-            : !isMapColumn
+            : !isKeyedColumn
               ? await datasource.fetchDistinctValues(selectedColumn, database, table)
               : [];
 
@@ -153,7 +164,7 @@ export const FilterPopover = (props: FilterPopoverProps) => {
         return [];
       }
     },
-    [datasource, database, table, selectedColumn, isMapColumn, selectedMapKey]
+    [datasource, database, table, selectedColumn, isMapColumn, isKeyedColumn, selectedMapKey]
   );
 
   const noValueNeeded = operator === FilterOperator.IsNull || operator === FilterOperator.IsNotNull;
@@ -162,7 +173,7 @@ export const FilterPopover = (props: FilterPopoverProps) => {
     filterKind === 'number' && !noValueNeeded && (value.trim() === '' || isNaN(numericValue));
 
   const handleAdd = () => {
-    if (!selectedColumn || isNumberValueInvalid) {
+    if (!selectedColumn || isNumberValueInvalid || (isJSONColumn && !selectedMapKey)) {
       return;
     }
 
@@ -172,7 +183,7 @@ export const FilterPopover = (props: FilterPopoverProps) => {
       type: selectedColDef?.type || 'string',
       operator: operator as any,
       condition: 'AND',
-      ...(isMapColumn && selectedMapKey ? { mapKey: selectedMapKey } : {}),
+      ...(isKeyedColumn && selectedMapKey ? { mapKey: selectedMapKey } : {}),
     };
 
     const filter: StringFilter | NumberFilter =
@@ -214,9 +225,9 @@ export const FilterPopover = (props: FilterPopoverProps) => {
         />
       </div>
 
-      {isMapColumn && (
+      {isKeyedColumn && (
         <div className={styles.field}>
-          <span className={styles.fieldLabel}>Map key</span>
+          <span className={styles.fieldLabel}>{isJSONColumn ? 'JSON path' : 'Map key'}</span>
           <Combobox
             options={mapKeys.map((key) => ({ label: key, value: key }))}
             value={selectedMapKey || null}
@@ -227,8 +238,9 @@ export const FilterPopover = (props: FilterPopoverProps) => {
               setSelectedMapKey(option.value || '');
               setValue('');
             }}
+            createCustomValue
             width={20}
-            placeholder="Select key..."
+            placeholder={isJSONColumn ? 'Select path...' : 'Select key...'}
           />
         </div>
       )}
@@ -259,7 +271,11 @@ export const FilterPopover = (props: FilterPopoverProps) => {
       )}
 
       <div className={styles.actions}>
-        <Button size="sm" onClick={handleAdd} disabled={!selectedColumn || isNumberValueInvalid}>
+        <Button
+          size="sm"
+          onClick={handleAdd}
+          disabled={!selectedColumn || isNumberValueInvalid || (isJSONColumn && !selectedMapKey)}
+        >
           Add
         </Button>
         <Button size="sm" variant="secondary" onClick={onClose}>

--- a/src/data/sqlGenerator.test.ts
+++ b/src/data/sqlGenerator.test.ts
@@ -1402,6 +1402,27 @@ describe('getFilters', () => {
     expect(sql).toEqual("( ResourceAttributes.`service`.`name`::Nullable(String) LIKE '%my-service%' )");
   });
 
+  it('routes a compact popover JSON filter through the JSON accessor, not bare LIKE', () => {
+    // The compact filter popover keeps the real column type, which may carry
+    // parameters on newer schemas (e.g. JSON(max_dynamic_paths=100)).
+    const options = {
+      filters: [
+        {
+          condition: 'AND',
+          filterType: 'custom',
+          key: 'LogAttributes',
+          mapKey: 'service.name',
+          operator: FilterOperator.Like,
+          type: 'JSON(max_dynamic_paths=100)',
+          value: 'grafana',
+        },
+      ],
+    } as QueryBuilderOptions;
+    const sql = _testExports.getFilters(options);
+    expect(sql).toEqual("( LogAttributes.`service`.`name`::Nullable(String) LIKE '%grafana%' )");
+    expect(sql).not.toContain('LogAttributes LIKE');
+  });
+
   it('generates IS NULL clause for JSON mapKey filter', () => {
     const options = {
       filters: [


### PR DESCRIPTION
## Type of Change

- [x] 🐛 Bug Fix

---

## Bug Fix

### What is the bug?

The compact query builder's "Add filter" popover (introduced in #1841) only special-cases Map(...) columns for key-based filtering. JSON-typed attribute columns (e.g. LogAttributes on newer OTel logs schemas with JSON support from #1792/#1866) were offered as plain columns: no path picker was shown and the emitted filter had no mapKey, so sqlGenerator applied the operator to the whole JSON column (e.g. `LogAttributes LIKE '%...%'`), which ClickHouse rejects with ILLEGAL_TYPE_OF_ARGUMENT. The classic filter editor already handles this correctly via its JSON path picker and the JSON branch in sqlGenerator's getFilters.

### How to reproduce

1. Configure the datasource against a ClickHouse instance with a newer OTel logs schema where LogAttributes is a JSON column (not Map).
2. In a dashboard panel, open the query editor in compact builder mode and click "Add filter".
3. Select the LogAttributes column: no key/path input appears (unlike the classic builder).
4. Pick "contains" with any value and click Add.
5. Run the query: ClickHouse returns ILLEGAL_TYPE_OF_ARGUMENT because the generated SQL applies LIKE to the whole JSON column instead of a JSON path accessor.

### Environment (if no related issue)

- **ClickHouse version**: any supported
- **Grafana version**: any supported
- **Plugin version**: 4.19.0 and current main

---

## Please check that:

- [x] Tests for this change have been added/updated.
- [ ] Documentation has been added/updated (where applicable).

## Special notes for your reviewer

The fix mirrors the classic FilterEditor as closely as possible: JSON detection uses type.startsWith('JSON') (same as FilterEditor.tsx and sqlGenerator getFilters), path suggestions come from datasource.fetchUniqueJSONPaths with the same sibling '<column>Keys' column optimisation, and the emitted filter keeps the real column type plus mapKey so the generated SQL is identical to the classic builder's (dot accessor with ::Nullable(String) cast). getFilterValueKind now returns 'string' for JSON types so the operator list is string-flavoured even for parameterised types like JSON(max_dynamic_paths=100). The new sqlGenerator test covers exactly that parameterised-type shape, which no existing test hit. The Add button is only gated on a missing key for JSON columns, not Map columns, to avoid changing existing Map behaviour. Component tests drive the Grafana Combobox by typing plus Enter since its virtual-scrolled options do not render in jsdom.

Found by an automated audit of regressions introduced while integrating PRs across the v4.18.0 and v4.19.0 release cycles (range v4.17.0..main). Related PRs: #1841, #1792, #1866.
