### PR TITLE
fix(traces): trace-ID lookup, companion-table validation, and span-link fixes

### DIFF
--- a/src/data/CHDatasource.test.ts
+++ b/src/data/CHDatasource.test.ts
@@ -2630,6 +2630,30 @@ describe('ClickHouseDatasource', () => {
 
       await expect(ds.hasTraceTimestampTable('default', 'traces')).resolves.toBe(true);
     });
+
+    it('prefers an explicit suffix argument over the configured one', async () => {
+      // A saved query can bake a meta.traceTimestampTableSuffix that differs
+      // from the current datasource config. The check must probe the companion
+      // the generated SQL will reference (the query's suffix), and the two
+      // suffixes must not share a cache entry.
+      const ds = cloneDeep(mockDatasource);
+      ds.settings = {
+        ...ds.settings,
+        jsonData: {
+          ...ds.settings.jsonData,
+          traces: { ...(ds.settings.jsonData.traces || {}), traceTimestampTableSuffix: '_idx_ts' },
+        },
+      };
+      jest.spyOn(ds, 'fetchTables').mockResolvedValue(['traces', 'traces_saved_ts']);
+      const columnsSpy = jest.spyOn(ds, 'fetchColumns').mockResolvedValue(timestampColumns());
+
+      await expect(ds.hasTraceTimestampTable('default', 'traces', '_saved_ts')).resolves.toBe(true);
+      expect(columnsSpy).toHaveBeenCalledWith('default', 'traces_saved_ts');
+
+      // The config-suffix companion does not exist, and the cached result for
+      // the explicit suffix must not leak into this separate check.
+      await expect(ds.hasTraceTimestampTable('default', 'traces')).resolves.toBe(false);
+    });
   });
 
   describe('peekTraceTimestampTable', () => {
@@ -2683,6 +2707,17 @@ describe('ClickHouseDatasource', () => {
       expect(ds.peekTraceTimestampTable('otel', 'otel_traces')).toBeUndefined();
 
       nowSpy.mockRestore();
+    });
+
+    it('keys cached results by the resolved suffix', async () => {
+      const ds = cloneDeep(mockDatasource);
+      jest.spyOn(ds, 'fetchTables').mockResolvedValue(['otel_traces', 'otel_traces_saved_ts']);
+      jest.spyOn(ds, 'fetchColumns').mockResolvedValue(timestampColumns());
+
+      await ds.hasTraceTimestampTable('otel', 'otel_traces', '_saved_ts');
+      expect(ds.peekTraceTimestampTable('otel', 'otel_traces', '_saved_ts')).toBe(true);
+      // The config-suffix check has not run, so it must still read as unknown.
+      expect(ds.peekTraceTimestampTable('otel', 'otel_traces')).toBeUndefined();
     });
   });
 

--- a/src/data/CHDatasource.ts
+++ b/src/data/CHDatasource.ts
@@ -225,8 +225,9 @@ export class Datasource
   private mapColumnsByTable: Map<string, Set<string>> = new Map();
   private static readonly TRACE_TIMESTAMP_TABLE_CACHE_TTL_MS = 30 * 1000;
   // Caches the in-flight or resolved existence check for the `<table>_trace_id_ts`
-  // companion, keyed by `${database}.${table}`. Caching the Promise dedupes concurrent
-  // callers and lets cache hits resolve in a microtask. Entries expire after
+  // companion, keyed by the qualified companion table name (`${database}.${table}${suffix}`)
+  // so checks against different suffixes never share a result. Caching the Promise dedupes
+  // concurrent callers and lets cache hits resolve in a microtask. Entries expire after
   // TRACE_TIMESTAMP_TABLE_CACHE_TTL_MS so a companion table created after the datasource
   // loaded is detected without a page reload.
   private traceTimestampTableCache = new Map<
@@ -1040,16 +1041,22 @@ export class Datasource
    * with trace_id/start_time/end_time) would produce an UNKNOWN_IDENTIFIER error,
    * so it is rejected here and the query falls back to the plain filter.
    *
+   * The companion name is resolved from the per-query `suffix` when one is
+   * given (saved queries bake it into `meta.traceTimestampTableSuffix`) so the
+   * probe targets the same table the SQL generator will reference; without it
+   * the datasource config suffix applies.
+   *
    * Caches the Promise so concurrent and repeat callers share a single
    * round-trip; on failure, evicts so the next caller retries and meanwhile
    * returns `false` (the safe, unoptimized path).
    */
-  async hasTraceTimestampTable(database: string, table: string): Promise<boolean> {
+  async hasTraceTimestampTable(database: string, table: string, suffix?: string): Promise<boolean> {
     if (!database || !table) {
       return false;
     }
 
-    const key = `${database}.${table}`;
+    const companionTable = table + (suffix || this.getTraceTimestampTableSuffix());
+    const key = `${database}.${companionTable}`;
     const now = Date.now();
 
     let entry = this.traceTimestampTableCache.get(key);
@@ -1057,7 +1064,6 @@ export class Datasource
     if (!entry || entry.expiresAt <= now) {
       const pending = (async () => {
         try {
-          const companionTable = table + this.getTraceTimestampTableSuffix();
           const tables = await this.fetchTables(database);
           if (!tables.includes(companionTable)) {
             return false;
@@ -1091,11 +1097,12 @@ export class Datasource
    * Lets the React hook seed its initial state from a warm cache and skip a
    * false→true render that would briefly clobber a known-good meta value.
    */
-  peekTraceTimestampTable(database: string, table: string): boolean | undefined {
+  peekTraceTimestampTable(database: string, table: string, suffix?: string): boolean | undefined {
     if (!database || !table) {
       return undefined;
     }
-    const entry = this.traceTimestampTableCache.get(`${database}.${table}`);
+    const companionTable = table + (suffix || this.getTraceTimestampTableSuffix());
+    const entry = this.traceTimestampTableCache.get(`${database}.${companionTable}`);
     if (!entry || entry.expiresAt <= Date.now()) {
       return undefined;
     }

--- a/src/data/CHDatasource.ts
+++ b/src/data/CHDatasource.ts
@@ -570,7 +570,9 @@ export class Datasource
       return query;
     }
 
-    const meta = query.builderOptions.meta;
+    // Hand-provisioned models can carry editorType 'builder' without builderOptions,
+    // and the query editor now calls this on every render, so guard the access.
+    const meta = query.builderOptions?.meta;
     if (!meta?.isTraceIdMode) {
       return query;
     }

--- a/src/data/sqlGenerator.test.ts
+++ b/src/data/sqlGenerator.test.ts
@@ -541,8 +541,8 @@ describe('SQL Generator', () => {
     };
 
     const expectedSqlParts = [
-      `WITH 'abcdefg' as trace_id, (SELECT min(Start) FROM "default"."otel_traces_trace_id_ts" WHERE TraceId = trace_id) as trace_start,`,
-      `(SELECT max(End) + 1 FROM "default"."otel_traces_trace_id_ts" WHERE TraceId = trace_id) as trace_end`,
+      `WITH 'abcdefg' as __gf_trace_id, (SELECT min(Start) FROM "default"."otel_traces_trace_id_ts" WHERE TraceId = __gf_trace_id) as __gf_trace_start,`,
+      `(SELECT max(End) + 1 FROM "default"."otel_traces_trace_id_ts" WHERE TraceId = __gf_trace_id) as __gf_trace_end`,
       'SELECT "TraceId" as traceID, "SpanId" as spanID, "ParentSpanId" as parentSpanID,',
       '"ServiceName" as serviceName, "SpanName" as operationName, multiply(toUnixTimestamp64Nano("Timestamp"), 0.000001) as startTime,',
       'multiply("Duration", 0.000001) as duration,',
@@ -557,7 +557,7 @@ describe('SQL Generator', () => {
       '"InstrumentationLibraryName" as instrumentationLibraryName,',
       '"InstrumentationLibraryVersion" as instrumentationLibraryVersion,',
       '"TraceState" as traceState',
-      `FROM "default"."otel_traces" WHERE traceID = trace_id AND "Timestamp" >= trace_start AND "Timestamp" <= trace_end`,
+      `FROM "default"."otel_traces" WHERE traceID = __gf_trace_id AND "Timestamp" >= __gf_trace_start AND "Timestamp" <= __gf_trace_end`,
     ];
 
     const sql = generateSql(opts);
@@ -604,8 +604,8 @@ describe('SQL Generator', () => {
     };
 
     const expectedSqlParts = [
-      `WITH 'abcdefg' as trace_id, (SELECT min(Start) FROM "default"."otel_traces_trace_id_ts" WHERE TraceId = trace_id) as trace_start,`,
-      `(SELECT max(End) + 1 FROM "default"."otel_traces_trace_id_ts" WHERE TraceId = trace_id) as trace_end`,
+      `WITH 'abcdefg' as __gf_trace_id, (SELECT min(Start) FROM "default"."otel_traces_trace_id_ts" WHERE TraceId = __gf_trace_id) as __gf_trace_start,`,
+      `(SELECT max(End) + 1 FROM "default"."otel_traces_trace_id_ts" WHERE TraceId = __gf_trace_id) as __gf_trace_end`,
       'SELECT "TraceId" as traceID, "SpanId" as spanID, "ParentSpanId" as parentSpanID,',
       '"ServiceName" as serviceName, "SpanName" as operationName, multiply(toUnixTimestamp64Nano("Timestamp"), 0.000001) as startTime,',
       'multiply("Duration", 0.000001) as duration,',
@@ -620,7 +620,7 @@ describe('SQL Generator', () => {
       '"InstrumentationLibraryName" as instrumentationLibraryName,',
       '"InstrumentationLibraryVersion" as instrumentationLibraryVersion,',
       '"TraceState" as traceState',
-      `FROM "default"."otel_traces" WHERE traceID = trace_id AND "Timestamp" >= trace_start AND "Timestamp" <= trace_end`,
+      `FROM "default"."otel_traces" WHERE traceID = __gf_trace_id AND "Timestamp" >= __gf_trace_start AND "Timestamp" <= __gf_trace_end`,
     ];
 
     const sql = generateSql(opts);
@@ -658,8 +658,8 @@ describe('SQL Generator', () => {
       orderBy: [],
     };
     const expectedSqlParts = [
-      `WITH 'abcdefg' as trace_id, (SELECT min(Start) FROM "default"."otel_traces_trace_id_ts" WHERE TraceId = trace_id) as trace_start,`,
-      `(SELECT max(End) + 1 FROM "default"."otel_traces_trace_id_ts" WHERE TraceId = trace_id) as trace_end`,
+      `WITH 'abcdefg' as __gf_trace_id, (SELECT min(Start) FROM "default"."otel_traces_trace_id_ts" WHERE TraceId = __gf_trace_id) as __gf_trace_start,`,
+      `(SELECT max(End) + 1 FROM "default"."otel_traces_trace_id_ts" WHERE TraceId = __gf_trace_id) as __gf_trace_end`,
       'SELECT "TraceId" as traceID, "SpanId" as spanID, "ParentSpanId" as parentSpanID,',
       '"ServiceName" as serviceName, "SpanName" as operationName, multiply(toUnixTimestamp64Nano("Timestamp"), 0.000001) as startTime,',
       'multiply("Duration", 0.000001) as duration,',
@@ -667,7 +667,7 @@ describe('SQL Generator', () => {
       `mapKeys("SpanAttributes")) as tags,`,
       `arrayMap(key -> map('key', key, 'value',"ResourceAttributes"[key]), mapKeys("ResourceAttributes")) as serviceTags,`,
       `if("StatusCode" IN ('Error', 'STATUS_CODE_ERROR'), 2, 0) as statusCode`,
-      `FROM "default"."otel_traces" WHERE traceID = trace_id AND "Timestamp" >= trace_start AND "Timestamp" <= trace_end`,
+      `FROM "default"."otel_traces" WHERE traceID = __gf_trace_id AND "Timestamp" >= __gf_trace_start AND "Timestamp" <= __gf_trace_end`,
     ];
 
     const sql = generateSql(opts);
@@ -777,8 +777,8 @@ describe('SQL Generator', () => {
       orderBy: [],
     };
     const expectedSqlParts = [
-      `WITH 'abcdefg' as trace_id, (SELECT min(Start) FROM "default"."custom_traces_trace_id_ts" WHERE TraceId = trace_id) as trace_start,`,
-      `(SELECT max(End) + 1 FROM "default"."custom_traces_trace_id_ts" WHERE TraceId = trace_id) as trace_end`,
+      `WITH 'abcdefg' as __gf_trace_id, (SELECT min(Start) FROM "default"."custom_traces_trace_id_ts" WHERE TraceId = __gf_trace_id) as __gf_trace_start,`,
+      `(SELECT max(End) + 1 FROM "default"."custom_traces_trace_id_ts" WHERE TraceId = __gf_trace_id) as __gf_trace_end`,
       'SELECT "TraceId" as traceID, "SpanId" as spanID, "ParentSpanId" as parentSpanID,',
       '"ServiceName" as serviceName, "SpanName" as operationName, multiply(toUnixTimestamp64Nano("Timestamp"), 0.000001) as startTime,',
       'multiply("Duration", 0.000001) as duration,',
@@ -786,7 +786,7 @@ describe('SQL Generator', () => {
       `mapKeys("SpanAttributes")) as tags,`,
       `arrayMap(key -> map('key', key, 'value',"ResourceAttributes"[key]), mapKeys("ResourceAttributes")) as serviceTags,`,
       `if("StatusCode" IN ('Error', 'STATUS_CODE_ERROR'), 2, 0) as statusCode`,
-      `FROM "default"."custom_traces" WHERE traceID = trace_id AND "Timestamp" >= trace_start AND "Timestamp" <= trace_end`,
+      `FROM "default"."custom_traces" WHERE traceID = __gf_trace_id AND "Timestamp" >= __gf_trace_start AND "Timestamp" <= __gf_trace_end`,
     ];
 
     const sql = generateSql(opts);
@@ -828,8 +828,47 @@ describe('SQL Generator', () => {
 
     expect(sql).toContain('FROM "default"."custom_traces_ts_index"');
     expect(sql).not.toContain('custom_traces_trace_id_ts');
-    expect(sql).toContain(`WITH 'abcdefg' as trace_id`);
-    expect(sql).toContain('"Timestamp" >= trace_start');
+    expect(sql).toContain(`WITH 'abcdefg' as __gf_trace_id`);
+    expect(sql).toContain('"Timestamp" >= __gf_trace_start');
+  });
+
+  // Regression guard: the WITH aliases must never collide with physical columns
+  // on the main traces table. A bare `trace_id` alias is shadowed by a physical
+  // `trace_id` column, so `WHERE traceID = trace_id` becomes a tautology and
+  // every span in the time window is returned mislabelled with the searched ID.
+  it('does not emit WITH aliases that can be shadowed by main-table columns named trace_id/trace_start/trace_end', () => {
+    const opts: QueryBuilderOptions = {
+      database: 'default',
+      table: 'custom_traces',
+      queryType: QueryType.Traces,
+      columns: [
+        { name: 'trace_id', type: 'String', hint: ColumnHint.TraceId },
+        { name: 'span_id', type: 'String', hint: ColumnHint.TraceSpanId },
+        { name: 'trace_start', type: 'DateTime64(9)', hint: ColumnHint.Time },
+        { name: 'duration', type: 'Int64', hint: ColumnHint.TraceDurationTime },
+      ],
+      filters: [],
+      meta: {
+        minimized: true,
+        otelEnabled: false,
+        otelVersion: undefined,
+        traceDurationUnit: TimeUnit.Nanoseconds,
+        isTraceIdMode: true,
+        traceId: 'abcdefg',
+        hasTraceTimestampTable: true,
+      },
+      limit: 1000,
+      orderBy: [],
+    };
+    const sql = generateSql(opts);
+
+    expect(sql).not.toMatch(/\bas trace_id\b/i);
+    expect(sql).not.toMatch(/\bas trace_start\b/i);
+    expect(sql).not.toMatch(/\bas trace_end\b/i);
+    expect(sql).toContain(`WITH 'abcdefg' as __gf_trace_id`);
+    expect(sql).toContain('WHERE traceID = __gf_trace_id');
+    expect(sql).toContain('"trace_start" >= __gf_trace_start');
+    expect(sql).toContain('"trace_start" <= __gf_trace_end');
   });
 
   it('generates trace search query', () => {

--- a/src/data/sqlGenerator.ts
+++ b/src/data/sqlGenerator.ts
@@ -281,10 +281,14 @@ const generateTraceIdQuery = (options: QueryBuilderOptions): string => {
     const traceIdValue = options.meta!.traceId;
     const suffix = options.meta?.traceTimestampTableSuffix || otel.traceTimestampTableSuffix;
     const timestampTable = getTableIdentifier(database, table + suffix);
+    // The WITH aliases are prefixed so they cannot collide with physical columns
+    // on the main traces table. A bare `trace_id` alias shadows a physical
+    // `trace_id` column, turning `WHERE traceID = trace_id` into a tautology
+    // that returns every span in the time window.
     queryParts.push('WITH');
-    queryParts.push(`'${traceIdValue}' as trace_id,`);
-    queryParts.push(`(SELECT min(Start) FROM ${timestampTable} WHERE TraceId = trace_id) as trace_start,`);
-    queryParts.push(`(SELECT max(End) + 1 FROM ${timestampTable} WHERE TraceId = trace_id) as trace_end`);
+    queryParts.push(`'${traceIdValue}' as __gf_trace_id,`);
+    queryParts.push(`(SELECT min(Start) FROM ${timestampTable} WHERE TraceId = __gf_trace_id) as __gf_trace_start,`);
+    queryParts.push(`(SELECT max(End) + 1 FROM ${timestampTable} WHERE TraceId = __gf_trace_id) as __gf_trace_end`);
   }
 
   queryParts.push('SELECT');
@@ -299,11 +303,11 @@ const generateTraceIdQuery = (options: QueryBuilderOptions): string => {
   }
 
   if (applyTraceIdOptimization) {
-    queryParts.push('traceID = trace_id');
+    queryParts.push('traceID = __gf_trace_id');
     queryParts.push('AND');
-    queryParts.push(`${escapeIdentifier(traceStartTime.name)} >= trace_start`);
+    queryParts.push(`${escapeIdentifier(traceStartTime.name)} >= __gf_trace_start`);
     queryParts.push('AND');
-    queryParts.push(`${escapeIdentifier(traceStartTime.name)} <= trace_end`);
+    queryParts.push(`${escapeIdentifier(traceStartTime.name)} <= __gf_trace_end`);
   } else if (hasTraceIdFilter) {
     const traceId = options.meta!.traceId;
     queryParts.push(`traceID = '${traceId}'`);

--- a/src/data/utils.test.ts
+++ b/src/data/utils.test.ts
@@ -1,4 +1,4 @@
-import { ColumnHint, QueryBuilderOptions, QueryType, TimeUnit } from 'types/queryBuilder';
+import { ColumnHint, QueryBuilderOptions, QueryType, TableColumn, TimeUnit } from 'types/queryBuilder';
 import {
   applyTraceSearchFieldConfig,
   columnLabelToPlaceholder,
@@ -552,6 +552,53 @@ describe('transformQueryResponseWithTraceAndLogLinks', () => {
       expect(traceQuery.rawSql).toContain('__gf_trace_start');
       expect(traceQuery.rawSql).toContain('__gf_trace_end');
       expect(traceQuery.builderOptions.meta?.hasTraceTimestampTable).toBe(true);
+    });
+
+    it('trace→trace link probes the companion named by the saved query suffix, not the config suffix', async () => {
+      // A saved query baked with meta.traceTimestampTableSuffix: '_saved_ts'
+      // generates SQL against otel_traces_saved_ts. The existence check must
+      // probe that same table: probing the config-suffix companion
+      // (otel_traces_trace_id_ts here, which does not exist) would drop the
+      // optimization, or in the reverse case pass the check and ship SQL
+      // referencing a missing table (UNKNOWN_TABLE).
+      const mockDatasource = newOtelMockDatasource();
+      jest.spyOn(mockDatasource, 'fetchTables').mockResolvedValue(['otel_traces', 'otel_traces_saved_ts']);
+      const companionColumns: TableColumn[] = [
+        { name: 'TraceId', type: 'String', label: 'TraceId', picklistValues: [] },
+        { name: 'Start', type: 'DateTime64(9)', label: 'Start', picklistValues: [] },
+        { name: 'End', type: 'DateTime64(9)', label: 'End', picklistValues: [] },
+      ];
+      jest
+        .spyOn(mockDatasource, 'fetchColumns')
+        .mockImplementation((_database, table) =>
+          Promise.resolve(table === 'otel_traces_saved_ts' ? companionColumns : [])
+        );
+      const otelConfig = otel.getVersion('latest')!;
+      const columns = Array.from(otelConfig.traceColumnMap, ([hint, name]) => ({ name, hint }));
+
+      const builderOptions: Partial<QueryBuilderOptions> = {
+        database: 'otel',
+        table: 'otel_traces',
+        queryType: QueryType.Traces,
+        columns,
+        meta: {
+          otelEnabled: true,
+          otelVersion: 'latest',
+          traceDurationUnit: TimeUnit.Nanoseconds,
+          traceTimestampTableSuffix: '_saved_ts',
+        },
+      };
+
+      const [request, response] = buildTestRequestResponse(builderOptions);
+      const out = await transformQueryResponseWithTraceAndLogLinks(mockDatasource, request, response);
+
+      const links = out?.data[0]?.fields[0]?.config?.links;
+      const viewTraceLink = links?.find((link: any) => link.title === 'View trace');
+      const traceQuery = viewTraceLink?.internal?.query as CHBuilderQuery;
+
+      expect(traceQuery.builderOptions.meta?.hasTraceTimestampTable).toBe(true);
+      expect(traceQuery.builderOptions.meta?.traceTimestampTableSuffix).toBe('_saved_ts');
+      expect(traceQuery.rawSql).toContain('otel_traces_saved_ts');
     });
 
     it('trace→trace link auto-detects JSON tag columns via fetchColumns', async () => {

--- a/src/data/utils.test.ts
+++ b/src/data/utils.test.ts
@@ -549,8 +549,8 @@ describe('transformQueryResponseWithTraceAndLogLinks', () => {
       const traceQuery = viewTraceLink?.internal?.query as CHBuilderQuery;
 
       expect(traceQuery.rawSql).toContain('otel_traces_trace_id_ts');
-      expect(traceQuery.rawSql).toContain('trace_start');
-      expect(traceQuery.rawSql).toContain('trace_end');
+      expect(traceQuery.rawSql).toContain('__gf_trace_start');
+      expect(traceQuery.rawSql).toContain('__gf_trace_end');
       expect(traceQuery.builderOptions.meta?.hasTraceTimestampTable).toBe(true);
     });
 
@@ -642,8 +642,8 @@ describe('transformQueryResponseWithTraceAndLogLinks', () => {
       expect(traceQuery.builderOptions.meta?.otelEnabled).toBe(true);
       expect(traceQuery.builderOptions.meta?.hasTraceTimestampTable).toBe(true);
       expect(traceQuery.rawSql).toContain('otel_traces_trace_id_ts');
-      expect(traceQuery.rawSql).toContain('trace_start');
-      expect(traceQuery.rawSql).toContain('trace_end');
+      expect(traceQuery.rawSql).toContain('__gf_trace_start');
+      expect(traceQuery.rawSql).toContain('__gf_trace_end');
     });
 
     it('sets format on the trace ID link query so Grafana picks the trace panel', async () => {

--- a/src/data/utils.ts
+++ b/src/data/utils.ts
@@ -413,9 +413,12 @@ export const transformQueryResponseWithTraceAndLogLinks = async (
           false) ||
         (!fetchedLiveSchema && !typeKnown && Boolean(originalQuery.builderOptions.meta?.tagsAreJSON));
 
+      // Validate the companion table the generated SQL will reference: the
+      // query's baked suffix wins over the current datasource config suffix.
       const hasTraceTimestampTable = await datasource.hasTraceTimestampTable(
         originalQuery.builderOptions.database || '',
-        originalQuery.builderOptions.table || ''
+        originalQuery.builderOptions.table || '',
+        originalQuery.builderOptions.meta?.traceTimestampTableSuffix
       );
 
       traceIdQuery.builderOptions = {

--- a/src/hooks/useHasTraceTimestampTable.test.ts
+++ b/src/hooks/useHasTraceTimestampTable.test.ts
@@ -14,7 +14,7 @@ describe('useHasTraceTimestampTable', () => {
     // The async check cannot have settled yet, so a `true` on the first render
     // proves the value was seeded synchronously from the cache peek.
     expect(result.current).toBe(true);
-    expect(mockDs.peekTraceTimestampTable).toHaveBeenCalledWith('otel', 'otel_traces');
+    expect(mockDs.peekTraceTimestampTable).toHaveBeenCalledWith('otel', 'otel_traces', undefined);
 
     await act(async () => {}); // flush the pending async check
     expect(result.current).toBe(true);
@@ -49,6 +49,22 @@ describe('useHasTraceTimestampTable', () => {
 
     await act(async () => {});
     expect(result.current).toBe(false);
+  });
+
+  it('passes the per-query suffix through to the peek and the async check', async () => {
+    // A saved query can bake a meta.traceTimestampTableSuffix that differs
+    // from the datasource config suffix. The hook must probe the companion
+    // table the SQL generator will reference, not the config one.
+    const mockDs = {} as Datasource;
+    mockDs.peekTraceTimestampTable = jest.fn(() => undefined);
+    mockDs.hasTraceTimestampTable = jest.fn(() => Promise.resolve(true));
+
+    const { result } = renderHook(() => useHasTraceTimestampTable(mockDs, 'otel', 'otel_traces', '_saved_ts'));
+
+    await act(async () => {});
+    expect(result.current).toBe(true);
+    expect(mockDs.peekTraceTimestampTable).toHaveBeenCalledWith('otel', 'otel_traces', '_saved_ts');
+    expect(mockDs.hasTraceTimestampTable).toHaveBeenCalledWith('otel', 'otel_traces', '_saved_ts');
   });
 
   it('returns false when database or table is empty', async () => {

--- a/src/hooks/useHasTraceTimestampTable.ts
+++ b/src/hooks/useHasTraceTimestampTable.ts
@@ -4,15 +4,20 @@ import { Datasource } from 'data/CHDatasource';
 /**
  * Resolves whether the `<table>_trace_id_ts` companion exists.
  *
+ * Pass the query's `meta.traceTimestampTableSuffix` as `suffix` so the check
+ * probes the same companion table the SQL generator will reference, since a
+ * saved query can carry a suffix that differs from the current datasource
+ * config.
+ *
  * Returns `undefined` while the lookup is still in flight on a cold cache.
  * Callers that mirror this into builder options must treat `undefined` as
  * "don't know yet" and leave the upstream meta value alone — otherwise the
  * transient `false` clobbers the optimized value that the response-transform
  * path bakes into trace ID deep-link queries (see issue #1918).
  */
-export default (datasource: Datasource, database: string, table: string): boolean | undefined => {
+export default (datasource: Datasource, database: string, table: string, suffix?: string): boolean | undefined => {
   const [result, setResult] = useState<boolean | undefined>(() =>
-    datasource.peekTraceTimestampTable(database, table)
+    datasource.peekTraceTimestampTable(database, table, suffix)
   );
 
   useEffect(() => {
@@ -23,7 +28,7 @@ export default (datasource: Datasource, database: string, table: string): boolea
 
     let cancelled = false;
     datasource
-      .hasTraceTimestampTable(database, table)
+      .hasTraceTimestampTable(database, table, suffix)
       .then((v) => {
         if (!cancelled) {
           setResult(v);
@@ -38,7 +43,7 @@ export default (datasource: Datasource, database: string, table: string): boolea
     return () => {
       cancelled = true;
     };
-  }, [datasource, database, table]);
+  }, [datasource, database, table, suffix]);
 
   return result;
 };

--- a/src/views/CHQueryEditor.test.tsx
+++ b/src/views/CHQueryEditor.test.tsx
@@ -7,6 +7,7 @@ import { mockDatasource, newMockDatasource } from '__mocks__/datasource';
 import { EditorType } from 'types/sql';
 import { ColumnHint, FilterOperator, QueryType } from 'types/queryBuilder';
 import { pluginVersion } from 'utils/version';
+import { selectors } from 'selectors';
 
 jest.mock('@grafana/ui', () => ({
   ...jest.requireActual<typeof ui>('@grafana/ui'),
@@ -484,5 +485,88 @@ describe('Query Editor', () => {
 
     await waitFor(() => expect(screen.getByText('SeverityText')).toBeInTheDocument());
     expect(screen.getByText('error')).toBeInTheDocument();
+  });
+
+  // Regression guard for the one-shot span-link `query` field (#1889 follow-up):
+  // Grafana core injects a top-level `query` field when a span link is followed.
+  // The editor must fold that trace id into the builder options and never spread
+  // the injected field back out through onChange, otherwise the saved model stays
+  // pinned to the linked trace after the user targets a different trace id.
+  describe('span link one-shot query field', () => {
+    const originalTraceId = 'a55d8be622a816047a902c60adedd776';
+    const linkedTraceId = '4ea6a6e0d0525ed05ecc350d3cdd66b6';
+    const userTraceId = 'c3b5f0a1d2e4968877665544332211ff';
+
+    const spanLinkQuery = () => ({
+      pluginVersion,
+      refId: 'A',
+      editorType: EditorType.Builder as const,
+      rawSql: `SELECT "TraceId" as traceID FROM "otel"."otel_traces" WHERE traceID = '${originalTraceId}'`,
+      builderOptions: {
+        database: 'otel',
+        table: 'otel_traces',
+        queryType: QueryType.Traces,
+        columns: [{ name: 'TraceId', hint: ColumnHint.TraceId }],
+        meta: { isTraceIdMode: true, traceId: originalTraceId },
+      },
+      // Grafana core builds the span-link navigation target as { ...currentQuery, query: linkedTraceId }.
+      query: linkedTraceId,
+    });
+
+    const newTraceDatasource = () => {
+      const datasource = newMockDatasource();
+      datasource.fetchColumns = jest.fn(() => Promise.resolve([]));
+      datasource.fetchDatabases = jest.fn(() => Promise.resolve([]));
+      datasource.fetchTables = jest.fn(() => Promise.resolve([]));
+      jest.spyOn(datasource, 'peekTraceTimestampTable').mockReturnValue(false);
+      jest.spyOn(datasource, 'hasTraceTimestampTable').mockResolvedValue(false);
+      return datasource;
+    };
+
+    it('retargets a freshly injected span-link trace id and strips the one-shot field', async () => {
+      const onChange = jest.fn();
+
+      render(
+        <CHQueryEditor
+          query={spanLinkQuery()}
+          onChange={onChange}
+          onRunQuery={jest.fn()}
+          datasource={newTraceDatasource()}
+        />
+      );
+      await act(async () => {});
+
+      expect(onChange).toHaveBeenCalled();
+      const [propagated] = onChange.mock.calls[onChange.mock.calls.length - 1];
+      expect('query' in propagated).toBe(false);
+      expect(propagated.builderOptions?.meta?.traceId).toEqual(linkedTraceId);
+      expect(propagated.rawSql).toContain(linkedTraceId);
+      expect(propagated.rawSql).not.toContain(originalTraceId);
+    });
+
+    it('follows the user trace id after an edit instead of re-pinning the linked trace', async () => {
+      const onChange = jest.fn();
+
+      render(
+        <CHQueryEditor
+          query={spanLinkQuery()}
+          onChange={onChange}
+          onRunQuery={jest.fn()}
+          datasource={newTraceDatasource()}
+        />
+      );
+      await act(async () => {});
+
+      const traceIdInput = screen.getByTestId(selectors.components.QueryBuilder.TraceIdInput.input);
+      fireEvent.change(traceIdInput, { target: { value: userTraceId } });
+      fireEvent.blur(traceIdInput);
+      await act(async () => {});
+
+      const [propagated] = onChange.mock.calls[onChange.mock.calls.length - 1];
+      expect('query' in propagated).toBe(false);
+      expect(propagated.builderOptions?.meta?.traceId).toEqual(userTraceId);
+      expect(propagated.rawSql).toContain(userTraceId);
+      expect(propagated.rawSql).not.toContain(linkedTraceId);
+    });
   });
 });

--- a/src/views/CHQueryEditor.test.tsx
+++ b/src/views/CHQueryEditor.test.tsx
@@ -152,6 +152,49 @@ describe('Query Editor', () => {
     }
   });
 
+  it('validates the companion table named by the query meta suffix on trace ID deep-links', async () => {
+    // A saved deep-link query can bake a meta.traceTimestampTableSuffix that
+    // differs from the current datasource config suffix. The editor's check
+    // must probe the companion the generated SQL will reference (the query's
+    // suffix), otherwise it validates one table while the emitted SQL joins
+    // against another.
+    const ds = newMockDatasource();
+    jest.spyOn(ds, 'peekTraceTimestampTable').mockReturnValue(undefined);
+    const hasSpy = jest.spyOn(ds, 'hasTraceTimestampTable').mockResolvedValue(true);
+
+    render(
+      <CHQueryEditor
+        query={{
+          pluginVersion,
+          refId: 'Trace ID',
+          editorType: EditorType.Builder,
+          rawSql: '',
+          builderOptions: {
+            database: 'otel',
+            table: 'otel_traces',
+            queryType: QueryType.Traces,
+            columns: [
+              { name: 'Timestamp', hint: ColumnHint.Time },
+              { name: 'TraceId', hint: ColumnHint.TraceId },
+            ],
+            meta: {
+              minimized: true,
+              isTraceIdMode: true,
+              traceId: 'abc',
+              traceTimestampTableSuffix: '_saved_ts',
+            },
+          },
+        }}
+        onChange={jest.fn()}
+        onRunQuery={jest.fn()}
+        datasource={ds}
+      />
+    );
+    await act(async () => {});
+
+    expect(hasSpy).toHaveBeenCalledWith('otel', 'otel_traces', '_saved_ts');
+  });
+
   it('renders compact SQL chrome for single-table datasources', () => {
     const datasource = newMockDatasource();
     datasource.settings.jsonData.configMode = 'single-table';

--- a/src/views/CHQueryEditor.test.tsx
+++ b/src/views/CHQueryEditor.test.tsx
@@ -98,11 +98,11 @@ describe('Query Editor', () => {
     jest.spyOn(ds, 'hasTraceTimestampTable').mockResolvedValue(true);
 
     const optimizedSql =
-      `WITH 'abc' as trace_id, ` +
-      `(SELECT min(Start) FROM "otel"."otel_traces_trace_id_ts" WHERE TraceId = trace_id) as trace_start, ` +
-      `(SELECT max(End) + 1 FROM "otel"."otel_traces_trace_id_ts" WHERE TraceId = trace_id) as trace_end ` +
+      `WITH 'abc' as __gf_trace_id, ` +
+      `(SELECT min(Start) FROM "otel"."otel_traces_trace_id_ts" WHERE TraceId = __gf_trace_id) as __gf_trace_start, ` +
+      `(SELECT max(End) + 1 FROM "otel"."otel_traces_trace_id_ts" WHERE TraceId = __gf_trace_id) as __gf_trace_end ` +
       `SELECT "TraceId" as traceID FROM "otel"."otel_traces" ` +
-      `WHERE traceID = trace_id AND "Timestamp" >= trace_start AND "Timestamp" <= trace_end`;
+      `WHERE traceID = __gf_trace_id AND "Timestamp" >= __gf_trace_start AND "Timestamp" <= __gf_trace_end`;
 
     const onChange = jest.fn();
     render(

--- a/src/views/CHQueryEditor.tsx
+++ b/src/views/CHQueryEditor.tsx
@@ -21,28 +21,49 @@ import { isEqual } from 'lodash';
 export type CHQueryEditorProps = QueryEditorProps<Datasource, CHQuery, CHConfig>;
 
 /**
+ * Grafana core injects a one-shot top-level `query` field into the pane query when a span
+ * link is followed (see Datasource.retargetSpanLinkTrace). The injected value must only
+ * apply until the user next edits the query, so drop it from every change the editor
+ * propagates. Otherwise it survives in the saved model and pins every run to the linked
+ * trace, even after the user targets a different trace id.
+ */
+const removeSpanLinkQueryField = (query: CHQuery): CHQuery => {
+  if (!('query' in query)) {
+    return query;
+  }
+
+  const { query: discardedSpanLinkQuery, ...rest } = query;
+  void discardedSpanLinkQuery;
+  return rest;
+};
+
+/**
  * Top level query editor component
  */
 export const CHQueryEditor = (props: CHQueryEditorProps) => {
-  const { datasource, query: savedQuery, onRunQuery } = props;
-  const query = migrateCHQuery(savedQuery);
+  const { datasource, query: savedQuery, onChange, onRunQuery } = props;
+  // Fold a span-link injected trace id into the builder options before rendering, so the
+  // editor shows the linked trace and the first propagated change keeps targeting it once
+  // removeSpanLinkQueryField drops the one-shot field.
+  const query = datasource.retargetSpanLinkTrace(migrateCHQuery(savedQuery));
+  const handleChange = useCallback((nextQuery: CHQuery) => onChange(removeSpanLinkQueryField(nextQuery)), [onChange]);
   const singleTableMode = datasource.isSingleTableMode();
 
   if (singleTableMode && query.editorType === EditorType.SQL) {
-    return <CompactSqlMode {...props} query={query} />;
+    return <CompactSqlMode {...props} query={query} onChange={handleChange} />;
   }
 
   if (singleTableMode) {
-    return <CHEditorByType {...props} query={query} />;
+    return <CHEditorByType {...props} query={query} onChange={handleChange} />;
   }
 
   return (
     <>
       <InlineFieldRow className={styles.QueryEditor.queryType}>
-        <EditorTypeSwitcher {...props} query={query} datasource={datasource} />
+        <EditorTypeSwitcher {...props} query={query} onChange={handleChange} datasource={datasource} />
         <Button onClick={() => onRunQuery()}>Run Query</Button>
       </InlineFieldRow>
-      <CHEditorByType {...props} query={query} />
+      <CHEditorByType {...props} query={query} onChange={handleChange} />
     </>
   );
 };

--- a/src/views/CHQueryEditor.tsx
+++ b/src/views/CHQueryEditor.tsx
@@ -110,7 +110,10 @@ const CHEditorByType = (props: CHQueryEditorProps) => {
   const hasTraceTimestampTable = useHasTraceTimestampTable(
     props.datasource,
     needsTraceTableCheck ? builderOptions.database || '' : '',
-    needsTraceTableCheck ? builderOptions.table || '' : ''
+    needsTraceTableCheck ? builderOptions.table || '' : '',
+    // Probe the companion table the generated SQL will reference: a saved
+    // query's baked suffix wins over the current datasource config suffix.
+    builderOptions.meta?.traceTimestampTableSuffix
   );
 
   useEffect(() => {

--- a/tests/benchmarks/trace-id-query.sh
+++ b/tests/benchmarks/trace-id-query.sh
@@ -129,13 +129,13 @@ SLOW_SQL="SELECT /* ${SLOW_TAG} */ * FROM ${CH_DB}.bench_traces WHERE TraceId = 
 # Optimized: the exact shape generateTraceIdQuery() emits today when
 # applyTraceIdOptimization fires.
 FAST_SQL="WITH /* ${FAST_TAG} */
-  '${TARGET_TRACE_ID}' AS trace_id,
-  (SELECT min(Start) FROM ${CH_DB}.bench_traces_trace_id_ts WHERE TraceId = trace_id) AS trace_start,
-  (SELECT max(End) + 1 FROM ${CH_DB}.bench_traces_trace_id_ts WHERE TraceId = trace_id) AS trace_end
+  '${TARGET_TRACE_ID}' AS __gf_trace_id,
+  (SELECT min(Start) FROM ${CH_DB}.bench_traces_trace_id_ts WHERE TraceId = __gf_trace_id) AS __gf_trace_start,
+  (SELECT max(End) + 1 FROM ${CH_DB}.bench_traces_trace_id_ts WHERE TraceId = __gf_trace_id) AS __gf_trace_end
 SELECT * FROM ${CH_DB}.bench_traces
-WHERE TraceId = trace_id
-  AND Timestamp >= trace_start
-  AND Timestamp <= trace_end
+WHERE TraceId = __gf_trace_id
+  AND Timestamp >= __gf_trace_start
+  AND Timestamp <= __gf_trace_end
 FORMAT Null"
 
 run_sql "SET use_query_cache = 0; ${SLOW_SQL};"

--- a/tests/e2e/traceTimestampTable.spec.ts
+++ b/tests/e2e/traceTimestampTable.spec.ts
@@ -5,7 +5,7 @@ import { Page } from '@playwright/test';
 // regression guard. The tests exercise the two SQL shapes the plugin
 // generates against real ClickHouse:
 //
-//   Optimized  – WITH trace_id / trace_start / trace_end + Timestamp bounds
+//   Optimized  – WITH __gf_trace_id / __gf_trace_start / __gf_trace_end + Timestamp bounds
 //   Fallback   – plain WHERE traceID = '<id>'
 //
 // Fixture: tests/e2e/fixtures/trace_id_ts.sql creates
@@ -35,14 +35,14 @@ const TRACE_B_SPAN_COUNT = 1;
 // SQL the plugin generates with hasTraceTimestampTable: true
 function optimizedSql(traceId: string): string {
   return [
-    `WITH '${traceId}' as trace_id,`,
-    `(SELECT min(Start) FROM "e2e_test"."trace_ts_spans_trace_id_ts" WHERE TraceId = trace_id) as trace_start,`,
-    `(SELECT max(End) + 1 FROM "e2e_test"."trace_ts_spans_trace_id_ts" WHERE TraceId = trace_id) as trace_end`,
+    `WITH '${traceId}' as __gf_trace_id,`,
+    `(SELECT min(Start) FROM "e2e_test"."trace_ts_spans_trace_id_ts" WHERE TraceId = __gf_trace_id) as __gf_trace_start,`,
+    `(SELECT max(End) + 1 FROM "e2e_test"."trace_ts_spans_trace_id_ts" WHERE TraceId = __gf_trace_id) as __gf_trace_end`,
     `SELECT "TraceId" as traceID, "SpanId" as spanID`,
     `FROM "e2e_test"."trace_ts_spans"`,
-    `WHERE traceID = trace_id`,
-    `AND "Timestamp" >= trace_start`,
-    `AND "Timestamp" <= trace_end`,
+    `WHERE traceID = __gf_trace_id`,
+    `AND "Timestamp" >= __gf_trace_start`,
+    `AND "Timestamp" <= __gf_trace_end`,
   ].join(' ');
 }
 


### PR DESCRIPTION
## Type of Change

- [x] 🐛 Bug Fix

---

## Bug Fix

### What is the bug?

Three trace defects from the v4.18.0/v4.19.0 cycles, all in the trace-ID lookup optimisation and span-link flow (#1786, #1853, #1890, #1919, #1920, #1937, #1992, #1994 all reworked this area), one commit each:

1. **Trace-ID lookup aliases shadow table columns.** `generateTraceIdQuery` emitted `WITH '<id>' as trace_id, ... trace_start, ... trace_end`. On tables with physical columns of those names (common on non-OTel tables, and #1791's heuristics auto-map `trace_id`), the ClickHouse alias shadows the column: `WHERE traceID = trace_id` becomes a tautology and the trace view renders every span in the time window mislabelled with the searched trace id (reproduced against live ClickHouse 24.8). The aliases are now `__gf_`-prefixed.
2. **Companion-table check validates a different suffix than the query uses.** `hasTraceTimestampTable` probed the table named by the datasource config suffix, while the generated SQL and the deep-link transform use the per-query `meta.traceTimestampTableSuffix`. When a saved query's baked suffix differs from the current config, the check passed against one table and the query hit another (UNKNOWN_TABLE). The check now validates the same suffix the query will use.
3. **A followed span link permanently overrides the trace ID.** Grafana injects a one-shot top-level `query` field when a span link is followed, but nothing ever cleared it, so the pane stayed pinned to the linked trace: typing a different trace ID showed the new ID in the UI while the data stayed on the old trace, and saving persisted the stale field. The field is now stripped on the first user edit, restoring one-shot semantics.

### How to reproduce

Each fix's regression tests document the exact scenario (`sqlGenerator.test.ts`, `CHDatasource.test.ts`, `utils.test.ts`, `CHQueryEditor.test.tsx`). Representative example for 1: non-OTel traces table `t(trace_id, span_id, start_time, ...)` with companion `t_trace_id_ts`; open a trace via "View trace" and observe spans from unrelated traces rendered under the opened trace id before this PR.

### Environment (if no related issue)

- **ClickHouse version**: any supported
- **Grafana version**: any supported
- **Plugin version**: 4.19.0 and current main

---

## Please check that:

- [x] Tests for this change have been added/updated.
- [ ] Documentation has been added/updated (where applicable).

## Special notes for your reviewer

Supersedes #2046, #2047 and #2048 (same fixes, previously one PR each, closed in favour of this bundle). Commits are kept separate, one per fix. The renamed WITH aliases in fix 1 are generated per execution and never persisted, so no saved dashboards are affected.

Found by an automated audit of regressions introduced while integrating PRs across the v4.18.0 and v4.19.0 release cycles (range v4.17.0..main). Related PRs: #1786, #1853, #1994, #1890, #1791.
