### PR TITLE
fix(config): wire the Map keys discovery switch to its stored value

### DIFF
--- a/src/views/CHConfigEditor.test.tsx
+++ b/src/views/CHConfigEditor.test.tsx
@@ -190,6 +190,44 @@ describe('ConfigEditor', () => {
     );
   });
 
+  describe('classic mode map keys discovery switch', () => {
+    // dialTimeout keeps the collapsible "Additional settings" section
+    // initially open so the query settings render.
+    const overrides: Partial<CHConfig> = { dialTimeout: '10', enableMapKeysDiscovery: false };
+
+    const getMapKeysSwitch = (): HTMLInputElement => {
+      const labelText = screen.getByText(allLabels.components.Config.QuerySettingsConfig.enableMapKeysDiscovery.label);
+      // The switch is inside a grafana-ui Field: the input lives in a sibling
+      // of the label element, under the shared field container.
+      const input = labelText.closest('label')?.parentElement?.parentElement?.querySelector('input[type="checkbox"]');
+      if (!(input instanceof HTMLInputElement)) {
+        throw new Error('map keys discovery switch not found');
+      }
+      return input;
+    };
+
+    it('reflects a stored enableMapKeysDiscovery=false', () => {
+      render(<ConfigEditor {...mockConfigEditorProps(overrides)} />);
+      expect(getMapKeysSwitch()).not.toBeChecked();
+    });
+
+    it('writes true when toggled back on', () => {
+      const props = mockConfigEditorProps(overrides);
+      render(<ConfigEditor {...props} />);
+
+      (props.onOptionsChange as jest.Mock).mockClear();
+      fireEvent.click(getMapKeysSwitch());
+
+      expect(props.onOptionsChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          jsonData: expect.objectContaining({
+            enableMapKeysDiscovery: true,
+          }),
+        })
+      );
+    });
+  });
+
   it('persists the single-table logs trace correlation setting', () => {
     const props = mockConfigEditorProps({
       configMode: 'single-table',

--- a/src/views/CHConfigEditor.tsx
+++ b/src/views/CHConfigEditor.tsx
@@ -641,6 +641,7 @@ export const ConfigEditor: React.FC<ConfigEditorProps> = (props) => {
               queryTimeout={jsonData.queryTimeout}
               rowCapacityHint={jsonData.rowCapacityHint}
               validateSql={jsonData.validateSql}
+              enableMapKeysDiscovery={jsonData.enableMapKeysDiscovery}
               onDialTimeoutChange={(e) => {
                 trackingV1.trackClickhouseConfigV1QuerySettings({ dialTimeout: Number(e.currentTarget.value) });
                 onUpdateDatasourceJsonDataOption(props, 'dialTimeout')(e);


### PR DESCRIPTION
## Type of Change

- [x] 🐛 Bug Fix

---

## Bug Fix

### What is the bug?

In the v1 config editor's classic mode, the QuerySettingsConfig call site passed the onEnableMapKeysDiscoveryChange handler but not the enableMapKeysDiscovery value prop (the single-table block and both v2 call sites pass both). The switch renders value={enableMapKeysDiscovery ?? true}, so with the prop always undefined it was permanently checked: a stored false was never reflected, and because the displayed value was always true, every click wrote false. The setting was therefore impossible to re-enable from the classic-mode UI. Introduced in #1885 and carried through #2014.

User-facing impact: users on the classic (v1) config editor who disabled "Suggest Map keys in filter editor" could not turn it back on from the UI, and the switch always displayed as enabled regardless of the saved value.

### How to reproduce

1. Open a ClickHouse datasource's configuration page with the classic (v1) config editor.
2. Expand "Additional settings" and toggle "Suggest Map keys in filter editor" off, then save. jsonData.enableMapKeysDiscovery is now false.
3. Reload the config page: the switch shows as checked even though the stored value is false.
4. Click the switch to try to re-enable it: it writes false again (the handler reads the toggled value of the always-true display state), so the setting can never return to true from this UI.

### Environment (if no related issue)

- **ClickHouse version**: any supported
- **Grafana version**: any supported
- **Plugin version**: 4.19.0 and current main

---

## Please check that:

- [x] Tests for this change have been added/updated.
- [ ] Documentation has been added/updated (where applicable).

## Special notes for your reviewer

The fix is a one-line prop addition matching the exact expression used by the sibling single-table call site (CHConfigEditor.tsx line 598) and the v2 call sites (ConfigurationModeSection.tsx, AdditionalSettingsSection.tsx). The regression tests locate the switch via the Field label's container because the Switch has no testid or label association, and set dialTimeout in the overrides so the collapsible "Additional settings" section renders open. Both tests were verified to fail against the unfixed code. Separately (not addressed here), enableMapKeysDiscovery is not part of the hasAdditionalSettings check at CHConfigEditor.tsx line 247, so a datasource whose only non-default additional setting is a disabled map keys discovery opens with the section collapsed.

Found by an automated audit of regressions introduced while integrating PRs across the v4.18.0 and v4.19.0 release cycles (range v4.17.0..main). Related PRs: #1885, #2014.
