### PR TITLE
fix(queryBuilder): don't replace authored queries when compact mode initialises

### DIFF
--- a/src/components/queryBuilder/QueryBuilder.test.tsx
+++ b/src/components/queryBuilder/QueryBuilder.test.tsx
@@ -3,7 +3,7 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { getCompactFilterColumns, QueryBuilder } from './QueryBuilder';
 import { getDefaultCompactMode } from './CompactModeBar';
 import { Datasource } from 'data/CHDatasource';
-import { BuilderMode, ColumnHint, FilterOperator, QueryType, TimeUnit } from 'types/queryBuilder';
+import { BuilderMode, ColumnHint, FilterOperator, OrderByDirection, QueryType, TimeUnit } from 'types/queryBuilder';
 import { CoreApp } from '@grafana/data';
 
 jest.mock('./views/TableQueryBuilder', () => ({
@@ -324,6 +324,56 @@ describe('QueryBuilder', () => {
         queryType: QueryType.Logs,
       })
     );
+  });
+
+  it('preserves an authored query when its type does not match the datasource signal', async () => {
+    const compactDs = {
+      ...mockDs,
+      getSignalType: jest.fn(() => 'logs'),
+      getConfigMode: jest.fn(() => 'single-table'),
+      isSingleTableMode: jest.fn(() => true),
+      getDefaultLogsDatabase: jest.fn(() => 'otel_v2'),
+      getDefaultLogsTable: jest.fn(() => 'otel_logs'),
+      getDefaultLogsColumns: jest.fn(
+        () =>
+          new Map([
+            ['time', 'Timestamp'],
+            ['log_message', 'Body'],
+          ])
+      ),
+      getLogsOtelVersion: jest.fn(() => '1.29.0'),
+      shouldSelectLogContextColumns: jest.fn(() => false),
+      getLogContextColumnNames: jest.fn(() => []),
+    } as unknown as Datasource;
+    const builderOptionsDispatch = jest.fn();
+    const onQueryChange = jest.fn();
+
+    render(
+      <QueryBuilder
+        app={CoreApp.PanelEditor}
+        builderOptions={{
+          queryType: QueryType.TimeSeries,
+          mode: BuilderMode.Trend,
+          database: 'metrics_db',
+          table: 'requests',
+          columns: [{ name: 'created_at', hint: ColumnHint.Time }, { name: 'requests_count' }],
+          filters: [],
+          orderBy: [{ name: 'created_at', dir: OrderByDirection.ASC }],
+        }}
+        builderOptionsDispatch={builderOptionsDispatch}
+        datasource={compactDs}
+        generatedSql=""
+        onQueryChange={onQueryChange}
+      />
+    );
+
+    // The authored time series query falls back to the classic builder instead of being
+    // replaced with compact logs defaults.
+    expect(await screen.findByTestId('time-series-component')).toBeInTheDocument();
+    expect(screen.queryByTestId('compact-mode-bar')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('compact-filter-bar')).not.toBeInTheDocument();
+    expect(builderOptionsDispatch).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'set_all_options' }));
+    expect(onQueryChange).not.toHaveBeenCalled();
   });
 
   it('renders traces compact mode without database/table or query type selectors', async () => {

--- a/src/components/queryBuilder/QueryBuilder.tsx
+++ b/src/components/queryBuilder/QueryBuilder.tsx
@@ -30,7 +30,11 @@ import TraceIdInput from './TraceIdInput';
 import { Alert, Button, InlineFieldRow, Stack } from '@grafana/ui';
 import { Components as allSelectors } from 'selectors';
 import allLabels from 'labels';
-import { buildCompactQueryDefaults, isDefaultOrMismatchedCompactQuery } from './compactQueryDefaults';
+import {
+  buildCompactQueryDefaults,
+  isCompactQueryTypeMismatch,
+  shouldBuildCompactQueryDefaults,
+} from './compactQueryDefaults';
 import { SignalType } from 'types/config';
 import useColumns from 'hooks/useColumns';
 import { CompactModeBar, getDefaultCompactMode } from './CompactModeBar';
@@ -70,18 +74,27 @@ export const QueryBuilder = (props: QueryBuilderProps) => {
   }
 
   if (singleTableMode && signalType) {
-    return (
-      <CompactQueryEditor
-        datasource={datasource}
-        builderOptions={builderOptions}
-        builderOptionsDispatch={builderOptionsDispatch}
-        generatedSql={generatedSql}
-        signalType={signalType}
-        onQueryChange={onQueryChange}
-        onEditAsSql={onEditAsSql}
-        onRunQuery={onRunQuery}
-      />
-    );
+    // An authored query whose type does not match the datasource signal falls through to
+    // the classic builder, so switching a datasource to single-table mode never silently
+    // replaces the saved options of pre-existing queries.
+    const preserveAuthoredQuery =
+      isCompactQueryTypeMismatch(builderOptions, signalType) &&
+      !shouldBuildCompactQueryDefaults(builderOptions, signalType);
+
+    if (!preserveAuthoredQuery) {
+      return (
+        <CompactQueryEditor
+          datasource={datasource}
+          builderOptions={builderOptions}
+          builderOptionsDispatch={builderOptionsDispatch}
+          generatedSql={generatedSql}
+          signalType={signalType}
+          onQueryChange={onQueryChange}
+          onEditAsSql={onEditAsSql}
+          onRunQuery={onRunQuery}
+        />
+      );
+    }
   }
 
   return (
@@ -168,7 +181,7 @@ const CompactQueryEditor = (props: CompactQueryEditorProps) => {
     onEditAsSql,
     onRunQuery,
   } = props;
-  const needsInitialization = isDefaultOrMismatchedCompactQuery(builderOptions, signalType);
+  const needsInitialization = shouldBuildCompactQueryDefaults(builderOptions, signalType);
   const [advancedOpen, setAdvancedOpen] = useState(false);
   const lastInitializationKey = useRef<string>();
   const onQueryChangeRef = useRef(onQueryChange);

--- a/src/components/queryBuilder/compactQueryDefaults.test.ts
+++ b/src/components/queryBuilder/compactQueryDefaults.test.ts
@@ -1,0 +1,107 @@
+import {
+  isCompactQueryTypeMismatch,
+  isDefaultCompactQuery,
+  shouldBuildCompactQueryDefaults,
+} from './compactQueryDefaults';
+import { BuilderMode, ColumnHint, OrderByDirection, QueryBuilderOptions, QueryType } from 'types/queryBuilder';
+import { SignalType } from 'types/config';
+
+const defaultOptions: QueryBuilderOptions = {
+  database: '',
+  table: '',
+  queryType: QueryType.Table,
+  mode: BuilderMode.List,
+  columns: [],
+  filters: [],
+};
+
+const emptyMismatchedOptions: QueryBuilderOptions = {
+  database: 'logs_db',
+  table: 'logs_table',
+  queryType: QueryType.Logs,
+  mode: BuilderMode.List,
+  columns: [],
+  filters: [],
+};
+
+const authoredTimeSeriesOptions: QueryBuilderOptions = {
+  database: 'metrics_db',
+  table: 'requests',
+  queryType: QueryType.TimeSeries,
+  mode: BuilderMode.Trend,
+  columns: [{ name: 'created_at', hint: ColumnHint.Time }, { name: 'requests_count' }],
+  filters: [],
+  orderBy: [{ name: 'created_at', dir: OrderByDirection.ASC }],
+  limit: 100,
+};
+
+const authoredLogsOptions: QueryBuilderOptions = {
+  database: 'otel_v2',
+  table: 'otel_logs',
+  queryType: QueryType.Logs,
+  mode: BuilderMode.List,
+  columns: [
+    { name: 'Timestamp', hint: ColumnHint.Time },
+    { name: 'Body', hint: ColumnHint.LogMessage },
+  ],
+  filters: [],
+};
+
+describe('isDefaultCompactQuery', () => {
+  it('is true for a fresh default query', () => {
+    expect(isDefaultCompactQuery(defaultOptions)).toBe(true);
+  });
+
+  it('is false for a query with user content', () => {
+    expect(isDefaultCompactQuery(authoredTimeSeriesOptions)).toBe(false);
+  });
+});
+
+describe('isCompactQueryTypeMismatch', () => {
+  it('is true when the query type does not match the signal type', () => {
+    expect(isCompactQueryTypeMismatch(authoredTimeSeriesOptions, 'logs')).toBe(true);
+    expect(isCompactQueryTypeMismatch(authoredLogsOptions, 'traces')).toBe(true);
+  });
+
+  it('is false when the query type matches the signal type', () => {
+    expect(isCompactQueryTypeMismatch(authoredLogsOptions, 'logs')).toBe(false);
+  });
+});
+
+describe('shouldBuildCompactQueryDefaults', () => {
+  const cases: Array<{
+    name: string;
+    builderOptions: QueryBuilderOptions;
+    signalType: SignalType;
+    expected: boolean;
+  }> = [
+    {
+      name: 'builds defaults for a fresh default query',
+      builderOptions: defaultOptions,
+      signalType: 'logs',
+      expected: true,
+    },
+    {
+      name: 'builds defaults for a mismatched query without user content',
+      builderOptions: emptyMismatchedOptions,
+      signalType: 'traces',
+      expected: true,
+    },
+    {
+      name: 'preserves an authored query whose type does not match the signal type',
+      builderOptions: authoredTimeSeriesOptions,
+      signalType: 'logs',
+      expected: false,
+    },
+    {
+      name: 'preserves an authored query whose type matches the signal type',
+      builderOptions: authoredLogsOptions,
+      signalType: 'logs',
+      expected: false,
+    },
+  ];
+
+  it.each(cases)('$name', ({ builderOptions, signalType, expected }) => {
+    expect(shouldBuildCompactQueryDefaults(builderOptions, signalType)).toBe(expected);
+  });
+});

--- a/src/components/queryBuilder/compactQueryDefaults.ts
+++ b/src/components/queryBuilder/compactQueryDefaults.ts
@@ -1,6 +1,7 @@
 import { Datasource } from 'data/CHDatasource';
 import { BuilderMode, ColumnHint, QueryBuilderOptions, QueryType, SelectedColumn } from 'types/queryBuilder';
 import { SignalType } from 'types/config';
+import { isBuilderOptionsRunnable } from 'data/utils';
 import {
   getDefaultLogsFilters,
   getDefaultLogsOrderBy,
@@ -12,20 +13,36 @@ export const getCompactQueryType = (signalType: SignalType): QueryType => {
   return signalType === 'logs' ? QueryType.Logs : QueryType.Traces;
 };
 
-export const isDefaultOrMismatchedCompactQuery = (
-  builderOptions: QueryBuilderOptions,
-  signalType: SignalType
-): boolean => {
-  const expectedQueryType = getCompactQueryType(signalType);
-  const isDefaultState =
+export const isDefaultCompactQuery = (builderOptions: QueryBuilderOptions): boolean => {
+  return (
     builderOptions.queryType === QueryType.Table &&
     !builderOptions.database &&
     !builderOptions.table &&
     (!builderOptions.columns || builderOptions.columns.length === 0) &&
     (!builderOptions.filters || builderOptions.filters.length === 0) &&
-    (!builderOptions.aggregates || builderOptions.aggregates.length === 0);
+    (!builderOptions.aggregates || builderOptions.aggregates.length === 0)
+  );
+};
 
-  return isDefaultState || builderOptions.queryType !== expectedQueryType;
+export const isCompactQueryTypeMismatch = (builderOptions: QueryBuilderOptions, signalType: SignalType): boolean => {
+  return builderOptions.queryType !== getCompactQueryType(signalType);
+};
+
+/**
+ * True when the compact editor should replace the saved options with generated defaults.
+ * A mismatched query type alone is not enough: a query with meaningful user content
+ * (columns, filters, aggregates, group by, or order by) must be preserved, never
+ * silently replaced.
+ */
+export const shouldBuildCompactQueryDefaults = (
+  builderOptions: QueryBuilderOptions,
+  signalType: SignalType
+): boolean => {
+  if (isDefaultCompactQuery(builderOptions)) {
+    return true;
+  }
+
+  return isCompactQueryTypeMismatch(builderOptions, signalType) && !isBuilderOptionsRunnable(builderOptions);
 };
 
 export function buildCompactQueryDefaults(


### PR DESCRIPTION
## Type of Change

- [x] 🐛 Bug Fix

---

## Bug Fix

### What is the bug?

In single-table (compact) mode, CompactQueryEditor's init effect rebuilt compact defaults and wrote them to the query via onQueryChange whenever the saved builderOptions queryType mismatched the datasource signal type, even for fully authored saved queries. Flipping a datasource to single-table mode therefore silently replaced every pre-existing panel's builderOptions and rawSql as soon as its editor was opened, and cross-signal deep-link queries were wiped when clicking "Expand builder". The SQL-editor path of the same feature shows an explicit ConfirmModal before discarding, but the builder path replaced silently.

### How to reproduce

1. Create a ClickHouse datasource in classic mode and build a dashboard panel with an authored Time series builder query (columns, order by, etc.). 2. Edit the datasource and switch it to single-table mode with signal type "logs". 3. Open the panel editor for the existing panel. 4. Without this fix, the saved builderOptions and rawSql are immediately replaced with generated compact logs defaults and written back to the query model. With the fix, the authored query renders in the classic builder untouched. The same applies to a logs-to-traces deep-link query when clicking "Expand builder".

### Environment (if no related issue)

- **ClickHouse version**: any supported
- **Grafana version**: any supported
- **Plugin version**: 4.19.0 and current main

---

## Please check that:

- [x] Tests for this change have been added/updated.
- [ ] Documentation has been added/updated (where applicable).

## Special notes for your reviewer

isDefaultOrMismatchedCompactQuery is split into its two conditions: isDefaultCompactQuery (the untouched fresh-query state) and isCompactQueryTypeMismatch. The new shouldBuildCompactQueryDefaults only returns true for a default query, or a mismatched query with no meaningful user content, where content is judged by the existing isBuilderOptionsRunnable helper from data/utils. A mismatched authored query now falls through to the classic (expanded) builder in QueryBuilder rather than rendering compact bars against options of the wrong query type, which was the least invasive rendering path. Behaviour for empty or default queries is unchanged, covered by the pre-existing "renders logs/traces compact mode" tests which still pass, so a mismatched query carrying only database/table but no columns/filters/aggregates/orderBy/groupBy is still initialised as before.

Found by an automated audit of regressions introduced while integrating PRs across the v4.18.0 and v4.19.0 release cycles (range v4.17.0..main). Related PRs: #1841, #1832, #1992.
