### PR TITLE
fix(queryBuilder): allow manual Map keys in the compact filter popover

### DIFF
--- a/src/components/queryBuilder/FilterPopover.test.tsx
+++ b/src/components/queryBuilder/FilterPopover.test.tsx
@@ -1,5 +1,9 @@
-import { FilterOperator } from 'types/queryBuilder';
-import { getFilterValueKind, getOperatorOptions, toFilterValueOption } from './FilterPopover';
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { FilterOperator, TableColumn } from 'types/queryBuilder';
+import { FilterPopover, getFilterValueKind, getOperatorOptions, toFilterValueOption } from './FilterPopover';
+import { newMockDatasource } from '__mocks__/datasource';
 
 describe('FilterPopover', () => {
   it('infers number filter kind from ClickHouse numeric types', () => {
@@ -43,5 +47,66 @@ describe('FilterPopover', () => {
       { label: 'error', value: 'error' },
       { label: 'true', value: 'true' },
     ]);
+  });
+
+  describe('Map columns', () => {
+    const mapColumns: TableColumn[] = [{ name: 'SpanAttributes', type: 'Map(String, String)', picklistValues: [] }];
+
+    const renderMapPopover = (onAddFilter: jest.Mock, onClose: jest.Mock) => {
+      const datasource = newMockDatasource();
+      jest.spyOn(datasource, 'fetchUniqueMapKeys').mockResolvedValue([]);
+      jest.spyOn(datasource, 'fetchDistinctMapValues').mockResolvedValue([]);
+      const result = render(
+        <FilterPopover
+          datasource={datasource}
+          database="foo"
+          table="bar"
+          allColumns={mapColumns}
+          onAddFilter={onAddFilter}
+          onClose={onClose}
+        />
+      );
+      return { result, datasource };
+    };
+
+    it('disables Add while a Map column has no key selected', async () => {
+      const onAddFilter = jest.fn();
+      const onClose = jest.fn();
+      const { result, datasource } = renderMapPopover(onAddFilter, onClose);
+
+      await userEvent.type(result.getAllByRole('combobox')[0], 'SpanAttributes');
+      await userEvent.keyboard('{ArrowDown}{Enter}');
+      await waitFor(() => expect(datasource.fetchUniqueMapKeys).toHaveBeenCalled());
+
+      expect(result.getByRole('button', { name: 'Add' })).toBeDisabled();
+      expect(onAddFilter).not.toHaveBeenCalled();
+    });
+
+    it('accepts a typed custom key when key discovery returns no keys', async () => {
+      const onAddFilter = jest.fn();
+      const onClose = jest.fn();
+      const { result, datasource } = renderMapPopover(onAddFilter, onClose);
+
+      await userEvent.type(result.getAllByRole('combobox')[0], 'SpanAttributes');
+      await userEvent.keyboard('{ArrowDown}{Enter}');
+      await waitFor(() => expect(datasource.fetchUniqueMapKeys).toHaveBeenCalled());
+
+      await userEvent.type(result.getAllByRole('combobox')[1], 'http.status_code');
+      await userEvent.keyboard('{Enter}');
+
+      const addButton = result.getByRole('button', { name: 'Add' });
+      expect(addButton).toBeEnabled();
+      await userEvent.click(addButton);
+
+      expect(onAddFilter).toHaveBeenCalledWith(
+        expect.objectContaining({
+          key: 'SpanAttributes',
+          mapKey: 'http.status_code',
+          type: 'Map(String, String)',
+          operator: FilterOperator.Like,
+        })
+      );
+      expect(onClose).toHaveBeenCalled();
+    });
   });
 });

--- a/src/components/queryBuilder/FilterPopover.tsx
+++ b/src/components/queryBuilder/FilterPopover.tsx
@@ -160,9 +160,10 @@ export const FilterPopover = (props: FilterPopoverProps) => {
   const numericValue = Number(value);
   const isNumberValueInvalid =
     filterKind === 'number' && !noValueNeeded && (value.trim() === '' || isNaN(numericValue));
+  const isMapKeyMissing = isMapColumn && !selectedMapKey;
 
   const handleAdd = () => {
-    if (!selectedColumn || isNumberValueInvalid) {
+    if (!selectedColumn || isMapKeyMissing || isNumberValueInvalid) {
       return;
     }
 
@@ -227,8 +228,9 @@ export const FilterPopover = (props: FilterPopoverProps) => {
               setSelectedMapKey(option.value || '');
               setValue('');
             }}
+            createCustomValue
             width={20}
-            placeholder="Select key..."
+            placeholder="Type or select key..."
           />
         </div>
       )}
@@ -259,7 +261,7 @@ export const FilterPopover = (props: FilterPopoverProps) => {
       )}
 
       <div className={styles.actions}>
-        <Button size="sm" onClick={handleAdd} disabled={!selectedColumn || isNumberValueInvalid}>
+        <Button size="sm" onClick={handleAdd} disabled={!selectedColumn || isMapKeyMissing || isNumberValueInvalid}>
           Add
         </Button>
         <Button size="sm" variant="secondary" onClick={onClose}>


### PR DESCRIPTION
## Type of Change

- [x] 🐛 Bug Fix

---

## Bug Fix

### What is the bug?

In the compact query builder's filter popover, the Map-key dropdown is populated only by fetchUniqueMapKeys. When map key discovery is disabled via the enableMapKeysDiscovery setting (#1885), when the probe finds no keys, or when the probe errors, the dropdown is empty and, unlike the full FilterEditor and SchemaPicker, it offered no way to type a key manually. No Map key could ever be chosen, yet the Add button stayed enabled and emitted a filter comparing the whole Map column to a scalar value, which ClickHouse rejects. The enableMapKeysDiscovery tooltip explicitly promises manual key entry remains possible.

### How to reproduce

1. Configure a ClickHouse datasource with "Enable map keys discovery" turned off (or point at a table whose Map column has no rows).
2. Open a panel in the compact builder mode and click "Add filter" to open the filter popover.
3. Select a Map(...) column, e.g. SpanAttributes on an OTel traces table.
4. Open the "Map key" dropdown: it is empty and typing a key does not commit it.
5. Pick an operator and value anyway and click Add: the generated SQL compares the whole Map column to the value and ClickHouse returns a type error.

### Environment (if no related issue)

- **ClickHouse version**: any supported
- **Grafana version**: any supported
- **Plugin version**: 4.19.0 and current main

---

## Please check that:

- [x] Tests for this change have been added/updated.
- [ ] Documentation has been added/updated (where applicable).

## Special notes for your reviewer

The fix mirrors the existing pattern in FilterEditor.tsx, where the map-key Combobox already sets createCustomValue. The new isMapKeyMissing guard is applied both to the Add button's disabled prop and inside handleAdd for safety. handleAdd already only attaches mapKey when one is set, so the guard also closes the path where a keyless add silently dropped the mapKey field. Regression tests were verified to fail against the unfixed component (Add enabled with no key, emitted filter missing mapKey) before passing with the fix.

Found by an automated audit of regressions introduced while integrating PRs across the v4.18.0 and v4.19.0 release cycles (range v4.17.0..main). Related PRs: #1885, #1841.
