### PR TITLE
fix(variables): forward scoped variables to query variable execution

### DIFF
--- a/src/data/CHVariableSupport.test.tsx
+++ b/src/data/CHVariableSupport.test.tsx
@@ -361,6 +361,47 @@ describe('CHVariableSupport', () => {
     expect(frame.fields[1].values).toEqual(['id-a', 'id-b']);
   });
 
+  it('forwards scopedVars from the request into metricFindQuery so scoped variables resolve', async () => {
+    const datasource = buildDatasource();
+    const support = new CHVariableSupport(datasource);
+    const scopedVars = {
+      namespace: { text: 'prod', value: 'prod' },
+      __searchFilter: { text: 'foo', value: 'foo' },
+    };
+    const request = {
+      targets: [
+        {
+          refId: 'v',
+          queryType: 'sql' as CHVariableQueryType,
+          rawSql: 'SELECT name FROM t WHERE ns = ${namespace} AND name LIKE $__searchFilter',
+        },
+      ],
+      range: { from: new Date(), to: new Date() },
+      scopedVars,
+    };
+    await firstValueFrom(support.query(request as unknown as DataQueryRequest<CHVariableQuery>));
+    expect(datasource.metricFindQuery).toHaveBeenCalledWith(
+      'SELECT name FROM t WHERE ns = ${namespace} AND name LIKE $__searchFilter',
+      expect.objectContaining({ scopedVars })
+    );
+  });
+
+  it('forwards scopedVars for a legacy string target', async () => {
+    const datasource = buildDatasource();
+    const support = new CHVariableSupport(datasource);
+    const scopedVars = { namespace: { text: 'prod', value: 'prod' } };
+    const request = {
+      targets: ['SELECT name FROM t WHERE ns = ${namespace}'],
+      range: { from: new Date(), to: new Date() },
+      scopedVars,
+    };
+    await firstValueFrom(support.query(request as unknown as DataQueryRequest<CHVariableQuery>));
+    expect(datasource.metricFindQuery).toHaveBeenCalledWith(
+      'SELECT name FROM t WHERE ns = ${namespace}',
+      expect.objectContaining({ scopedVars })
+    );
+  });
+
   it('resolves a legacy string target', async () => {
     const datasource = buildDatasource();
     const support = new CHVariableSupport(datasource);

--- a/src/data/CHVariableSupport.tsx
+++ b/src/data/CHVariableSupport.tsx
@@ -266,9 +266,11 @@ export class CHVariableSupport extends CustomVariableSupport<Datasource, CHVaria
     }
     // Pass rawSql as a string. metricFindQuery accepts (CHQuery | string) and
     // wraps a string into a minimal SQL-mode CHQuery internally; that keeps
-    // pluginVersion / refId concerns where they already live.
+    // pluginVersion / refId concerns where they already live. Forward
+    // scopedVars so scoped variables and __searchFilter resolve inside
+    // variable queries (they reach applyTemplateVariables via runQuery).
     const promise = this.datasource
-      .metricFindQuery(rawSql, { range: request.range })
+      .metricFindQuery(rawSql, { range: request.range, scopedVars: request.scopedVars })
       .then((values: MetricFindValue[]) => ({
         // Emit text and value separately so a `SELECT value, label` query
         // substitutes the value while displaying the label. Fall back to text


### PR DESCRIPTION
## Type of Change

- [x] 🐛 Bug Fix

---

## Bug Fix

### What is the bug?

Since CustomVariableSupport was registered (#1868), dashboard query variables are dispatched through CHVariableSupport.query, which called metricFindQuery with only { range: request.range } and discarded request.scopedVars. Scoped variables (for example variables referenced inside another variable's query) and __searchFilter therefore no longer resolved in variable queries, regressing the fix from #1840 (grafana/grafana#122553). CHVariableSupport.query now forwards request.scopedVars into the metricFindQuery options, where the existing runQuery/applyTemplateVariables path already handles them.

### How to reproduce

1. Configure a ClickHouse datasource and create a dashboard.
2. Add a query variable "namespace" (any query returning values).
3. Add a second query variable whose SQL references it, for example: SELECT DISTINCT name FROM t WHERE ns = ${namespace}, or a query using $__searchFilter.
4. Open the variable editor preview or refresh the dashboard: before this fix the reference stays unresolved (or resolves to the wrong value) because scopedVars never reach template interpolation, with the fix it resolves correctly.

### Environment (if no related issue)

- **ClickHouse version**: any supported
- **Grafana version**: any supported
- **Plugin version**: 4.19.0 and current main

---

## Please check that:

- [x] Tests for this change have been added/updated.
- [ ] Documentation has been added/updated (where applicable).

## Special notes for your reviewer

The change is one line in CHVariableSupport.query plus a comment. request.filters is deliberately not forwarded: Datasource.runQuery only reads options.range and options.scopedVars, so filters would be silently dropped, and extending runQuery is out of scope here. The two new tests in CHVariableSupport.test.tsx cover the object-target and legacy string-target paths and fail without the fix. The scopedVars-to-templateSrv.replace leg is already covered by the existing metricFindQuery test from #1840 in CHDatasource.test.ts.

Found by an automated audit of regressions introduced while integrating PRs across the v4.18.0 and v4.19.0 release cycles (range v4.17.0..main). Related PRs: #1840, #1868.
