### PR TITLE
fix(config): fall back to legacy feature toggles when OpenFeature has no provider

### DIFF
--- a/src/views/ConfigEditor.test.tsx
+++ b/src/views/ConfigEditor.test.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { config } from '@grafana/runtime';
+import { OpenFeature, TypedInMemoryProvider } from '@openfeature/web-sdk';
+import { ConfigEditor } from './ConfigEditor';
+import { mockConfigEditorProps } from '__mocks__/ConfigEditor';
+import '@testing-library/jest-dom';
+
+jest.mock('./CHConfigEditor', () => ({
+  ConfigEditor: () => <div data-testid="config-editor-v1" />,
+}));
+
+jest.mock('./config-v2/CHConfigEditor', () => ({
+  ConfigEditor: () => <div data-testid="config-editor-v2" />,
+}));
+
+const setLegacyToggle = (value: boolean | undefined) => {
+  (config.featureToggles as Record<string, boolean | undefined>)['newClickhouseConfigPageDesign'] = value;
+};
+
+const registerProvider = (flagValue: boolean) =>
+  OpenFeature.setProviderAndWait(
+    'internal-grafana-core',
+    new TypedInMemoryProvider({
+      newClickhouseConfigPageDesign: {
+        variants: { on: true, off: false },
+        defaultVariant: flagValue ? 'on' : 'off',
+        disabled: false,
+      },
+    })
+  );
+
+describe('ConfigEditor', () => {
+  afterEach(async () => {
+    setLegacyToggle(undefined);
+    await OpenFeature.clearProviders();
+  });
+
+  it('renders the V1 editor when no OpenFeature provider is registered and the legacy toggle is unset', () => {
+    render(<ConfigEditor {...mockConfigEditorProps()} />);
+    expect(screen.getByTestId('config-editor-v1')).toBeInTheDocument();
+    expect(screen.queryByTestId('config-editor-v2')).not.toBeInTheDocument();
+  });
+
+  it('renders the V2 editor when no OpenFeature provider is registered and the legacy toggle is enabled', () => {
+    // Grafana versions before 12.3 never register an OpenFeature provider,
+    // so the legacy featureToggles map is the only signal available.
+    setLegacyToggle(true);
+    render(<ConfigEditor {...mockConfigEditorProps()} />);
+    expect(screen.getByTestId('config-editor-v2')).toBeInTheDocument();
+    expect(screen.queryByTestId('config-editor-v1')).not.toBeInTheDocument();
+  });
+
+  it('prefers the OpenFeature provider value over the legacy toggle', async () => {
+    setLegacyToggle(true);
+    await registerProvider(false);
+    render(<ConfigEditor {...mockConfigEditorProps()} />);
+    expect(screen.getByTestId('config-editor-v1')).toBeInTheDocument();
+    expect(screen.queryByTestId('config-editor-v2')).not.toBeInTheDocument();
+  });
+
+  it('renders the V2 editor when the OpenFeature provider enables the flag', async () => {
+    await registerProvider(true);
+    render(<ConfigEditor {...mockConfigEditorProps()} />);
+    expect(screen.getByTestId('config-editor-v2')).toBeInTheDocument();
+    expect(screen.queryByTestId('config-editor-v1')).not.toBeInTheDocument();
+  });
+});

--- a/src/views/ConfigEditor.tsx
+++ b/src/views/ConfigEditor.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { DataSourcePluginOptionsEditorProps } from '@grafana/data';
+import { config } from '@grafana/runtime';
 import { OpenFeature } from '@openfeature/web-sdk';
 import { CHConfig, CHSecureConfig } from 'types/config';
 import { ConfigEditor as ConfigEditorV1 } from './CHConfigEditor';
@@ -12,9 +13,16 @@ const GRAFANA_CORE_OPEN_FEATURE_DOMAIN = 'internal-grafana-core';
 export type ConfigEditorProps = DataSourcePluginOptionsEditorProps<CHConfig, CHSecureConfig>;
 
 export const ConfigEditor: React.FC<ConfigEditorProps> = (props) => {
+  // Grafana only registers an OpenFeature provider from 12.3, so on older
+  // versions the flag read falls through to the default. Passing the legacy
+  // featureToggles value as the default keeps the ini toggle working pre-12.3
+  // while still letting the provider win where one is registered.
+  const legacyToggle = Boolean(
+    (config.featureToggles as Record<string, boolean | undefined> | undefined)?.['newClickhouseConfigPageDesign']
+  );
   const useV2 = OpenFeature.getClient(GRAFANA_CORE_OPEN_FEATURE_DOMAIN).getBooleanValue(
     'newClickhouseConfigPageDesign',
-    false
+    legacyToggle
   );
   return useV2 ? <ConfigEditorV2 {...props} /> : <ConfigEditorV1 {...props} />;
 };


### PR DESCRIPTION
## Type of Change

- [x] 🐛 Bug Fix

---

## Bug Fix

### What is the bug?

PR #1921 replaced the legacy config.featureToggles read for newClickhouseConfigPageDesign with OpenFeature.getClient('internal-grafana-core').getBooleanValue(flag, false). Grafana core only registers that OpenFeature provider from 12.3, so on Grafana 11.6 to 12.2 (still supported by plugin.json, >=11.6.0-0) the SDK's no-op provider always returns the hard-coded default false. The V2 config editor became unreachable even with the ini feature toggle enabled, a regression from v4.18.0. The fix passes the legacy toggle value as the OpenFeature default, so a registered provider (12.3+) still wins while the ini toggle works again pre-12.3.

### How to reproduce

1. Run Grafana 12.2 (or any 11.6 to 12.2 version) with feature_toggles.newClickhouseConfigPageDesign = true in custom.ini.
2. Install the plugin at v4.19.0 (first release containing #1921) and open the ClickHouse datasource configuration page.
3. Observe the V1 editor renders (no "new design" banner) despite the toggle being enabled, whereas v4.18.0 rendered the V2 editor.
4. With this fix, repeat step 2 and confirm the V2 editor renders. On Grafana 12.3+ behaviour is unchanged, as the OpenFeature provider's value still takes precedence.

### Environment (if no related issue)

- **ClickHouse version**: any supported
- **Grafana version**: any supported
- **Plugin version**: 4.19.0 and current main

---

## Please check that:

- [x] Tests for this change have been added/updated.
- [ ] Documentation has been added/updated (where applicable).

## Special notes for your reviewer

This was the only call site introduced by #1921, src/module.ts just imports the wrapper (verified via git show 7c6693a and a grep for getBooleanValue and newClickhouseConfigPageDesign). The featureToggles cast to Record<string, boolean | undefined> matches the existing clickHouseConfigValidation reads in both CHConfigEditor variants. The new test file stubs the V1/V2 editors and exercises the wrapper against real OpenFeature global state, the provider-wins cases use TypedInMemoryProvider (the non-deprecated variant) on the internal-grafana-core domain with clearProviders() in afterEach. The legacy-toggle test fails without the source change, confirmed by stashing the fix and rerunning.

Found by an automated audit of regressions introduced while integrating PRs across the v4.18.0 and v4.19.0 release cycles (range v4.17.0..main). Related PRs: #1921, #1995.
