### PR TITLE
fix(queryBuilder): apply OTel logs schema auto-detection in compact mode

### DIFF
--- a/src/components/queryBuilder/QueryBuilder.test.tsx
+++ b/src/components/queryBuilder/QueryBuilder.test.tsx
@@ -326,6 +326,65 @@ describe('QueryBuilder', () => {
     );
   });
 
+  it('re-resolves compact logs defaults to the pre-v0.151.0 otel schema once table columns load', async () => {
+    const compactDs = {
+      ...mockDs,
+      uid: 'compact-otel-latest',
+      getSignalType: jest.fn(() => 'logs'),
+      getConfigMode: jest.fn(() => 'single-table'),
+      isSingleTableMode: jest.fn(() => true),
+      getDefaultLogsDatabase: jest.fn(() => 'otel_v2'),
+      getDefaultLogsTable: jest.fn(() => 'otel_logs'),
+      // The static "latest" schema has no filter_time mapping, so the initial
+      // defaults order and filter on Timestamp only.
+      getDefaultLogsColumns: jest.fn(
+        () =>
+          new Map([
+            ['time', 'Timestamp'],
+            ['log_message', 'Body'],
+          ])
+      ),
+      getLogsOtelVersion: jest.fn(() => 'latest'),
+      shouldSelectLogContextColumns: jest.fn(() => false),
+      getLogContextColumnNames: jest.fn(() => []),
+      // The table itself is the older schema, identified by TimestampTime.
+      fetchColumns: jest.fn(() =>
+        Promise.resolve([
+          { name: 'Timestamp', type: 'DateTime64(9)', picklistValues: [] },
+          { name: 'TimestampTime', type: 'DateTime', picklistValues: [] },
+          { name: 'Body', type: 'String', picklistValues: [] },
+        ])
+      ),
+    } as unknown as Datasource;
+    const onQueryChange = jest.fn();
+
+    render(
+      <QueryBuilder
+        app={CoreApp.PanelEditor}
+        builderOptions={{
+          queryType: QueryType.Table,
+          mode: BuilderMode.List,
+          database: '',
+          table: '',
+          columns: [],
+          filters: [],
+        }}
+        builderOptionsDispatch={jest.fn()}
+        datasource={compactDs}
+        generatedSql=""
+        onQueryChange={onQueryChange}
+      />
+    );
+
+    await waitFor(() =>
+      expect(onQueryChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          columns: expect.arrayContaining([{ name: 'TimestampTime', hint: ColumnHint.FilterTime }]),
+        })
+      )
+    );
+  });
+
   it('renders traces compact mode without database/table or query type selectors', async () => {
     const compactDs = {
       ...mockDs,

--- a/src/components/queryBuilder/QueryBuilder.tsx
+++ b/src/components/queryBuilder/QueryBuilder.tsx
@@ -168,10 +168,21 @@ const CompactQueryEditor = (props: CompactQueryEditorProps) => {
     onEditAsSql,
     onRunQuery,
   } = props;
-  const needsInitialization = isDefaultOrMismatchedCompactQuery(builderOptions, signalType);
+  // Defaults are built in two passes: database and table never depend on the
+  // table's columns, so a build without column names locates the table for the
+  // columns fetch, and the fetched column names then feed the OTel logs schema
+  // detection inside buildCompactQueryDefaults. Treating a query that still
+  // equals the base defaults as needing initialization lets that detection
+  // correct the defaults once the columns arrive, without clobbering edits.
+  const baseDefaults = buildCompactQueryDefaults(datasource, signalType, builderOptions.table);
+  const needsInitialization =
+    isDefaultOrMismatchedCompactQuery(builderOptions, signalType) || isEqual(builderOptions, baseDefaults);
   const [advancedOpen, setAdvancedOpen] = useState(false);
   const lastInitializationKey = useRef<string>();
   const onQueryChangeRef = useRef(onQueryChange);
+  const locationOptions = needsInitialization ? baseDefaults : builderOptions;
+  const allColumns = useColumns(datasource, locationOptions.database, locationOptions.table);
+  const tableColumnNames = useMemo(() => allColumns.map((column) => column.name), [allColumns]);
 
   useEffect(() => {
     onQueryChangeRef.current = onQueryChange;
@@ -182,23 +193,22 @@ const CompactQueryEditor = (props: CompactQueryEditorProps) => {
       return;
     }
 
-    const initializationKey = `${datasource.uid}:${signalType}:${builderOptions.table}`;
+    const initializationKey = `${datasource.uid}:${signalType}:${builderOptions.table}:${tableColumnNames.length > 0}`;
     if (lastInitializationKey.current === initializationKey) {
       return;
     }
     lastInitializationKey.current = initializationKey;
 
-    const nextOptions = buildCompactQueryDefaults(datasource, signalType, builderOptions.table);
+    const nextOptions = buildCompactQueryDefaults(datasource, signalType, builderOptions.table, tableColumnNames);
     if (!isEqual(builderOptions, nextOptions)) {
       builderOptionsDispatch(setAllOptions(nextOptions));
       onQueryChangeRef.current?.(nextOptions);
     }
-  }, [builderOptions, builderOptionsDispatch, datasource, needsInitialization, signalType]);
+  }, [builderOptions, builderOptionsDispatch, datasource, needsInitialization, signalType, tableColumnNames]);
 
   const activeOptions = needsInitialization
-    ? buildCompactQueryDefaults(datasource, signalType, builderOptions.table)
+    ? buildCompactQueryDefaults(datasource, signalType, builderOptions.table, tableColumnNames)
     : builderOptions;
-  const allColumns = useColumns(datasource, activeOptions.database, activeOptions.table);
   const filterColumns = useMemo(() => getCompactFilterColumns(allColumns, activeOptions), [allColumns, activeOptions]);
 
   const onActiveOptionsChange = (nextOptions: QueryBuilderOptions, shouldRunQuery = false) => {

--- a/src/components/queryBuilder/compactQueryDefaults.test.ts
+++ b/src/components/queryBuilder/compactQueryDefaults.test.ts
@@ -1,0 +1,80 @@
+import { Datasource } from 'data/CHDatasource';
+import { ColumnHint } from 'types/queryBuilder';
+import otel from 'otel';
+import { buildCompactQueryDefaults } from './compactQueryDefaults';
+
+describe('buildCompactQueryDefaults', () => {
+  // Mirrors Datasource.getDefaultLogsColumns for an OTel-enabled logs config.
+  const createLogsDatasource = (otelVersion: string): Datasource => {
+    const mockDs = {} as Datasource;
+    mockDs.getDefaultLogsDatabase = jest.fn(() => 'otel');
+    mockDs.getDefaultDatabase = jest.fn(() => 'default');
+    mockDs.getDefaultLogsTable = jest.fn(() => 'otel_logs');
+    mockDs.getDefaultTable = jest.fn(() => '');
+    mockDs.getLogsOtelVersion = jest.fn(() => otelVersion);
+    mockDs.getDefaultLogsColumns = jest.fn(
+      () => otel.getVersion(otelVersion)?.logColumnMap || new Map<ColumnHint, string>()
+    );
+    mockDs.shouldSelectLogContextColumns = jest.fn(() => false);
+    mockDs.getLogContextColumnNames = jest.fn(() => []);
+    return mockDs;
+  };
+
+  // otel_logs table created by clickhouseexporter before v0.151.0.
+  const preV151ColumnNames = [
+    'Timestamp',
+    'TimestampTime',
+    'TraceId',
+    'SpanId',
+    'SeverityText',
+    'Body',
+    'ResourceAttributes',
+    'ScopeAttributes',
+    'LogAttributes',
+  ];
+
+  // otel_logs table created by clickhouseexporter v0.151.0+, which dropped TimestampTime.
+  const v151ColumnNames = preV151ColumnNames.filter((name) => name !== 'TimestampTime');
+
+  it('resolves the pre-v0.151.0 log schema when otel version is "latest" and the table has TimestampTime', () => {
+    const options = buildCompactQueryDefaults(createLogsDatasource('latest'), 'logs', '', preV151ColumnNames);
+
+    expect(options.columns).toContainEqual({ name: 'TimestampTime', hint: ColumnHint.FilterTime });
+    expect(options.columns).toContainEqual({ name: 'Timestamp', hint: ColumnHint.Time });
+  });
+
+  it('resolves the latest log schema when otel version is "latest" and the table has no TimestampTime', () => {
+    const options = buildCompactQueryDefaults(createLogsDatasource('latest'), 'logs', '', v151ColumnNames);
+
+    expect(options.columns).toContainEqual({ name: 'Timestamp', hint: ColumnHint.Time });
+    expect(options.columns?.some((column) => column.hint === ColumnHint.FilterTime)).toBe(false);
+  });
+
+  it('keeps the static latest log schema when otel version is "latest" and no columns are available', () => {
+    const options = buildCompactQueryDefaults(createLogsDatasource('latest'), 'logs', '', []);
+
+    expect(options.columns).toContainEqual({ name: 'Timestamp', hint: ColumnHint.Time });
+    expect(options.columns?.some((column) => column.hint === ColumnHint.FilterTime)).toBe(false);
+  });
+
+  it('bypasses detection when an explicit otel version is pinned', () => {
+    const pinnedLatest = createLogsDatasource('1.30.0');
+    const pinnedOlder = createLogsDatasource('1.29.0');
+
+    // Pinned 1.30.0 keeps its FilterTime-less map even though the table has TimestampTime.
+    const pinnedLatestOptions = buildCompactQueryDefaults(pinnedLatest, 'logs', '', preV151ColumnNames);
+    expect(pinnedLatestOptions.columns?.some((column) => column.hint === ColumnHint.FilterTime)).toBe(false);
+    expect(pinnedLatest.getDefaultLogsColumns).toHaveBeenCalled();
+
+    // Pinned 1.29.0 keeps its TimestampTime mapping even though the table lacks the column.
+    const pinnedOlderOptions = buildCompactQueryDefaults(pinnedOlder, 'logs', '', v151ColumnNames);
+    expect(pinnedOlderOptions.columns).toContainEqual({ name: 'TimestampTime', hint: ColumnHint.FilterTime });
+  });
+
+  it('keeps the configured meta values when detection resolves an older schema', () => {
+    const options = buildCompactQueryDefaults(createLogsDatasource('latest'), 'logs', '', preV151ColumnNames);
+
+    expect(options.meta?.otelEnabled).toBe(true);
+    expect(options.meta?.otelVersion).toBe('latest');
+  });
+});

--- a/src/components/queryBuilder/compactQueryDefaults.ts
+++ b/src/components/queryBuilder/compactQueryDefaults.ts
@@ -1,6 +1,7 @@
 import { Datasource } from 'data/CHDatasource';
 import { BuilderMode, ColumnHint, QueryBuilderOptions, QueryType, SelectedColumn } from 'types/queryBuilder';
 import { SignalType } from 'types/config';
+import otel from 'otel';
 import {
   getDefaultLogsFilters,
   getDefaultLogsOrderBy,
@@ -31,18 +32,23 @@ export const isDefaultOrMismatchedCompactQuery = (
 export function buildCompactQueryDefaults(
   datasource: Datasource,
   signalType: SignalType,
-  fallbackTable = ''
+  fallbackTable = '',
+  tableColumnNames: readonly string[] = []
 ): QueryBuilderOptions {
   return signalType === 'logs'
-    ? buildCompactLogsDefaults(datasource, fallbackTable)
+    ? buildCompactLogsDefaults(datasource, fallbackTable, tableColumnNames)
     : buildCompactTracesDefaults(datasource, fallbackTable);
 }
 
-const buildCompactLogsDefaults = (datasource: Datasource, fallbackTable: string): QueryBuilderOptions => {
+const buildCompactLogsDefaults = (
+  datasource: Datasource,
+  fallbackTable: string,
+  tableColumnNames: readonly string[]
+): QueryBuilderOptions => {
   const defaultDb = datasource.getDefaultLogsDatabase() || datasource.getDefaultDatabase();
   const defaultTable = datasource.getDefaultLogsTable() || datasource.getDefaultTable() || fallbackTable;
   const otelVersion = datasource.getLogsOtelVersion();
-  const columns = getLogsDefaultColumns(datasource);
+  const columns = getLogsDefaultColumns(datasource, tableColumnNames);
 
   return {
     database: defaultDb,
@@ -85,8 +91,26 @@ const buildCompactTracesDefaults = (datasource: Datasource, fallbackTable: strin
   };
 };
 
-const getLogsDefaultColumns = (datasource: Datasource): SelectedColumn[] => {
-  const nextColumns = getDefaultColumns(datasource.getDefaultLogsColumns());
+// The 'latest' OTel alias resolves the log schema against the actual table
+// rather than a fixed version: pre-v0.151.0 collector tables keep their
+// TimestampTime column, newer ones don't, and both exist in the wild (see
+// #1900). This mirrors useOtelColumns in logsQueryBuilderHooks. Pinned
+// versions are honoured as-is, and without fetched columns the static latest
+// map from the datasource remains the fallback.
+const getLogsDefaultColumnMap = (
+  datasource: Datasource,
+  tableColumnNames: readonly string[]
+): Map<ColumnHint, string> => {
+  const otelConfig = otel.getVersion(datasource.getLogsOtelVersion());
+  if (otelConfig?.version === 'latest' && tableColumnNames.length > 0) {
+    return otel.detectLogsVersion(tableColumnNames).logColumnMap;
+  }
+
+  return datasource.getDefaultLogsColumns();
+};
+
+const getLogsDefaultColumns = (datasource: Datasource, tableColumnNames: readonly string[]): SelectedColumn[] => {
+  const nextColumns = getDefaultColumns(getLogsDefaultColumnMap(datasource, tableColumnNames));
   const includedColumns = new Set(nextColumns.map((c) => c.name));
 
   if (datasource.shouldSelectLogContextColumns()) {


### PR DESCRIPTION
## Type of Change

- [x] 🐛 Bug Fix

---

## Bug Fix

### What is the bug?

Compact (single-table) mode ignored the OTel logs schema auto-detection added in #2017. buildCompactLogsDefaults always used the static 'latest' OTel column map from the datasource config, even though the compact editor already fetches the table's columns and otel.detectLogsVersion exists. On otel_logs tables created by opentelemetry-collector-contrib's clickhouseexporter before v0.151.0 (which have the TimestampTime primary-key column), compact queries filtered and ordered on Timestamp instead of TimestampTime, full-scanning parts, and the compact and classic builders generated different SQL for the same datasource.

### How to reproduce

1. Create an otel_logs table with the pre-v0.151.0 collector schema (includes the TimestampTime DateTime column as primary key) and ingest some logs.
2. Configure a ClickHouse datasource in single-table logs mode pointing at that table, with OTel enabled and the version left as "auto (latest)".
3. Open a new query in Explore or a panel editor so the compact query editor initialises its defaults.
4. Inspect the generated SQL: the time range filter and ORDER BY use Timestamp rather than TimestampTime, unlike the classic builder against the same datasource (which detects the older schema via useOtelColumns).
5. With this fix, once the table's columns load, the compact defaults resolve to the older schema and the SQL filters and orders on TimestampTime.

### Environment (if no related issue)

- **ClickHouse version**: any supported
- **Grafana version**: any supported
- **Plugin version**: 4.19.0 and current main

---

## Please check that:

- [x] Tests for this change have been added/updated.
- [ ] Documentation has been added/updated (where applicable).

## Special notes for your reviewer

The detection lives in getLogsDefaultColumnMap in compactQueryDefaults.ts and only fires when OTel is enabled, the configured version resolves to the 'latest' alias, and fetched column names are available, pinned versions and non-OTel column configs fall through to datasource.getDefaultLogsColumns() unchanged, as do traces defaults. In CompactQueryEditor, defaults are built in two passes because database/table never depend on the table's columns: the column-free build feeds useColumns, and the initialization effect re-runs when columns arrive (the initialization key now includes whether columns have loaded). needsInitialization additionally treats a query that still deep-equals the column-free defaults as initialisable so the async correction can land exactly once and never clobbers user edits. meta.otelVersion deliberately keeps the 'latest' alias rather than the resolved version, mirroring useOtelColumns in logsQueryBuilderHooks, so the version select in the advanced view still shows "auto (latest)". The CompactSqlMode switch path also benefits: it dispatches column-free defaults, which the compact editor then corrects once columns load.

Found by an automated audit of regressions introduced while integrating PRs across the v4.18.0 and v4.19.0 release cycles (range v4.17.0..main). Related PRs: #1841, #2017, #1899.
