### PR TITLE
fix(variables): forward scoped variables and filter missing Map keys

### DIFF
--- a/src/data/CHVariableSupport.test.tsx
+++ b/src/data/CHVariableSupport.test.tsx
@@ -88,8 +88,10 @@ describe('generateVariableSql', () => {
       }),
       ''
     );
+    // Map subscript on a missing key yields the value type's default, never
+    // NULL, so the guard must be mapContains rather than IS NOT NULL.
     expect(sql).toBe(
-      `SELECT DISTINCT "ResourceAttributes"['service.version'] AS value FROM "otel"."otel_logs" WHERE "ResourceAttributes"['service.version'] IS NOT NULL ORDER BY value LIMIT 1000`
+      `SELECT DISTINCT "ResourceAttributes"['service.version'] AS value FROM "otel"."otel_logs" WHERE mapContains("ResourceAttributes", 'service.version') ORDER BY value LIMIT 1000`
     );
   });
 
@@ -139,7 +141,7 @@ describe('generateVariableSql', () => {
       ''
     );
     expect(mapSql).toBe(
-      `SELECT DISTINCT "ResourceAttributes"['a\\'b'] AS value FROM "otel"."otel_logs" WHERE "ResourceAttributes"['a\\'b'] IS NOT NULL ORDER BY value LIMIT 1000`
+      `SELECT DISTINCT "ResourceAttributes"['a\\'b'] AS value FROM "otel"."otel_logs" WHERE mapContains("ResourceAttributes", 'a\\'b') ORDER BY value LIMIT 1000`
     );
   });
 

--- a/src/data/CHVariableSupport.test.tsx
+++ b/src/data/CHVariableSupport.test.tsx
@@ -361,6 +361,47 @@ describe('CHVariableSupport', () => {
     expect(frame.fields[1].values).toEqual(['id-a', 'id-b']);
   });
 
+  it('forwards scopedVars from the request into metricFindQuery so scoped variables resolve', async () => {
+    const datasource = buildDatasource();
+    const support = new CHVariableSupport(datasource);
+    const scopedVars = {
+      namespace: { text: 'prod', value: 'prod' },
+      __searchFilter: { text: 'foo', value: 'foo' },
+    };
+    const request = {
+      targets: [
+        {
+          refId: 'v',
+          queryType: 'sql' as CHVariableQueryType,
+          rawSql: 'SELECT name FROM t WHERE ns = ${namespace} AND name LIKE $__searchFilter',
+        },
+      ],
+      range: { from: new Date(), to: new Date() },
+      scopedVars,
+    };
+    await firstValueFrom(support.query(request as unknown as DataQueryRequest<CHVariableQuery>));
+    expect(datasource.metricFindQuery).toHaveBeenCalledWith(
+      'SELECT name FROM t WHERE ns = ${namespace} AND name LIKE $__searchFilter',
+      expect.objectContaining({ scopedVars })
+    );
+  });
+
+  it('forwards scopedVars for a legacy string target', async () => {
+    const datasource = buildDatasource();
+    const support = new CHVariableSupport(datasource);
+    const scopedVars = { namespace: { text: 'prod', value: 'prod' } };
+    const request = {
+      targets: ['SELECT name FROM t WHERE ns = ${namespace}'],
+      range: { from: new Date(), to: new Date() },
+      scopedVars,
+    };
+    await firstValueFrom(support.query(request as unknown as DataQueryRequest<CHVariableQuery>));
+    expect(datasource.metricFindQuery).toHaveBeenCalledWith(
+      'SELECT name FROM t WHERE ns = ${namespace}',
+      expect.objectContaining({ scopedVars })
+    );
+  });
+
   it('resolves a legacy string target', async () => {
     const datasource = buildDatasource();
     const support = new CHVariableSupport(datasource);

--- a/src/data/CHVariableSupport.tsx
+++ b/src/data/CHVariableSupport.tsx
@@ -88,9 +88,14 @@ export function generateVariableSql(query: CHVariableQuery, defaultDatabase: str
         return '';
       }
       const column = escapeIdentifier(query.column);
-      const target =
-        query.columnIsMap && query.mapKey ? `${column}['${escapeCHStringLiteral(query.mapKey)}']` : column;
-      return `SELECT DISTINCT ${target} AS value FROM ${escapeIdentifier(db)}.${escapeIdentifier(query.table)} WHERE ${target} IS NOT NULL ORDER BY value LIMIT 1000`;
+      if (query.columnIsMap && query.mapKey) {
+        // Map subscript on a missing key returns the value type's default
+        // (e.g. '' for String), never NULL, so an IS NOT NULL guard would be a
+        // no-op and add a spurious empty entry. Guard with mapContains instead.
+        const mapKey = `'${escapeCHStringLiteral(query.mapKey)}'`;
+        return `SELECT DISTINCT ${column}[${mapKey}] AS value FROM ${escapeIdentifier(db)}.${escapeIdentifier(query.table)} WHERE mapContains(${column}, ${mapKey}) ORDER BY value LIMIT 1000`;
+      }
+      return `SELECT DISTINCT ${column} AS value FROM ${escapeIdentifier(db)}.${escapeIdentifier(query.table)} WHERE ${column} IS NOT NULL ORDER BY value LIMIT 1000`;
     }
     case 'sql':
     default:

--- a/src/data/CHVariableSupport.tsx
+++ b/src/data/CHVariableSupport.tsx
@@ -266,9 +266,11 @@ export class CHVariableSupport extends CustomVariableSupport<Datasource, CHVaria
     }
     // Pass rawSql as a string. metricFindQuery accepts (CHQuery | string) and
     // wraps a string into a minimal SQL-mode CHQuery internally; that keeps
-    // pluginVersion / refId concerns where they already live.
+    // pluginVersion / refId concerns where they already live. Forward
+    // scopedVars so scoped variables and __searchFilter resolve inside
+    // variable queries (they reach applyTemplateVariables via runQuery).
     const promise = this.datasource
-      .metricFindQuery(rawSql, { range: request.range })
+      .metricFindQuery(rawSql, { range: request.range, scopedVars: request.scopedVars })
       .then((values: MetricFindValue[]) => ({
         // Emit text and value separately so a `SELECT value, label` query
         // substitutes the value while displaying the label. Fall back to text


### PR DESCRIPTION
## Type of Change

- [x] 🐛 Bug Fix

---

## Bug Fix

### What is the bug?

Two template variable defects from the v4.18.0/v4.19.0 cycles, one commit each:

1. **Variable queries drop `scopedVars`.** #1840 fixed scoped/section variable resolution by forwarding `options.scopedVars` through `metricFindQuery`, but #1868's `CustomVariableSupport` registration changed the dispatch path: `CHVariableSupport.query` called `metricFindQuery(rawSql, { range })` and discarded `request.scopedVars`, so scope variables and `__searchFilter` stopped resolving in variable queries (the grafana/grafana#122553 regression returned). The request's `scopedVars` are now forwarded.
2. **Map-key variable SQL never filters missing keys.** The guided Column-values flow on a Map column emitted `WHERE map['key'] IS NOT NULL`, but a ClickHouse Map subscript on a missing key returns the value type's default (`''`), never NULL, so the dropdown gained a spurious empty entry sorted first. The generated SQL now uses `WHERE mapContains(map, 'key')`, matching the ad-hoc filter probe.

### How to reproduce

1. For fix 1: enable scoped/section variables, create a query variable whose SQL references a scope variable (`SELECT DISTINCT pod FROM logs WHERE namespace = '$namespace'`); before this PR the scoped variable does not resolve and the full unfiltered list returns.
2. For fix 2: create a Column-values variable on an OTel attributes Map column with a key some rows lack; before this PR the dropdown shows a blank first entry.

Both covered by regression tests in `CHVariableSupport.test.tsx`.

### Environment (if no related issue)

- **ClickHouse version**: any supported
- **Grafana version**: any supported
- **Plugin version**: 4.19.0 and current main

---

## Please check that:

- [x] Tests for this change have been added/updated.
- [ ] Documentation has been added/updated (where applicable).

## Special notes for your reviewer

Supersedes #2057 and #2058 (same fixes, previously one PR each, closed in favour of this bundle). Commits are kept separate, one per fix.

Found by an automated audit of regressions introduced while integrating PRs across the v4.18.0 and v4.19.0 release cycles (range v4.17.0..main). Related PRs: #1840, #1868, #1793, #1993.
