### PR TITLE
fix(queryBuilder): only auto-detect column roles on new queries

### DIFF
--- a/src/components/queryBuilder/views/LogsQueryBuilder.tsx
+++ b/src/components/queryBuilder/views/LogsQueryBuilder.tsx
@@ -113,6 +113,7 @@ export const LogsQueryBuilder = (props: LogsQueryBuilderProps) => {
   useDefaultLogColumnsByName(
     allColumns,
     builderOptions.table,
+    isNewQuery,
     builderState.messageColumn,
     builderState.logLevelColumn,
     builderState.otelEnabled,

--- a/src/components/queryBuilder/views/TraceQueryBuilder.tsx
+++ b/src/components/queryBuilder/views/TraceQueryBuilder.tsx
@@ -150,6 +150,7 @@ export const TraceQueryBuilder = (props: TraceQueryBuilderProps) => {
   useDefaultTraceColumnsByName(
     allColumns,
     builderOptions.table,
+    isNewQuery,
     {
       traceId: builderState.traceIdColumn,
       spanId: builderState.spanIdColumn,

--- a/src/components/queryBuilder/views/logsQueryBuilderHooks.test.ts
+++ b/src/components/queryBuilder/views/logsQueryBuilderHooks.test.ts
@@ -390,7 +390,7 @@ describe('useDefaultLogColumnsByName', () => {
     ];
 
     renderHook(() =>
-      useDefaultLogColumnsByName(allColumns, 'logs', undefined, undefined, false, builderOptionsDispatch)
+      useDefaultLogColumnsByName(allColumns, 'logs', true, undefined, undefined, false, builderOptionsDispatch)
     );
 
     expect(builderOptionsDispatch).toHaveBeenCalledTimes(2);
@@ -413,7 +413,7 @@ describe('useDefaultLogColumnsByName', () => {
     const userPickedMessage: SelectedColumn = { name: 'custom_msg', type: 'String', hint: ColumnHint.LogMessage };
 
     renderHook(() =>
-      useDefaultLogColumnsByName(allColumns, 'logs', userPickedMessage, undefined, false, builderOptionsDispatch)
+      useDefaultLogColumnsByName(allColumns, 'logs', true, userPickedMessage, undefined, false, builderOptionsDispatch)
     );
 
     // Only Log Level should be filled; Message is preserved.
@@ -431,7 +431,7 @@ describe('useDefaultLogColumnsByName', () => {
     ];
 
     renderHook(() =>
-      useDefaultLogColumnsByName(allColumns, 'otel_logs', undefined, undefined, true, builderOptionsDispatch)
+      useDefaultLogColumnsByName(allColumns, 'otel_logs', true, undefined, undefined, true, builderOptionsDispatch)
     );
 
     expect(builderOptionsDispatch).toHaveBeenCalledTimes(0);
@@ -442,10 +442,43 @@ describe('useDefaultLogColumnsByName', () => {
     const allColumns: readonly TableColumn[] = [{ name: 'unrelated', type: 'String', picklistValues: [] }];
 
     renderHook(() =>
-      useDefaultLogColumnsByName(allColumns, 'logs', undefined, undefined, false, builderOptionsDispatch)
+      useDefaultLogColumnsByName(allColumns, 'logs', true, undefined, undefined, false, builderOptionsDispatch)
     );
 
     expect(builderOptionsDispatch).toHaveBeenCalledTimes(0);
+  });
+
+  it('does not fill empty slots on mount for a saved query', async () => {
+    const builderOptionsDispatch = jest.fn();
+    // Conventional names are present, but the saved query has both slots
+    // deliberately cleared. Opening the editor must not re-add them.
+    const allColumns: readonly TableColumn[] = [
+      { name: 'message', type: 'String', picklistValues: [] },
+      { name: 'level', type: 'LowCardinality(String)', picklistValues: [] },
+    ];
+
+    renderHook(() =>
+      useDefaultLogColumnsByName(allColumns, 'logs', false, undefined, undefined, false, builderOptionsDispatch)
+    );
+
+    expect(builderOptionsDispatch).toHaveBeenCalledTimes(0);
+  });
+
+  it('fills empty slots when the table changes on a saved query', async () => {
+    const builderOptionsDispatch = jest.fn();
+    const allColumns: readonly TableColumn[] = [
+      { name: 'message', type: 'String', picklistValues: [] },
+      { name: 'level', type: 'String', picklistValues: [] },
+    ];
+
+    const hook = renderHook(
+      (table) =>
+        useDefaultLogColumnsByName(allColumns, table, false, undefined, undefined, false, builderOptionsDispatch),
+      { initialProps: 'logs' }
+    );
+    expect(builderOptionsDispatch).toHaveBeenCalledTimes(0);
+    hook.rerender('other_logs');
+    expect(builderOptionsDispatch).toHaveBeenCalledTimes(2);
   });
 
   it('re-runs on table change and fills empty slots for the new table', async () => {
@@ -456,7 +489,8 @@ describe('useDefaultLogColumnsByName', () => {
     ];
 
     const hook = renderHook(
-      (table) => useDefaultLogColumnsByName(allColumns, table, undefined, undefined, false, builderOptionsDispatch),
+      (table) =>
+        useDefaultLogColumnsByName(allColumns, table, true, undefined, undefined, false, builderOptionsDispatch),
       { initialProps: 'logs' }
     );
     // After the first render both slots are filled (2 dispatches). Changing the

--- a/src/components/queryBuilder/views/logsQueryBuilderHooks.ts
+++ b/src/components/queryBuilder/views/logsQueryBuilderHooks.ts
@@ -185,8 +185,12 @@ export const useDefaultTimeColumn = (
  * Fills the Message and Log Level role slots from common non-OTel column names
  * (message, body, log_message; level, severity, severity_text, ...) when:
  *   - OTel mode is off (OTel has its own detection path),
- *   - the current table has changed since last run, and
+ *   - the query is new, or the current table has changed since last run, and
  *   - the role slot is still empty (never overwrites explicit user picks).
+ *
+ * Saved queries never auto-fill on mount: a deliberately cleared slot must
+ * stay cleared, otherwise opening the panel editor would silently mutate the
+ * saved query model.
  *
  * The Time role is handled separately by `useDefaultTimeColumn` so the two
  * stay independently testable and the Time fallback behavior is preserved.
@@ -194,13 +198,14 @@ export const useDefaultTimeColumn = (
 export const useDefaultLogColumnsByName = (
   allColumns: readonly TableColumn[],
   table: string,
+  isNewQuery: boolean,
   messageColumn: SelectedColumn | undefined,
   logLevelColumn: SelectedColumn | undefined,
   otelEnabled: boolean,
   builderOptionsDispatch: React.Dispatch<BuilderOptionsReducerAction>
 ) => {
   const lastTable = useRef<string>(table || '');
-  const didRun = useRef<boolean>(false);
+  const didRun = useRef<boolean>(!isNewQuery);
   if (table !== lastTable.current) {
     didRun.current = false;
   }

--- a/src/components/queryBuilder/views/traceQueryBuilderHooks.test.ts
+++ b/src/components/queryBuilder/views/traceQueryBuilderHooks.test.ts
@@ -339,7 +339,9 @@ describe('useDefaultTraceColumnsByName', () => {
   it('fills every role slot from conventional column names', () => {
     const builderOptionsDispatch = jest.fn();
 
-    renderHook(() => useDefaultTraceColumnsByName(traceTableColumns, 'traces', {}, false, builderOptionsDispatch));
+    renderHook(() =>
+      useDefaultTraceColumnsByName(traceTableColumns, 'traces', true, {}, false, builderOptionsDispatch)
+    );
 
     expect(builderOptionsDispatch).toHaveBeenCalledTimes(7);
     const expected: Array<[ColumnHint, string, string]> = [
@@ -363,7 +365,14 @@ describe('useDefaultTraceColumnsByName', () => {
     const userTraceId: SelectedColumn = { name: 'myTraceId', type: 'String', hint: ColumnHint.TraceId };
 
     renderHook(() =>
-      useDefaultTraceColumnsByName(traceTableColumns, 'traces', { traceId: userTraceId }, false, builderOptionsDispatch)
+      useDefaultTraceColumnsByName(
+        traceTableColumns,
+        'traces',
+        true,
+        { traceId: userTraceId },
+        false,
+        builderOptionsDispatch
+      )
     );
 
     // 7 slots minus the already-filled TraceId = 6 dispatches.
@@ -376,20 +385,43 @@ describe('useDefaultTraceColumnsByName', () => {
 
   it('does nothing when OTel mode is enabled', () => {
     const builderOptionsDispatch = jest.fn();
-    renderHook(() => useDefaultTraceColumnsByName(traceTableColumns, 'traces', {}, true, builderOptionsDispatch));
+    renderHook(() =>
+      useDefaultTraceColumnsByName(traceTableColumns, 'traces', true, {}, true, builderOptionsDispatch)
+    );
     expect(builderOptionsDispatch).toHaveBeenCalledTimes(0);
   });
 
   it('does nothing when allColumns is empty', () => {
     const builderOptionsDispatch = jest.fn();
-    renderHook(() => useDefaultTraceColumnsByName([], 'traces', {}, false, builderOptionsDispatch));
+    renderHook(() => useDefaultTraceColumnsByName([], 'traces', true, {}, false, builderOptionsDispatch));
     expect(builderOptionsDispatch).toHaveBeenCalledTimes(0);
+  });
+
+  it('does not fill empty slots on mount for a saved query', () => {
+    const builderOptionsDispatch = jest.fn();
+    // Conventional names are present, but the saved query has its slots
+    // deliberately cleared. Opening the editor must not re-add them.
+    renderHook(() =>
+      useDefaultTraceColumnsByName(traceTableColumns, 'traces', false, {}, false, builderOptionsDispatch)
+    );
+    expect(builderOptionsDispatch).toHaveBeenCalledTimes(0);
+  });
+
+  it('fills empty slots when the table changes on a saved query', () => {
+    const builderOptionsDispatch = jest.fn();
+    const hook = renderHook(
+      (table) => useDefaultTraceColumnsByName(traceTableColumns, table, false, {}, false, builderOptionsDispatch),
+      { initialProps: 'traces' }
+    );
+    expect(builderOptionsDispatch).toHaveBeenCalledTimes(0);
+    hook.rerender('other_traces');
+    expect(builderOptionsDispatch).toHaveBeenCalledTimes(7);
   });
 
   it('re-runs when the table changes', () => {
     const builderOptionsDispatch = jest.fn();
     const hook = renderHook(
-      (table) => useDefaultTraceColumnsByName(traceTableColumns, table, {}, false, builderOptionsDispatch),
+      (table) => useDefaultTraceColumnsByName(traceTableColumns, table, true, {}, false, builderOptionsDispatch),
       { initialProps: 'traces' }
     );
     const first = builderOptionsDispatch.mock.calls.length;
@@ -402,7 +434,7 @@ describe('useDefaultTraceColumnsByName', () => {
     // `duration` here is a String — heuristic must skip it, leaving the slot empty.
     const cols: readonly TableColumn[] = [{ name: 'duration', type: 'String', picklistValues: [] }];
 
-    renderHook(() => useDefaultTraceColumnsByName(cols, 'traces', {}, false, builderOptionsDispatch));
+    renderHook(() => useDefaultTraceColumnsByName(cols, 'traces', true, {}, false, builderOptionsDispatch));
 
     const durationDispatch = builderOptionsDispatch.mock.calls.find(
       ([action]) => action?.payload?.column?.hint === ColumnHint.TraceDurationTime

--- a/src/components/queryBuilder/views/traceQueryBuilderHooks.ts
+++ b/src/components/queryBuilder/views/traceQueryBuilderHooks.ts
@@ -190,6 +190,10 @@ export const useOtelColumns = (
  * OTel toggle is off). Runs once per table change; never overwrites an
  * explicit user pick.
  *
+ * Saved queries never auto-fill on mount: a deliberately cleared slot must
+ * stay cleared, otherwise opening the panel editor would silently mutate the
+ * saved query model.
+ *
  * The trace builder has many slots; we only heuristic-fill the ones with
  * unambiguous conventional names (Trace ID, Span ID, Parent Span ID, Service
  * Name, Operation/Span Name, Start Time, Duration). Other slots (Tags, Kind,
@@ -199,6 +203,7 @@ export const useOtelColumns = (
 export const useDefaultTraceColumnsByName = (
   allColumns: readonly TableColumn[],
   table: string,
+  isNewQuery: boolean,
   currentColumns: {
     traceId?: SelectedColumn;
     spanId?: SelectedColumn;
@@ -212,7 +217,7 @@ export const useDefaultTraceColumnsByName = (
   builderOptionsDispatch: React.Dispatch<BuilderOptionsReducerAction>
 ) => {
   const lastTable = useRef<string>(table || '');
-  const didRun = useRef<boolean>(false);
+  const didRun = useRef<boolean>(!isNewQuery);
   if (table !== lastTable.current) {
     didRun.current = false;
   }


### PR DESCRIPTION
## Type of Change

- [x] 🐛 Bug Fix

---

## Bug Fix

### What is the bug?

The column-name heuristics introduced in #1791 (useDefaultLogColumnsByName and useDefaultTraceColumnsByName) had no isNewQuery gate, unlike the sibling hooks useLogDefaultsOnMount/useTraceDefaultsOnMount/useDefaultFilters. They re-filled any empty role slot on every builder mount, so a deliberately cleared Message or Level column on a saved dashboard query was silently re-added the moment the panel editor opened. The dispatch regenerates rawSql, marks the dashboard dirty, and the altered SQL runs on the next refresh. Both hooks now initialise their run-once guard to !isNewQuery (the same wiring useDefaultFilters uses), so saved queries mount untouched while new queries and explicit table changes still auto-fill.

### How to reproduce

1. Create a Logs query against a non-OTel table that has a conventionally named column (e.g. level or severity).
2. Clear the Log Level column slot in the query builder and save the dashboard.
3. Reopen the panel editor on the saved dashboard.
4. Without this fix, the Level slot is instantly re-filled by the heuristic, rawSql changes, and the dashboard shows unsaved changes. With the fix, the cleared slot stays empty. The same applies to the trace builder's role slots (Trace ID, Span ID, Service Name, etc.).

### Environment (if no related issue)

- **ClickHouse version**: any supported
- **Grafana version**: any supported
- **Plugin version**: 4.19.0 and current main

---

## Please check that:

- [x] Tests for this change have been added/updated.
- [ ] Documentation has been added/updated (where applicable).

## Special notes for your reviewer

The fix mirrors the existing useDefaultFilters pattern exactly: the didRun ref starts as !isNewQuery, and the table-change branch still resets it, so switching tables on a saved query re-fills only empty slots (covered by the new "fills empty slots when the table changes on a saved query" tests). isNewQuery comes from the useIsNewQuery hook already computed in both builder components, so no new state is introduced. Verified the regression tests fail with the old guard initialisation (4 failures) and pass with the fix, plus tsc, eslint, cspell, and the full queryBuilder suite (243 tests) are green.

Found by an automated audit of regressions introduced while integrating PRs across the v4.18.0 and v4.19.0 release cycles (range v4.17.0..main). Related PRs: #1791.
