### PR TITLE
fix(dashboards): make shipped deployment annotations round-trip the editor

### DIFF
--- a/src/dashboards/otel-logs-explorer.json
+++ b/src/dashboards/otel-logs-explorer.json
@@ -258,12 +258,13 @@
         "type": "dashboard"
       },
       {
+        "customSql": "SELECT\n  time,\n  ServiceName AS tags,\n  concat(ServiceName, ' deployed ', version, if(prev_version != '', concat(' (was ', prev_version, ')'), '')) AS text,\n  'Deployment' AS title\nFROM (\n  SELECT\n    toStartOfInterval(Timestamp, INTERVAL 30 second) AS time,\n    ServiceName,\n    topK(1)(ResourceAttributes['service.version'])[1] AS version,\n    lagInFrame(topK(1)(ResourceAttributes['service.version'])[1])\n      OVER (PARTITION BY ServiceName ORDER BY time) AS prev_version\n  FROM otel_traces\n  WHERE $__timeFilter(Timestamp)\n    AND $__conditionalAll(ServiceName IN ($service), $service)\n    AND ResourceAttributes['service.version'] != ''\n  GROUP BY ServiceName, time\n  ORDER BY ServiceName, time\n)\nWHERE prev_version != '' AND prev_version != version\nORDER BY time",
         "datasource": { "type": "grafana-clickhouse-datasource", "uid": "${datasource}" },
         "enable": true,
         "hide": false,
         "iconColor": "#73BF69",
         "name": "Deployments (service.version)",
-        "preset": "deployment_detection",
+        "preset": "custom",
         "target": {
           "editorType": "sql",
           "rawSql": "SELECT\n  time,\n  ServiceName AS tags,\n  concat(ServiceName, ' deployed ', version, if(prev_version != '', concat(' (was ', prev_version, ')'), '')) AS text,\n  'Deployment' AS title\nFROM (\n  SELECT\n    toStartOfInterval(Timestamp, INTERVAL 30 second) AS time,\n    ServiceName,\n    topK(1)(ResourceAttributes['service.version'])[1] AS version,\n    lagInFrame(topK(1)(ResourceAttributes['service.version'])[1])\n      OVER (PARTITION BY ServiceName ORDER BY time) AS prev_version\n  FROM otel_traces\n  WHERE $__timeFilter(Timestamp)\n    AND $__conditionalAll(ServiceName IN ($service), $service)\n    AND ResourceAttributes['service.version'] != ''\n  GROUP BY ServiceName, time\n  ORDER BY ServiceName, time\n)\nWHERE prev_version != '' AND prev_version != version\nORDER BY time",

--- a/src/dashboards/otel-service-dashboard.json
+++ b/src/dashboards/otel-service-dashboard.json
@@ -49,6 +49,7 @@
         "type": "dashboard"
       },
       {
+        "customSql": "SELECT\n  time,\n  ServiceName AS tags,\n  concat(ServiceName, ' deployed ', version, if(prev_version != '', concat(' (was ', prev_version, ')'), '')) AS text,\n  'Deployment' AS title\nFROM (\n  SELECT\n    toStartOfInterval(Timestamp, INTERVAL 30 second) AS time,\n    ServiceName,\n    topK(1)(ResourceAttributes['service.version'])[1] AS version,\n    lagInFrame(topK(1)(ResourceAttributes['service.version'])[1])\n      OVER (PARTITION BY ServiceName ORDER BY time) AS prev_version\n  FROM otel_traces\n  WHERE $__timeFilter(Timestamp)\n    AND ServiceName = '${service}'\n    AND ResourceAttributes['service.version'] != ''\n  GROUP BY ServiceName, time\n  ORDER BY ServiceName, time\n)\nWHERE prev_version != '' AND prev_version != version\nORDER BY time",
         "datasource": {
           "type": "grafana-clickhouse-datasource",
           "uid": "${datasource}"
@@ -57,7 +58,7 @@
         "hide": false,
         "iconColor": "#73BF69",
         "name": "Deployments (service.version)",
-        "preset": "deployment_detection",
+        "preset": "custom",
         "rawQuery": "SELECT\n  time,\n  ServiceName AS tags,\n  concat(ServiceName, ' deployed ', version, if(prev_version != '', concat(' (was ', prev_version, ')'), '')) AS text,\n  'Deployment' AS title\nFROM (\n  SELECT\n    toStartOfInterval(Timestamp, INTERVAL 30 second) AS time,\n    ServiceName,\n    topK(1)(ResourceAttributes['service.version'])[1] AS version,\n    lagInFrame(topK(1)(ResourceAttributes['service.version'])[1])\n      OVER (PARTITION BY ServiceName ORDER BY time) AS prev_version\n  FROM otel_traces\n  WHERE $__timeFilter(Timestamp)\n    AND ServiceName = '${service}'\n    AND ResourceAttributes['service.version'] != ''\n  GROUP BY ServiceName, time\n  ORDER BY ServiceName, time\n)\nWHERE prev_version != '' AND prev_version != version\nORDER BY time",
         "target": {
           "editorType": "sql",

--- a/src/dashboards/otel-traces-explorer.json
+++ b/src/dashboards/otel-traces-explorer.json
@@ -42,6 +42,7 @@
         "type": "dashboard"
       },
       {
+        "customSql": "SELECT\n  time,\n  ServiceName AS tags,\n  concat(ServiceName, ' deployed ', version, if(prev_version != '', concat(' (was ', prev_version, ')'), '')) AS text,\n  'Deployment' AS title\nFROM (\n  SELECT\n    toStartOfInterval(Timestamp, INTERVAL 30 second) AS time,\n    ServiceName,\n    topK(1)(ResourceAttributes['service.version'])[1] AS version,\n    lagInFrame(topK(1)(ResourceAttributes['service.version'])[1])\n      OVER (PARTITION BY ServiceName ORDER BY time) AS prev_version\n  FROM otel_traces\n  WHERE $__timeFilter(Timestamp)\n    AND $__conditionalAll(ServiceName IN ($service), $service)\n    AND ResourceAttributes['service.version'] != ''\n  GROUP BY ServiceName, time\n  ORDER BY ServiceName, time\n)\nWHERE prev_version != '' AND prev_version != version\nORDER BY time",
         "datasource": {
           "type": "grafana-clickhouse-datasource",
           "uid": "${datasource}"
@@ -50,7 +51,7 @@
         "hide": false,
         "iconColor": "#73BF69",
         "name": "Deployments (service.version)",
-        "preset": "deployment_detection",
+        "preset": "custom",
         "rawQuery": "SELECT\n  time,\n  ServiceName AS tags,\n  concat(ServiceName, ' deployed ', version, if(prev_version != '', concat(' (was ', prev_version, ')'), '')) AS text,\n  'Deployment' AS title\nFROM (\n  SELECT\n    toStartOfInterval(Timestamp, INTERVAL 30 second) AS time,\n    ServiceName,\n    topK(1)(ResourceAttributes['service.version'])[1] AS version,\n    lagInFrame(topK(1)(ResourceAttributes['service.version'])[1])\n      OVER (PARTITION BY ServiceName ORDER BY time) AS prev_version\n  FROM otel_traces\n  WHERE $__timeFilter(Timestamp)\n    AND $__conditionalAll(ServiceName IN ($service), $service)\n    AND ResourceAttributes['service.version'] != ''\n  GROUP BY ServiceName, time\n  ORDER BY ServiceName, time\n)\nWHERE prev_version != '' AND prev_version != version\nORDER BY time",
         "target": {
           "editorType": "sql",

--- a/src/data/CHAnnotationSupport.test.tsx
+++ b/src/data/CHAnnotationSupport.test.tsx
@@ -220,6 +220,67 @@ describe('createAnnotationSupport: prepareAnnotation', () => {
     const result = support.prepareAnnotation?.({ name: 'empty', enable: true, iconColor: 'red' });
     expect(result?.target).toBeUndefined();
   });
+
+  it('migrates an unknown preset id to custom and seeds customSql from the target SQL', () => {
+    // Early bundled dashboards shipped 'deployment_detection', a preset id
+    // unknown to the editor. Without the migration, switching the unmatched Type
+    // select to Custom SQL would overwrite the query with an empty stash.
+    const result = support.prepareAnnotation?.({
+      name: 'Deployments (service.version)',
+      enable: true,
+      iconColor: '#73BF69',
+      preset: 'deployment_detection',
+      target: { refId: 'anno', pluginVersion: '', editorType: EditorType.SQL, rawSql: 'SELECT 3 AS time' },
+    });
+    expect(result?.preset).toBe('custom');
+    expect(result?.customSql).toBe('SELECT 3 AS time');
+    expect(result?.target?.rawSql).toBe('SELECT 3 AS time');
+  });
+
+  it('seeds customSql from a legacy rawQuery when migrating an unknown preset', () => {
+    const result = support.prepareAnnotation?.({
+      name: 'legacy-preset',
+      enable: true,
+      iconColor: 'red',
+      preset: 'deployment_detection',
+      rawQuery: 'SELECT 4 AS time',
+    });
+    expect(result?.preset).toBe('custom');
+    expect(result?.customSql).toBe('SELECT 4 AS time');
+    expect(result?.target?.rawSql).toBe('SELECT 4 AS time');
+  });
+
+  it('keeps an existing customSql stash when migrating an unknown preset', () => {
+    const result = support.prepareAnnotation?.({
+      name: 'stashed',
+      enable: true,
+      iconColor: 'red',
+      preset: 'deployment_detection',
+      customSql: 'SELECT stashed AS time',
+      target: { refId: 'anno', pluginVersion: '', editorType: EditorType.SQL, rawSql: 'SELECT 5 AS time' },
+    });
+    expect(result?.preset).toBe('custom');
+    expect(result?.customSql).toBe('SELECT stashed AS time');
+  });
+
+  it.each(['custom', 'change_detection'])('leaves the known %s preset untouched', (preset) => {
+    const result = support.prepareAnnotation?.({
+      name: 'known',
+      enable: true,
+      iconColor: 'red',
+      preset,
+      target: { refId: 'anno', pluginVersion: '', editorType: EditorType.SQL, rawSql: 'SELECT 6 AS time' },
+    });
+    expect(result?.preset).toBe(preset);
+    expect(result?.customSql).toBeUndefined();
+    expect(result?.target?.rawSql).toBe('SELECT 6 AS time');
+  });
+
+  it('does not add a preset to an annotation that has none', () => {
+    const result = support.prepareAnnotation?.({ name: 'bare', enable: true, iconColor: 'red' });
+    expect(result?.preset).toBeUndefined();
+    expect(result?.customSql).toBeUndefined();
+  });
 });
 
 describe('createAnnotationSupport: getDefaultQuery', () => {

--- a/src/data/CHAnnotationSupport.tsx
+++ b/src/data/CHAnnotationSupport.tsx
@@ -348,13 +348,22 @@ export function createAnnotationSupport(datasource: Datasource): AnnotationSuppo
       // it into the modern target shape once. `rawQuery` is read via the
       // AnnotationQuery index signature, so no cast is needed.
       const legacyRawQuery: string | undefined = json?.rawQuery;
-      if (legacyRawQuery && !json?.target?.rawSql) {
+      const prepared: CHAnnotationQuery =
+        legacyRawQuery && !json?.target?.rawSql ? { ...json, target: buildTarget(json.target, legacyRawQuery) } : json;
+
+      // Dashboards may carry a preset id unknown to this editor (early
+      // bundled dashboards shipped 'deployment_detection'). Migrate it to
+      // 'custom' and seed the customSql stash from the shipped SQL, otherwise
+      // the preset round trip would overwrite the query with an empty string.
+      const preset: string | undefined = prepared.preset;
+      if (preset !== undefined && preset !== 'custom' && preset !== 'change_detection') {
         return {
-          ...json,
-          target: buildTarget(json.target, legacyRawQuery),
+          ...prepared,
+          preset: 'custom',
+          customSql: prepared.customSql || prepared.target?.rawSql || legacyRawQuery || '',
         };
       }
-      return json;
+      return prepared;
     },
 
     getDefaultQuery: (): Partial<CHQuery> => ({


### PR DESCRIPTION
## Type of Change

- [x] 🐛 Bug Fix

---

## Bug Fix

### What is the bug?

The three OTel dashboards introduced in #1869 (otel-logs-explorer, otel-traces-explorer, otel-service-dashboard) ship a 'Deployments (service.version)' annotation with "preset": "deployment_detection". The annotation editor added in #1922 only knows the preset ids 'custom' and 'change_detection', so opening this annotation renders an unmatched Annotation Type select. From there, either choice silently destroys the shipped query: selecting 'Custom SQL' overwrites rawSql with the customSql stash, which is absent, so the query becomes an empty string once saved, and selecting 'Change Detection' regenerates generic SQL that drops the dashboard's $service scoping.

### How to reproduce

1. On a build without this fix, import any of the bundled OTel dashboards (Logs Explorer, Traces Explorer, or Service Dashboard).
2. Open Dashboard settings > Annotations > 'Deployments (service.version)'.
3. Note the Annotation Type select shows no matching option (the stored preset id is 'deployment_detection').
4. Choose 'Custom SQL' from the select and save the dashboard.
5. The annotation's SQL query is now empty and the deployment markers disappear from every panel. (Choosing 'Change Detection' instead replaces the query with regenerated SQL that has lost the $service filter.)

### Environment (if no related issue)

- **ClickHouse version**: any supported
- **Grafana version**: any supported
- **Plugin version**: 4.19.0 and current main

---

## Please check that:

- [x] Tests for this change have been added/updated.
- [ ] Documentation has been added/updated (where applicable).

## Special notes for your reviewer

The dashboard JSON edits were applied programmatically so each new customSql string is byte-identical to the annotation's target.rawSql, and this was asserted via a JSON round trip. The prepareAnnotation migration is the defensive half: it fixes copies of these dashboards users have already imported, mapping any unknown preset id to 'custom' and seeding customSql from the stash, target.rawSql, or legacy rawQuery in that order (|| not ??, so an empty stash cannot shadow a real query). Known presets and preset-less annotations pass through unchanged, covered by tests. The two ESLint warnings on CHAnnotationSupport.tsx (deprecated Select) predate this change. The legacy rawQuery keys in two of the dashboards were intentionally left as-is to keep the diff minimal.

Found by an automated audit of regressions introduced while integrating PRs across the v4.18.0 and v4.19.0 release cycles (range v4.17.0..main). Related PRs: #1869, #1922.
