### PR TITLE
fix(adhoc): use mapKeys() so Map-key discovery works on ClickHouse before 24.3

### DIFF
--- a/src/data/CHDatasource.test.ts
+++ b/src/data/CHDatasource.test.ts
@@ -721,7 +721,7 @@ describe('ClickHouseDatasource', () => {
       const mapKeysFrame = arrayToDataFrame([{ keys: 'http.method' }, { keys: 'http.status' }]);
       jest.spyOn(ds, 'query').mockImplementation((request) => {
         const sql = request.targets[0].rawSql ?? '';
-        if (sql.includes('arrayJoin("labels".keys)')) {
+        if (sql.includes('arrayJoin(mapKeys("labels"))')) {
           return of({ data: [mapKeysFrame] });
         }
         return of({ data: [columnsFrame] });
@@ -758,7 +758,7 @@ describe('ClickHouseDatasource', () => {
 
       const spyOnQuery = jest.spyOn(ds, 'query').mockImplementation((request) => {
         const sql = request.targets[0].rawSql ?? '';
-        if (sql.includes('arrayJoin("labels".keys)')) {
+        if (sql.includes('arrayJoin(mapKeys("labels"))')) {
           return of({ data: [mapKeysFrame] });
         }
         if (sql.includes("labels['http.method']")) {
@@ -802,7 +802,7 @@ describe('ClickHouseDatasource', () => {
 
       jest.spyOn(ds, 'query').mockImplementation((request) => {
         const sql = request.targets[0].rawSql ?? '';
-        if (sql.includes('arrayJoin("labels".keys)')) {
+        if (sql.includes('arrayJoin(mapKeys("labels"))')) {
           return of({ data: [mapKeysFrame] });
         }
         if (sql.includes("labels['region']")) {
@@ -829,7 +829,7 @@ describe('ClickHouseDatasource', () => {
 
       const spyOnQuery = jest.spyOn(ds, 'query').mockImplementation((request) => {
         const sql = request.targets[0].rawSql ?? '';
-        if (sql.includes('arrayJoin("labels".keys)')) {
+        if (sql.includes('arrayJoin(mapKeys("labels"))')) {
           return of({ data: [mapKeysFrame] });
         }
         if (sql.includes("labels['weird\\'key']")) {
@@ -863,7 +863,7 @@ describe('ClickHouseDatasource', () => {
       const mapKeysFrame = arrayToDataFrame([{ keys: 'a' }]);
       jest.spyOn(ds, 'query').mockImplementation((request) => {
         const sql = request.targets[0].rawSql ?? '';
-        if (sql.includes('.keys)')) {
+        if (sql.includes('mapKeys(')) {
           return of({ data: [mapKeysFrame] });
         }
         return of({ data: [columnsFrame] });
@@ -893,8 +893,35 @@ describe('ClickHouseDatasource', () => {
       expect(result).toEqual(['a', 'b']);
       const sql = spy.mock.calls[0][0].targets[0].rawSql!;
       expect(sql).toBe(
-        'SELECT DISTINCT arrayJoin("labels".keys) as keys FROM (SELECT "labels" FROM "db"."events" LIMIT 100000) LIMIT 1000'
+        'SELECT DISTINCT arrayJoin(mapKeys("labels")) as keys FROM (SELECT "labels" FROM "db"."events" LIMIT 100000) LIMIT 1000'
       );
+    });
+
+    it('uses the mapKeys() function rather than the .keys sub-column so the old analyzer can resolve it', async () => {
+      // ClickHouse's old analyzer (the default before 24.3, or with
+      // allow_experimental_analyzer=0) cannot resolve `.keys` sub-columns on
+      // subquery results and fails with UNKNOWN_IDENTIFIER (code 47). Every
+      // call site swallows the error, so Map-key ad-hoc filters silently
+      // vanish on 22.7-24.2 unless the probe uses the mapKeys() function.
+      const ds = cloneDeep(mockDatasource);
+      ds.settings.jsonData.logs = {
+        defaultDatabase: 'otel',
+        defaultTable: 'otel_logs',
+        otelEnabled: false,
+        timeColumn: 'Timestamp',
+      };
+      const frame = arrayToDataFrame([{ keys: 'a' }]);
+      const spy = jest.spyOn(ds, 'query').mockImplementation(() => of({ data: [frame] }));
+
+      // Subquery-sampled path (free-form table) and time-bounded path (OTel
+      // logs table) must both avoid the sub-column syntax.
+      await ds.fetchUniqueMapKeys('labels', 'db', 'events');
+      await ds.fetchUniqueMapKeys('LogAttributes', 'otel', 'otel_logs');
+      for (const call of spy.mock.calls) {
+        const sql = call[0].targets[0].rawSql!;
+        expect(sql).not.toContain('.keys');
+        expect(sql).toContain('arrayJoin(mapKeys(');
+      }
     });
 
     it('bounds the probe to the configured logs time column when target matches OTel logs table', async () => {

--- a/src/data/CHDatasource.ts
+++ b/src/data/CHDatasource.ts
@@ -1153,7 +1153,10 @@ export class Datasource
     const source = timeColumn
       ? `${tableIdentifier} WHERE ${escapeIdentifier(timeColumn)} >= now() - INTERVAL 6 HOUR`
       : `(SELECT ${escapedColumn} FROM ${tableIdentifier} LIMIT ${MAP_KEY_PROBE_ROW_SAMPLE})`;
-    const rawSql = `SELECT DISTINCT arrayJoin(${escapedColumn}.keys) as keys FROM ${source} LIMIT 1000`;
+    // mapKeys() rather than the `.keys` sub-column: ClickHouse's old analyzer
+    // (the default before 24.3) cannot resolve sub-columns on subquery results
+    // and fails with UNKNOWN_IDENTIFIER, silently breaking key discovery.
+    const rawSql = `SELECT DISTINCT arrayJoin(mapKeys(${escapedColumn})) as keys FROM ${source} LIMIT 1000`;
     return this.fetchData(rawSql);
   }
 

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -66,7 +66,7 @@ export interface CHConfig extends DataSourceJsonData {
   /**
    * Controls the Map-column key discovery probe that populates the filter-key
    * dropdown for `Map(...)` columns. The probe issues
-   * `SELECT DISTINCT arrayJoin(col.keys) FROM db.table LIMIT 1000` and can be
+   * `SELECT DISTINCT arrayJoin(mapKeys(col)) FROM db.table LIMIT 1000` and can be
    * expensive on large tables when the map has high key cardinality. Defaults
    * to true to preserve existing UX; operators on large OTel logs/traces tables
    * may want to disable it. See issue #1843.

--- a/tests/e2e/mapFilter.spec.ts
+++ b/tests/e2e/mapFilter.spec.ts
@@ -87,7 +87,7 @@ test.describe('Map column adhoc filters', () => {
     // the fixture has the expected distinct keys so that any future change
     // to the discovery query (e.g. sampling via a subquery) keeps surfacing
     // all map keys present in a small table.
-    await enterSql(page, 'SELECT DISTINCT arrayJoin(labels.keys) AS keys FROM e2e_test.map_events ORDER BY keys');
+    await enterSql(page, 'SELECT DISTINCT arrayJoin(mapKeys(labels)) AS keys FROM e2e_test.map_events ORDER BY keys');
 
     const { responsePromise, getBody } = await waitForQueryDataResponseWithBody(explorePage);
     await page.locator('.query-editor-row').getByRole('button', { name: 'Run Query' }).click();


### PR DESCRIPTION
## Type of Change

- [x] 🐛 Bug Fix

---

## Bug Fix

### What is the bug?

The bounded Map-key discovery probe introduced in #1993 reads a Map sub-column from a subquery: `SELECT DISTINCT arrayJoin("col".keys) as keys FROM (SELECT "col" FROM db.tbl LIMIT 100000) LIMIT 1000`. ClickHouse's old analyzer (the default before 24.3, or whenever `allow_experimental_analyzer=0`) cannot resolve `.keys` sub-columns on subquery results and fails with UNKNOWN_IDENTIFIER (code 47). Every call site swallows the error, so Map-key ad-hoc filters and filter-key dropdowns silently disappear on ClickHouse 22.7-24.2. The fix switches the probe to the `mapKeys()` function, which the old analyzer resolves on subquery columns, producing `SELECT DISTINCT arrayJoin(mapKeys("col")) as keys FROM (...) LIMIT 1000`. User-facing impact: Map-column ad-hoc filter keys reappear for users on ClickHouse versions older than 24.3 (or with the new analyzer disabled).

### How to reproduce

1. Run ClickHouse 23.8 (or any 22.7-24.2, or a newer version with `allow_experimental_analyzer=0`) with a table containing a `Map(String, String)` column, e.g. `db.events` with column `labels`.
2. Configure the ClickHouse datasource with that default database/table and open a dashboard with an ad-hoc filter variable (or any UI that populates the Map filter-key dropdown).
3. Before this fix: the probe query fails server-side with UNKNOWN_IDENTIFIER (code 47), the error is swallowed, and the dropdown shows no Map keys (only the flat `events.labels` entry). Running the old probe SQL manually confirms the error: `SELECT DISTINCT arrayJoin("labels".keys) as keys FROM (SELECT "labels" FROM db.events LIMIT 100000) LIMIT 1000`.
4. After this fix: the probe uses `arrayJoin(mapKeys("labels"))`, succeeds on both old and new analyzers, and the Map keys appear in the dropdown.

### Environment (if no related issue)

- **ClickHouse version**: any supported
- **Grafana version**: any supported
- **Plugin version**: 4.19.0 and current main

---

## Please check that:

- [x] Tests for this change have been added/updated.
- [ ] Documentation has been added/updated (where applicable).

## Special notes for your reviewer

Only fetchUniqueMapKeys had the sub-column-on-subquery pattern. fetchDistinctMapValues uses bracket access plus mapContains directly on the table, and fetchUniqueJSONPaths/fetchPathsForJSONColumns query the table directly, so none of them are affected by the old-analyzer limitation and they were left untouched. The time-bounded OTel probe path (direct table access) also worked on the old analyzer, but it was switched to mapKeys() too so both branches emit the same shape. tests/e2e/mapFilter.spec.ts exists specifically to run the exact SQL shape the adhoc code paths produce against a real ClickHouse, so its probe-shape query was updated to match, and the doc comment on enableMapKeysDiscovery in src/types/config.ts quoted the old SQL and was updated for accuracy. The new unit test asserts both probe paths avoid `.keys` and use `arrayJoin(mapKeys(`, and it fails against the previous implementation.

Found by an automated audit of regressions introduced while integrating PRs across the v4.18.0 and v4.19.0 release cycles (range v4.17.0..main). Related PRs: #1993, #1793, #1885, #1841.
