### PR TITLE
fix(queryBuilder): auto-detect the log message column in compact mode

### DIFF
--- a/src/components/queryBuilder/QueryBuilder.test.tsx
+++ b/src/components/queryBuilder/QueryBuilder.test.tsx
@@ -4,6 +4,7 @@ import { getCompactFilterColumns, QueryBuilder } from './QueryBuilder';
 import { getDefaultCompactMode } from './CompactModeBar';
 import { Datasource } from 'data/CHDatasource';
 import { BuilderMode, ColumnHint, FilterOperator, QueryType, TimeUnit } from 'types/queryBuilder';
+import { setColumnByHint } from 'hooks/useBuilderOptionsState';
 import { CoreApp } from '@grafana/data';
 
 jest.mock('./views/TableQueryBuilder', () => ({
@@ -375,5 +376,88 @@ describe('QueryBuilder', () => {
     await waitFor(() =>
       expect(builderOptionsDispatch).toHaveBeenCalledWith(expect.objectContaining({ type: 'set_all_options' }))
     );
+  });
+
+  describe('compact logs message column detection', () => {
+    const buildCompactLogsDs = (defaultColumns: Map<ColumnHint, string>): Datasource =>
+      ({
+        ...mockDs,
+        getSignalType: jest.fn(() => 'logs'),
+        getConfigMode: jest.fn(() => 'single-table'),
+        isSingleTableMode: jest.fn(() => true),
+        getDefaultLogsDatabase: jest.fn(() => 'default'),
+        getDefaultLogsTable: jest.fn(() => 'app_logs'),
+        getDefaultLogsColumns: jest.fn(() => defaultColumns),
+        getLogsOtelVersion: jest.fn(() => ''),
+        shouldSelectLogContextColumns: jest.fn(() => false),
+        getLogContextColumnNames: jest.fn(() => []),
+        fetchColumns: jest.fn(() =>
+          Promise.resolve([
+            { name: 'timestamp', type: 'DateTime', picklistValues: [] },
+            { name: 'message', type: 'String', picklistValues: [] },
+            { name: 'level', type: 'LowCardinality(String)', picklistValues: [] },
+          ])
+        ),
+      }) as unknown as Datasource;
+
+    const initialBuilderOptions = {
+      queryType: QueryType.Table,
+      mode: BuilderMode.List,
+      database: '',
+      table: '',
+      columns: [],
+      filters: [],
+    };
+
+    it('detects LogMessage and LogLevel columns by name when config has no columns', async () => {
+      const datasource = buildCompactLogsDs(new Map());
+      const builderOptionsDispatch = jest.fn();
+
+      render(
+        <QueryBuilder
+          app={CoreApp.PanelEditor}
+          builderOptions={initialBuilderOptions}
+          builderOptionsDispatch={builderOptionsDispatch}
+          datasource={datasource}
+          generatedSql=""
+        />
+      );
+
+      await waitFor(() =>
+        expect(builderOptionsDispatch).toHaveBeenCalledWith(
+          setColumnByHint({ name: 'message', type: 'String', hint: ColumnHint.LogMessage })
+        )
+      );
+      expect(builderOptionsDispatch).toHaveBeenCalledWith(
+        setColumnByHint({ name: 'level', type: 'LowCardinality(String)', hint: ColumnHint.LogLevel })
+      );
+    });
+
+    it('never overrides an explicitly configured message column', async () => {
+      const datasource = buildCompactLogsDs(new Map([[ColumnHint.LogMessage, 'my_msg_col']]));
+      const builderOptionsDispatch = jest.fn();
+
+      render(
+        <QueryBuilder
+          app={CoreApp.PanelEditor}
+          builderOptions={initialBuilderOptions}
+          builderOptionsDispatch={builderOptionsDispatch}
+          datasource={datasource}
+          generatedSql=""
+        />
+      );
+
+      // The level slot is not configured, so detection has run once this dispatch appears
+      await waitFor(() =>
+        expect(builderOptionsDispatch).toHaveBeenCalledWith(
+          setColumnByHint({ name: 'level', type: 'LowCardinality(String)', hint: ColumnHint.LogLevel })
+        )
+      );
+
+      const logMessageDispatches = builderOptionsDispatch.mock.calls.filter(
+        ([action]) => action.type === 'set_column_by_hint' && action.payload?.column?.hint === ColumnHint.LogMessage
+      );
+      expect(logMessageDispatches).toHaveLength(0);
+    });
   });
 });

--- a/src/components/queryBuilder/QueryBuilder.tsx
+++ b/src/components/queryBuilder/QueryBuilder.tsx
@@ -31,6 +31,8 @@ import { Alert, Button, InlineFieldRow, Stack } from '@grafana/ui';
 import { Components as allSelectors } from 'selectors';
 import allLabels from 'labels';
 import { buildCompactQueryDefaults, isDefaultOrMismatchedCompactQuery } from './compactQueryDefaults';
+import { useDefaultLogColumnsByName } from './views/logsQueryBuilderHooks';
+import { getColumnByHint } from 'data/sqlGenerator';
 import { SignalType } from 'types/config';
 import useColumns from 'hooks/useColumns';
 import { CompactModeBar, getDefaultCompactMode } from './CompactModeBar';
@@ -200,6 +202,21 @@ const CompactQueryEditor = (props: CompactQueryEditorProps) => {
     : builderOptions;
   const allColumns = useColumns(datasource, activeOptions.database, activeOptions.table);
   const filterColumns = useMemo(() => getCompactFilterColumns(allColumns, activeOptions), [allColumns, activeOptions]);
+
+  // Compact defaults take columns from datasource config only, so a non-OTel
+  // table without a configured Message column would leave the search box inert
+  // (generateLogsQuery drops meta.logMessageLike unless a column carries the
+  // LogMessage hint). Reuse the classic builder's conventional-name heuristic
+  // to fill the empty Message and Level slots once table columns are fetched.
+  // Configured columns already carry the hint, so they are never overridden.
+  useDefaultLogColumnsByName(
+    signalType === 'logs' ? allColumns : [],
+    activeOptions.table,
+    getColumnByHint(activeOptions, ColumnHint.LogMessage),
+    getColumnByHint(activeOptions, ColumnHint.LogLevel),
+    activeOptions.meta?.otelEnabled || false,
+    builderOptionsDispatch
+  );
 
   const onActiveOptionsChange = (nextOptions: QueryBuilderOptions, shouldRunQuery = false) => {
     builderOptionsDispatch(setAllOptions(nextOptions));


### PR DESCRIPTION
## Type of Change

- [x] 🐛 Bug Fix

---

## Bug Fix

### What is the bug?

In the compact (single-table) query editor for a logs datasource, the log search box writes meta.logMessageLike, but generateLogsQuery only emits the LIKE clause when a selected column carries the LogMessage hint. Compact defaults take columns exclusively from datasource config (getDefaultLogsColumns) and never run the conventional-name heuristic that #1791 added to the classic builder. On a non-OTel single-table datasource with no configured Message column but a conventionally named column (message, body, msg, log_message), typing in the search box silently did nothing: the query re-ran but the SQL was unchanged. The Log Level slot had the same gap.

### How to reproduce

1. Configure a ClickHouse datasource in single-table mode with signal type Logs, pointing at a non-OTel table that has a String column named "message" (for example message String, timestamp DateTime, level String).
2. Leave the logs column configuration empty (no Message column configured) and keep OTel disabled.
3. Open Explore or a panel with this datasource so the compact query editor renders.
4. Type any text into the log search box and blur the field.
5. Before the fix: the query re-runs but the generated SQL contains no LIKE clause, so results do not change. After the fix: the "message" column is auto-assigned the LogMessage role and the SQL gains (message LIKE '%<text>%').

### Environment (if no related issue)

- **ClickHouse version**: any supported
- **Grafana version**: any supported
- **Plugin version**: 4.19.0 and current main

---

## Please check that:

- [x] Tests for this change have been added/updated.
- [ ] Documentation has been added/updated (where applicable).

## Special notes for your reviewer

The fix reuses useDefaultLogColumnsByName from views/logsQueryBuilderHooks rather than duplicating the name-pattern list in compactQueryDefaults.ts. Threading fetched columns into buildCompactLogsDefaults would not work: columns arrive asynchronously after the compact initialisation effect has already dispatched the defaults and needsInitialization has flipped false, so the detection has to live in CompactQueryEditor where useColumns delivers the fetched schema. The hook already carries the right guards: it skips when OTel is enabled, only fills empty role slots (a configured Message column arrives with the LogMessage hint, so it is never overridden), and runs once per table. For the traces signal type an empty column list is passed, which makes the hook a no-op. The dispatched setColumnByHint updates the query model through CHEditorByType's builderOptions sync effect, mirroring how the classic builder applies the same heuristic.

Found by an automated audit of regressions introduced while integrating PRs across the v4.18.0 and v4.19.0 release cycles (range v4.17.0..main). Related PRs: #1841, #1791.
