### PR TITLE
fix(adhoc): resolve filter columns from the single-table configuration

### DIFF
--- a/src/data/CHDatasource.test.ts
+++ b/src/data/CHDatasource.test.ts
@@ -495,6 +495,105 @@ describe('ClickHouseDatasource', () => {
       expect(keys).toEqual([{ text: 'table.foo' }]);
     });
 
+    it('coerces an unset default database to the literal default on a classic datasource', async () => {
+      jest.spyOn(templateSrvMock, 'replace').mockImplementation(() => '$clickhouse_adhoc_query');
+      const frame = arrayToDataFrame([{ name: 'foo', type: 'string', table: 'table' }]);
+      const ds = cloneDeep(mockDatasource);
+      ds.settings.jsonData.defaultDatabase = undefined;
+      ds.settings.jsonData.defaultTable = undefined;
+      const spyOnQuery = jest.spyOn(ds, 'query').mockImplementation((_request) => of({ data: [frame] }));
+
+      await ds.getTagKeys();
+      const expected = { rawSql: "SELECT name, type, table FROM system.columns WHERE database IN ('default')" };
+
+      expect(spyOnQuery).toHaveBeenCalledWith(
+        expect.objectContaining({ targets: expect.arrayContaining([expect.objectContaining(expected)]) })
+      );
+    });
+
+    it('should Fetch Tags From the single-table logs source when no default database is set', async () => {
+      jest.spyOn(templateSrvMock, 'replace').mockImplementation(() => '$clickhouse_adhoc_query');
+      const frame = arrayToDataFrame([{ name: 'foo', type: 'string', table: 'otel_logs' }]);
+      const ds = cloneDeep(mockDatasource);
+      ds.settings.jsonData.defaultDatabase = undefined;
+      ds.settings.jsonData.defaultTable = undefined;
+      ds.settings.jsonData.configMode = 'single-table';
+      ds.settings.jsonData.signalType = 'logs';
+      ds.settings.jsonData.logs = { defaultDatabase: 'otel', defaultTable: 'otel_logs' };
+      const spyOnQuery = jest.spyOn(ds, 'query').mockImplementation((_request) => of({ data: [frame] }));
+
+      const keys = await ds.getTagKeys();
+      const expected = {
+        rawSql: "SELECT name, type, table FROM system.columns WHERE database IN ('otel') AND table = 'otel_logs'",
+      };
+
+      expect(spyOnQuery).toHaveBeenCalledWith(
+        expect.objectContaining({ targets: expect.arrayContaining([expect.objectContaining(expected)]) })
+      );
+
+      expect(keys).toEqual([{ text: 'otel_logs.foo' }]);
+    });
+
+    it('should Fetch Tags From the single-table traces source when no default database is set', async () => {
+      jest.spyOn(templateSrvMock, 'replace').mockImplementation(() => '$clickhouse_adhoc_query');
+      const frame = arrayToDataFrame([{ name: 'foo', type: 'string', table: 'otel_traces' }]);
+      const ds = cloneDeep(mockDatasource);
+      ds.settings.jsonData.defaultDatabase = undefined;
+      ds.settings.jsonData.defaultTable = undefined;
+      ds.settings.jsonData.configMode = 'single-table';
+      ds.settings.jsonData.signalType = 'traces';
+      ds.settings.jsonData.traces = { defaultDatabase: 'otel', defaultTable: 'otel_traces' };
+      const spyOnQuery = jest.spyOn(ds, 'query').mockImplementation((_request) => of({ data: [frame] }));
+
+      await ds.getTagKeys();
+      const expected = {
+        rawSql: "SELECT name, type, table FROM system.columns WHERE database IN ('otel') AND table = 'otel_traces'",
+      };
+
+      expect(spyOnQuery).toHaveBeenCalledWith(
+        expect.objectContaining({ targets: expect.arrayContaining([expect.objectContaining(expected)]) })
+      );
+    });
+
+    it('coerces an unset single-table logs database to the literal default', async () => {
+      jest.spyOn(templateSrvMock, 'replace').mockImplementation(() => '$clickhouse_adhoc_query');
+      const frame = arrayToDataFrame([{ name: 'foo', type: 'string', table: 'otel_logs' }]);
+      const ds = cloneDeep(mockDatasource);
+      ds.settings.jsonData.defaultDatabase = undefined;
+      ds.settings.jsonData.defaultTable = undefined;
+      ds.settings.jsonData.configMode = 'single-table';
+      ds.settings.jsonData.signalType = 'logs';
+      ds.settings.jsonData.logs = { defaultTable: 'otel_logs' };
+      const spyOnQuery = jest.spyOn(ds, 'query').mockImplementation((_request) => of({ data: [frame] }));
+
+      await ds.getTagKeys();
+      const expected = {
+        rawSql: "SELECT name, type, table FROM system.columns WHERE database IN ('default') AND table = 'otel_logs'",
+      };
+
+      expect(spyOnQuery).toHaveBeenCalledWith(
+        expect.objectContaining({ targets: expect.arrayContaining([expect.objectContaining(expected)]) })
+      );
+    });
+
+    it('prefers an explicit default database over the single-table source', async () => {
+      jest.spyOn(templateSrvMock, 'replace').mockImplementation(() => '$clickhouse_adhoc_query');
+      const frame = arrayToDataFrame([{ name: 'foo', type: 'string', table: 'table' }]);
+      const ds = cloneDeep(mockDatasource);
+      ds.settings.jsonData.defaultDatabase = 'foo';
+      ds.settings.jsonData.configMode = 'single-table';
+      ds.settings.jsonData.signalType = 'logs';
+      ds.settings.jsonData.logs = { defaultDatabase: 'otel', defaultTable: 'otel_logs' };
+      const spyOnQuery = jest.spyOn(ds, 'query').mockImplementation((_request) => of({ data: [frame] }));
+
+      await ds.getTagKeys();
+      const expected = { rawSql: "SELECT name, type, table FROM system.columns WHERE database IN ('foo')" };
+
+      expect(spyOnQuery).toHaveBeenCalledWith(
+        expect.objectContaining({ targets: expect.arrayContaining([expect.objectContaining(expected)]) })
+      );
+    });
+
     it('should Fetch Tags From Query', async () => {
       const spyOnReplace = jest.spyOn(templateSrvMock, 'replace').mockImplementation(() => 'select name from foo');
       const frame = arrayToDataFrame([{ name: 'foo' }]);

--- a/src/data/CHDatasource.ts
+++ b/src/data/CHDatasource.ts
@@ -28,7 +28,7 @@ import {
 import { DataSourceWithBackend, getTemplateSrv } from '@grafana/runtime';
 import { trackClickhouseHealthCheckFailed } from 'tracking';
 import LogsContextPanel from 'components/LogsContextPanel';
-import { cloneDeep, isEmpty, isString } from 'lodash';
+import { cloneDeep, isString } from 'lodash';
 import otel from 'otel';
 import { createElement as createReactElement, ReactNode } from 'react';
 import { concatMap, firstValueFrom, Observable } from 'rxjs';
@@ -1557,16 +1557,38 @@ export class Datasource
   }
 
   /**
+   * Default source for ad-hoc filter key/value discovery, used when the
+   * dashboard does not define `$clickhouse_adhoc_query`. Returns a bare
+   * database name or `db.table`. Single-table mode (#1832) hides the classic
+   * Default database field in the config editor, so when that field is unset
+   * the source is derived from the configured signal's database and table
+   * (mirroring buildCompactQueryDefaults) rather than the literal 'default'
+   * database that getDefaultDatabase coerces to.
+   */
+  private getDefaultAdhocSource(): string | undefined {
+    if (!this.settings.jsonData.defaultDatabase && this.isSingleTableMode()) {
+      const isTraces = this.getSignalType() === 'traces';
+      const signalDb = isTraces ? this.getDefaultTraceDatabase() : this.getDefaultLogsDatabase();
+      const signalTable = isTraces ? this.getDefaultTraceTable() : this.getDefaultLogsTable();
+      const table = signalTable || this.getDefaultTable();
+      if (table) {
+        return `${signalDb || this.getDefaultDatabase()}.${table}`;
+      }
+    }
+    return this.getDefaultDatabase();
+  }
+
+  /**
    * The `$clickhouse_adhoc_query` template variable may resolve to a bare
    * database name or `db.table`. This returns the database component, or
    * undefined when we can't derive one (free-form SELECT variable, etc.).
    */
   private resolveAdhocDatabase(_frame: DataFrame): string | undefined {
     const source = getTemplateSrv().replace('$clickhouse_adhoc_query');
-    const defaultDatabase = this.getDefaultDatabase();
-    const raw = source === '$clickhouse_adhoc_query' ? defaultDatabase : source;
+    const defaultSource = this.getDefaultAdhocSource();
+    const raw = source === '$clickhouse_adhoc_query' ? defaultSource : source;
     if (!raw || raw.toLowerCase().startsWith('select')) {
-      return defaultDatabase;
+      return defaultSource?.split('.')[0];
     }
     return raw.includes('.') ? raw.split('.')[0] : raw;
   }
@@ -1579,7 +1601,7 @@ export class Datasource
    */
   private resolveAdhocSingleTable(): string | undefined {
     const source = getTemplateSrv().replace('$clickhouse_adhoc_query');
-    const raw = source === '$clickhouse_adhoc_query' ? this.getDefaultDatabase() : source;
+    const raw = source === '$clickhouse_adhoc_query' ? this.getDefaultAdhocSource() : source;
     if (!raw || raw.toLowerCase().startsWith('select')) {
       return undefined;
     }
@@ -1751,12 +1773,14 @@ export class Datasource
   private getTagSource() {
     // @todo https://github.com/grafana/grafana/issues/13109
     const ADHOC_VAR = '$clickhouse_adhoc_query';
-    const defaultDatabase = this.getDefaultDatabase();
     let source = getTemplateSrv().replace(ADHOC_VAR);
-    if (source === ADHOC_VAR && isEmpty(defaultDatabase)) {
-      return { type: TagType.schema, source: undefined };
+    if (source === ADHOC_VAR) {
+      const defaultSource = this.getDefaultAdhocSource();
+      if (!defaultSource) {
+        return { type: TagType.schema, source: undefined };
+      }
+      source = defaultSource;
     }
-    source = source === ADHOC_VAR ? defaultDatabase! : source;
     if (source.toLowerCase().startsWith('select')) {
       return { type: TagType.query, source };
     }


### PR DESCRIPTION
## Type of Change

- [x] 🐛 Bug Fix

---

## Bug Fix

### What is the bug?

Ad-hoc filter key/value discovery (getTagKeys/getTagValues) resolved its source solely from jsonData.defaultDatabase, coercing an unset value to the literal 'default' database. Single-table mode (#1832) stores the database and table under jsonData.logs / jsonData.traces and hides the classic Default database field in the config editor, so on a single-table datasource the ad-hoc key dropdown listed columns of the wrong database ('default', typically every table in it) and the picked keys did not match the compact query's FROM table, meaning ad-hoc filters could not be applied. The Map-key discovery probe was likewise skipped because no db.table target could be resolved.

### How to reproduce

1. Configure a ClickHouse datasource in single-table mode: Configuration Mode = "Single table", Signal type = "Logs", logs database e.g. "otel" and table e.g. "otel_logs". Leave the classic Default database unset (the field is hidden in this mode).
2. Create a dashboard with an ad-hoc filters variable bound to this datasource (no $clickhouse_adhoc_query variable).
3. Open the ad-hoc filter key dropdown.
4. Before the fix: the dropdown lists columns from every table in the 'default' database instead of otel.otel_logs, and selected keys do not match the compact query's FROM table. After the fix: it lists otel_logs columns and filters apply to the compact query.

### Environment (if no related issue)

- **ClickHouse version**: any supported
- **Grafana version**: any supported
- **Plugin version**: 4.19.0 and current main

---

## Please check that:

- [x] Tests for this change have been added/updated.
- [ ] Documentation has been added/updated (where applicable).

## Special notes for your reviewer

The new getDefaultAdhocSource() keeps the existing precedence: a $clickhouse_adhoc_query dashboard variable always wins, then an explicit jsonData.defaultDatabase, and only then the single-table signal source. The signal source resolution deliberately mirrors buildCompactQueryDefaults (signalDb || getDefaultDatabase(), signalTable || getDefaultTable()) so the ad-hoc target is exactly the table the compact editor queries, and it picks logs or traces config based on the active signalType rather than a fixed order. The helper is wired into all three resolution sites (getTagSource, resolveAdhocDatabase, resolveAdhocSingleTable), so the Map-key discovery probe now also targets the signal table on single-table datasources. The getTagSource restructure drops a lodash isEmpty call and a pre-existing non-null assertion, for string inputs !defaultSource is equivalent to isEmpty, and the early-return branch is only reachable when tests mock getDefaultDatabase to undefined (the real accessor coerces to 'default'). Classic-mode behaviour is unchanged and covered by both the existing suite and two new guard tests.

Found by an automated audit of regressions introduced while integrating PRs across the v4.18.0 and v4.19.0 release cycles (range v4.17.0..main). Related PRs: #1832, #1841.
