### PR TITLE
fix(variables): filter missing Map keys with mapContains

### DIFF
--- a/src/data/CHVariableSupport.test.tsx
+++ b/src/data/CHVariableSupport.test.tsx
@@ -88,8 +88,10 @@ describe('generateVariableSql', () => {
       }),
       ''
     );
+    // Map subscript on a missing key yields the value type's default, never
+    // NULL, so the guard must be mapContains rather than IS NOT NULL.
     expect(sql).toBe(
-      `SELECT DISTINCT "ResourceAttributes"['service.version'] AS value FROM "otel"."otel_logs" WHERE "ResourceAttributes"['service.version'] IS NOT NULL ORDER BY value LIMIT 1000`
+      `SELECT DISTINCT "ResourceAttributes"['service.version'] AS value FROM "otel"."otel_logs" WHERE mapContains("ResourceAttributes", 'service.version') ORDER BY value LIMIT 1000`
     );
   });
 
@@ -139,7 +141,7 @@ describe('generateVariableSql', () => {
       ''
     );
     expect(mapSql).toBe(
-      `SELECT DISTINCT "ResourceAttributes"['a\\'b'] AS value FROM "otel"."otel_logs" WHERE "ResourceAttributes"['a\\'b'] IS NOT NULL ORDER BY value LIMIT 1000`
+      `SELECT DISTINCT "ResourceAttributes"['a\\'b'] AS value FROM "otel"."otel_logs" WHERE mapContains("ResourceAttributes", 'a\\'b') ORDER BY value LIMIT 1000`
     );
   });
 

--- a/src/data/CHVariableSupport.tsx
+++ b/src/data/CHVariableSupport.tsx
@@ -88,9 +88,14 @@ export function generateVariableSql(query: CHVariableQuery, defaultDatabase: str
         return '';
       }
       const column = escapeIdentifier(query.column);
-      const target =
-        query.columnIsMap && query.mapKey ? `${column}['${escapeCHStringLiteral(query.mapKey)}']` : column;
-      return `SELECT DISTINCT ${target} AS value FROM ${escapeIdentifier(db)}.${escapeIdentifier(query.table)} WHERE ${target} IS NOT NULL ORDER BY value LIMIT 1000`;
+      if (query.columnIsMap && query.mapKey) {
+        // Map subscript on a missing key returns the value type's default
+        // (e.g. '' for String), never NULL, so an IS NOT NULL guard would be a
+        // no-op and add a spurious empty entry. Guard with mapContains instead.
+        const mapKey = `'${escapeCHStringLiteral(query.mapKey)}'`;
+        return `SELECT DISTINCT ${column}[${mapKey}] AS value FROM ${escapeIdentifier(db)}.${escapeIdentifier(query.table)} WHERE mapContains(${column}, ${mapKey}) ORDER BY value LIMIT 1000`;
+      }
+      return `SELECT DISTINCT ${column} AS value FROM ${escapeIdentifier(db)}.${escapeIdentifier(query.table)} WHERE ${column} IS NOT NULL ORDER BY value LIMIT 1000`;
     }
     case 'sql':
     default:


### PR DESCRIPTION
## Type of Change

- [x] 🐛 Bug Fix

---

## Bug Fix

### What is the bug?

The guided "Column values" variable flow, when pointed at a Map column key, generated SQL guarded by WHERE map['key'] IS NOT NULL. ClickHouse Map subscript access on a missing key returns the value type's default ('' for String), never NULL, so the guard filtered nothing. Rows without the key contributed an empty-string value, which sorts first in the ORDER BY and shows up as a spurious blank option that becomes the variable's default selection. The ad-hoc filter path already handled this correctly via mapContains in fetchDistinctMapValues (src/data/CHDatasource.ts). generateVariableSql now emits WHERE mapContains("col", 'key') for the Map branch, using the same identifier and string-literal escaping as fetchDistinctMapValues.

### How to reproduce

1. On a table with a Map(String, String) column (e.g. an OTel logs table with ResourceAttributes) where some rows lack a given key, create a dashboard variable using the ClickHouse datasource.
2. Choose the "Column values" variable type, then pick the database, table, the Map column, and a key that is absent from at least one row (e.g. service.version).
3. Inspect the generated SQL: it reads WHERE "ResourceAttributes"['service.version'] IS NOT NULL.
4. Run the variable query: the dropdown contains an empty entry sorted first, which becomes the default selection. With the fix, the SQL uses mapContains and the empty entry is gone.

### Environment (if no related issue)

- **ClickHouse version**: any supported
- **Grafana version**: any supported
- **Plugin version**: 4.19.0 and current main

---

## Please check that:

- [x] Tests for this change have been added/updated.
- [ ] Documentation has been added/updated (where applicable).

## Special notes for your reviewer

The fix mirrors the quoting/escaping style of fetchDistinctMapValues (src/data/CHDatasource.ts:1173-1183): identifier via escapeIdentifier, map key as a single-quoted escapeCHStringLiteral literal reused for both the subscript and the mapContains call. The non-Map path is unchanged and still uses IS NOT NULL, which is correct for Nullable scalar columns. The Map branch was restructured into an early return so the mapKey narrows under strict TS without a non-null assertion. Users who saved a variable before this fix keep their old rawSql (the runtime resolver reads rawSql verbatim), so existing variables only pick up the new guard when re-generated through the editor.

Found by an automated audit of regressions introduced while integrating PRs across the v4.18.0 and v4.19.0 release cycles (range v4.17.0..main). Related PRs: #1868, #1793, #1993.
