### PR TITLE
fix(logs): recognise editor-created filters in the log-view filter toggles

### DIFF
--- a/src/data/CHDatasource.test.ts
+++ b/src/data/CHDatasource.test.ts
@@ -2707,6 +2707,31 @@ describe('ClickHouseDatasource', () => {
       expect(datasource.queryHasFilter(queryWithLevel, { key: 'level', value: 'info' })).toBe(true);
     });
 
+    it('returns true for an editor-created filter that stores the real column type', () => {
+      // The compact FilterPopover and the classic FilterEditor store the real
+      // ClickHouse column type, not the 'string' sentinel the log-view toggles
+      // use, so the same column's filters must still be found.
+      const queryWithFilter: CHBuilderQuery = {
+        ...query,
+        builderOptions: {
+          ...query.builderOptions,
+          columns: [{ name: 'SeverityText', type: 'LowCardinality(String)' }],
+          filters: [
+            {
+              condition: 'AND',
+              key: 'SeverityText',
+              type: 'LowCardinality(String)',
+              filterType: 'custom',
+              operator: FilterOperator.Equals,
+              value: 'Error',
+            },
+          ],
+        },
+      };
+
+      expect(datasource.queryHasFilter(queryWithFilter, { key: 'SeverityText', value: 'Error' })).toBe(true);
+    });
+
     it('returns true for OTel map key match', () => {
       const queryWithMap: CHBuilderQuery = {
         ...query,
@@ -3026,6 +3051,66 @@ describe('ClickHouseDatasource', () => {
       expect(result.builderOptions.filters![0]).toMatchObject({
         operator: FilterOperator.NotEquals,
         value: 'error',
+      });
+    });
+
+    it('FILTER_FOR toggles off an editor-created filter that stores the real column type', () => {
+      const queryWithFilter: CHBuilderQuery = {
+        ...query,
+        builderOptions: {
+          ...query.builderOptions,
+          columns: [{ name: 'SeverityText', type: 'LowCardinality(String)' }],
+          filters: [
+            {
+              condition: 'AND',
+              key: 'SeverityText',
+              type: 'LowCardinality(String)',
+              filterType: 'custom',
+              operator: FilterOperator.Equals,
+              value: 'Error',
+            },
+          ],
+        },
+      };
+
+      const result = datasource.toggleQueryFilter(queryWithFilter, {
+        type: 'FILTER_FOR',
+        options: { key: 'SeverityText', value: 'Error' },
+      }) as CHBuilderQuery;
+
+      expect(result.builderOptions.filters).toHaveLength(0);
+    });
+
+    it('FILTER_FOR replaces an editor-created Equals filter with a different value (no AND-ing)', () => {
+      const queryWithFilter: CHBuilderQuery = {
+        ...query,
+        builderOptions: {
+          ...query.builderOptions,
+          columns: [{ name: 'SeverityText', type: 'LowCardinality(String)' }],
+          filters: [
+            {
+              condition: 'AND',
+              key: 'SeverityText',
+              type: 'LowCardinality(String)',
+              filterType: 'custom',
+              operator: FilterOperator.Equals,
+              value: 'Error',
+            },
+          ],
+        },
+      };
+
+      const result = datasource.toggleQueryFilter(queryWithFilter, {
+        type: 'FILTER_FOR',
+        options: { key: 'SeverityText', value: 'Info' },
+      }) as CHBuilderQuery;
+
+      // Must NOT produce `SeverityText = 'Error' AND SeverityText = 'Info'` (zero rows).
+      expect(result.builderOptions.filters).toHaveLength(1);
+      expect(result.builderOptions.filters![0]).toMatchObject({
+        key: 'SeverityText',
+        operator: FilterOperator.Equals,
+        value: 'Info',
       });
     });
 

--- a/src/data/CHDatasource.ts
+++ b/src/data/CHDatasource.ts
@@ -60,7 +60,7 @@ import {
   splitLogsVolumeFrames,
   TIME_FIELD_ALIAS,
 } from './logs';
-import { escapeIdentifier, generateSql, getColumnByHint, logAliasToColumnHints } from './sqlGenerator';
+import { escapeIdentifier, generateSql, getColumnByHint, isStringType, logAliasToColumnHints } from './sqlGenerator';
 import { labelsFieldName, transformQueryResponseWithTraceAndLogLinks } from './utils';
 import { CHVariableSupport } from './CHVariableSupport';
 import { createAnnotationSupport } from './CHAnnotationSupport';
@@ -197,7 +197,10 @@ function filterMatchesColumn(f: Filter, resolved: ResolvedColumn): boolean {
   if (resolved.hasMapKey) {
     return (f.type.startsWith('Map') || f.type.startsWith('JSON')) && f.mapKey === resolved.mapKey && sameColumn;
   }
-  return f.type === 'string' && sameColumn;
+  // Log-view toggles store the 'string' sentinel type, but the filter editors store the
+  // real column type ('String', 'LowCardinality(String)', ...). Accept any string-like
+  // type so editor-created filters toggle off instead of gaining a contradictory duplicate.
+  return isStringType(f.type) && sameColumn;
 }
 
 export class Datasource

--- a/src/data/sqlGenerator.ts
+++ b/src/data/sqlGenerator.ts
@@ -996,7 +996,7 @@ const isNumberType = (type: string): boolean => numberTypes.some((t) => type?.to
 const isDateType = (type: string): boolean =>
   type?.toLowerCase().startsWith('date') || type?.toLowerCase().startsWith('nullable(date');
 // const isDateTimeType = (type: string): boolean => type?.toLowerCase().startsWith('datetime') || type?.toLowerCase().startsWith('nullable(datetime');
-const isStringType = (type: string): boolean => {
+export const isStringType = (type: string): boolean => {
   type = stripTypeModifiers(type.toLowerCase());
   return (
     (type === 'string' || type.startsWith('fixedstring')) &&


### PR DESCRIPTION
## Type of Change

- [x] 🐛 Bug Fix

---

## Bug Fix

### What is the bug?

The log-view filter matcher (`filterMatchesColumn` in `src/data/CHDatasource.ts`, used by `queryHasFilter` and `toggleQueryFilter`) only treated a non-map filter as matching when its `type` was exactly `'string'`, the sentinel value that the log-view toggle's own `buildFilter` writes. Filters created through the compact FilterPopover or the classic FilterEditor store the real ClickHouse column type (`'LowCardinality(String)'`, `'String'`, `'Nullable(String)'`, ...), so the same column's filters lived in disjoint sets: the Log Details +/- toggle never lit up for editor-created filters, toggling could not remove them, and FILTER_FOR on another value appended a contradictory second Equals filter (`col = 'a' AND col = 'b'`), returning zero rows.

### How to reproduce

1. Create a logs query in the query builder against a table with a `LowCardinality(String)` column, e.g. `SeverityText`, selecting it as a plain column.
2. In the Filters editor, add a filter `SeverityText = Error` (the editor stores the real column type on the filter).
3. Run the query in Explore and expand a log row's details.
4. Observe the "filter for value" (+) toggle for `SeverityText: Error` is not highlighted even though the filter is active (`queryHasFilter` returns false).
5. Click the + toggle on a different value, e.g. `Info`: instead of replacing the existing Equals filter, a second contradictory `SeverityText = 'Info'` filter is appended and the query returns no rows.

### Environment (if no related issue)

- **ClickHouse version**: any supported
- **Grafana version**: any supported
- **Plugin version**: 4.19.0 and current main

---

## Please check that:

- [x] Tests for this change have been added/updated.
- [ ] Documentation has been added/updated (where applicable).

## Special notes for your reviewer

The fix reuses `isStringType` from `src/data/sqlGenerator.ts` (now exported directly instead of only via `_testExports`), which lowercases and strips `LowCardinality`/`Nullable` wrappers before comparing against `string`/`fixedstring`. The `'string'` sentinel itself passes this predicate, so log-view-created filters keep matching. The stricter predicate was chosen over the looser `isStringType` in `components/queryBuilder/utils.ts` on purpose: that one treats anything non-boolean/number/date as string-like, which would let `Map(String, String)` filters leak into the non-map branch and undo the map/non-map separation introduced in #2020. The `hasMapKey` branch and the hint/key `sameColumn` comparison are unchanged. Known remaining gaps (pre-existing, out of scope): Enum-typed filters still do not match, and editor filters keyed by the real column name are not matched when the toggle arrives via a hint alias such as `level`.

Found by an automated audit of regressions introduced while integrating PRs across the v4.18.0 and v4.19.0 release cycles (range v4.17.0..main). Related PRs: #1824, #1841, #2020.
