### PR TITLE
fix(schema): honour the plugin cache settings in schema resource responses

### DIFF
--- a/pkg/plugin/datasource.go
+++ b/pkg/plugin/datasource.go
@@ -2,6 +2,7 @@ package plugin
 
 import (
 	"context"
+	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/instancemgmt"
@@ -25,6 +26,27 @@ func (i *clickhouseInstance) Dispose() {
 	}
 }
 
+// schemaResourceOptions maps the plugin's enableSchemaCache and
+// schemaCacheTTLSeconds settings onto the schemads response-cache options so
+// the schema resource endpoints honour the same knobs as the SchemaProvider's
+// sub-fetch caches (see NewSchemaProvider in schema.go). Without this the
+// schemads defaults apply and the settings silently stop working.
+func schemaResourceOptions(settings Settings) schemas.Options {
+	if !settings.EnableSchemaCache {
+		return schemas.Options{DisableCache: true}
+	}
+	opts := schemas.DefaultOptions
+	if ttl := time.Duration(settings.SchemaCacheTTLSeconds) * time.Second; ttl > 0 {
+		// Only the endpoints this plugin serves are overridden; ColumnValues
+		// stays at the library default of uncached because its responses are
+		// time-range dependent.
+		opts.TTL.FullSchema = ttl
+		opts.TTL.Tables = ttl
+		opts.TTL.Columns = ttl
+	}
+	return opts
+}
+
 func NewDatasource(ctx context.Context, settings backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
 	clickhousePlugin := Clickhouse{}
 	ds := sqlds.NewDatasource(&clickhousePlugin)
@@ -37,14 +59,22 @@ func NewDatasource(ctx context.Context, settings backend.DataSourceInstanceSetti
 	}
 
 	schemaProvider := NewSchemaProvider(ctx, &clickhousePlugin, settings)
+	// Mirror NewSchemaProvider: if the settings cannot be parsed, degrade to
+	// no response caching rather than caching with defaults the user cannot
+	// influence.
+	schemaOptions := schemas.Options{DisableCache: true}
+	if parsed, err := LoadSettings(ctx, settings); err == nil {
+		schemaOptions = schemaResourceOptions(parsed)
+	}
 	ds.ResourceMiddleware = func(next backend.CallResourceHandler) backend.CallResourceHandler {
-		return schemas.NewSchemaDatasource(
+		return schemas.NewSchemaDatasourceWithOptions(
 			schemaProvider,
 			schemaProvider,
 			schemaProvider,
 			nil, // no table parameter values handler
 			schemaProvider,
 			next,
+			schemaOptions,
 		)
 	}
 

--- a/pkg/plugin/datasource_test.go
+++ b/pkg/plugin/datasource_test.go
@@ -1,0 +1,129 @@
+package plugin
+
+import (
+	"context"
+	"net/http"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	schemas "github.com/grafana/schemads"
+)
+
+func TestSchemaResourceOptions(t *testing.T) {
+	ttlOverride := schemas.DefaultOptions
+	ttlOverride.TTL.FullSchema = 120 * time.Second
+	ttlOverride.TTL.Tables = 120 * time.Second
+	ttlOverride.TTL.Columns = 120 * time.Second
+
+	tests := []struct {
+		name     string
+		settings Settings
+		want     schemas.Options
+	}{
+		{
+			name:     "cache disabled turns off response caching",
+			settings: Settings{EnableSchemaCache: false, SchemaCacheTTLSeconds: 60},
+			want:     schemas.Options{DisableCache: true},
+		},
+		{
+			name:     "configured TTL propagates to schema endpoints",
+			settings: Settings{EnableSchemaCache: true, SchemaCacheTTLSeconds: 120},
+			want:     ttlOverride,
+		},
+		{
+			// LoadSettings clamps the TTL to a positive value, but the
+			// mapping must not zero every endpoint if that invariant breaks.
+			name:     "non-positive TTL keeps schemads defaults",
+			settings: Settings{EnableSchemaCache: true, SchemaCacheTTLSeconds: 0},
+			want:     schemas.DefaultOptions,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := schemaResourceOptions(tt.settings)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("schemaResourceOptions(%+v) = %+v, want %+v", tt.settings, got, tt.want)
+			}
+		})
+	}
+}
+
+// countingTablesHandler records how many times the tables endpoint handler
+// runs, so tests can observe whether responses were served from cache.
+type countingTablesHandler struct {
+	calls int
+}
+
+func (h *countingTablesHandler) Tables(context.Context, *schemas.TablesRequest) (*schemas.TablesResponse, error) {
+	h.calls++
+	return &schemas.TablesResponse{Tables: []string{"events"}}, nil
+}
+
+// TestSchemaResourceOptionsControlResponseCache drives the schemads resource
+// handler exactly as NewDatasource wires it, asserting that the plugin's
+// enableSchemaCache setting controls schemads response-level caching rather
+// than the schemads defaults applying regardless.
+func TestSchemaResourceOptionsControlResponseCache(t *testing.T) {
+	tests := []struct {
+		name      string
+		settings  Settings
+		wantCalls int
+	}{
+		{
+			name:      "enabled cache serves repeat request from cache",
+			settings:  Settings{EnableSchemaCache: true, SchemaCacheTTLSeconds: 300},
+			wantCalls: 1,
+		},
+		{
+			name:      "disabled cache re-runs the handler",
+			settings:  Settings{EnableSchemaCache: false},
+			wantCalls: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler := &countingTablesHandler{}
+			resource := schemas.NewSchemaDatasourceWithOptions(
+				nil,
+				handler,
+				nil,
+				nil,
+				nil,
+				nil,
+				schemaResourceOptions(tt.settings),
+			)
+
+			req := &backend.CallResourceRequest{
+				PluginContext: backend.PluginContext{
+					Namespace: "default",
+					User:      &backend.User{Login: "admin"},
+					DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{
+						UID: "test-uid",
+					},
+				},
+				Path:   schemas.BaseResourcePath + "/" + schemas.RequestTypeTables,
+				Method: http.MethodPost,
+			}
+			sender := backend.CallResourceResponseSenderFunc(func(resp *backend.CallResourceResponse) error {
+				if resp.Status != http.StatusOK {
+					t.Errorf("unexpected response status %d, body %q", resp.Status, resp.Body)
+				}
+				return nil
+			})
+
+			for i := 0; i < 2; i++ {
+				if err := resource.CallResource(context.Background(), req, sender); err != nil {
+					t.Fatalf("CallResource request %d: %v", i+1, err)
+				}
+			}
+
+			if handler.calls != tt.wantCalls {
+				t.Errorf("tables handler ran %d times, want %d", handler.calls, tt.wantCalls)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Type of Change

- [x] 🐛 Bug Fix

---

## Bug Fix

### What is the bug?

PR #1997 bumped github.com/grafana/schemads from v0.0.6 to v0.2.3, and v0.2.x's schemas.NewSchemaDatasource enables response-level caching by default (fullSchema 5m, tables 5m, columns 2m, bypass only via an X-Schemads-Refresh header this plugin never sends). The call site in pkg/plugin/datasource.go was only updated for the compile break, so the datasource's own enableSchemaCache and schemaCacheTTLSeconds settings (which NewSchemaProvider in pkg/plugin/schema.go honours for its sub-fetch caches) had no effect on the schema resource endpoints: disabling the cache or lowering the TTL silently did nothing at the response layer.

### How to reproduce

1. Configure a ClickHouse datasource with enableSchemaCache set to false (or a schemaCacheTTLSeconds well below 120) in the datasource JSON data.
2. Open the query builder so the frontend calls the abstractionSchema/tables or abstractionSchema/columns resource endpoints.
3. Run ALTER TABLE (or create/drop a table) on the ClickHouse server.
4. Reload the query builder within 2-5 minutes: the stale table/column list is still served because the schemads response cache uses its hardcoded defaults regardless of the plugin settings.
5. With this fix, disabling the cache returns fresh results immediately, and a custom TTL expires entries on the configured schedule.

### Environment (if no related issue)

- **ClickHouse version**: any supported
- **Grafana version**: any supported
- **Plugin version**: 4.19.0 and current main

---

## Please check that:

- [x] Tests for this change have been added/updated.
- [ ] Documentation has been added/updated (where applicable).

## Special notes for your reviewer

The mapping lives in schemaResourceOptions so both cache layers (schemads response cache and the SchemaProvider sub-fetch caches) are driven by the same parsed settings. It starts from schemas.DefaultOptions and overrides only the TTLs for the three endpoints this plugin serves, keeping the library's refresh-header policy and per-user scoping. ColumnValues stays uncached (time-range dependent) and TableParameterValues is irrelevant because that handler is nil. On LoadSettings error the response cache is disabled, mirroring NewSchemaProvider's cache-disabled degrade rather than caching with knobs the user cannot influence. The behavioural test constructs the schemads handler exactly as NewDatasource does and was verified to fail (handler runs once instead of twice with caching disabled) when fed the pre-fix DefaultOptions. Note schemads Options.resolve treats an all-zero TTL block as "use defaults", which is why the helper guards ttl > 0 even though LoadSettings clamps the TTL to at least 60 seconds.

Found by an automated audit of regressions introduced while integrating PRs across the v4.18.0 and v4.19.0 release cycles (range v4.17.0..main). Related PRs: #1997, #1787.
