### PR TITLE
fix(logs): handle JSON attribute columns and numeric values in log context

### DIFF
--- a/src/data/CHDatasource.test.ts
+++ b/src/data/CHDatasource.test.ts
@@ -2,6 +2,7 @@ import {
   arrayToDataFrame,
   CoreApp,
   DataQueryRequest,
+  FieldType,
   SupplementaryQueryType,
   TimeRange,
   toDataFrame,
@@ -2397,6 +2398,82 @@ describe('ClickHouseDatasource', () => {
       await expect(ds.getLogRowContext(makeRow(), contextOptions, cloneDeep(baseQuery))).rejects.toThrow(
         /Syntax error/
       );
+    });
+
+    describe('context columns on attribute map columns', () => {
+      // Row whose LogAttributes field carries object values, as returned for
+      // both Map- and JSON-typed attribute columns.
+      const makeAttributesRow = (attributes: Record<string, unknown>) => {
+        const frame = toDataFrame({
+          fields: [
+            { name: 'timestamp', values: [1700000000000] },
+            { name: 'LogAttributes', type: FieldType.other, values: [attributes] },
+          ],
+        });
+        return { ...makeRow(), dataFrame: frame };
+      };
+
+      const setup = (contextColumn: string, attributesColumnType: string | undefined) => {
+        const ds = cloneDeep(mockDatasource);
+        ds.settings.jsonData.logs = { contextColumns: [contextColumn] };
+        const querySpy = jest.spyOn(ds, 'query').mockImplementation((_req) => of({ data: [toDataFrame([])] }));
+
+        const query = cloneDeep(baseQuery);
+        query.builderOptions.columns = [
+          ...(query.builderOptions.columns ?? []),
+          { name: 'LogAttributes', type: attributesColumnType },
+        ];
+
+        return { ds, querySpy, query };
+      };
+
+      const sentQuery = (querySpy: jest.SpyInstance): CHBuilderQuery => {
+        const request = querySpy.mock.calls[0][0] as DataQueryRequest<CHQuery>;
+        return request.targets[0] as CHBuilderQuery;
+      };
+
+      it('builds a JSON accessor filter when the attributes column is JSON-typed', async () => {
+        const { ds, querySpy, query } = setup("LogAttributes['host.name']", 'JSON');
+
+        await ds.getLogRowContext(makeAttributesRow({ 'host.name': 'web-01' }), contextOptions, query);
+
+        const sent = sentQuery(querySpy);
+        expect(sent.builderOptions.filters).toContainEqual(
+          expect.objectContaining({ key: 'LogAttributes', mapKey: 'host.name', type: 'JSON', value: 'web-01' })
+        );
+        expect(sent.rawSql).toContain("LogAttributes.`host`.`name`::Nullable(String) = 'web-01'");
+        expect(sent.rawSql).not.toContain("LogAttributes['host.name']");
+      });
+
+      it('does not throw when a JSON-typed attribute value is numeric', async () => {
+        const { ds, querySpy, query } = setup("LogAttributes['bytes']", 'JSON');
+
+        await ds.getLogRowContext(makeAttributesRow({ bytes: 42 }), contextOptions, query);
+
+        const sent = sentQuery(querySpy);
+        expect(sent.rawSql).toContain("LogAttributes.`bytes`::Nullable(String) = '42'");
+      });
+
+      it('keeps the raw subscript filter for Map-typed attribute columns', async () => {
+        const { ds, querySpy, query } = setup("LogAttributes['host']", 'Map(String, String)');
+
+        await ds.getLogRowContext(makeAttributesRow({ host: 'web' }), contextOptions, query);
+
+        const sent = sentQuery(querySpy);
+        expect(sent.builderOptions.filters).toContainEqual(
+          expect.objectContaining({ key: "LogAttributes['host']", value: 'web', type: 'string' })
+        );
+        expect(sent.rawSql).toContain("LogAttributes['host'] = 'web'");
+      });
+
+      it('does not throw on a numeric value when the attributes column type is unknown', async () => {
+        const { ds, querySpy, query } = setup("LogAttributes['bytes']", undefined);
+
+        await ds.getLogRowContext(makeAttributesRow({ bytes: 42 }), contextOptions, query);
+
+        const sent = sentQuery(querySpy);
+        expect(sent.rawSql).toContain("LogAttributes['bytes'] = 42");
+      });
     });
   });
 

--- a/src/data/CHDatasource.ts
+++ b/src/data/CHDatasource.ts
@@ -1932,14 +1932,40 @@ export class Datasource
       throw new Error('Unable to match any log context columns');
     }
 
-    const contextColumnFilters: Filter[] = contextColumns.map((c) => ({
-      operator: FilterOperator.Equals,
-      filterType: 'custom',
-      key: c.name,
-      value: c.value,
-      type: 'string',
-      condition: 'AND',
-    }));
+    const contextColumnFilters: Filter[] = contextColumns.map((c) => {
+      // Configured context columns can reference a map key, e.g. LogAttributes['host.name'].
+      // When the underlying attributes column is JSON-typed, the Map subscript syntax is
+      // invalid SQL, so resolve the real column type from the query and let the SQL
+      // generator build the JSON accessor from the map key instead. The value is coerced
+      // to a string because the generator compares JSON paths as Nullable(String), and
+      // JSON attribute values can be numeric or boolean at runtime.
+      const bracketIndex = c.name.indexOf("['");
+      if (bracketIndex !== -1 && c.name.endsWith("']")) {
+        const mapName = c.name.substring(0, bracketIndex);
+        const keyName = c.name.substring(bracketIndex + 2, c.name.length - 2);
+        const mapColumnType = builderOptions.columns?.find((col) => col.name === mapName)?.type;
+        if (mapColumnType?.startsWith('JSON')) {
+          return {
+            operator: FilterOperator.Equals,
+            filterType: 'custom',
+            key: mapName,
+            mapKey: keyName,
+            value: String(c.value),
+            type: mapColumnType,
+            condition: 'AND',
+          };
+        }
+      }
+
+      return {
+        operator: FilterOperator.Equals,
+        filterType: 'custom',
+        key: c.name,
+        value: c.value,
+        type: 'string',
+        condition: 'AND',
+      };
+    });
     builderOptions.filters.push(...contextColumnFilters);
 
     contextQuery.rawSql = generateSql(builderOptions);

--- a/src/data/sqlGenerator.test.ts
+++ b/src/data/sqlGenerator.test.ts
@@ -91,6 +91,32 @@ describe('SQL Generator', () => {
     expect(jsonSql).toContain('LogAttributes.`method`');
   });
 
+  // Log-context filters are declared with sentinel type 'string', but JSON-typed
+  // attribute columns can carry numeric values at runtime. See getLogRowContext.
+  it('renders a numeric value on a string-typed filter without throwing', () => {
+    const opts: QueryBuilderOptions = {
+      database: 'default',
+      table: 'otel_logs',
+      queryType: QueryType.Table,
+      columns: [{ name: 'Body', type: 'String' }],
+      limit: 1000,
+      filters: [
+        {
+          filterType: 'custom',
+          key: "LogAttributes['bytes']",
+          type: 'string',
+          condition: 'AND',
+          operator: FilterOperator.Equals,
+          value: 42,
+        },
+      ],
+      orderBy: [],
+    };
+
+    const sql = generateSql(opts);
+    expect(sql).toContain("LogAttributes['bytes'] = 42");
+  });
+
   it('generates aggregate table query', () => {
     const opts: QueryBuilderOptions = {
       database: 'default',
@@ -1054,6 +1080,18 @@ describe('escapeValue', () => {
   ];
 
   it.each(cases)('returns escaped value (case %#)', (c) => {
+    expect(_testExports.escapeValue(c.input)).toEqual(c.expected);
+  });
+
+  const nonStringCases: Array<{ input: number | boolean; expected: string }> = [
+    { input: 42, expected: '42' },
+    { input: 4.2, expected: '4.2' },
+    { input: 0, expected: '0' },
+    { input: true, expected: 'true' },
+    { input: false, expected: 'false' },
+  ];
+
+  it.each(nonStringCases)('renders non-string primitive unquoted (case %#)', (c) => {
     expect(_testExports.escapeValue(c.input)).toEqual(c.expected);
   });
 });

--- a/src/data/sqlGenerator.ts
+++ b/src/data/sqlGenerator.ts
@@ -715,7 +715,14 @@ export const escapeIdentifier = (id: string): string => {
  */
 export const JSON_SENTINEL_KEY = '__ch_json__';
 
-const escapeValue = (value: string): string => {
+const escapeValue = (value: string | number | boolean): string => {
+  // Filter values are typed as strings, but JSON-typed attribute columns can
+  // carry numeric/boolean values at runtime. Render those unquoted instead of
+  // throwing on the string methods below.
+  if (typeof value !== 'string') {
+    return String(value);
+  }
+
   if (value.includes('$') || value.includes('(') || value.includes(')') || value.includes("'") || value.includes('"')) {
     return value;
   }


### PR DESCRIPTION
## Type of Change

- [x] 🐛 Bug Fix

---

## Bug Fix

### What is the bug?

Log context ("show context" in Explore/Logs) builds its narrowing filters from the configured context columns as raw keys like LogAttributes['host.name'] with a sentinel type of 'string', bypassing column type resolution. Two failures follow: (1) against JSON-typed attribute columns (OTel JSON schema) the emitted Map-subscript SQL is invalid, and (2) when the attribute value is numeric or boolean (possible in JSON, not in Map(String, String)) the value reaches escapeValue, which calls value.includes and throws TypeError('value.includes is not a function') inside generateSql before any query is sent, so the context panel fails with a client-side error.

### How to reproduce

1. Configure the datasource with an OTel logs table whose LogAttributes column is JSON-typed, and set a log context column such as LogAttributes['bytes'] where the attribute holds a numeric value.
2. Run a logs query in Explore with the query builder and open "Show context" on a log row.
3. Without the fix, the context query throws TypeError('value.includes is not a function') during SQL generation when the attribute value is numeric, and for string values it emits invalid subscript SQL (LogAttributes['bytes'] = ...) that ClickHouse rejects on JSON columns.
4. With the fix, the generated SQL uses the JSON accessor (LogAttributes.`bytes`::Nullable(String) = '42') and the query runs.

### Environment (if no related issue)

- **ClickHouse version**: any supported
- **Grafana version**: any supported
- **Plugin version**: 4.19.0 and current main

---

## Please check that:

- [x] Tests for this change have been added/updated.
- [ ] Documentation has been added/updated (where applicable).

## Special notes for your reviewer

The JSON detection reuses the existing getFilters JSON branch (real column type plus mapKey) rather than duplicating accessor SQL in CHDatasource. The value is coerced with String() in the JSON path because getFilters casts the JSON path to Nullable(String), so the literal must be quoted for a valid comparison (ClickHouse rejects String-vs-number equality). Map-typed context columns keep the previous filter shape byte-identical, covered by a non-regression test. escapeValue's widened signature only adds a typeof guard ahead of the existing logic, all existing escapeValue test cases are unchanged. When the attributes column type cannot be resolved from the query's selected columns the code falls back to the old raw-subscript filter, which no longer throws client-side, and any server-side error surfaces through the existing log-context error reporting added for #1362.

Found by an automated audit of regressions introduced while integrating PRs across the v4.18.0 and v4.19.0 release cycles (range v4.17.0..main). Related PRs: #1796, #1866, #1841.
