### PR TITLE
fix(config): clear the username required error once the field is filled

### DIFF
--- a/src/views/config-v2/DatabaseCredentialsSection.test.tsx
+++ b/src/views/config-v2/DatabaseCredentialsSection.test.tsx
@@ -80,6 +80,25 @@ describe('DatabaseCredentialsSection', () => {
       mocks: { onOptionsChange: jest.fn() },
     });
 
+    it('shows username error on blur when empty and no validation API is present', () => {
+      render(<DatabaseCredentialsSection {...emptyProps} />);
+
+      fireEvent.blur(screen.getByLabelText(/username/i));
+
+      expect(screen.getByText('Username is required')).toBeInTheDocument();
+    });
+
+    it('clears username error once the field is filled and no validation API is present', () => {
+      const { rerender } = render(<DatabaseCredentialsSection {...emptyProps} />);
+
+      fireEvent.blur(screen.getByLabelText(/username/i));
+      expect(screen.getByText('Username is required')).toBeInTheDocument();
+
+      rerender(<DatabaseCredentialsSection {...filledProps} />);
+
+      expect(screen.queryByText('Username is required')).not.toBeInTheDocument();
+    });
+
     it('shows inline error for username when validator is called with empty value', async () => {
       const validation = createMockValidation();
       render(<DatabaseCredentialsSection {...emptyProps} validation={validation} />);

--- a/src/views/config-v2/DatabaseCredentialsSection.tsx
+++ b/src/views/config-v2/DatabaseCredentialsSection.tsx
@@ -29,16 +29,18 @@ export const DatabaseCredentialsSection = (props: Props) => {
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
 
   useEffect(() => {
-    if (!validation) {
-      return;
-    }
+    // Always clear the error eagerly when the user fills in the field,
+    // regardless of whether the ValidationAPI is available.
     if (jsonData.username) {
       setFieldErrors((prev) => {
         const next = { ...prev };
         delete next.username;
         return next;
       });
-      validation.clearError('username');
+      validation?.clearError('username');
+    }
+    if (!validation) {
+      return;
     }
     return validation.registerValidation(() => {
       const errors: Record<string, string> = {};


### PR DESCRIPTION
## Type of Change

- [x] 🐛 Bug Fix

---

## Bug Fix

### What is the bug?

In the v2 config editor, blurring the empty Username field sets the 'Username is required' inline error unconditionally, but the code that clears the error lived inside a useEffect that early-returned when the ValidationAPI prop was undefined. The ValidationAPI only exists behind the non-default clickHouseConfigValidation feature toggle, so in the default configuration the error, once shown, persisted for the rest of the session even after the user typed a username. The sibling ServerAndEncryptionSection was already restructured in #1831 to clear errors eagerly regardless of ValidationAPI availability, but DatabaseCredentialsSection was missed.

### How to reproduce

1. Run Grafana with the ClickHouse datasource and the clickHouseConfigValidation feature toggle disabled (the default).
2. Open the v2 config editor for a ClickHouse datasource and expand the Database Credentials section.
3. Click into the Username field, then click away without typing anything: the 'Username is required' error appears.
4. Type a username into the field.
5. Observe the error never clears, even after blurring again or editing other fields.

### Environment (if no related issue)

- **ClickHouse version**: any supported
- **Grafana version**: any supported
- **Plugin version**: 4.19.0 and current main

---

## Please check that:

- [x] Tests for this change have been added/updated.
- [ ] Documentation has been added/updated (where applicable).

## Special notes for your reviewer

The fix moves the eager-clear block above the `if (!validation) return` guard in the useEffect and switches `validation.clearError` to optional chaining, exactly mirroring the pattern already used in ServerAndEncryptionSection (#1831). The registerValidation path behind the guard is unchanged. The new test 'clears username error once the field is filled and no validation API is present' was verified to fail against the unfixed component and pass with the fix. Password has no required validation, so username is the only field affected in this section.

Found by an automated audit of regressions introduced while integrating PRs across the v4.18.0 and v4.19.0 release cycles (range v4.17.0..main). Related PRs: #1769, #1831, #1995.
