### PR TITLE
fix(adhoc): make saved Map-key filters apply without prior key discovery

### DIFF
--- a/src/data/CHDatasource.test.ts
+++ b/src/data/CHDatasource.test.ts
@@ -728,11 +728,32 @@ describe('ClickHouseDatasource', () => {
       });
 
       const keys = await ds.getTagKeys();
+      // Bracket form is self-describing: applying the saved filter must not
+      // depend on the Map-column caches populated by this method (#2043).
       expect(keys).toEqual([
         { text: 'events.level' },
-        { text: 'events.labels.http.method' },
-        { text: 'events.labels.http.status' },
+        { text: "events.labels['http.method']" },
+        { text: "events.labels['http.status']" },
       ]);
+    });
+
+    it('mints bracketed keys with the map key escaped as a ClickHouse string literal', async () => {
+      jest.spyOn(templateSrvMock, 'replace').mockImplementation(() => 'db.events');
+      const ds = cloneDeep(mockDatasource);
+      ds.settings.jsonData.defaultDatabase = 'db';
+      ds.settings.jsonData.defaultTable = 'events';
+      const columnsFrame = arrayToDataFrame([{ name: 'labels', type: 'Map(String, String)', table: 'events' }]);
+      const mapKeysFrame = arrayToDataFrame([{ keys: "weird'key" }]);
+      jest.spyOn(ds, 'query').mockImplementation((request) => {
+        const sql = request.targets[0].rawSql ?? '';
+        if (sql.includes('arrayJoin("labels".keys)')) {
+          return of({ data: [mapKeysFrame] });
+        }
+        return of({ data: [columnsFrame] });
+      });
+
+      const keys = await ds.getTagKeys();
+      expect(keys).toEqual([{ text: "events.labels['weird\\'key']" }]);
     });
 
     it('falls back to a flat Map column entry when no table context is available', async () => {
@@ -769,6 +790,30 @@ describe('ClickHouseDatasource', () => {
 
       await ds.getTagKeys(); // populates the mapColumnsByTable cache
       const values = await ds.getTagValues({ key: 'events.labels.http.method' });
+      expect(values).toEqual([{ text: 'GET' }, { text: 'POST' }]);
+      expect(spyOnQuery).toHaveBeenCalledWith(
+        expect.objectContaining({
+          targets: expect.arrayContaining([
+            expect.objectContaining({
+              rawSql: "select distinct labels['http.method'] from db.events limit 1000",
+            }),
+          ]),
+        })
+      );
+    });
+
+    it('fetches values for a bracketed Map key without a prior getTagKeys call', async () => {
+      // Round-trip of a key minted by getTagKeys: the bracketed form must
+      // produce the same values SELECT with no stored state, i.e. on a
+      // fresh dashboard load where the Map-column caches are still empty
+      // (#2043).
+      jest.spyOn(templateSrvMock, 'replace').mockImplementation(() => 'db.events');
+      const ds = cloneDeep(mockDatasource);
+      ds.settings.jsonData.defaultDatabase = 'db';
+      const valuesFrame = arrayToDataFrame([{ val: 'GET' }, { val: 'POST' }]);
+      const spyOnQuery = jest.spyOn(ds, 'query').mockImplementation(() => of({ data: [valuesFrame] }));
+
+      const values = await ds.getTagValues({ key: "events.labels['http.method']" });
       expect(values).toEqual([{ text: 'GET' }, { text: 'POST' }]);
       expect(spyOnQuery).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/src/data/CHDatasource.ts
+++ b/src/data/CHDatasource.ts
@@ -1528,7 +1528,10 @@ export class Datasource
 
     // Replace each top-level Map-column entry with one entry per discovered
     // map key. If probing returned nothing (empty set, stripped by the
-    // filter), keep the original entry as a no-op fallback.
+    // filter), keep the original entry as a no-op fallback. Keys are minted
+    // in explicit bracket form (`col['key']`) so that filter application is
+    // stateless: a saved filter must render correct SQL on fresh dashboard
+    // load, before this method has run and populated the Map-column caches.
     const expandedKeyByCol = new Map<string, string[]>();
     for (const p of probed) {
       if (p.keys.length > 0) {
@@ -1550,7 +1553,7 @@ export class Datasource
         return;
       }
       for (const k of mapKeys) {
-        expanded.push({ text: `${baseText}.${k}` });
+        expanded.push({ text: `${baseText}['${escapeCHStringLiteral(k)}']` });
       }
     });
     return expanded;
@@ -1627,7 +1630,9 @@ export class Datasource
     // distinct Map values rather than stringified Map objects (which the
     // Grafana frame layer renders as `[object Object]`). The map key is
     // escaped for CH string-literal embedding so that keys containing `'`
-    // or `\` produce valid SQL.
+    // or `\` produce valid SQL. Keys minted by getTagKeys arrive already in
+    // bracket form (`mapCol['key']`, literal body pre-escaped) and pass
+    // through unchanged as valid bracket access.
     const mapAccess = this.asMapAccess(col, source);
     const selectExpr = mapAccess ? `${mapAccess.column}['${escapeCHStringLiteral(mapAccess.key)}']` : col;
 

--- a/src/data/adHocFilter.test.ts
+++ b/src/data/adHocFilter.test.ts
@@ -400,4 +400,64 @@ describe('AdHocManager', () => {
       expect(val).toContain("labels[\\'a\\\\\\\\b\\']");
     });
   });
+
+  describe('self-describing bracketed Map keys (#2043)', () => {
+    it('renders a bracketed key without any setMapColumns call (table-prefixed)', () => {
+      // Saved filters must apply on a fresh dashboard load, before
+      // getTagKeys has run, because the key itself carries the Map access.
+      const ahm = new AdHocFilter();
+      const val = ahm.apply('SELECT * FROM events', [
+        { key: "events.metadata['region']", operator: '=', value: 'eu' },
+      ] as AdHocVariableFilter[]);
+      expect(val).toContain("metadata[\\'region\\'] = \\'eu\\'");
+    });
+
+    it('renders a bracketed key without any setMapColumns call (hideTableName)', () => {
+      const ahm = new AdHocFilter();
+      const val = ahm.apply('SELECT * FROM events', [
+        { key: "metadata['region']", operator: '=', value: 'eu' },
+      ] as AdHocVariableFilter[]);
+      expect(val).toContain("metadata[\\'region\\'] = \\'eu\\'");
+    });
+
+    it('renders a bracketed key whose map key contains dots', () => {
+      const ahm = new AdHocFilter();
+      const val = ahm.apply('SELECT * FROM events', [
+        { key: "events.labels['http.method']", operator: '=', value: 'GET' },
+      ] as AdHocVariableFilter[]);
+      expect(val).toContain("labels[\\'http.method\\'] = \\'GET\\'");
+    });
+
+    it('re-escapes quotes from the minted string-literal body for the outer filter string', () => {
+      // getTagKeys mints `labels['weird\'key']` for the raw map key
+      // `weird'key`. The outer additional_table_filters embedding needs the
+      // same two-layer escape as the legacy dotted form.
+      const ahm = new AdHocFilter();
+      const val = ahm.apply('SELECT * FROM events', [
+        { key: "events.labels['weird\\'key']", operator: '=', value: 'x' },
+      ] as AdHocVariableFilter[]);
+      expect(val).toContain("labels[\\'weird\\\\\\'key\\']");
+    });
+
+    it('renders a bracketed key as dot access when useJSON is set', () => {
+      const ahm = new AdHocFilter();
+      const val = ahm.apply(
+        'SELECT * FROM events',
+        [{ key: "events.metadata['region']", operator: '=', value: 'eu' }] as AdHocVariableFilter[],
+        true
+      );
+      expect(val).toContain("metadata.region = \\'eu\\'");
+    });
+
+    it('legacy dotted keys still render via the registered Map-column set', () => {
+      // Already-saved dashboards persist the dotted form; it must keep
+      // working when getTagKeys has populated the column set.
+      const ahm = new AdHocFilter();
+      ahm.setMapColumns(new Set(['metadata']));
+      const val = ahm.apply('SELECT * FROM events', [
+        { key: 'events.metadata.region', operator: '=', value: 'eu' },
+      ] as AdHocVariableFilter[]);
+      expect(val).toContain("metadata[\\'region\\'] = \\'eu\\'");
+    });
+  });
 });

--- a/src/data/adHocFilter.ts
+++ b/src/data/adHocFilter.ts
@@ -111,6 +111,17 @@ function escapeMapKeyForOuterFilter(key: string): string {
   return key.replace(/\\/g, '\\\\\\\\').replace(/'/g, "\\\\\\'");
 }
 
+// Self-describing Map access minted by getTagKeys: `MapCol['key']` or
+// `table.MapCol['key']`. The bracket content is a ClickHouse string-literal
+// body (quotes and backslashes pre-escaped with `\`).
+const BRACKET_MAP_ACCESS = /^(?:([^.[\]']+)\.)?([^.[\]']+)\['((?:[^'\\]|\\.)*)'\]$/;
+
+// Inverse of the ClickHouse string-literal escaping applied when the key was
+// minted: `\X` → `X`.
+function unescapeCHStringLiteral(s: string): string {
+  return s.replace(/\\(.)/g, '$1');
+}
+
 function escapeKey(s: string, isJSON = false, mapColumns: ReadonlySet<string> = DEFAULT_MAP_COLUMNS): string {
   // Convert arrayElement(col, 'key') → col['key']. Handled up front so the
   // dotted-path logic below doesn't see synthetic function syntax.
@@ -120,6 +131,20 @@ function escapeKey(s: string, isJSON = false, mapColumns: ReadonlySet<string> = 
       const [_, array, key] = match;
       return `${array}[\\'${escapeMapKeyForOuterFilter(key)}\\']`;
     }
+  }
+
+  // Explicit bracket form (`MapCol['key']` or `table.MapCol['key']`) is
+  // handled without consulting mapColumns, so saved filters render
+  // correctly on a fresh dashboard load, before getTagKeys has populated
+  // the Map-column cache.
+  const bracketed = s.match(BRACKET_MAP_ACCESS);
+  if (bracketed) {
+    const [, , mapCol, literalKey] = bracketed;
+    const mapKey = unescapeCHStringLiteral(literalKey);
+    if (isJSON) {
+      return `${mapCol}.${mapKey}`;
+    }
+    return `${mapCol}[\\'${escapeMapKeyForOuterFilter(mapKey)}\\']`;
   }
 
   const parts = s.split('.');


### PR DESCRIPTION
## Type of Change

- [x] 🐛 Bug Fix

---

## Bug Fix

### What is the bug?

AdHocFilter.escapeKey only rewrites a dotted Map key such as events.metadata.region into bracket access (metadata['region']) when the Map-column set has been populated via setMapColumns, which happens exclusively inside getTagKeys, i.e. lazily when a user opens the filter key dropdown. On a fresh dashboard load with a saved adhoc filter on a non-default Map column, the key is emitted as a plain dotted identifier inside additional_table_filters and every panel fails with UNKNOWN_IDENTIFIER until the dropdown is opened once. DEFAULT_MAP_COLUMNS only covers the OTel attribute columns, so any custom Map column is affected. Root cause: the persisted key format depended on transient in-memory state (introduced across #1793/#1885/#1993).

### How to reproduce

1. Create a table with a custom Map column, e.g. CREATE TABLE db.events (ts DateTime, metadata Map(String, String)) ENGINE=MergeTree ORDER BY ts, and insert a few rows.
2. Add a ClickHouse datasource, create a dashboard with an adhoc filter variable targeting db.events and a panel querying the table.
3. Open the filter key dropdown (this runs getTagKeys), pick metadata.region, set a value, and confirm the panel filters correctly. Save the dashboard.
4. Reload the dashboard in a fresh browser session without touching the filter dropdown.
5. Before this fix: every panel errors with UNKNOWN_IDENTIFIER because the filter renders as metadata.region instead of metadata['region']. After this fix: the saved key is minted as metadata['region'] and renders correct SQL immediately.

### Environment (if no related issue)

- **ClickHouse version**: any supported
- **Grafana version**: any supported
- **Plugin version**: 4.19.0 and current main

---

## Please check that:

- [x] Tests for this change have been added/updated.
- [ ] Documentation has been added/updated (where applicable).

## Special notes for your reviewer

The fix has two halves. First, getTagKeys mints expanded Map keys in explicit bracket form, baseText['key'] with the map key escaped via escapeCHStringLiteral, so the persisted key carries the Map access itself (works identically for hideTableNameInAdhocFilters true and false since it appends to baseText). Second, escapeKey gains an up-front match for that form (BRACKET_MAP_ACCESS) that unescapes the literal body and re-escapes it with the existing two-layer escapeMapKeyForOuterFilter, before any mapColumns lookup. The legacy dotted branches are untouched, so dashboards saved with the old key format keep working via setMapColumns and DEFAULT_MAP_COLUMNS. getTagValues needs no code change: the table.mapCol['key'] split/rejoin in fetchTagValuesFromSchema reconstructs the bracket expression exactly and the minted literal body is already valid ClickHouse escaping, pinned by the new stateless round-trip test in CHDatasource.test.ts. One pre-existing test expectation changed (minted keys are now bracketed), the dotted getTagValues tests were intentionally left as legacy-path coverage. Verified new tests fail 7/7 with the source reverted.

Found by an automated audit of regressions introduced while integrating PRs across the v4.18.0 and v4.19.0 release cycles (range v4.17.0..main). Related PRs: #1793, #1885, #1993.
