### PR TITLE
fix(config): keep inline required-field errors when the validation toggle is on

### DIFF
--- a/src/views/CHConfigEditor.test.tsx
+++ b/src/views/CHConfigEditor.test.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
+import { config } from '@grafana/runtime';
 import { ConfigEditor } from './CHConfigEditor';
+import { createValidationAPI } from './CHConfigEditorHooks';
 import { mockConfigEditorProps } from '__mocks__/ConfigEditor';
 import '@testing-library/jest-dom';
 import { CHConfig, Protocol } from 'types/config';
@@ -10,7 +12,7 @@ jest.mock('@grafana/runtime', () => {
   const original = jest.requireActual('@grafana/runtime');
   return {
     ...original,
-    config: { buildInfo: { version: '10.0.0' }, secureSocksDSProxyEnabled: true },
+    config: { buildInfo: { version: '10.0.0' }, secureSocksDSProxyEnabled: true, featureToggles: {} },
   };
 });
 
@@ -143,6 +145,44 @@ describe('ConfigEditor', () => {
   it('hides the required-field error once the host is filled (no validation toggle)', () => {
     render(<ConfigEditor {...mockConfigEditorProps({ host: 'localhost' } as Partial<CHConfig>)} />);
     expect(screen.queryByText(labels.serverAddress.error)).not.toBeInTheDocument();
+  });
+
+  describe('with the clickHouseConfigValidation feature toggle enabled', () => {
+    const featureToggles = config.featureToggles as Record<string, boolean | undefined>;
+
+    beforeEach(() => {
+      featureToggles.clickHouseConfigValidation = true;
+    });
+
+    afterEach(() => {
+      delete featureToggles.clickHouseConfigValidation;
+    });
+
+    it('shows the required-field error on an empty host', () => {
+      // Before Grafana 13.1 nothing calls validate() on the local
+      // ValidationAPI, so field errors never populate. The structural empty
+      // check must still surface the inline error.
+      render(<ConfigEditor {...mockConfigEditorProps({ host: '' } as Partial<CHConfig>)} />);
+      expect(screen.getByText(labels.serverAddress.error)).toBeInTheDocument();
+    });
+
+    it('shows the required-field error on an empty port', () => {
+      render(<ConfigEditor {...mockConfigEditorProps({ host: 'localhost', port: 0 } as Partial<CHConfig>)} />);
+      expect(screen.getByText(labels.serverPort.error)).toBeInTheDocument();
+    });
+
+    it('hides the required-field error once the host is filled', () => {
+      render(<ConfigEditor {...mockConfigEditorProps({ host: 'localhost' } as Partial<CHConfig>)} />);
+      expect(screen.queryByText(labels.serverAddress.error)).not.toBeInTheDocument();
+    });
+
+    it('prefers the validation API error message when one is set', () => {
+      const validation = createValidationAPI();
+      validation.setError('host', 'Custom validation error');
+      render(<ConfigEditor {...mockConfigEditorProps({ host: '' } as Partial<CHConfig>)} validation={validation} />);
+      expect(screen.getByText('Custom validation error')).toBeInTheDocument();
+      expect(screen.queryByText(labels.serverAddress.error)).not.toBeInTheDocument();
+    });
   });
 
   it('renders single-table logs configuration', () => {

--- a/src/views/CHConfigEditor.tsx
+++ b/src/views/CHConfigEditor.tsx
@@ -96,15 +96,16 @@ export const ConfigEditor: React.FC<ConfigEditorProps> = (props) => {
 
   const fieldErrors = validation?.getErrors() ?? {};
 
-  // When the clickHouseConfigValidation feature toggle is off (the default),
-  // `validation` is undefined and `fieldErrors` is always empty — which dropped
-  // the inline required-field indicator that shipped in v4.17.0. Fall back to a
-  // structural empty check so the required host/port fields still surface an
-  // inline error on the default install, before Save & Test round-trips.
-  const hostInvalid = validation ? Boolean(fieldErrors.host) : !jsonData.host;
-  const hostError = validation ? fieldErrors.host : jsonData.host ? undefined : labels.serverAddress.error;
-  const portInvalid = validation ? Boolean(fieldErrors.port) : !jsonData.port;
-  const portError = validation ? fieldErrors.port : jsonData.port ? undefined : labels.serverPort.error;
+  // The structural empty check must run regardless of the validation plumbing:
+  // with the clickHouseConfigValidation toggle off `validation` is undefined,
+  // and with it on the local ValidationAPI only gains errors once Grafana
+  // calls validate() (13.1+). Either way an empty required host/port field
+  // must surface an inline error immediately, as it did in v4.17.0, with any
+  // API-driven error message taking precedence when present.
+  const hostInvalid = Boolean(fieldErrors.host) || !jsonData.host;
+  const hostError = fieldErrors.host || (jsonData.host ? undefined : labels.serverAddress.error);
+  const portInvalid = Boolean(fieldErrors.port) || !jsonData.port;
+  const portError = fieldErrors.port || (jsonData.port ? undefined : labels.serverPort.error);
 
   const onPortChange = (port: string) => {
     onOptionsChange({


### PR DESCRIPTION
## Type of Change

- [x] 🐛 Bug Fix

---

## Bug Fix

### What is the bug?

#1995 restored the v1 config editor's inline required-field errors with `validation ? Boolean(fieldErrors.host) : !jsonData.host`, treating the presence of a ValidationAPI as proof that field errors are populated. But when the clickHouseConfigValidation feature toggle is on, the editor creates a local ValidationAPI instance whose errors are only populated when Grafana calls validate(), which no Grafana release before 13.1 does. `validation` is therefore truthy while `fieldErrors` stays permanently empty, so enabling the toggle on Grafana < 13.1 silently disables the inline required-field errors for Server address and Server port. The fix makes the structural empty check unconditional (`Boolean(fieldErrors.host) || !jsonData.host`), with any API-driven error message taking precedence over the generic required-field label.

### How to reproduce

1. Run Grafana < 13.1 with the `clickHouseConfigValidation` feature toggle enabled.
2. Add a new ClickHouse datasource and open its configuration page.
3. Leave Server address and Server port empty.
4. Before this fix: no inline "Server address required" / "Server port required" errors appear under the empty required fields (they do appear with the toggle off). After this fix: the inline errors appear regardless of the toggle state.

### Environment (if no related issue)

- **ClickHouse version**: any supported
- **Grafana version**: any supported
- **Plugin version**: 4.19.0 and current main

---

## Please check that:

- [x] Tests for this change have been added/updated.
- [ ] Documentation has been added/updated (where applicable).

## Special notes for your reviewer

The change is confined to the four derived values in src/views/CHConfigEditor.tsx (hostInvalid/hostError/portInvalid/portError), the useEffect that registers the validator and eagerly clears errors is unchanged. Empty-vs-undefined semantics match the old fallback branch: `!jsonData.host` covers '' and undefined, `!jsonData.port` covers 0 and undefined. `fieldErrors.host || ...` (rather than `??`) is intentional so an empty-string error message also falls back to the structural label. Tests flip the toggle by mutating a `featureToggles` object added to the existing @grafana/runtime mock, and the API-precedence test passes a real createValidationAPI() instance as props.validation. The empty-host and empty-port toggle-on tests fail without the fix (verified against the HEAD version of the component). The v2 editor shares the createValidationAPI fallback but handles field errors in its own section components, so it is out of scope here.

Found by an automated audit of regressions introduced while integrating PRs across the v4.18.0 and v4.19.0 release cycles (range v4.17.0..main). Related PRs: #1769, #1995.
