### PR TITLE
fix(logs): re-apply OTel columns when the schema version changes

### DIFF
--- a/src/components/queryBuilder/views/logsQueryBuilderHooks.test.ts
+++ b/src/components/queryBuilder/views/logsQueryBuilderHooks.test.ts
@@ -280,6 +280,80 @@ describe('useOtelColumns', () => {
 
     expect(builderOptionsDispatch).toHaveBeenCalledTimes(1);
   });
+
+  it('should re-dispatch columns when otelVersion changes while OTEL is enabled', async () => {
+    // prevOtelVersion detects the version change and resets the flag so the
+    // Effect re-applies the new version's column map.
+    jest.spyOn(mockDatasource, 'shouldSelectLogContextColumns').mockReturnValue(false);
+    const builderOptionsDispatch = jest.fn();
+    const allColumns: readonly TableColumn[] = [
+      { name: 'TimestampTime', type: 'DateTime', picklistValues: [] },
+      { name: 'LogAttributes', type: 'Map(String, String)', picklistValues: [] },
+    ];
+
+    // Mount with OTel already enabled (saved query), no dispatch expected
+    const hook = renderHook(
+      (version: string) => useOtelColumns(mockDatasource, allColumns, true, version, builderOptionsDispatch),
+      { initialProps: '1.29.0' }
+    );
+    expect(builderOptionsDispatch).toHaveBeenCalledTimes(0);
+
+    // Change version while OTel is on, the new version's column map is applied
+    hook.rerender('1.30.0');
+
+    const columns: SelectedColumn[] = [];
+    otel.getVersion('1.30.0')!.logColumnMap.forEach((v, k) => {
+      columns.push({ name: v, hint: k, type: allColumns.find((c) => c.name === v)?.type });
+    });
+    const expectedOptions = { columns };
+
+    expect(builderOptionsDispatch).toHaveBeenCalledTimes(1);
+    expect(builderOptionsDispatch).toHaveBeenCalledWith(expect.objectContaining(setOptions(expectedOptions)));
+  });
+
+  it('should re-run auto-detection when switching from a pinned version to "latest"', async () => {
+    jest.spyOn(mockDatasource, 'shouldSelectLogContextColumns').mockReturnValue(false);
+    const builderOptionsDispatch = jest.fn();
+    // Table has TimestampTime, so "latest" detection resolves to 1.29.0.
+    const allColumns: readonly TableColumn[] = [
+      { name: 'TimestampTime', type: 'DateTime', picklistValues: [] },
+      { name: 'LogAttributes', type: 'Map(String, String)', picklistValues: [] },
+    ];
+
+    const hook = renderHook(
+      (version: string) => useOtelColumns(mockDatasource, allColumns, true, version, builderOptionsDispatch),
+      { initialProps: '1.30.0' }
+    );
+    expect(builderOptionsDispatch).toHaveBeenCalledTimes(0);
+
+    hook.rerender('latest');
+
+    const columns: SelectedColumn[] = [];
+    otel.getVersion('1.29.0')!.logColumnMap.forEach((v, k) => {
+      columns.push({ name: v, hint: k, type: allColumns.find((c) => c.name === v)?.type });
+    });
+    const expectedOptions = { columns };
+
+    expect(builderOptionsDispatch).toHaveBeenCalledTimes(1);
+    expect(builderOptionsDispatch).toHaveBeenCalledWith(expect.objectContaining(setOptions(expectedOptions)));
+  });
+
+  it('should not re-dispatch when rerendered with an unchanged version', async () => {
+    jest.spyOn(mockDatasource, 'shouldSelectLogContextColumns').mockReturnValue(false);
+    const builderOptionsDispatch = jest.fn();
+    const allColumns: readonly TableColumn[] = [
+      { name: 'LogAttributes', type: 'Map(String, String)', picklistValues: [] },
+    ];
+
+    const hook = renderHook(
+      (version: string) => useOtelColumns(mockDatasource, allColumns, true, version, builderOptionsDispatch),
+      { initialProps: '1.29.0' }
+    );
+    hook.rerender('1.30.0'); // version change applies the new column map
+    hook.rerender('1.30.0'); // unchanged, must not re-apply
+
+    expect(builderOptionsDispatch).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe('useDefaultTimeColumn', () => {

--- a/src/components/queryBuilder/views/logsQueryBuilderHooks.ts
+++ b/src/components/queryBuilder/views/logsQueryBuilderHooks.ts
@@ -71,7 +71,8 @@ export const useLogDefaultsOnMount = (
 
 /**
  * Sets OTEL Logs columns automatically when OTEL is enabled.
- * Does not run if OTEL is already enabled, only when it's changed.
+ * Does not run if OTEL is already enabled, only when the toggle or the
+ * selected schema version changes.
  */
 export const useOtelColumns = (
   datasource: Datasource,
@@ -81,8 +82,15 @@ export const useOtelColumns = (
   builderOptionsDispatch: React.Dispatch<BuilderOptionsReducerAction>
 ) => {
   const didSetColumns = useRef<boolean>(otelEnabled);
+  const prevOtelVersion = useRef<string>(otelVersion);
   if (!otelEnabled) {
     didSetColumns.current = false;
+    prevOtelVersion.current = otelVersion;
+  } else if (otelVersion !== prevOtelVersion.current) {
+    // Version changed while OTel is on: reset the flag so the Effect re-applies
+    // the new version's column map ('latest' re-runs auto-detection).
+    didSetColumns.current = false;
+    prevOtelVersion.current = otelVersion;
   }
 
   useEffect(() => {


### PR DESCRIPTION
## Type of Change

- [x] 🐛 Bug Fix

---

## Bug Fix

### What is the bug?

In the LOGS query builder, the OTel schema-version dropdown is a dead control once columns have been applied. useOtelColumns in src/components/queryBuilder/views/logsQueryBuilderHooks.ts latches its didSetColumns ref to true after the first column application (and initialises it to true for saved queries with OTel already on) and never resets it when otelVersion changes, so switching between auto (latest), 1.29.0, and 1.30.0 never re-applies the corresponding column map. This became user-visible when #1899 introduced a second genuinely different logs column map (1.30.0 drops TimestampTime) and #2017 documented pinning a version as the override for auto-detection. The TRACE builder's useOtelColumns already handles this correctly via a prevOtelVersion ref that resets the latch on version change.

### How to reproduce

1. Open the query editor on an OTel logs table and select the Logs query type with the OTel toggle enabled (columns are applied for the current version, or load a saved OTel logs query).
2. Change the OTel schema version dropdown to a different version, for example from auto (latest) or 1.29.0 to 1.30.0.
3. Observe that the selected columns do not change to the new version's column map (for example the Time column is not switched between TimestampTime and Timestamp) and the generated SQL is unchanged. The same steps in the Traces builder correctly re-apply the columns.

### Environment (if no related issue)

- **ClickHouse version**: any supported
- **Grafana version**: any supported
- **Plugin version**: 4.19.0 and current main

---

## Please check that:

- [x] Tests for this change have been added/updated.
- [ ] Documentation has been added/updated (where applicable).

## Special notes for your reviewer

This is a direct port of the prevOtelVersion ref pattern from the trace builder's useOtelColumns (src/components/queryBuilder/views/traceQueryBuilderHooks.ts, around lines 119-133): a version change while OTel is on clears didSetColumns and updates the ref, and the existing Effect (which already has otelVersion in its dependency array) re-applies the map. Switching to 'latest' re-runs the TimestampTime-based detection against allColumns. The OTel-off reset branch now also syncs prevOtelVersion, matching the trace hook, so toggling off and changing version does not double-fire on re-enable. The pre-existing guard that skips dispatch while allColumns is empty is deliberately left in place (the trace hook dispatches without a schema, but changing that here would widen the fix). The three new tests mirror the trace suite's version-switch test and were confirmed to fail against the unmodified hook.

Found by an automated audit of regressions introduced while integrating PRs across the v4.18.0 and v4.19.0 release cycles (range v4.17.0..main). Related PRs: #1899, #2017.
