### PR TITLE
fix(dashboards): unpin cluster-analysis ad-hoc filters from a hardcoded uid

### DIFF
--- a/src/dashboards/__tests__/dashboards.test.ts
+++ b/src/dashboards/__tests__/dashboards.test.ts
@@ -10,6 +10,36 @@ const otelDashboards = [
   'otel-service-dashboard.json',
 ] as const;
 
+const allDashboards = fs.readdirSync(DASHBOARDS_DIR).filter((filename) => filename.endsWith('.json'));
+
+// Built-in Grafana datasources referenced by annotations
+const builtInDatasourceUids = new Set(['grafana', '-- Grafana --']);
+
+const isRecord = (value: unknown): value is Record<string, unknown> => typeof value === 'object' && value !== null;
+
+const collectDatasourceUids = (node: unknown): string[] => {
+  if (Array.isArray(node)) {
+    return node.flatMap(collectDatasourceUids);
+  }
+  if (!isRecord(node)) {
+    return [];
+  }
+  const datasource = node.datasource;
+  const uids = isRecord(datasource) && typeof datasource.uid === 'string' ? [datasource.uid] : [];
+  return uids.concat(Object.values(node).flatMap(collectDatasourceUids));
+};
+
+describe('shipped dashboards', () => {
+  it.each(allDashboards)('%s references datasources only via variables or built-ins', (filename) => {
+    const content = fs.readFileSync(path.join(DASHBOARDS_DIR, filename), 'utf8');
+    const dashboard: unknown = JSON.parse(content);
+    const hardcodedUids = collectDatasourceUids(dashboard).filter(
+      (uid) => !uid.startsWith('${') && !builtInDatasourceUids.has(uid)
+    );
+    expect(hardcodedUids).toEqual([]);
+  });
+});
+
 describe('OTel dashboards', () => {
   describe.each(otelDashboards)('%s', (filename) => {
     const filepath = path.join(DASHBOARDS_DIR, filename);

--- a/src/dashboards/cluster-analysis.json
+++ b/src/dashboards/cluster-analysis.json
@@ -1718,7 +1718,7 @@
       {
         "datasource": {
           "type": "grafana-clickhouse-datasource",
-          "uid": "y-Ka8y37k"
+          "uid": "${datasource}"
         },
         "filters": [],
         "hide": 0,


### PR DESCRIPTION
## Type of Change

- [x] 🐛 Bug Fix

---

## Bug Fix

### What is the bug?

The "filters" ad-hoc variable in the shipped Cluster Analysis dashboard (src/dashboards/cluster-analysis.json) was pinned to the hardcoded datasource uid "y-Ka8y37k", the original author's local instance, while every panel and the other template variables resolve through the ${datasource} dashboard variable. On any imported instance that uid does not exist, so the ad-hoc filter picker offers no keys and filters are silently never applied. #1896 fixed exactly this defect class in data-analysis.json but did not sweep the sibling dashboards, this change completes that sweep (a repo-wide grep found no other hardcoded datasource uids).

### How to reproduce

1. Install the ClickHouse datasource plugin on any Grafana instance and configure a ClickHouse datasource (its generated uid will not be "y-Ka8y37k").
2. Import the bundled "ClickHouse - Cluster Analysis" dashboard from the datasource's Dashboards tab.
3. Select your datasource in the Datasource variable, panels load correctly.
4. Click the ad-hoc "filters" picker at the top of the dashboard and try to add a filter: no key suggestions appear, and any filter entered has no effect, because the variable targets the non-existent datasource uid "y-Ka8y37k".

### Environment (if no related issue)

- **ClickHouse version**: any supported
- **Grafana version**: any supported
- **Plugin version**: 4.19.0 and current main

---

## Please check that:

- [x] Tests for this change have been added/updated.
- [ ] Documentation has been added/updated (where applicable).

## Special notes for your reviewer

The fix mirrors the exact datasource reference shape #1896 applied in data-analysis.json: {"type": "grafana-clickhouse-datasource", "uid": "${datasource}"}. A new regression test in src/dashboards/__tests__/dashboards.test.ts recursively collects every datasource.uid across all shipped dashboard JSON files and rejects anything that is not a ${...} variable reference or a built-in Grafana annotation datasource ("grafana", "-- Grafana --"), so any future dashboard exported with a pinned instance uid will fail CI. The test was verified to fail on the pre-fix JSON, reporting exactly ["y-Ka8y37k"]. system-dashboards.json uses ${the_datasource} rather than ${datasource}, which the test accepts by design since any variable reference is portable.

Found by an automated audit of regressions introduced while integrating PRs across the v4.18.0 and v4.19.0 release cycles (range v4.17.0..main). Related PRs: #1896.
