### PR TITLE
fix(queryBuilder): compact editor, filter popover, and column auto-detection fixes

### DIFF
--- a/src/components/queryBuilder/FilterPopover.test.tsx
+++ b/src/components/queryBuilder/FilterPopover.test.tsx
@@ -1,5 +1,47 @@
-import { FilterOperator } from 'types/queryBuilder';
-import { getFilterValueKind, getOperatorOptions, toFilterValueOption } from './FilterPopover';
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Datasource } from 'data/CHDatasource';
+import { FilterOperator, TableColumn } from 'types/queryBuilder';
+import { FilterPopover, getFilterValueKind, getOperatorOptions, toFilterValueOption } from './FilterPopover';
+
+const createMockDatasource = (): Datasource => {
+  const datasource = {} as Datasource;
+  datasource.fetchUniqueMapKeys = jest.fn(() => Promise.resolve(['mapKey']));
+  datasource.fetchUniqueJSONPaths = jest.fn(() => Promise.resolve(['service.name', 'http.status_code']));
+  datasource.fetchDistinctValues = jest.fn(() => Promise.resolve([]));
+  datasource.fetchDistinctMapValues = jest.fn(() => Promise.resolve([]));
+  return datasource;
+};
+
+const allColumns: TableColumn[] = [
+  { name: 'Body', type: 'String', picklistValues: [] },
+  { name: 'LogAttributes', type: 'JSON', picklistValues: [] },
+  { name: 'ResourceAttributes', type: 'Map(String, String)', picklistValues: [] },
+];
+
+const renderPopover = (overrides?: { onAddFilter?: jest.Mock; onClose?: jest.Mock; columns?: TableColumn[] }) => {
+  const datasource = createMockDatasource();
+  render(
+    <FilterPopover
+      datasource={datasource}
+      database="default"
+      table="otel_logs"
+      allColumns={overrides?.columns || allColumns}
+      onAddFilter={overrides?.onAddFilter || jest.fn()}
+      onClose={overrides?.onClose || jest.fn()}
+    />
+  );
+  return datasource;
+};
+
+// Typing highlights the first (exact) match, so a plain Enter selects it. The
+// options list uses virtual scrolling and does not render in jsdom, so
+// clicking an option is not possible here.
+const selectColumn = async (columnName: string) => {
+  await userEvent.type(screen.getAllByRole('combobox')[0], columnName);
+  await userEvent.keyboard('{Enter}');
+};
 
 describe('FilterPopover', () => {
   it('infers number filter kind from ClickHouse numeric types', () => {
@@ -14,6 +56,11 @@ describe('FilterPopover', () => {
     expect(getFilterValueKind('LowCardinality(String)')).toBe('string');
     expect(getFilterValueKind('DateTime64(9)')).toBe('string');
     expect(getFilterValueKind('Map(String, String)')).toBe('string');
+  });
+
+  it('treats JSON columns as string filters since JSON paths are cast to Nullable(String)', () => {
+    expect(getFilterValueKind('JSON')).toBe('string');
+    expect(getFilterValueKind('JSON(max_dynamic_paths=100)')).toBe('string');
   });
 
   it('returns type-specific operator options', () => {
@@ -43,5 +90,88 @@ describe('FilterPopover', () => {
       { label: 'error', value: 'error' },
       { label: 'true', value: 'true' },
     ]);
+  });
+
+  it('shows a path input and probes JSON paths when a JSON column is selected', async () => {
+    const datasource = renderPopover();
+
+    await selectColumn('LogAttributes');
+
+    await waitFor(() =>
+      expect(datasource.fetchUniqueJSONPaths).toHaveBeenCalledWith('LogAttributes', 'default', 'otel_logs', undefined)
+    );
+    expect(screen.getByText('JSON path')).toBeInTheDocument();
+    expect(datasource.fetchUniqueMapKeys).not.toHaveBeenCalled();
+  });
+
+  it('probes JSON paths via the sibling keys column when one exists', async () => {
+    const columns: TableColumn[] = [
+      ...allColumns,
+      { name: 'LogAttributesKeys', type: 'Array(String)', picklistValues: [] },
+    ];
+    const datasource = renderPopover({ columns });
+
+    await selectColumn('LogAttributes');
+
+    await waitFor(() =>
+      expect(datasource.fetchUniqueJSONPaths).toHaveBeenCalledWith(
+        'LogAttributes',
+        'default',
+        'otel_logs',
+        'LogAttributesKeys'
+      )
+    );
+  });
+
+  it('still probes map keys when a Map column is selected', async () => {
+    const datasource = renderPopover();
+
+    await selectColumn('ResourceAttributes');
+
+    await waitFor(() =>
+      expect(datasource.fetchUniqueMapKeys).toHaveBeenCalledWith('ResourceAttributes', 'default', 'otel_logs')
+    );
+    expect(screen.getByText('Map key')).toBeInTheDocument();
+    expect(datasource.fetchUniqueJSONPaths).not.toHaveBeenCalled();
+  });
+
+  it('disables Add for a JSON column until a path is set', async () => {
+    renderPopover();
+
+    await selectColumn('LogAttributes');
+
+    expect(screen.getByRole('button', { name: 'Add' })).toBeDisabled();
+
+    await userEvent.type(screen.getAllByRole('combobox')[1], 'service.name');
+    await userEvent.keyboard('{Enter}');
+
+    expect(screen.getByRole('button', { name: 'Add' })).toBeEnabled();
+  });
+
+  it('adds a JSON filter with the selected path as mapKey and the real column type', async () => {
+    const onAddFilter = jest.fn();
+    const onClose = jest.fn();
+    renderPopover({ onAddFilter, onClose });
+
+    await selectColumn('LogAttributes');
+
+    await userEvent.type(screen.getAllByRole('combobox')[1], 'service.name');
+    await userEvent.keyboard('{Enter}');
+
+    await userEvent.type(screen.getAllByRole('combobox')[3], 'grafana');
+    await userEvent.keyboard('{Enter}');
+
+    await userEvent.click(screen.getByRole('button', { name: 'Add' }));
+
+    expect(onAddFilter).toHaveBeenCalledWith({
+      filterType: 'custom',
+      key: 'LogAttributes',
+      type: 'JSON',
+      operator: FilterOperator.Like,
+      condition: 'AND',
+      mapKey: 'service.name',
+      value: 'grafana',
+    });
+    expect(onClose).toHaveBeenCalled();
   });
 });

--- a/src/components/queryBuilder/FilterPopover.test.tsx
+++ b/src/components/queryBuilder/FilterPopover.test.tsx
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { Datasource } from 'data/CHDatasource';
 import { FilterOperator, TableColumn } from 'types/queryBuilder';
 import { FilterPopover, getFilterValueKind, getOperatorOptions, toFilterValueOption } from './FilterPopover';
+import { newMockDatasource } from '__mocks__/datasource';
 
 const createMockDatasource = (): Datasource => {
   const datasource = {} as Datasource;
@@ -173,5 +174,66 @@ describe('FilterPopover', () => {
       value: 'grafana',
     });
     expect(onClose).toHaveBeenCalled();
+  });
+
+  describe('Map columns', () => {
+    const mapColumns: TableColumn[] = [{ name: 'SpanAttributes', type: 'Map(String, String)', picklistValues: [] }];
+
+    const renderMapPopover = (onAddFilter: jest.Mock, onClose: jest.Mock) => {
+      const datasource = newMockDatasource();
+      jest.spyOn(datasource, 'fetchUniqueMapKeys').mockResolvedValue([]);
+      jest.spyOn(datasource, 'fetchDistinctMapValues').mockResolvedValue([]);
+      const result = render(
+        <FilterPopover
+          datasource={datasource}
+          database="foo"
+          table="bar"
+          allColumns={mapColumns}
+          onAddFilter={onAddFilter}
+          onClose={onClose}
+        />
+      );
+      return { result, datasource };
+    };
+
+    it('disables Add while a Map column has no key selected', async () => {
+      const onAddFilter = jest.fn();
+      const onClose = jest.fn();
+      const { result, datasource } = renderMapPopover(onAddFilter, onClose);
+
+      await userEvent.type(result.getAllByRole('combobox')[0], 'SpanAttributes');
+      await userEvent.keyboard('{ArrowDown}{Enter}');
+      await waitFor(() => expect(datasource.fetchUniqueMapKeys).toHaveBeenCalled());
+
+      expect(result.getByRole('button', { name: 'Add' })).toBeDisabled();
+      expect(onAddFilter).not.toHaveBeenCalled();
+    });
+
+    it('accepts a typed custom key when key discovery returns no keys', async () => {
+      const onAddFilter = jest.fn();
+      const onClose = jest.fn();
+      const { result, datasource } = renderMapPopover(onAddFilter, onClose);
+
+      await userEvent.type(result.getAllByRole('combobox')[0], 'SpanAttributes');
+      await userEvent.keyboard('{ArrowDown}{Enter}');
+      await waitFor(() => expect(datasource.fetchUniqueMapKeys).toHaveBeenCalled());
+
+      await userEvent.type(result.getAllByRole('combobox')[1], 'http.status_code');
+      await userEvent.keyboard('{Enter}');
+
+      const addButton = result.getByRole('button', { name: 'Add' });
+      expect(addButton).toBeEnabled();
+      await userEvent.click(addButton);
+
+      expect(onAddFilter).toHaveBeenCalledWith(
+        expect.objectContaining({
+          key: 'SpanAttributes',
+          mapKey: 'http.status_code',
+          type: 'Map(String, String)',
+          operator: FilterOperator.Like,
+        })
+      );
+      expect(onClose).toHaveBeenCalled();
+    });
   });
 });

--- a/src/components/queryBuilder/FilterPopover.tsx
+++ b/src/components/queryBuilder/FilterPopover.tsx
@@ -53,6 +53,12 @@ const getMapValueType = (type: string): string => {
 };
 
 export const getFilterValueKind = (type = ''): FilterValueKind => {
+  // JSON path filters are cast to Nullable(String) by the SQL generator, so
+  // string operators always apply regardless of any parameters in the type.
+  if (type.startsWith('JSON')) {
+    return 'string';
+  }
+
   const valueType = getMapValueType(type);
 
   return utils.isNumberType(valueType) ? 'number' : 'string';
@@ -110,20 +116,25 @@ export const FilterPopover = (props: FilterPopoverProps) => {
 
   const selectedColDef = allColumns.find((column) => column.name === selectedColumn);
   const isMapColumn = selectedColDef?.type?.startsWith('Map(') || false;
+  const isJSONColumn = selectedColDef?.type?.startsWith('JSON') || false;
+  const isKeyedColumn = isMapColumn || isJSONColumn;
+  const jsonKeysColumn = isJSONColumn
+    ? allColumns.find((column) => column.name === `${selectedColumn}Keys`)?.name
+    : undefined;
   const filterKind = getFilterValueKind(selectedColDef?.type);
   const currentOperatorOptions = useMemo(() => getOperatorOptions(filterKind), [filterKind]);
 
   useEffect(() => {
-    if (isMapColumn && selectedColumn && database && table) {
-      datasource
-        .fetchUniqueMapKeys(selectedColumn, database, table)
-        .then(setMapKeys)
-        .catch(() => setMapKeys([]));
+    if ((isMapColumn || isJSONColumn) && selectedColumn && database && table) {
+      const fetchKeys = isMapColumn
+        ? datasource.fetchUniqueMapKeys(selectedColumn, database, table)
+        : datasource.fetchUniqueJSONPaths(selectedColumn, database, table, jsonKeysColumn);
+      fetchKeys.then(setMapKeys).catch(() => setMapKeys([]));
     } else {
       setMapKeys([]);
       setSelectedMapKey('');
     }
-  }, [datasource, database, table, selectedColumn, isMapColumn]);
+  }, [datasource, database, table, selectedColumn, isMapColumn, isJSONColumn, jsonKeysColumn]);
 
   const columnOptions: Array<ComboboxOption<string>> = allColumns.map((column) => ({
     label: column.label || column.name,
@@ -140,7 +151,7 @@ export const FilterPopover = (props: FilterPopoverProps) => {
         const values =
           isMapColumn && selectedMapKey
             ? await datasource.fetchDistinctMapValues(selectedColumn, selectedMapKey, database, table)
-            : !isMapColumn
+            : !isKeyedColumn
               ? await datasource.fetchDistinctValues(selectedColumn, database, table)
               : [];
 
@@ -153,7 +164,7 @@ export const FilterPopover = (props: FilterPopoverProps) => {
         return [];
       }
     },
-    [datasource, database, table, selectedColumn, isMapColumn, selectedMapKey]
+    [datasource, database, table, selectedColumn, isMapColumn, isKeyedColumn, selectedMapKey]
   );
 
   const noValueNeeded = operator === FilterOperator.IsNull || operator === FilterOperator.IsNotNull;
@@ -162,7 +173,7 @@ export const FilterPopover = (props: FilterPopoverProps) => {
     filterKind === 'number' && !noValueNeeded && (value.trim() === '' || isNaN(numericValue));
 
   const handleAdd = () => {
-    if (!selectedColumn || isNumberValueInvalid) {
+    if (!selectedColumn || isNumberValueInvalid || (isJSONColumn && !selectedMapKey)) {
       return;
     }
 
@@ -172,7 +183,7 @@ export const FilterPopover = (props: FilterPopoverProps) => {
       type: selectedColDef?.type || 'string',
       operator: operator as any,
       condition: 'AND',
-      ...(isMapColumn && selectedMapKey ? { mapKey: selectedMapKey } : {}),
+      ...(isKeyedColumn && selectedMapKey ? { mapKey: selectedMapKey } : {}),
     };
 
     const filter: StringFilter | NumberFilter =
@@ -214,9 +225,9 @@ export const FilterPopover = (props: FilterPopoverProps) => {
         />
       </div>
 
-      {isMapColumn && (
+      {isKeyedColumn && (
         <div className={styles.field}>
-          <span className={styles.fieldLabel}>Map key</span>
+          <span className={styles.fieldLabel}>{isJSONColumn ? 'JSON path' : 'Map key'}</span>
           <Combobox
             options={mapKeys.map((key) => ({ label: key, value: key }))}
             value={selectedMapKey || null}
@@ -227,8 +238,9 @@ export const FilterPopover = (props: FilterPopoverProps) => {
               setSelectedMapKey(option.value || '');
               setValue('');
             }}
+            createCustomValue
             width={20}
-            placeholder="Select key..."
+            placeholder={isJSONColumn ? 'Select path...' : 'Select key...'}
           />
         </div>
       )}
@@ -259,7 +271,11 @@ export const FilterPopover = (props: FilterPopoverProps) => {
       )}
 
       <div className={styles.actions}>
-        <Button size="sm" onClick={handleAdd} disabled={!selectedColumn || isNumberValueInvalid}>
+        <Button
+          size="sm"
+          onClick={handleAdd}
+          disabled={!selectedColumn || isNumberValueInvalid || (isJSONColumn && !selectedMapKey)}
+        >
           Add
         </Button>
         <Button size="sm" variant="secondary" onClick={onClose}>

--- a/src/components/queryBuilder/FilterPopover.tsx
+++ b/src/components/queryBuilder/FilterPopover.tsx
@@ -173,7 +173,7 @@ export const FilterPopover = (props: FilterPopoverProps) => {
     filterKind === 'number' && !noValueNeeded && (value.trim() === '' || isNaN(numericValue));
 
   const handleAdd = () => {
-    if (!selectedColumn || isNumberValueInvalid || (isJSONColumn && !selectedMapKey)) {
+    if (!selectedColumn || isNumberValueInvalid || (isKeyedColumn && !selectedMapKey)) {
       return;
     }
 
@@ -240,7 +240,7 @@ export const FilterPopover = (props: FilterPopoverProps) => {
             }}
             createCustomValue
             width={20}
-            placeholder={isJSONColumn ? 'Select path...' : 'Select key...'}
+            placeholder={isJSONColumn ? 'Type or select path...' : 'Type or select key...'}
           />
         </div>
       )}
@@ -274,7 +274,7 @@ export const FilterPopover = (props: FilterPopoverProps) => {
         <Button
           size="sm"
           onClick={handleAdd}
-          disabled={!selectedColumn || isNumberValueInvalid || (isJSONColumn && !selectedMapKey)}
+          disabled={!selectedColumn || isNumberValueInvalid || (isKeyedColumn && !selectedMapKey)}
         >
           Add
         </Button>

--- a/src/components/queryBuilder/QueryBuilder.test.tsx
+++ b/src/components/queryBuilder/QueryBuilder.test.tsx
@@ -376,6 +376,65 @@ describe('QueryBuilder', () => {
     expect(onQueryChange).not.toHaveBeenCalled();
   });
 
+  it('re-resolves compact logs defaults to the pre-v0.151.0 otel schema once table columns load', async () => {
+    const compactDs = {
+      ...mockDs,
+      uid: 'compact-otel-latest',
+      getSignalType: jest.fn(() => 'logs'),
+      getConfigMode: jest.fn(() => 'single-table'),
+      isSingleTableMode: jest.fn(() => true),
+      getDefaultLogsDatabase: jest.fn(() => 'otel_v2'),
+      getDefaultLogsTable: jest.fn(() => 'otel_logs'),
+      // The static "latest" schema has no filter_time mapping, so the initial
+      // defaults order and filter on Timestamp only.
+      getDefaultLogsColumns: jest.fn(
+        () =>
+          new Map([
+            ['time', 'Timestamp'],
+            ['log_message', 'Body'],
+          ])
+      ),
+      getLogsOtelVersion: jest.fn(() => 'latest'),
+      shouldSelectLogContextColumns: jest.fn(() => false),
+      getLogContextColumnNames: jest.fn(() => []),
+      // The table itself is the older schema, identified by TimestampTime.
+      fetchColumns: jest.fn(() =>
+        Promise.resolve([
+          { name: 'Timestamp', type: 'DateTime64(9)', picklistValues: [] },
+          { name: 'TimestampTime', type: 'DateTime', picklistValues: [] },
+          { name: 'Body', type: 'String', picklistValues: [] },
+        ])
+      ),
+    } as unknown as Datasource;
+    const onQueryChange = jest.fn();
+
+    render(
+      <QueryBuilder
+        app={CoreApp.PanelEditor}
+        builderOptions={{
+          queryType: QueryType.Table,
+          mode: BuilderMode.List,
+          database: '',
+          table: '',
+          columns: [],
+          filters: [],
+        }}
+        builderOptionsDispatch={jest.fn()}
+        datasource={compactDs}
+        generatedSql=""
+        onQueryChange={onQueryChange}
+      />
+    );
+
+    await waitFor(() =>
+      expect(onQueryChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          columns: expect.arrayContaining([{ name: 'TimestampTime', hint: ColumnHint.FilterTime }]),
+        })
+      )
+    );
+  });
+
   it('renders traces compact mode without database/table or query type selectors', async () => {
     const compactDs = {
       ...mockDs,

--- a/src/components/queryBuilder/QueryBuilder.test.tsx
+++ b/src/components/queryBuilder/QueryBuilder.test.tsx
@@ -3,7 +3,7 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { getCompactFilterColumns, QueryBuilder } from './QueryBuilder';
 import { getDefaultCompactMode } from './CompactModeBar';
 import { Datasource } from 'data/CHDatasource';
-import { BuilderMode, ColumnHint, FilterOperator, QueryType, TimeUnit } from 'types/queryBuilder';
+import { BuilderMode, ColumnHint, FilterOperator, OrderByDirection, QueryType, TimeUnit } from 'types/queryBuilder';
 import { CoreApp } from '@grafana/data';
 
 jest.mock('./views/TableQueryBuilder', () => ({
@@ -324,6 +324,56 @@ describe('QueryBuilder', () => {
         queryType: QueryType.Logs,
       })
     );
+  });
+
+  it('preserves an authored query when its type does not match the datasource signal', async () => {
+    const compactDs = {
+      ...mockDs,
+      getSignalType: jest.fn(() => 'logs'),
+      getConfigMode: jest.fn(() => 'single-table'),
+      isSingleTableMode: jest.fn(() => true),
+      getDefaultLogsDatabase: jest.fn(() => 'otel_v2'),
+      getDefaultLogsTable: jest.fn(() => 'otel_logs'),
+      getDefaultLogsColumns: jest.fn(
+        () =>
+          new Map([
+            ['time', 'Timestamp'],
+            ['log_message', 'Body'],
+          ])
+      ),
+      getLogsOtelVersion: jest.fn(() => '1.29.0'),
+      shouldSelectLogContextColumns: jest.fn(() => false),
+      getLogContextColumnNames: jest.fn(() => []),
+    } as unknown as Datasource;
+    const builderOptionsDispatch = jest.fn();
+    const onQueryChange = jest.fn();
+
+    render(
+      <QueryBuilder
+        app={CoreApp.PanelEditor}
+        builderOptions={{
+          queryType: QueryType.TimeSeries,
+          mode: BuilderMode.Trend,
+          database: 'metrics_db',
+          table: 'requests',
+          columns: [{ name: 'created_at', hint: ColumnHint.Time }, { name: 'requests_count' }],
+          filters: [],
+          orderBy: [{ name: 'created_at', dir: OrderByDirection.ASC }],
+        }}
+        builderOptionsDispatch={builderOptionsDispatch}
+        datasource={compactDs}
+        generatedSql=""
+        onQueryChange={onQueryChange}
+      />
+    );
+
+    // The authored time series query falls back to the classic builder instead of being
+    // replaced with compact logs defaults.
+    expect(await screen.findByTestId('time-series-component')).toBeInTheDocument();
+    expect(screen.queryByTestId('compact-mode-bar')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('compact-filter-bar')).not.toBeInTheDocument();
+    expect(builderOptionsDispatch).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'set_all_options' }));
+    expect(onQueryChange).not.toHaveBeenCalled();
   });
 
   it('renders traces compact mode without database/table or query type selectors', async () => {

--- a/src/components/queryBuilder/QueryBuilder.test.tsx
+++ b/src/components/queryBuilder/QueryBuilder.test.tsx
@@ -4,6 +4,7 @@ import { getCompactFilterColumns, QueryBuilder } from './QueryBuilder';
 import { getDefaultCompactMode } from './CompactModeBar';
 import { Datasource } from 'data/CHDatasource';
 import { BuilderMode, ColumnHint, FilterOperator, OrderByDirection, QueryType, TimeUnit } from 'types/queryBuilder';
+import { setColumnByHint } from 'hooks/useBuilderOptionsState';
 import { CoreApp } from '@grafana/data';
 
 jest.mock('./views/TableQueryBuilder', () => ({
@@ -484,5 +485,88 @@ describe('QueryBuilder', () => {
     await waitFor(() =>
       expect(builderOptionsDispatch).toHaveBeenCalledWith(expect.objectContaining({ type: 'set_all_options' }))
     );
+  });
+
+  describe('compact logs message column detection', () => {
+    const buildCompactLogsDs = (defaultColumns: Map<ColumnHint, string>): Datasource =>
+      ({
+        ...mockDs,
+        getSignalType: jest.fn(() => 'logs'),
+        getConfigMode: jest.fn(() => 'single-table'),
+        isSingleTableMode: jest.fn(() => true),
+        getDefaultLogsDatabase: jest.fn(() => 'default'),
+        getDefaultLogsTable: jest.fn(() => 'app_logs'),
+        getDefaultLogsColumns: jest.fn(() => defaultColumns),
+        getLogsOtelVersion: jest.fn(() => ''),
+        shouldSelectLogContextColumns: jest.fn(() => false),
+        getLogContextColumnNames: jest.fn(() => []),
+        fetchColumns: jest.fn(() =>
+          Promise.resolve([
+            { name: 'timestamp', type: 'DateTime', picklistValues: [] },
+            { name: 'message', type: 'String', picklistValues: [] },
+            { name: 'level', type: 'LowCardinality(String)', picklistValues: [] },
+          ])
+        ),
+      }) as unknown as Datasource;
+
+    const initialBuilderOptions = {
+      queryType: QueryType.Table,
+      mode: BuilderMode.List,
+      database: '',
+      table: '',
+      columns: [],
+      filters: [],
+    };
+
+    it('detects LogMessage and LogLevel columns by name when config has no columns', async () => {
+      const datasource = buildCompactLogsDs(new Map());
+      const builderOptionsDispatch = jest.fn();
+
+      render(
+        <QueryBuilder
+          app={CoreApp.PanelEditor}
+          builderOptions={initialBuilderOptions}
+          builderOptionsDispatch={builderOptionsDispatch}
+          datasource={datasource}
+          generatedSql=""
+        />
+      );
+
+      await waitFor(() =>
+        expect(builderOptionsDispatch).toHaveBeenCalledWith(
+          setColumnByHint({ name: 'message', type: 'String', hint: ColumnHint.LogMessage })
+        )
+      );
+      expect(builderOptionsDispatch).toHaveBeenCalledWith(
+        setColumnByHint({ name: 'level', type: 'LowCardinality(String)', hint: ColumnHint.LogLevel })
+      );
+    });
+
+    it('never overrides an explicitly configured message column', async () => {
+      const datasource = buildCompactLogsDs(new Map([[ColumnHint.LogMessage, 'my_msg_col']]));
+      const builderOptionsDispatch = jest.fn();
+
+      render(
+        <QueryBuilder
+          app={CoreApp.PanelEditor}
+          builderOptions={initialBuilderOptions}
+          builderOptionsDispatch={builderOptionsDispatch}
+          datasource={datasource}
+          generatedSql=""
+        />
+      );
+
+      // The level slot is not configured, so detection has run once this dispatch appears
+      await waitFor(() =>
+        expect(builderOptionsDispatch).toHaveBeenCalledWith(
+          setColumnByHint({ name: 'level', type: 'LowCardinality(String)', hint: ColumnHint.LogLevel })
+        )
+      );
+
+      const logMessageDispatches = builderOptionsDispatch.mock.calls.filter(
+        ([action]) => action.type === 'set_column_by_hint' && action.payload?.column?.hint === ColumnHint.LogMessage
+      );
+      expect(logMessageDispatches).toHaveLength(0);
+    });
   });
 });

--- a/src/components/queryBuilder/QueryBuilder.tsx
+++ b/src/components/queryBuilder/QueryBuilder.tsx
@@ -233,9 +233,12 @@ const CompactQueryEditor = (props: CompactQueryEditorProps) => {
   // LogMessage hint). Reuse the classic builder's conventional-name heuristic
   // to fill the empty Message and Level slots once table columns are fetched.
   // Configured columns already carry the hint, so they are never overridden.
+  // A query whose defaults are still being built is the compact equivalent of
+  // a new query: saved compact queries keep deliberately cleared slots.
   useDefaultLogColumnsByName(
     signalType === 'logs' ? allColumns : [],
     activeOptions.table,
+    needsInitialization,
     getColumnByHint(activeOptions, ColumnHint.LogMessage),
     getColumnByHint(activeOptions, ColumnHint.LogLevel),
     activeOptions.meta?.otelEnabled || false,

--- a/src/components/queryBuilder/QueryBuilder.tsx
+++ b/src/components/queryBuilder/QueryBuilder.tsx
@@ -181,10 +181,22 @@ const CompactQueryEditor = (props: CompactQueryEditorProps) => {
     onEditAsSql,
     onRunQuery,
   } = props;
-  const needsInitialization = shouldBuildCompactQueryDefaults(builderOptions, signalType);
+  // Defaults are built in two passes: database and table never depend on the
+  // table's columns, so a build without column names locates the table for the
+  // columns fetch, and the fetched column names then feed the OTel logs schema
+  // detection inside buildCompactQueryDefaults. Treating a query that still
+  // equals the base defaults as needing initialization lets that detection
+  // correct the defaults once the columns arrive, without clobbering edits:
+  // authored queries differ from the generated defaults and are never replaced.
+  const baseDefaults = buildCompactQueryDefaults(datasource, signalType, builderOptions.table);
+  const needsInitialization =
+    shouldBuildCompactQueryDefaults(builderOptions, signalType) || isEqual(builderOptions, baseDefaults);
   const [advancedOpen, setAdvancedOpen] = useState(false);
   const lastInitializationKey = useRef<string>();
   const onQueryChangeRef = useRef(onQueryChange);
+  const locationOptions = needsInitialization ? baseDefaults : builderOptions;
+  const allColumns = useColumns(datasource, locationOptions.database, locationOptions.table);
+  const tableColumnNames = useMemo(() => allColumns.map((column) => column.name), [allColumns]);
 
   useEffect(() => {
     onQueryChangeRef.current = onQueryChange;
@@ -195,23 +207,22 @@ const CompactQueryEditor = (props: CompactQueryEditorProps) => {
       return;
     }
 
-    const initializationKey = `${datasource.uid}:${signalType}:${builderOptions.table}`;
+    const initializationKey = `${datasource.uid}:${signalType}:${builderOptions.table}:${tableColumnNames.length > 0}`;
     if (lastInitializationKey.current === initializationKey) {
       return;
     }
     lastInitializationKey.current = initializationKey;
 
-    const nextOptions = buildCompactQueryDefaults(datasource, signalType, builderOptions.table);
+    const nextOptions = buildCompactQueryDefaults(datasource, signalType, builderOptions.table, tableColumnNames);
     if (!isEqual(builderOptions, nextOptions)) {
       builderOptionsDispatch(setAllOptions(nextOptions));
       onQueryChangeRef.current?.(nextOptions);
     }
-  }, [builderOptions, builderOptionsDispatch, datasource, needsInitialization, signalType]);
+  }, [builderOptions, builderOptionsDispatch, datasource, needsInitialization, signalType, tableColumnNames]);
 
   const activeOptions = needsInitialization
-    ? buildCompactQueryDefaults(datasource, signalType, builderOptions.table)
+    ? buildCompactQueryDefaults(datasource, signalType, builderOptions.table, tableColumnNames)
     : builderOptions;
-  const allColumns = useColumns(datasource, activeOptions.database, activeOptions.table);
   const filterColumns = useMemo(() => getCompactFilterColumns(allColumns, activeOptions), [allColumns, activeOptions]);
 
   const onActiveOptionsChange = (nextOptions: QueryBuilderOptions, shouldRunQuery = false) => {

--- a/src/components/queryBuilder/QueryBuilder.tsx
+++ b/src/components/queryBuilder/QueryBuilder.tsx
@@ -35,6 +35,8 @@ import {
   isCompactQueryTypeMismatch,
   shouldBuildCompactQueryDefaults,
 } from './compactQueryDefaults';
+import { useDefaultLogColumnsByName } from './views/logsQueryBuilderHooks';
+import { getColumnByHint } from 'data/sqlGenerator';
 import { SignalType } from 'types/config';
 import useColumns from 'hooks/useColumns';
 import { CompactModeBar, getDefaultCompactMode } from './CompactModeBar';
@@ -224,6 +226,21 @@ const CompactQueryEditor = (props: CompactQueryEditorProps) => {
     ? buildCompactQueryDefaults(datasource, signalType, builderOptions.table, tableColumnNames)
     : builderOptions;
   const filterColumns = useMemo(() => getCompactFilterColumns(allColumns, activeOptions), [allColumns, activeOptions]);
+
+  // Compact defaults take columns from datasource config only, so a non-OTel
+  // table without a configured Message column would leave the search box inert
+  // (generateLogsQuery drops meta.logMessageLike unless a column carries the
+  // LogMessage hint). Reuse the classic builder's conventional-name heuristic
+  // to fill the empty Message and Level slots once table columns are fetched.
+  // Configured columns already carry the hint, so they are never overridden.
+  useDefaultLogColumnsByName(
+    signalType === 'logs' ? allColumns : [],
+    activeOptions.table,
+    getColumnByHint(activeOptions, ColumnHint.LogMessage),
+    getColumnByHint(activeOptions, ColumnHint.LogLevel),
+    activeOptions.meta?.otelEnabled || false,
+    builderOptionsDispatch
+  );
 
   const onActiveOptionsChange = (nextOptions: QueryBuilderOptions, shouldRunQuery = false) => {
     builderOptionsDispatch(setAllOptions(nextOptions));

--- a/src/components/queryBuilder/QueryBuilder.tsx
+++ b/src/components/queryBuilder/QueryBuilder.tsx
@@ -30,7 +30,11 @@ import TraceIdInput from './TraceIdInput';
 import { Alert, Button, InlineFieldRow, Stack } from '@grafana/ui';
 import { Components as allSelectors } from 'selectors';
 import allLabels from 'labels';
-import { buildCompactQueryDefaults, isDefaultOrMismatchedCompactQuery } from './compactQueryDefaults';
+import {
+  buildCompactQueryDefaults,
+  isCompactQueryTypeMismatch,
+  shouldBuildCompactQueryDefaults,
+} from './compactQueryDefaults';
 import { SignalType } from 'types/config';
 import useColumns from 'hooks/useColumns';
 import { CompactModeBar, getDefaultCompactMode } from './CompactModeBar';
@@ -70,18 +74,27 @@ export const QueryBuilder = (props: QueryBuilderProps) => {
   }
 
   if (singleTableMode && signalType) {
-    return (
-      <CompactQueryEditor
-        datasource={datasource}
-        builderOptions={builderOptions}
-        builderOptionsDispatch={builderOptionsDispatch}
-        generatedSql={generatedSql}
-        signalType={signalType}
-        onQueryChange={onQueryChange}
-        onEditAsSql={onEditAsSql}
-        onRunQuery={onRunQuery}
-      />
-    );
+    // An authored query whose type does not match the datasource signal falls through to
+    // the classic builder, so switching a datasource to single-table mode never silently
+    // replaces the saved options of pre-existing queries.
+    const preserveAuthoredQuery =
+      isCompactQueryTypeMismatch(builderOptions, signalType) &&
+      !shouldBuildCompactQueryDefaults(builderOptions, signalType);
+
+    if (!preserveAuthoredQuery) {
+      return (
+        <CompactQueryEditor
+          datasource={datasource}
+          builderOptions={builderOptions}
+          builderOptionsDispatch={builderOptionsDispatch}
+          generatedSql={generatedSql}
+          signalType={signalType}
+          onQueryChange={onQueryChange}
+          onEditAsSql={onEditAsSql}
+          onRunQuery={onRunQuery}
+        />
+      );
+    }
   }
 
   return (
@@ -168,7 +181,7 @@ const CompactQueryEditor = (props: CompactQueryEditorProps) => {
     onEditAsSql,
     onRunQuery,
   } = props;
-  const needsInitialization = isDefaultOrMismatchedCompactQuery(builderOptions, signalType);
+  const needsInitialization = shouldBuildCompactQueryDefaults(builderOptions, signalType);
   const [advancedOpen, setAdvancedOpen] = useState(false);
   const lastInitializationKey = useRef<string>();
   const onQueryChangeRef = useRef(onQueryChange);

--- a/src/components/queryBuilder/compactQueryDefaults.test.ts
+++ b/src/components/queryBuilder/compactQueryDefaults.test.ts
@@ -1,0 +1,107 @@
+import {
+  isCompactQueryTypeMismatch,
+  isDefaultCompactQuery,
+  shouldBuildCompactQueryDefaults,
+} from './compactQueryDefaults';
+import { BuilderMode, ColumnHint, OrderByDirection, QueryBuilderOptions, QueryType } from 'types/queryBuilder';
+import { SignalType } from 'types/config';
+
+const defaultOptions: QueryBuilderOptions = {
+  database: '',
+  table: '',
+  queryType: QueryType.Table,
+  mode: BuilderMode.List,
+  columns: [],
+  filters: [],
+};
+
+const emptyMismatchedOptions: QueryBuilderOptions = {
+  database: 'logs_db',
+  table: 'logs_table',
+  queryType: QueryType.Logs,
+  mode: BuilderMode.List,
+  columns: [],
+  filters: [],
+};
+
+const authoredTimeSeriesOptions: QueryBuilderOptions = {
+  database: 'metrics_db',
+  table: 'requests',
+  queryType: QueryType.TimeSeries,
+  mode: BuilderMode.Trend,
+  columns: [{ name: 'created_at', hint: ColumnHint.Time }, { name: 'requests_count' }],
+  filters: [],
+  orderBy: [{ name: 'created_at', dir: OrderByDirection.ASC }],
+  limit: 100,
+};
+
+const authoredLogsOptions: QueryBuilderOptions = {
+  database: 'otel_v2',
+  table: 'otel_logs',
+  queryType: QueryType.Logs,
+  mode: BuilderMode.List,
+  columns: [
+    { name: 'Timestamp', hint: ColumnHint.Time },
+    { name: 'Body', hint: ColumnHint.LogMessage },
+  ],
+  filters: [],
+};
+
+describe('isDefaultCompactQuery', () => {
+  it('is true for a fresh default query', () => {
+    expect(isDefaultCompactQuery(defaultOptions)).toBe(true);
+  });
+
+  it('is false for a query with user content', () => {
+    expect(isDefaultCompactQuery(authoredTimeSeriesOptions)).toBe(false);
+  });
+});
+
+describe('isCompactQueryTypeMismatch', () => {
+  it('is true when the query type does not match the signal type', () => {
+    expect(isCompactQueryTypeMismatch(authoredTimeSeriesOptions, 'logs')).toBe(true);
+    expect(isCompactQueryTypeMismatch(authoredLogsOptions, 'traces')).toBe(true);
+  });
+
+  it('is false when the query type matches the signal type', () => {
+    expect(isCompactQueryTypeMismatch(authoredLogsOptions, 'logs')).toBe(false);
+  });
+});
+
+describe('shouldBuildCompactQueryDefaults', () => {
+  const cases: Array<{
+    name: string;
+    builderOptions: QueryBuilderOptions;
+    signalType: SignalType;
+    expected: boolean;
+  }> = [
+    {
+      name: 'builds defaults for a fresh default query',
+      builderOptions: defaultOptions,
+      signalType: 'logs',
+      expected: true,
+    },
+    {
+      name: 'builds defaults for a mismatched query without user content',
+      builderOptions: emptyMismatchedOptions,
+      signalType: 'traces',
+      expected: true,
+    },
+    {
+      name: 'preserves an authored query whose type does not match the signal type',
+      builderOptions: authoredTimeSeriesOptions,
+      signalType: 'logs',
+      expected: false,
+    },
+    {
+      name: 'preserves an authored query whose type matches the signal type',
+      builderOptions: authoredLogsOptions,
+      signalType: 'logs',
+      expected: false,
+    },
+  ];
+
+  it.each(cases)('$name', ({ builderOptions, signalType, expected }) => {
+    expect(shouldBuildCompactQueryDefaults(builderOptions, signalType)).toBe(expected);
+  });
+});

--- a/src/components/queryBuilder/compactQueryDefaults.test.ts
+++ b/src/components/queryBuilder/compactQueryDefaults.test.ts
@@ -1,10 +1,13 @@
+import { Datasource } from 'data/CHDatasource';
 import {
+  buildCompactQueryDefaults,
   isCompactQueryTypeMismatch,
   isDefaultCompactQuery,
   shouldBuildCompactQueryDefaults,
 } from './compactQueryDefaults';
 import { BuilderMode, ColumnHint, OrderByDirection, QueryBuilderOptions, QueryType } from 'types/queryBuilder';
 import { SignalType } from 'types/config';
+import otel from 'otel';
 
 const defaultOptions: QueryBuilderOptions = {
   database: '',
@@ -103,5 +106,81 @@ describe('shouldBuildCompactQueryDefaults', () => {
 
   it.each(cases)('$name', ({ builderOptions, signalType, expected }) => {
     expect(shouldBuildCompactQueryDefaults(builderOptions, signalType)).toBe(expected);
+  });
+});
+
+describe('buildCompactQueryDefaults', () => {
+  // Mirrors Datasource.getDefaultLogsColumns for an OTel-enabled logs config.
+  const createLogsDatasource = (otelVersion: string): Datasource => {
+    const mockDs = {} as Datasource;
+    mockDs.getDefaultLogsDatabase = jest.fn(() => 'otel');
+    mockDs.getDefaultDatabase = jest.fn(() => 'default');
+    mockDs.getDefaultLogsTable = jest.fn(() => 'otel_logs');
+    mockDs.getDefaultTable = jest.fn(() => '');
+    mockDs.getLogsOtelVersion = jest.fn(() => otelVersion);
+    mockDs.getDefaultLogsColumns = jest.fn(
+      () => otel.getVersion(otelVersion)?.logColumnMap || new Map<ColumnHint, string>()
+    );
+    mockDs.shouldSelectLogContextColumns = jest.fn(() => false);
+    mockDs.getLogContextColumnNames = jest.fn(() => []);
+    return mockDs;
+  };
+
+  // otel_logs table created by clickhouseexporter before v0.151.0.
+  const preV151ColumnNames = [
+    'Timestamp',
+    'TimestampTime',
+    'TraceId',
+    'SpanId',
+    'SeverityText',
+    'Body',
+    'ResourceAttributes',
+    'ScopeAttributes',
+    'LogAttributes',
+  ];
+
+  // otel_logs table created by clickhouseexporter v0.151.0+, which dropped TimestampTime.
+  const v151ColumnNames = preV151ColumnNames.filter((name) => name !== 'TimestampTime');
+
+  it('resolves the pre-v0.151.0 log schema when otel version is "latest" and the table has TimestampTime', () => {
+    const options = buildCompactQueryDefaults(createLogsDatasource('latest'), 'logs', '', preV151ColumnNames);
+
+    expect(options.columns).toContainEqual({ name: 'TimestampTime', hint: ColumnHint.FilterTime });
+    expect(options.columns).toContainEqual({ name: 'Timestamp', hint: ColumnHint.Time });
+  });
+
+  it('resolves the latest log schema when otel version is "latest" and the table has no TimestampTime', () => {
+    const options = buildCompactQueryDefaults(createLogsDatasource('latest'), 'logs', '', v151ColumnNames);
+
+    expect(options.columns).toContainEqual({ name: 'Timestamp', hint: ColumnHint.Time });
+    expect(options.columns?.some((column) => column.hint === ColumnHint.FilterTime)).toBe(false);
+  });
+
+  it('keeps the static latest log schema when otel version is "latest" and no columns are available', () => {
+    const options = buildCompactQueryDefaults(createLogsDatasource('latest'), 'logs', '', []);
+
+    expect(options.columns).toContainEqual({ name: 'Timestamp', hint: ColumnHint.Time });
+    expect(options.columns?.some((column) => column.hint === ColumnHint.FilterTime)).toBe(false);
+  });
+
+  it('bypasses detection when an explicit otel version is pinned', () => {
+    const pinnedLatest = createLogsDatasource('1.30.0');
+    const pinnedOlder = createLogsDatasource('1.29.0');
+
+    // Pinned 1.30.0 keeps its FilterTime-less map even though the table has TimestampTime.
+    const pinnedLatestOptions = buildCompactQueryDefaults(pinnedLatest, 'logs', '', preV151ColumnNames);
+    expect(pinnedLatestOptions.columns?.some((column) => column.hint === ColumnHint.FilterTime)).toBe(false);
+    expect(pinnedLatest.getDefaultLogsColumns).toHaveBeenCalled();
+
+    // Pinned 1.29.0 keeps its TimestampTime mapping even though the table lacks the column.
+    const pinnedOlderOptions = buildCompactQueryDefaults(pinnedOlder, 'logs', '', v151ColumnNames);
+    expect(pinnedOlderOptions.columns).toContainEqual({ name: 'TimestampTime', hint: ColumnHint.FilterTime });
+  });
+
+  it('keeps the configured meta values when detection resolves an older schema', () => {
+    const options = buildCompactQueryDefaults(createLogsDatasource('latest'), 'logs', '', preV151ColumnNames);
+
+    expect(options.meta?.otelEnabled).toBe(true);
+    expect(options.meta?.otelVersion).toBe('latest');
   });
 });

--- a/src/components/queryBuilder/compactQueryDefaults.ts
+++ b/src/components/queryBuilder/compactQueryDefaults.ts
@@ -2,6 +2,7 @@ import { Datasource } from 'data/CHDatasource';
 import { BuilderMode, ColumnHint, QueryBuilderOptions, QueryType, SelectedColumn } from 'types/queryBuilder';
 import { SignalType } from 'types/config';
 import { isBuilderOptionsRunnable } from 'data/utils';
+import otel from 'otel';
 import {
   getDefaultLogsFilters,
   getDefaultLogsOrderBy,
@@ -48,18 +49,23 @@ export const shouldBuildCompactQueryDefaults = (
 export function buildCompactQueryDefaults(
   datasource: Datasource,
   signalType: SignalType,
-  fallbackTable = ''
+  fallbackTable = '',
+  tableColumnNames: readonly string[] = []
 ): QueryBuilderOptions {
   return signalType === 'logs'
-    ? buildCompactLogsDefaults(datasource, fallbackTable)
+    ? buildCompactLogsDefaults(datasource, fallbackTable, tableColumnNames)
     : buildCompactTracesDefaults(datasource, fallbackTable);
 }
 
-const buildCompactLogsDefaults = (datasource: Datasource, fallbackTable: string): QueryBuilderOptions => {
+const buildCompactLogsDefaults = (
+  datasource: Datasource,
+  fallbackTable: string,
+  tableColumnNames: readonly string[]
+): QueryBuilderOptions => {
   const defaultDb = datasource.getDefaultLogsDatabase() || datasource.getDefaultDatabase();
   const defaultTable = datasource.getDefaultLogsTable() || datasource.getDefaultTable() || fallbackTable;
   const otelVersion = datasource.getLogsOtelVersion();
-  const columns = getLogsDefaultColumns(datasource);
+  const columns = getLogsDefaultColumns(datasource, tableColumnNames);
 
   return {
     database: defaultDb,
@@ -102,8 +108,26 @@ const buildCompactTracesDefaults = (datasource: Datasource, fallbackTable: strin
   };
 };
 
-const getLogsDefaultColumns = (datasource: Datasource): SelectedColumn[] => {
-  const nextColumns = getDefaultColumns(datasource.getDefaultLogsColumns());
+// The 'latest' OTel alias resolves the log schema against the actual table
+// rather than a fixed version: pre-v0.151.0 collector tables keep their
+// TimestampTime column, newer ones don't, and both exist in the wild (see
+// #1900). This mirrors useOtelColumns in logsQueryBuilderHooks. Pinned
+// versions are honoured as-is, and without fetched columns the static latest
+// map from the datasource remains the fallback.
+const getLogsDefaultColumnMap = (
+  datasource: Datasource,
+  tableColumnNames: readonly string[]
+): Map<ColumnHint, string> => {
+  const otelConfig = otel.getVersion(datasource.getLogsOtelVersion());
+  if (otelConfig?.version === 'latest' && tableColumnNames.length > 0) {
+    return otel.detectLogsVersion(tableColumnNames).logColumnMap;
+  }
+
+  return datasource.getDefaultLogsColumns();
+};
+
+const getLogsDefaultColumns = (datasource: Datasource, tableColumnNames: readonly string[]): SelectedColumn[] => {
+  const nextColumns = getDefaultColumns(getLogsDefaultColumnMap(datasource, tableColumnNames));
   const includedColumns = new Set(nextColumns.map((c) => c.name));
 
   if (datasource.shouldSelectLogContextColumns()) {

--- a/src/components/queryBuilder/compactQueryDefaults.ts
+++ b/src/components/queryBuilder/compactQueryDefaults.ts
@@ -1,6 +1,7 @@
 import { Datasource } from 'data/CHDatasource';
 import { BuilderMode, ColumnHint, QueryBuilderOptions, QueryType, SelectedColumn } from 'types/queryBuilder';
 import { SignalType } from 'types/config';
+import { isBuilderOptionsRunnable } from 'data/utils';
 import {
   getDefaultLogsFilters,
   getDefaultLogsOrderBy,
@@ -12,20 +13,36 @@ export const getCompactQueryType = (signalType: SignalType): QueryType => {
   return signalType === 'logs' ? QueryType.Logs : QueryType.Traces;
 };
 
-export const isDefaultOrMismatchedCompactQuery = (
-  builderOptions: QueryBuilderOptions,
-  signalType: SignalType
-): boolean => {
-  const expectedQueryType = getCompactQueryType(signalType);
-  const isDefaultState =
+export const isDefaultCompactQuery = (builderOptions: QueryBuilderOptions): boolean => {
+  return (
     builderOptions.queryType === QueryType.Table &&
     !builderOptions.database &&
     !builderOptions.table &&
     (!builderOptions.columns || builderOptions.columns.length === 0) &&
     (!builderOptions.filters || builderOptions.filters.length === 0) &&
-    (!builderOptions.aggregates || builderOptions.aggregates.length === 0);
+    (!builderOptions.aggregates || builderOptions.aggregates.length === 0)
+  );
+};
 
-  return isDefaultState || builderOptions.queryType !== expectedQueryType;
+export const isCompactQueryTypeMismatch = (builderOptions: QueryBuilderOptions, signalType: SignalType): boolean => {
+  return builderOptions.queryType !== getCompactQueryType(signalType);
+};
+
+/**
+ * True when the compact editor should replace the saved options with generated defaults.
+ * A mismatched query type alone is not enough: a query with meaningful user content
+ * (columns, filters, aggregates, group by, or order by) must be preserved, never
+ * silently replaced.
+ */
+export const shouldBuildCompactQueryDefaults = (
+  builderOptions: QueryBuilderOptions,
+  signalType: SignalType
+): boolean => {
+  if (isDefaultCompactQuery(builderOptions)) {
+    return true;
+  }
+
+  return isCompactQueryTypeMismatch(builderOptions, signalType) && !isBuilderOptionsRunnable(builderOptions);
 };
 
 export function buildCompactQueryDefaults(

--- a/src/components/queryBuilder/views/LogsQueryBuilder.tsx
+++ b/src/components/queryBuilder/views/LogsQueryBuilder.tsx
@@ -113,6 +113,7 @@ export const LogsQueryBuilder = (props: LogsQueryBuilderProps) => {
   useDefaultLogColumnsByName(
     allColumns,
     builderOptions.table,
+    isNewQuery,
     builderState.messageColumn,
     builderState.logLevelColumn,
     builderState.otelEnabled,

--- a/src/components/queryBuilder/views/TraceQueryBuilder.tsx
+++ b/src/components/queryBuilder/views/TraceQueryBuilder.tsx
@@ -150,6 +150,7 @@ export const TraceQueryBuilder = (props: TraceQueryBuilderProps) => {
   useDefaultTraceColumnsByName(
     allColumns,
     builderOptions.table,
+    isNewQuery,
     {
       traceId: builderState.traceIdColumn,
       spanId: builderState.spanIdColumn,

--- a/src/components/queryBuilder/views/logsQueryBuilderHooks.test.ts
+++ b/src/components/queryBuilder/views/logsQueryBuilderHooks.test.ts
@@ -390,7 +390,7 @@ describe('useDefaultLogColumnsByName', () => {
     ];
 
     renderHook(() =>
-      useDefaultLogColumnsByName(allColumns, 'logs', undefined, undefined, false, builderOptionsDispatch)
+      useDefaultLogColumnsByName(allColumns, 'logs', true, undefined, undefined, false, builderOptionsDispatch)
     );
 
     expect(builderOptionsDispatch).toHaveBeenCalledTimes(2);
@@ -413,7 +413,7 @@ describe('useDefaultLogColumnsByName', () => {
     const userPickedMessage: SelectedColumn = { name: 'custom_msg', type: 'String', hint: ColumnHint.LogMessage };
 
     renderHook(() =>
-      useDefaultLogColumnsByName(allColumns, 'logs', userPickedMessage, undefined, false, builderOptionsDispatch)
+      useDefaultLogColumnsByName(allColumns, 'logs', true, userPickedMessage, undefined, false, builderOptionsDispatch)
     );
 
     // Only Log Level should be filled; Message is preserved.
@@ -431,7 +431,7 @@ describe('useDefaultLogColumnsByName', () => {
     ];
 
     renderHook(() =>
-      useDefaultLogColumnsByName(allColumns, 'otel_logs', undefined, undefined, true, builderOptionsDispatch)
+      useDefaultLogColumnsByName(allColumns, 'otel_logs', true, undefined, undefined, true, builderOptionsDispatch)
     );
 
     expect(builderOptionsDispatch).toHaveBeenCalledTimes(0);
@@ -442,10 +442,43 @@ describe('useDefaultLogColumnsByName', () => {
     const allColumns: readonly TableColumn[] = [{ name: 'unrelated', type: 'String', picklistValues: [] }];
 
     renderHook(() =>
-      useDefaultLogColumnsByName(allColumns, 'logs', undefined, undefined, false, builderOptionsDispatch)
+      useDefaultLogColumnsByName(allColumns, 'logs', true, undefined, undefined, false, builderOptionsDispatch)
     );
 
     expect(builderOptionsDispatch).toHaveBeenCalledTimes(0);
+  });
+
+  it('does not fill empty slots on mount for a saved query', async () => {
+    const builderOptionsDispatch = jest.fn();
+    // Conventional names are present, but the saved query has both slots
+    // deliberately cleared. Opening the editor must not re-add them.
+    const allColumns: readonly TableColumn[] = [
+      { name: 'message', type: 'String', picklistValues: [] },
+      { name: 'level', type: 'LowCardinality(String)', picklistValues: [] },
+    ];
+
+    renderHook(() =>
+      useDefaultLogColumnsByName(allColumns, 'logs', false, undefined, undefined, false, builderOptionsDispatch)
+    );
+
+    expect(builderOptionsDispatch).toHaveBeenCalledTimes(0);
+  });
+
+  it('fills empty slots when the table changes on a saved query', async () => {
+    const builderOptionsDispatch = jest.fn();
+    const allColumns: readonly TableColumn[] = [
+      { name: 'message', type: 'String', picklistValues: [] },
+      { name: 'level', type: 'String', picklistValues: [] },
+    ];
+
+    const hook = renderHook(
+      (table) =>
+        useDefaultLogColumnsByName(allColumns, table, false, undefined, undefined, false, builderOptionsDispatch),
+      { initialProps: 'logs' }
+    );
+    expect(builderOptionsDispatch).toHaveBeenCalledTimes(0);
+    hook.rerender('other_logs');
+    expect(builderOptionsDispatch).toHaveBeenCalledTimes(2);
   });
 
   it('re-runs on table change and fills empty slots for the new table', async () => {
@@ -456,7 +489,8 @@ describe('useDefaultLogColumnsByName', () => {
     ];
 
     const hook = renderHook(
-      (table) => useDefaultLogColumnsByName(allColumns, table, undefined, undefined, false, builderOptionsDispatch),
+      (table) =>
+        useDefaultLogColumnsByName(allColumns, table, true, undefined, undefined, false, builderOptionsDispatch),
       { initialProps: 'logs' }
     );
     // After the first render both slots are filled (2 dispatches). Changing the

--- a/src/components/queryBuilder/views/logsQueryBuilderHooks.ts
+++ b/src/components/queryBuilder/views/logsQueryBuilderHooks.ts
@@ -185,8 +185,12 @@ export const useDefaultTimeColumn = (
  * Fills the Message and Log Level role slots from common non-OTel column names
  * (message, body, log_message; level, severity, severity_text, ...) when:
  *   - OTel mode is off (OTel has its own detection path),
- *   - the current table has changed since last run, and
+ *   - the query is new, or the current table has changed since last run, and
  *   - the role slot is still empty (never overwrites explicit user picks).
+ *
+ * Saved queries never auto-fill on mount: a deliberately cleared slot must
+ * stay cleared, otherwise opening the panel editor would silently mutate the
+ * saved query model.
  *
  * The Time role is handled separately by `useDefaultTimeColumn` so the two
  * stay independently testable and the Time fallback behavior is preserved.
@@ -194,13 +198,14 @@ export const useDefaultTimeColumn = (
 export const useDefaultLogColumnsByName = (
   allColumns: readonly TableColumn[],
   table: string,
+  isNewQuery: boolean,
   messageColumn: SelectedColumn | undefined,
   logLevelColumn: SelectedColumn | undefined,
   otelEnabled: boolean,
   builderOptionsDispatch: React.Dispatch<BuilderOptionsReducerAction>
 ) => {
   const lastTable = useRef<string>(table || '');
-  const didRun = useRef<boolean>(false);
+  const didRun = useRef<boolean>(!isNewQuery);
   if (table !== lastTable.current) {
     didRun.current = false;
   }

--- a/src/components/queryBuilder/views/traceQueryBuilderHooks.test.ts
+++ b/src/components/queryBuilder/views/traceQueryBuilderHooks.test.ts
@@ -339,7 +339,9 @@ describe('useDefaultTraceColumnsByName', () => {
   it('fills every role slot from conventional column names', () => {
     const builderOptionsDispatch = jest.fn();
 
-    renderHook(() => useDefaultTraceColumnsByName(traceTableColumns, 'traces', {}, false, builderOptionsDispatch));
+    renderHook(() =>
+      useDefaultTraceColumnsByName(traceTableColumns, 'traces', true, {}, false, builderOptionsDispatch)
+    );
 
     expect(builderOptionsDispatch).toHaveBeenCalledTimes(7);
     const expected: Array<[ColumnHint, string, string]> = [
@@ -363,7 +365,14 @@ describe('useDefaultTraceColumnsByName', () => {
     const userTraceId: SelectedColumn = { name: 'myTraceId', type: 'String', hint: ColumnHint.TraceId };
 
     renderHook(() =>
-      useDefaultTraceColumnsByName(traceTableColumns, 'traces', { traceId: userTraceId }, false, builderOptionsDispatch)
+      useDefaultTraceColumnsByName(
+        traceTableColumns,
+        'traces',
+        true,
+        { traceId: userTraceId },
+        false,
+        builderOptionsDispatch
+      )
     );
 
     // 7 slots minus the already-filled TraceId = 6 dispatches.
@@ -376,20 +385,43 @@ describe('useDefaultTraceColumnsByName', () => {
 
   it('does nothing when OTel mode is enabled', () => {
     const builderOptionsDispatch = jest.fn();
-    renderHook(() => useDefaultTraceColumnsByName(traceTableColumns, 'traces', {}, true, builderOptionsDispatch));
+    renderHook(() =>
+      useDefaultTraceColumnsByName(traceTableColumns, 'traces', true, {}, true, builderOptionsDispatch)
+    );
     expect(builderOptionsDispatch).toHaveBeenCalledTimes(0);
   });
 
   it('does nothing when allColumns is empty', () => {
     const builderOptionsDispatch = jest.fn();
-    renderHook(() => useDefaultTraceColumnsByName([], 'traces', {}, false, builderOptionsDispatch));
+    renderHook(() => useDefaultTraceColumnsByName([], 'traces', true, {}, false, builderOptionsDispatch));
     expect(builderOptionsDispatch).toHaveBeenCalledTimes(0);
+  });
+
+  it('does not fill empty slots on mount for a saved query', () => {
+    const builderOptionsDispatch = jest.fn();
+    // Conventional names are present, but the saved query has its slots
+    // deliberately cleared. Opening the editor must not re-add them.
+    renderHook(() =>
+      useDefaultTraceColumnsByName(traceTableColumns, 'traces', false, {}, false, builderOptionsDispatch)
+    );
+    expect(builderOptionsDispatch).toHaveBeenCalledTimes(0);
+  });
+
+  it('fills empty slots when the table changes on a saved query', () => {
+    const builderOptionsDispatch = jest.fn();
+    const hook = renderHook(
+      (table) => useDefaultTraceColumnsByName(traceTableColumns, table, false, {}, false, builderOptionsDispatch),
+      { initialProps: 'traces' }
+    );
+    expect(builderOptionsDispatch).toHaveBeenCalledTimes(0);
+    hook.rerender('other_traces');
+    expect(builderOptionsDispatch).toHaveBeenCalledTimes(7);
   });
 
   it('re-runs when the table changes', () => {
     const builderOptionsDispatch = jest.fn();
     const hook = renderHook(
-      (table) => useDefaultTraceColumnsByName(traceTableColumns, table, {}, false, builderOptionsDispatch),
+      (table) => useDefaultTraceColumnsByName(traceTableColumns, table, true, {}, false, builderOptionsDispatch),
       { initialProps: 'traces' }
     );
     const first = builderOptionsDispatch.mock.calls.length;
@@ -402,7 +434,7 @@ describe('useDefaultTraceColumnsByName', () => {
     // `duration` here is a String — heuristic must skip it, leaving the slot empty.
     const cols: readonly TableColumn[] = [{ name: 'duration', type: 'String', picklistValues: [] }];
 
-    renderHook(() => useDefaultTraceColumnsByName(cols, 'traces', {}, false, builderOptionsDispatch));
+    renderHook(() => useDefaultTraceColumnsByName(cols, 'traces', true, {}, false, builderOptionsDispatch));
 
     const durationDispatch = builderOptionsDispatch.mock.calls.find(
       ([action]) => action?.payload?.column?.hint === ColumnHint.TraceDurationTime

--- a/src/components/queryBuilder/views/traceQueryBuilderHooks.ts
+++ b/src/components/queryBuilder/views/traceQueryBuilderHooks.ts
@@ -190,6 +190,10 @@ export const useOtelColumns = (
  * OTel toggle is off). Runs once per table change; never overwrites an
  * explicit user pick.
  *
+ * Saved queries never auto-fill on mount: a deliberately cleared slot must
+ * stay cleared, otherwise opening the panel editor would silently mutate the
+ * saved query model.
+ *
  * The trace builder has many slots; we only heuristic-fill the ones with
  * unambiguous conventional names (Trace ID, Span ID, Parent Span ID, Service
  * Name, Operation/Span Name, Start Time, Duration). Other slots (Tags, Kind,
@@ -199,6 +203,7 @@ export const useOtelColumns = (
 export const useDefaultTraceColumnsByName = (
   allColumns: readonly TableColumn[],
   table: string,
+  isNewQuery: boolean,
   currentColumns: {
     traceId?: SelectedColumn;
     spanId?: SelectedColumn;
@@ -212,7 +217,7 @@ export const useDefaultTraceColumnsByName = (
   builderOptionsDispatch: React.Dispatch<BuilderOptionsReducerAction>
 ) => {
   const lastTable = useRef<string>(table || '');
-  const didRun = useRef<boolean>(false);
+  const didRun = useRef<boolean>(!isNewQuery);
   if (table !== lastTable.current) {
     didRun.current = false;
   }

--- a/src/data/sqlGenerator.test.ts
+++ b/src/data/sqlGenerator.test.ts
@@ -1402,6 +1402,27 @@ describe('getFilters', () => {
     expect(sql).toEqual("( ResourceAttributes.`service`.`name`::Nullable(String) LIKE '%my-service%' )");
   });
 
+  it('routes a compact popover JSON filter through the JSON accessor, not bare LIKE', () => {
+    // The compact filter popover keeps the real column type, which may carry
+    // parameters on newer schemas (e.g. JSON(max_dynamic_paths=100)).
+    const options = {
+      filters: [
+        {
+          condition: 'AND',
+          filterType: 'custom',
+          key: 'LogAttributes',
+          mapKey: 'service.name',
+          operator: FilterOperator.Like,
+          type: 'JSON(max_dynamic_paths=100)',
+          value: 'grafana',
+        },
+      ],
+    } as QueryBuilderOptions;
+    const sql = _testExports.getFilters(options);
+    expect(sql).toEqual("( LogAttributes.`service`.`name`::Nullable(String) LIKE '%grafana%' )");
+    expect(sql).not.toContain('LogAttributes LIKE');
+  });
+
   it('generates IS NULL clause for JSON mapKey filter', () => {
     const options = {
       filters: [


### PR DESCRIPTION
## Type of Change

- [x] 🐛 Bug Fix

---

## Bug Fix

### What is the bug?

Six related defects in the query builder, all introduced while the compact editor (#1841), column-role auto-detection (#1791), JSON attribute support (#1792/#1866), Map-key discovery (#1885) and OTel schema auto-detection (#2017) were integrated across the v4.18.0 and v4.19.0 cycles. One commit per fix:

1. **Compact init silently replaces authored queries.** Opening a panel after switching a datasource to single-table mode clobbered any saved query whose type mismatched the signal type. Authored queries now fall through to the classic builder untouched, and only genuinely default or empty queries are replaced with compact defaults.
2. **Compact mode ignored OTel logs schema auto-detection.** With OTel version "latest", compact defaults used the static latest column map even on pre-collector-v0.151.0 tables, filtering and ordering on `Timestamp` instead of the `TimestampTime` primary key. Defaults are now built in two passes so `otel.detectLogsVersion` runs once table columns are fetched.
3. **Compact search box silently no-ops without a Message column.** On non-OTel single-table configs with no configured Message column, typing in the search box changed nothing because `generateLogsQuery` drops `meta.logMessageLike` without a `LogMessage`-hinted column. The compact editor now reuses the classic builder's conventional-name heuristic to fill empty Message and Level slots.
4. **Compact filter popover generated invalid SQL for JSON attribute columns.** JSON columns were offered as plain columns, so filters emitted `LIKE`/`=` against the whole JSON column, which ClickHouse rejects (ILLEGAL_TYPE_OF_ARGUMENT). JSON columns now get a path picker fed by the same probe as the classic FilterEditor and set `filter.mapKey` so the JSON branch of the SQL generator applies.
5. **Compact filter popover could not set a Map key when discovery is off or empty.** The key dropdown had no manual entry, so with `enableMapKeysDiscovery` off (whose tooltip promises manual entry) no key could ever be set, and Add emitted a whole-Map comparison. Keys can now be typed, and Add is disabled while a keyed column has no key.
6. **Column-role auto-detect mutated saved queries.** The #1791 heuristics re-filled deliberately cleared Message/Level (and trace role) slots on every builder mount, dirtying dashboards and rewriting SQL. Both hooks now gate on the same `isNewQuery` signal as their sibling hooks.

### How to reproduce

Each fix's regression tests document the exact scenario (`compactQueryDefaults.test.ts`, `QueryBuilder.test.tsx`, `FilterPopover.test.tsx`, `logsQueryBuilderHooks.test.ts`, `traceQueryBuilderHooks.test.ts`). Representative example for 1: create a classic-mode dashboard panel with a time series builder query, switch the datasource to single-table logs mode, reopen the panel editor. Before this PR the saved query is replaced with compact logs defaults, after it the classic builder renders the authored query unchanged.

### Environment (if no related issue)

- **ClickHouse version**: any supported
- **Grafana version**: any supported
- **Plugin version**: 4.19.0 and current main

---

## Please check that:

- [x] Tests for this change have been added/updated.
- [ ] Documentation has been added/updated (where applicable).

## Special notes for your reviewer

Supersedes #2049, #2050, #2051, #2053, #2054 and #2066 (same fixes, previously one PR each, closed in favour of this bundle). The commits are kept separate, one per fix, so they can be reviewed independently. Two integration points were resolved while combining them: the compact init gate composes fix 1's authored-query preservation with fix 2's two-pass defaults (`shouldBuildCompactQueryDefaults(...) || isEqual(builderOptions, baseDefaults)`), and the compact editor passes `needsInitialization` as the `isNewQuery` argument that fix 6 added to `useDefaultLogColumnsByName`. Full Jest suite (1022 tests), typecheck, eslint and cspell pass on the combined branch.

Found by an automated audit of regressions introduced while integrating PRs across the v4.18.0 and v4.19.0 release cycles (range v4.17.0..main). Related PRs: #1841, #1791, #1792, #1866, #1885, #2017, #1899, #1832, #1992, #1824, #2020.
