### PR TITLE
fix(dashboards): disable the traces-backed annotation on the logs explorer

### DIFF
--- a/src/dashboards/__tests__/dashboards.test.ts
+++ b/src/dashboards/__tests__/dashboards.test.ts
@@ -31,6 +31,27 @@ describe('OTel dashboards', () => {
     });
   });
 
+  describe('otel-logs-explorer.json annotations', () => {
+    // Traces-backed annotations must ship disabled so logs-only installations
+    // do not hit UNKNOWN_TABLE errors on every dashboard load.
+    it('ships traces-backed annotations disabled but not hidden', () => {
+      const filepath = path.join(DASHBOARDS_DIR, 'otel-logs-explorer.json');
+      const dashboard = JSON.parse(fs.readFileSync(filepath, 'utf8')) as {
+        annotations?: {
+          list?: Array<{ name?: string; enable?: boolean; hide?: boolean; target?: { rawSql?: string } }>;
+        };
+      };
+      const tracesAnnotations = (dashboard.annotations?.list ?? []).filter((annotation) =>
+        annotation.target?.rawSql?.includes('otel_traces')
+      );
+      expect(tracesAnnotations.length).toBeGreaterThan(0);
+      tracesAnnotations.forEach((annotation) => {
+        expect(annotation.enable).toBe(false);
+        expect(annotation.hide).toBe(false);
+      });
+    });
+  });
+
   describe('plugin.json registration', () => {
     const pluginJson = JSON.parse(fs.readFileSync(PLUGIN_JSON, 'utf8')) as {
       includes: Array<{ type: string; name: string; path: string }>;

--- a/src/dashboards/otel-logs-explorer.json
+++ b/src/dashboards/otel-logs-explorer.json
@@ -259,10 +259,10 @@
       },
       {
         "datasource": { "type": "grafana-clickhouse-datasource", "uid": "${datasource}" },
-        "enable": true,
+        "enable": false,
         "hide": false,
         "iconColor": "#73BF69",
-        "name": "Deployments (service.version)",
+        "name": "Deployments (service.version, requires traces)",
         "preset": "deployment_detection",
         "target": {
           "editorType": "sql",


### PR DESCRIPTION
## Type of Change

- [x] 🐛 Bug Fix

---

## Bug Fix

### What is the bug?

The out-of-the-box OTel Logs Explorer dashboard ships its 'Deployments (service.version)' annotation with "enable": true, but the annotation's rawSql queries the otel_traces table. On logs-only installations, which are a core audience for a logs dashboard, every dashboard load and refresh fires the annotation query and ClickHouse returns UNKNOWN_TABLE, so users see a persistent error banner on a dashboard they never customised.

### How to reproduce

1. Provision a ClickHouse instance with an otel_logs table but no otel_traces table (logs-only OTel setup).
2. Install the ClickHouse datasource plugin and import the bundled "OTel Logs Explorer" dashboard from the datasource's Dashboards tab.
3. Open the dashboard: the deployment annotation query runs automatically and ClickHouse returns an UNKNOWN_TABLE error for otel_traces, shown as a persistent dashboard error.
4. The error reappears on every refresh (the dashboard defaults to 30s auto-refresh).

### Environment (if no related issue)

- **ClickHouse version**: any supported
- **Grafana version**: any supported
- **Plugin version**: 4.19.0 and current main

---

## Please check that:

- [x] Tests for this change have been added/updated.
- [ ] Documentation has been added/updated (where applicable).

## Special notes for your reviewer

Only otel-logs-explorer.json changes: "enable" flips to false while "hide" stays false, so the annotation toggle remains visible in the dashboard controls and trace-enabled users can switch it on. The annotation name gains a ', requires traces' hint because annotation objects here have no description field. The traces explorer and service dashboard keep their deployment annotations enabled since those dashboards require otel_traces anyway. A regression test in src/dashboards/__tests__/dashboards.test.ts asserts any traces-backed annotation in the logs explorer ships disabled but not hidden, and fails against the previous JSON. Note that cspell skips src/dashboards/** via ignorePaths, so no dictionary changes were needed.

Found by an automated audit of regressions introduced while integrating PRs across the v4.18.0 and v4.19.0 release cycles (range v4.17.0..main). Related PRs: #1869.
