### PR TITLE
fix(dashboards): let free-text search accept spaces and separators

### DIFF
--- a/src/dashboards/__tests__/dashboards.test.ts
+++ b/src/dashboards/__tests__/dashboards.test.ts
@@ -29,6 +29,14 @@ describe('OTel dashboards', () => {
       expect(dashboard.uid).toBeTruthy();
       expect(dashboard.title).toBeTruthy();
     });
+
+    it('does not pass the free-text search variable to hasToken', () => {
+      // hasToken() raises BAD_ARGUMENTS for needles containing whitespace or
+      // ASCII separators (e.g. 'GET /api'), so free-text search clauses must
+      // use substring matching such as positionCaseInsensitive() instead.
+      const content = fs.readFileSync(filepath, 'utf8');
+      expect(content).not.toContain('hasToken(');
+    });
   });
 
   describe('plugin.json registration', () => {

--- a/src/dashboards/otel-logs-explorer.json
+++ b/src/dashboards/otel-logs-explorer.json
@@ -54,7 +54,7 @@
         {
           "datasource": { "type": "grafana-clickhouse-datasource", "uid": "${datasource}" },
           "editorType": "sql",
-          "rawSql": "SELECT\n  toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time,\n  SeverityText AS metric,\n  count() AS count\nFROM otel_logs\nWHERE $__timeFilter(Timestamp)\n  AND $__conditionalAll(ServiceName IN ($service), $service)\n  AND $__conditionalAll(SeverityText IN ($level_filter), $level_filter)\n  AND $__conditionalAll(hasToken(Body, '$search'), $search)\nGROUP BY time, metric\nORDER BY time",
+          "rawSql": "SELECT\n  toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time,\n  SeverityText AS metric,\n  count() AS count\nFROM otel_logs\nWHERE $__timeFilter(Timestamp)\n  AND $__conditionalAll(ServiceName IN ($service), $service)\n  AND $__conditionalAll(SeverityText IN ($level_filter), $level_filter)\n  AND $__conditionalAll(positionCaseInsensitive(Body, '$search') > 0, $search)\nGROUP BY time, metric\nORDER BY time",
           "refId": "A",
           "format": 0
         }
@@ -86,7 +86,7 @@
         {
           "datasource": { "type": "grafana-clickhouse-datasource", "uid": "${datasource}" },
           "editorType": "sql",
-          "rawSql": "SELECT\n  ServiceName AS Service,\n  count() AS Count\nFROM otel_logs\nWHERE $__timeFilter(Timestamp)\n  AND $__conditionalAll(ServiceName IN ($service), $service)\n  AND $__conditionalAll(SeverityText IN ($level_filter), $level_filter)\n  AND $__conditionalAll(hasToken(Body, '$search'), $search)\nGROUP BY Service\nORDER BY Count DESC\nLIMIT 15",
+          "rawSql": "SELECT\n  ServiceName AS Service,\n  count() AS Count\nFROM otel_logs\nWHERE $__timeFilter(Timestamp)\n  AND $__conditionalAll(ServiceName IN ($service), $service)\n  AND $__conditionalAll(SeverityText IN ($level_filter), $level_filter)\n  AND $__conditionalAll(positionCaseInsensitive(Body, '$search') > 0, $search)\nGROUP BY Service\nORDER BY Count DESC\nLIMIT 15",
           "refId": "A",
           "format": 0
         }
@@ -122,7 +122,7 @@
         {
           "datasource": { "type": "grafana-clickhouse-datasource", "uid": "${datasource}" },
           "editorType": "sql",
-          "rawSql": "SELECT\n  SeverityText AS Level,\n  count() AS Count\nFROM otel_logs\nWHERE $__timeFilter(Timestamp)\n  AND $__conditionalAll(ServiceName IN ($service), $service)\n  AND $__conditionalAll(hasToken(Body, '$search'), $search)\nGROUP BY Level\nORDER BY Count DESC",
+          "rawSql": "SELECT\n  SeverityText AS Level,\n  count() AS Count\nFROM otel_logs\nWHERE $__timeFilter(Timestamp)\n  AND $__conditionalAll(ServiceName IN ($service), $service)\n  AND $__conditionalAll(positionCaseInsensitive(Body, '$search') > 0, $search)\nGROUP BY Level\nORDER BY Count DESC",
           "refId": "A",
           "format": 0
         }
@@ -159,7 +159,7 @@
         {
           "datasource": { "type": "grafana-clickhouse-datasource", "uid": "${datasource}" },
           "editorType": "sql",
-          "rawSql": "SELECT\n  SeverityText AS Level,\n  ServiceName AS Service,\n  replaceRegexpAll(Body, '(userId|orderId|cartId|requestId|traceId|spanId|ctId)=[a-zA-Z0-9-]+', '\\1=…') AS Message,\n  count() AS Count\nFROM otel_logs\nWHERE $__timeFilter(Timestamp)\n  AND SeverityText IN ('ERROR', 'WARN', 'FATAL', 'Error', 'Warning', 'error', 'warning', 'fatal', 'CRITICAL')\n  AND $__conditionalAll(ServiceName IN ($service), $service)\n  AND $__conditionalAll(hasToken(Body, '$search'), $search)\nGROUP BY Level, Service, Message\nORDER BY Count DESC\nLIMIT 20",
+          "rawSql": "SELECT\n  SeverityText AS Level,\n  ServiceName AS Service,\n  replaceRegexpAll(Body, '(userId|orderId|cartId|requestId|traceId|spanId|ctId)=[a-zA-Z0-9-]+', '\\1=…') AS Message,\n  count() AS Count\nFROM otel_logs\nWHERE $__timeFilter(Timestamp)\n  AND SeverityText IN ('ERROR', 'WARN', 'FATAL', 'Error', 'Warning', 'error', 'warning', 'fatal', 'CRITICAL')\n  AND $__conditionalAll(ServiceName IN ($service), $service)\n  AND $__conditionalAll(positionCaseInsensitive(Body, '$search') > 0, $search)\nGROUP BY Level, Service, Message\nORDER BY Count DESC\nLIMIT 20",
           "refId": "A",
           "format": 0
         }
@@ -208,7 +208,7 @@
         {
           "datasource": { "type": "grafana-clickhouse-datasource", "uid": "${datasource}" },
           "editorType": "sql",
-          "rawSql": "SELECT\n  toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time,\n  SeverityText AS metric,\n  count() AS count\nFROM otel_logs\nWHERE $__timeFilter(Timestamp)\n  AND ServiceName = '${service}'\n  AND $__conditionalAll(SeverityText IN ($level_filter), $level_filter)\n  AND $__conditionalAll(hasToken(Body, '$search'), $search)\nGROUP BY time, metric\nORDER BY time",
+          "rawSql": "SELECT\n  toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time,\n  SeverityText AS metric,\n  count() AS count\nFROM otel_logs\nWHERE $__timeFilter(Timestamp)\n  AND ServiceName = '${service}'\n  AND $__conditionalAll(SeverityText IN ($level_filter), $level_filter)\n  AND $__conditionalAll(positionCaseInsensitive(Body, '$search') > 0, $search)\nGROUP BY time, metric\nORDER BY time",
           "refId": "A",
           "format": 0
         }
@@ -238,7 +238,7 @@
         {
           "datasource": { "type": "grafana-clickhouse-datasource", "uid": "${datasource}" },
           "editorType": "sql",
-          "rawSql": "SELECT\n  Timestamp AS timestamp,\n  Body AS body,\n  SeverityText AS level,\n  ServiceName,\n  TraceId,\n  SpanId,\n  ResourceAttributes['service.namespace'] AS namespace,\n  ResourceAttributes['k8s.pod.name'] AS k8s_pod\nFROM otel_logs\nWHERE $__timeFilter(Timestamp)\n  AND ServiceName = '${service}'\n  AND $__conditionalAll(SeverityText IN ($level_filter), $level_filter)\n  AND $__conditionalAll(hasToken(Body, '$search'), $search)\nORDER BY Timestamp DESC\nLIMIT 200",
+          "rawSql": "SELECT\n  Timestamp AS timestamp,\n  Body AS body,\n  SeverityText AS level,\n  ServiceName,\n  TraceId,\n  SpanId,\n  ResourceAttributes['service.namespace'] AS namespace,\n  ResourceAttributes['k8s.pod.name'] AS k8s_pod\nFROM otel_logs\nWHERE $__timeFilter(Timestamp)\n  AND ServiceName = '${service}'\n  AND $__conditionalAll(SeverityText IN ($level_filter), $level_filter)\n  AND $__conditionalAll(positionCaseInsensitive(Body, '$search') > 0, $search)\nORDER BY Timestamp DESC\nLIMIT 200",
           "refId": "A",
           "format": 2
         }

--- a/src/dashboards/otel-service-dashboard.json
+++ b/src/dashboards/otel-service-dashboard.json
@@ -204,7 +204,7 @@
             "uid": "${datasource}"
           },
           "editorType": "sql",
-          "rawSql": "SELECT toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time, count() / $__interval_s AS rps FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND SpanKind = 'Server' AND $__conditionalAll(SpanName IN ($operation), $operation) AND $__conditionalAll(hasToken(SpanName, '$search'), $search) GROUP BY time ORDER BY time",
+          "rawSql": "SELECT toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time, count() / $__interval_s AS rps FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND SpanKind = 'Server' AND $__conditionalAll(SpanName IN ($operation), $operation) AND $__conditionalAll(positionCaseInsensitive(SpanName, '$search') > 0, $search) GROUP BY time ORDER BY time",
           "refId": "A",
           "format": 0
         }
@@ -266,7 +266,7 @@
             "uid": "${datasource}"
           },
           "editorType": "sql",
-          "rawSql": "SELECT toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time, countIf(StatusCode IN ('Error', 'STATUS_CODE_ERROR')) / count() AS error_rate FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND SpanKind = 'Server' AND $__conditionalAll(SpanName IN ($operation), $operation) AND $__conditionalAll(hasToken(SpanName, '$search'), $search) GROUP BY time ORDER BY time",
+          "rawSql": "SELECT toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time, countIf(StatusCode IN ('Error', 'STATUS_CODE_ERROR')) / count() AS error_rate FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND SpanKind = 'Server' AND $__conditionalAll(SpanName IN ($operation), $operation) AND $__conditionalAll(positionCaseInsensitive(SpanName, '$search') > 0, $search) GROUP BY time ORDER BY time",
           "refId": "A",
           "format": 0
         }
@@ -336,7 +336,7 @@
             "uid": "${datasource}"
           },
           "editorType": "sql",
-          "rawSql": "SELECT toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time, quantile(0.5)(Duration) AS p50, quantile(0.9)(Duration) AS p90, quantile(0.99)(Duration) AS p99 FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND SpanKind = 'Server' AND $__conditionalAll(SpanName IN ($operation), $operation) AND $__conditionalAll(hasToken(SpanName, '$search'), $search) GROUP BY time ORDER BY time",
+          "rawSql": "SELECT toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time, quantile(0.5)(Duration) AS p50, quantile(0.9)(Duration) AS p90, quantile(0.99)(Duration) AS p99 FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND SpanKind = 'Server' AND $__conditionalAll(SpanName IN ($operation), $operation) AND $__conditionalAll(positionCaseInsensitive(SpanName, '$search') > 0, $search) GROUP BY time ORDER BY time",
           "refId": "A",
           "format": 0
         }
@@ -420,7 +420,7 @@
             "uid": "${datasource}"
           },
           "editorType": "sql",
-          "rawSql": "SELECT SpanName AS Operation, count() AS Count, quantile(0.5)(Duration) AS P50, quantile(0.99)(Duration) AS P99 FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND SpanKind = 'Server' AND $__conditionalAll(SpanName IN ($operation), $operation) AND $__conditionalAll(hasToken(SpanName, '$search'), $search) GROUP BY SpanName ORDER BY P99 DESC LIMIT 20",
+          "rawSql": "SELECT SpanName AS Operation, count() AS Count, quantile(0.5)(Duration) AS P50, quantile(0.99)(Duration) AS P99 FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND SpanKind = 'Server' AND $__conditionalAll(SpanName IN ($operation), $operation) AND $__conditionalAll(positionCaseInsensitive(SpanName, '$search') > 0, $search) GROUP BY SpanName ORDER BY P99 DESC LIMIT 20",
           "refId": "A",
           "format": 1
         }
@@ -478,7 +478,7 @@
             "uid": "${datasource}"
           },
           "editorType": "sql",
-          "rawSql": "SELECT toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time, count() / $__interval_s AS rps FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND SpanKind = 'Client' AND $__conditionalAll(SpanName IN ($operation), $operation) AND $__conditionalAll(hasToken(SpanName, '$search'), $search) GROUP BY time ORDER BY time",
+          "rawSql": "SELECT toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time, count() / $__interval_s AS rps FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND SpanKind = 'Client' AND $__conditionalAll(SpanName IN ($operation), $operation) AND $__conditionalAll(positionCaseInsensitive(SpanName, '$search') > 0, $search) GROUP BY time ORDER BY time",
           "refId": "A",
           "format": 0
         }
@@ -540,7 +540,7 @@
             "uid": "${datasource}"
           },
           "editorType": "sql",
-          "rawSql": "SELECT toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time, countIf(StatusCode IN ('Error', 'STATUS_CODE_ERROR')) / count() AS error_rate FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND SpanKind = 'Client' AND $__conditionalAll(SpanName IN ($operation), $operation) AND $__conditionalAll(hasToken(SpanName, '$search'), $search) GROUP BY time ORDER BY time",
+          "rawSql": "SELECT toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time, countIf(StatusCode IN ('Error', 'STATUS_CODE_ERROR')) / count() AS error_rate FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND SpanKind = 'Client' AND $__conditionalAll(SpanName IN ($operation), $operation) AND $__conditionalAll(positionCaseInsensitive(SpanName, '$search') > 0, $search) GROUP BY time ORDER BY time",
           "refId": "A",
           "format": 0
         }
@@ -610,7 +610,7 @@
             "uid": "${datasource}"
           },
           "editorType": "sql",
-          "rawSql": "SELECT toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time, quantile(0.5)(Duration) AS p50, quantile(0.9)(Duration) AS p90, quantile(0.99)(Duration) AS p99 FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND SpanKind = 'Client' AND $__conditionalAll(SpanName IN ($operation), $operation) AND $__conditionalAll(hasToken(SpanName, '$search'), $search) GROUP BY time ORDER BY time",
+          "rawSql": "SELECT toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time, quantile(0.5)(Duration) AS p50, quantile(0.9)(Duration) AS p90, quantile(0.99)(Duration) AS p99 FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND SpanKind = 'Client' AND $__conditionalAll(SpanName IN ($operation), $operation) AND $__conditionalAll(positionCaseInsensitive(SpanName, '$search') > 0, $search) GROUP BY time ORDER BY time",
           "refId": "A",
           "format": 0
         }
@@ -694,7 +694,7 @@
             "uid": "${datasource}"
           },
           "editorType": "sql",
-          "rawSql": "SELECT SpanName AS Operation, count() AS Count, quantile(0.5)(Duration) AS P50, quantile(0.99)(Duration) AS P99 FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND SpanKind = 'Client' AND $__conditionalAll(SpanName IN ($operation), $operation) AND $__conditionalAll(hasToken(SpanName, '$search'), $search) GROUP BY SpanName ORDER BY P99 DESC LIMIT 20",
+          "rawSql": "SELECT SpanName AS Operation, count() AS Count, quantile(0.5)(Duration) AS P50, quantile(0.99)(Duration) AS P99 FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND SpanKind = 'Client' AND $__conditionalAll(SpanName IN ($operation), $operation) AND $__conditionalAll(positionCaseInsensitive(SpanName, '$search') > 0, $search) GROUP BY SpanName ORDER BY P99 DESC LIMIT 20",
           "refId": "A",
           "format": 1
         }
@@ -779,7 +779,7 @@
             "uid": "${datasource}"
           },
           "editorType": "sql",
-          "rawSql": "SELECT SpanName AS Operation, SpanKind AS Kind, StatusMessage AS Error, count() AS Count, max(Timestamp) AS \"Last Seen\" FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND StatusCode IN ('Error', 'STATUS_CODE_ERROR') AND $__conditionalAll(hasToken(SpanName, '$search'), $search) GROUP BY SpanName, SpanKind, StatusMessage ORDER BY Count DESC LIMIT 20",
+          "rawSql": "SELECT SpanName AS Operation, SpanKind AS Kind, StatusMessage AS Error, count() AS Count, max(Timestamp) AS \"Last Seen\" FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND StatusCode IN ('Error', 'STATUS_CODE_ERROR') AND $__conditionalAll(positionCaseInsensitive(SpanName, '$search') > 0, $search) GROUP BY SpanName, SpanKind, StatusMessage ORDER BY Count DESC LIMIT 20",
           "refId": "A",
           "format": 1
         }
@@ -821,7 +821,7 @@
             "uid": "${datasource}"
           },
           "editorType": "sql",
-          "rawSql": "SELECT Timestamp AS timestamp, Body AS body, SeverityText AS level, ServiceName, TraceId, SpanId FROM otel_logs WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND $__conditionalAll(hasToken(Body, '$search'), $search) ORDER BY Timestamp DESC LIMIT 200",
+          "rawSql": "SELECT Timestamp AS timestamp, Body AS body, SeverityText AS level, ServiceName, TraceId, SpanId FROM otel_logs WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND $__conditionalAll(positionCaseInsensitive(Body, '$search') > 0, $search) ORDER BY Timestamp DESC LIMIT 200",
           "refId": "A",
           "format": 2
         }
@@ -878,7 +878,7 @@
                 "uid": "${datasource}"
               },
               "editorType": "sql",
-              "rawSql": "SELECT toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time, count() / $__interval_s AS rps FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND SpanKind = 'Internal' AND $__conditionalAll(SpanName IN ($operation), $operation) AND $__conditionalAll(hasToken(SpanName, '$search'), $search) GROUP BY time ORDER BY time",
+              "rawSql": "SELECT toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time, count() / $__interval_s AS rps FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND SpanKind = 'Internal' AND $__conditionalAll(SpanName IN ($operation), $operation) AND $__conditionalAll(positionCaseInsensitive(SpanName, '$search') > 0, $search) GROUP BY time ORDER BY time",
               "refId": "A",
               "format": 0
             }
@@ -940,7 +940,7 @@
                 "uid": "${datasource}"
               },
               "editorType": "sql",
-              "rawSql": "SELECT toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time, countIf(StatusCode IN ('Error', 'STATUS_CODE_ERROR')) / count() AS error_rate FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND SpanKind = 'Internal' AND $__conditionalAll(SpanName IN ($operation), $operation) AND $__conditionalAll(hasToken(SpanName, '$search'), $search) GROUP BY time ORDER BY time",
+              "rawSql": "SELECT toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time, countIf(StatusCode IN ('Error', 'STATUS_CODE_ERROR')) / count() AS error_rate FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND SpanKind = 'Internal' AND $__conditionalAll(SpanName IN ($operation), $operation) AND $__conditionalAll(positionCaseInsensitive(SpanName, '$search') > 0, $search) GROUP BY time ORDER BY time",
               "refId": "A",
               "format": 0
             }
@@ -1010,7 +1010,7 @@
                 "uid": "${datasource}"
               },
               "editorType": "sql",
-              "rawSql": "SELECT toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time, quantile(0.5)(Duration) AS p50, quantile(0.9)(Duration) AS p90, quantile(0.99)(Duration) AS p99 FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND SpanKind = 'Internal' AND $__conditionalAll(SpanName IN ($operation), $operation) AND $__conditionalAll(hasToken(SpanName, '$search'), $search) GROUP BY time ORDER BY time",
+              "rawSql": "SELECT toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time, quantile(0.5)(Duration) AS p50, quantile(0.9)(Duration) AS p90, quantile(0.99)(Duration) AS p99 FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND SpanKind = 'Internal' AND $__conditionalAll(SpanName IN ($operation), $operation) AND $__conditionalAll(positionCaseInsensitive(SpanName, '$search') > 0, $search) GROUP BY time ORDER BY time",
               "refId": "A",
               "format": 0
             }
@@ -1094,7 +1094,7 @@
                 "uid": "${datasource}"
               },
               "editorType": "sql",
-              "rawSql": "SELECT SpanName AS Operation, count() AS Count, quantile(0.5)(Duration) AS P50, quantile(0.99)(Duration) AS P99 FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND SpanKind = 'Internal' AND $__conditionalAll(SpanName IN ($operation), $operation) AND $__conditionalAll(hasToken(SpanName, '$search'), $search) GROUP BY SpanName ORDER BY P99 DESC LIMIT 20",
+              "rawSql": "SELECT SpanName AS Operation, count() AS Count, quantile(0.5)(Duration) AS P50, quantile(0.99)(Duration) AS P99 FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND SpanKind = 'Internal' AND $__conditionalAll(SpanName IN ($operation), $operation) AND $__conditionalAll(positionCaseInsensitive(SpanName, '$search') > 0, $search) GROUP BY SpanName ORDER BY P99 DESC LIMIT 20",
               "refId": "A",
               "format": 1
             }
@@ -1153,7 +1153,7 @@
                 "uid": "${datasource}"
               },
               "editorType": "sql",
-              "rawSql": "SELECT toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time, count() / $__interval_s AS rps FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND SpanKind IN ('Producer', 'Consumer') AND $__conditionalAll(SpanName IN ($operation), $operation) AND $__conditionalAll(hasToken(SpanName, '$search'), $search) GROUP BY time ORDER BY time",
+              "rawSql": "SELECT toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time, count() / $__interval_s AS rps FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND SpanKind IN ('Producer', 'Consumer') AND $__conditionalAll(SpanName IN ($operation), $operation) AND $__conditionalAll(positionCaseInsensitive(SpanName, '$search') > 0, $search) GROUP BY time ORDER BY time",
               "refId": "A",
               "format": 0
             }
@@ -1215,7 +1215,7 @@
                 "uid": "${datasource}"
               },
               "editorType": "sql",
-              "rawSql": "SELECT toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time, countIf(StatusCode IN ('Error', 'STATUS_CODE_ERROR')) / count() AS error_rate FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND SpanKind IN ('Producer', 'Consumer') AND $__conditionalAll(SpanName IN ($operation), $operation) AND $__conditionalAll(hasToken(SpanName, '$search'), $search) GROUP BY time ORDER BY time",
+              "rawSql": "SELECT toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time, countIf(StatusCode IN ('Error', 'STATUS_CODE_ERROR')) / count() AS error_rate FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND SpanKind IN ('Producer', 'Consumer') AND $__conditionalAll(SpanName IN ($operation), $operation) AND $__conditionalAll(positionCaseInsensitive(SpanName, '$search') > 0, $search) GROUP BY time ORDER BY time",
               "refId": "A",
               "format": 0
             }
@@ -1285,7 +1285,7 @@
                 "uid": "${datasource}"
               },
               "editorType": "sql",
-              "rawSql": "SELECT toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time, quantile(0.5)(Duration) AS p50, quantile(0.9)(Duration) AS p90, quantile(0.99)(Duration) AS p99 FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND SpanKind IN ('Producer', 'Consumer') AND $__conditionalAll(SpanName IN ($operation), $operation) AND $__conditionalAll(hasToken(SpanName, '$search'), $search) GROUP BY time ORDER BY time",
+              "rawSql": "SELECT toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time, quantile(0.5)(Duration) AS p50, quantile(0.9)(Duration) AS p90, quantile(0.99)(Duration) AS p99 FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND SpanKind IN ('Producer', 'Consumer') AND $__conditionalAll(SpanName IN ($operation), $operation) AND $__conditionalAll(positionCaseInsensitive(SpanName, '$search') > 0, $search) GROUP BY time ORDER BY time",
               "refId": "A",
               "format": 0
             }
@@ -1381,7 +1381,7 @@
                 "uid": "${datasource}"
               },
               "editorType": "sql",
-              "rawSql": "SELECT SpanName AS Operation, SpanKind AS Kind, count() AS Count, quantile(0.5)(Duration) AS P50, quantile(0.99)(Duration) AS P99 FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND SpanKind IN ('Producer', 'Consumer') AND $__conditionalAll(SpanName IN ($operation), $operation) AND $__conditionalAll(hasToken(SpanName, '$search'), $search) GROUP BY SpanName, SpanKind ORDER BY P99 DESC LIMIT 20",
+              "rawSql": "SELECT SpanName AS Operation, SpanKind AS Kind, count() AS Count, quantile(0.5)(Duration) AS P50, quantile(0.99)(Duration) AS P99 FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND SpanKind IN ('Producer', 'Consumer') AND $__conditionalAll(SpanName IN ($operation), $operation) AND $__conditionalAll(positionCaseInsensitive(SpanName, '$search') > 0, $search) GROUP BY SpanName, SpanKind ORDER BY P99 DESC LIMIT 20",
               "refId": "A",
               "format": 1
             }

--- a/src/dashboards/otel-traces-explorer.json
+++ b/src/dashboards/otel-traces-explorer.json
@@ -333,7 +333,7 @@
           },
           "editorType": "sql",
           "format": 1,
-          "rawSql": "SELECT\n  TraceId,\n  any(ServiceName) AS Service,\n  any(SpanName) AS RootOperation,\n  min(Timestamp) AS Time,\n  max(Duration) AS Duration,\n  count() AS Spans,\n  anyIf(StatusCode, StatusCode IN ('Error', 'STATUS_CODE_ERROR')) AS Status\nFROM otel_traces\nWHERE $__timeFilter(Timestamp)\n  AND $__conditionalAll(ServiceName IN ($service), $service)\n  AND $__conditionalAll(SpanName IN ($operation), $operation)\n  AND $__conditionalAll(StatusCode IN ($status), $status)\n  AND $__conditionalAll(hasToken(SpanName, '$search'), $search)\nGROUP BY TraceId\nHAVING $__conditionalAll(max(Duration) >= toUInt64($min_duration) * 1000000, $min_duration)\nORDER BY Time DESC\nLIMIT 200",
+          "rawSql": "SELECT\n  TraceId,\n  any(ServiceName) AS Service,\n  any(SpanName) AS RootOperation,\n  min(Timestamp) AS Time,\n  max(Duration) AS Duration,\n  count() AS Spans,\n  anyIf(StatusCode, StatusCode IN ('Error', 'STATUS_CODE_ERROR')) AS Status\nFROM otel_traces\nWHERE $__timeFilter(Timestamp)\n  AND $__conditionalAll(ServiceName IN ($service), $service)\n  AND $__conditionalAll(SpanName IN ($operation), $operation)\n  AND $__conditionalAll(StatusCode IN ($status), $status)\n  AND $__conditionalAll(positionCaseInsensitive(SpanName, '$search') > 0, $search)\nGROUP BY TraceId\nHAVING $__conditionalAll(max(Duration) >= toUInt64($min_duration) * 1000000, $min_duration)\nORDER BY Time DESC\nLIMIT 200",
           "refId": "A"
         }
       ]
@@ -404,7 +404,7 @@
           },
           "editorType": "sql",
           "format": 0,
-          "rawSql": "SELECT\n  toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time,\n  Duration / 1000000 AS duration_ms\nFROM otel_traces\nWHERE $__timeFilter(Timestamp)\n  AND ServiceName IN (${service:singlequote}) AND $__conditionalAll(hasToken(SpanName, '$search'), $search)\n  AND cityHash64(SpanId) % 500 = 0\nORDER BY time",
+          "rawSql": "SELECT\n  toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time,\n  Duration / 1000000 AS duration_ms\nFROM otel_traces\nWHERE $__timeFilter(Timestamp)\n  AND ServiceName IN (${service:singlequote}) AND $__conditionalAll(positionCaseInsensitive(SpanName, '$search') > 0, $search)\n  AND cityHash64(SpanId) % 500 = 0\nORDER BY time",
           "refId": "A"
         }
       ]
@@ -430,7 +430,7 @@
       "targets": [{
         "datasource": { "type": "grafana-clickhouse-datasource", "uid": "${datasource}" },
         "editorType": "sql",
-        "rawSql": "SELECT toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time, count() AS Spans FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName IN (${service:singlequote}) AND $__conditionalAll(hasToken(SpanName, '$search'), $search) GROUP BY time ORDER BY time",
+        "rawSql": "SELECT toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time, count() AS Spans FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName IN (${service:singlequote}) AND $__conditionalAll(positionCaseInsensitive(SpanName, '$search') > 0, $search) GROUP BY time ORDER BY time",
         "refId": "A",
         "format": 1
       }]
@@ -456,7 +456,7 @@
       "targets": [{
         "datasource": { "type": "grafana-clickhouse-datasource", "uid": "${datasource}" },
         "editorType": "sql",
-        "rawSql": "SELECT toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time, countIf(StatusCode IN ('Error', 'STATUS_CODE_ERROR')) AS Errors FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName IN (${service:singlequote}) AND $__conditionalAll(hasToken(SpanName, '$search'), $search) GROUP BY time ORDER BY time",
+        "rawSql": "SELECT toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time, countIf(StatusCode IN ('Error', 'STATUS_CODE_ERROR')) AS Errors FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName IN (${service:singlequote}) AND $__conditionalAll(positionCaseInsensitive(SpanName, '$search') > 0, $search) GROUP BY time ORDER BY time",
         "refId": "A",
         "format": 1
       }]
@@ -487,7 +487,7 @@
           },
           "editorType": "sql",
           "format": 0,
-          "rawSql": "SELECT\n  toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time,\n  quantile(0.99)(Duration) / 1000000 AS p99_ms\nFROM otel_traces\nWHERE $__timeFilter(Timestamp)\n  AND ServiceName IN (${service:singlequote}) AND $__conditionalAll(hasToken(SpanName, '$search'), $search)\nGROUP BY time\nORDER BY time",
+          "rawSql": "SELECT\n  toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time,\n  quantile(0.99)(Duration) / 1000000 AS p99_ms\nFROM otel_traces\nWHERE $__timeFilter(Timestamp)\n  AND ServiceName IN (${service:singlequote}) AND $__conditionalAll(positionCaseInsensitive(SpanName, '$search') > 0, $search)\nGROUP BY time\nORDER BY time",
           "refId": "A"
         }
       ]
@@ -513,7 +513,7 @@
       "targets": [{
         "datasource": { "type": "grafana-clickhouse-datasource", "uid": "${datasource}" },
         "editorType": "sql",
-        "rawSql": "SELECT toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time, avg(Duration) / 1000000 AS \"Avg Duration\" FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName IN (${service:singlequote}) AND $__conditionalAll(hasToken(SpanName, '$search'), $search) GROUP BY time ORDER BY time",
+        "rawSql": "SELECT toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time, avg(Duration) / 1000000 AS \"Avg Duration\" FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName IN (${service:singlequote}) AND $__conditionalAll(positionCaseInsensitive(SpanName, '$search') > 0, $search) GROUP BY time ORDER BY time",
         "refId": "A",
         "format": 1
       }]
@@ -641,7 +641,7 @@
           },
           "editorType": "sql",
           "format": 1,
-          "rawSql": "SELECT\n  SpanName AS Operation,\n  count() AS Count,\n  countIf(StatusCode IN ('Error', 'STATUS_CODE_ERROR')) AS Errors,\n  round(countIf(StatusCode IN ('Error', 'STATUS_CODE_ERROR')) / count() * 100, 2) AS \"Error %\",\n  quantile(0.5)(Duration) AS P50,\n  quantile(0.99)(Duration) AS P99,\n  anyIf(if(StatusMessage != '', StatusMessage, SpanAttributes['http.status_code']), StatusCode IN ('Error', 'STATUS_CODE_ERROR')) AS \"Top Error\"\nFROM otel_traces\nWHERE $__timeFilter(Timestamp)\n  AND ServiceName IN (${service:singlequote}) AND $__conditionalAll(hasToken(SpanName, '$search'), $search)\nGROUP BY Operation\nORDER BY Count DESC\nLIMIT 15",
+          "rawSql": "SELECT\n  SpanName AS Operation,\n  count() AS Count,\n  countIf(StatusCode IN ('Error', 'STATUS_CODE_ERROR')) AS Errors,\n  round(countIf(StatusCode IN ('Error', 'STATUS_CODE_ERROR')) / count() * 100, 2) AS \"Error %\",\n  quantile(0.5)(Duration) AS P50,\n  quantile(0.99)(Duration) AS P99,\n  anyIf(if(StatusMessage != '', StatusMessage, SpanAttributes['http.status_code']), StatusCode IN ('Error', 'STATUS_CODE_ERROR')) AS \"Top Error\"\nFROM otel_traces\nWHERE $__timeFilter(Timestamp)\n  AND ServiceName IN (${service:singlequote}) AND $__conditionalAll(positionCaseInsensitive(SpanName, '$search') > 0, $search)\nGROUP BY Operation\nORDER BY Count DESC\nLIMIT 15",
           "refId": "A"
         }
       ]


### PR DESCRIPTION
## Type of Change

- [x] 🐛 Bug Fix

---

## Bug Fix

### What is the bug?

The three OTel dashboards (Logs Explorer, Traces Explorer, Service Dashboard) wire the free-text "Search" textbox variable into hasToken(Body, '$search') / hasToken(SpanName, '$search') inside $__conditionalAll clauses (31 occurrences total). ClickHouse's hasToken() requires the needle to be a single token and throws a BAD_ARGUMENTS error for any input containing whitespace or ASCII separator characters (spaces, '/', '-', '.'). Since the variable is explicitly a free-text search box, typing any multi-word phrase or a path such as "GET /api" made every panel carrying the clause fail with a query error. The fix replaces each call with positionCaseInsensitive(column, '$search') > 0, which accepts arbitrary needles and performs case-insensitive substring matching, matching the advertised free-text behaviour.

### How to reproduce

1. Import any of the three OTel dashboards (e.g. OTel Logs Explorer) from the plugin's dashboards tab against a ClickHouse instance with an otel_logs/otel_traces schema. 2. Type a multi-word or separator-containing phrase into the Search textbox, for example "GET /api" or "connection refused". 3. Every panel whose query contains the $__conditionalAll(hasToken(...), $search) clause errors with ClickHouse BAD_ARGUMENTS instead of filtering results. 4. With this fix, the same input filters rows by case-insensitive substring match.

### Environment (if no related issue)

- **ClickHouse version**: any supported
- **Grafana version**: any supported
- **Plugin version**: 4.19.0 and current main

---

## Please check that:

- [x] Tests for this change have been added/updated.
- [ ] Documentation has been added/updated (where applicable).

## Special notes for your reviewer

All 31 occurrences were exactly one of two literal forms (hasToken(Body, '$search') and hasToken(SpanName, '$search')), replaced mechanically with positionCaseInsensitive(...) > 0, so the surrounding $__conditionalAll structure is untouched. grep confirms zero hasToken occurrences remain in src/dashboards and each JSON still parses. The new test in src/dashboards/__tests__/dashboards.test.ts asserts per-dashboard that the file contains no hasToken( call, and was verified to fail against the unfixed JSONs. Semantics change slightly from token matching to substring matching (broader matches), which is intentional for a free-text search box. cspell skips src/dashboards/** via ignorePaths, so no dictionary changes were needed.

Found by an automated audit of regressions introduced while integrating PRs across the v4.18.0 and v4.19.0 release cycles (range v4.17.0..main). Related PRs: #1869.
