### PR TITLE
fix(config): v1/v2 editor validation, Map keys switch, and feature toggle fixes

### DIFF
--- a/src/components/configEditor/QuerySettingsConfig.tsx
+++ b/src/components/configEditor/QuerySettingsConfig.tsx
@@ -131,6 +131,7 @@ export const QuerySettingsConfig = (props: QuerySettingsConfigProps) => {
       <Field label={labels.enableMapKeysDiscovery.label} description={labels.enableMapKeysDiscovery.tooltip}>
         <Switch
           value={enableMapKeysDiscovery ?? true}
+          data-testid={labels.enableMapKeysDiscovery.testid}
           onChange={onEnableMapKeysDiscoveryChange}
           role="checkbox"
         />

--- a/src/labels.ts
+++ b/src/labels.ts
@@ -176,6 +176,7 @@ export default {
         },
         enableMapKeysDiscovery: {
           label: 'Suggest Map keys in filter editor',
+          testid: 'data-testid enable-map-keys-discovery-switch',
           tooltip:
             'When enabled, the filter editor probes Map(...) columns for distinct keys to populate the key-suggestion dropdown. ' +
             'On large tables with high-cardinality maps this probe can scan billions of rows. ' +

--- a/src/views/CHConfigEditor.test.tsx
+++ b/src/views/CHConfigEditor.test.tsx
@@ -190,6 +190,44 @@ describe('ConfigEditor', () => {
     );
   });
 
+  describe('classic mode map keys discovery switch', () => {
+    // dialTimeout keeps the collapsible "Additional settings" section
+    // initially open so the query settings render.
+    const overrides: Partial<CHConfig> = { dialTimeout: '10', enableMapKeysDiscovery: false };
+
+    const getMapKeysSwitch = (): HTMLInputElement => {
+      const labelText = screen.getByText(allLabels.components.Config.QuerySettingsConfig.enableMapKeysDiscovery.label);
+      // The switch is inside a grafana-ui Field: the input lives in a sibling
+      // of the label element, under the shared field container.
+      const input = labelText.closest('label')?.parentElement?.parentElement?.querySelector('input[type="checkbox"]');
+      if (!(input instanceof HTMLInputElement)) {
+        throw new Error('map keys discovery switch not found');
+      }
+      return input;
+    };
+
+    it('reflects a stored enableMapKeysDiscovery=false', () => {
+      render(<ConfigEditor {...mockConfigEditorProps(overrides)} />);
+      expect(getMapKeysSwitch()).not.toBeChecked();
+    });
+
+    it('writes true when toggled back on', () => {
+      const props = mockConfigEditorProps(overrides);
+      render(<ConfigEditor {...props} />);
+
+      (props.onOptionsChange as jest.Mock).mockClear();
+      fireEvent.click(getMapKeysSwitch());
+
+      expect(props.onOptionsChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          jsonData: expect.objectContaining({
+            enableMapKeysDiscovery: true,
+          }),
+        })
+      );
+    });
+  });
+
   it('persists the single-table logs trace correlation setting', () => {
     const props = mockConfigEditorProps({
       configMode: 'single-table',

--- a/src/views/CHConfigEditor.test.tsx
+++ b/src/views/CHConfigEditor.test.tsx
@@ -235,16 +235,8 @@ describe('ConfigEditor', () => {
     // initially open so the query settings render.
     const overrides: Partial<CHConfig> = { dialTimeout: '10', enableMapKeysDiscovery: false };
 
-    const getMapKeysSwitch = (): HTMLInputElement => {
-      const labelText = screen.getByText(allLabels.components.Config.QuerySettingsConfig.enableMapKeysDiscovery.label);
-      // The switch is inside a grafana-ui Field: the input lives in a sibling
-      // of the label element, under the shared field container.
-      const input = labelText.closest('label')?.parentElement?.parentElement?.querySelector('input[type="checkbox"]');
-      if (!(input instanceof HTMLInputElement)) {
-        throw new Error('map keys discovery switch not found');
-      }
-      return input;
-    };
+    const getMapKeysSwitch = (): HTMLElement =>
+      screen.getByTestId(allLabels.components.Config.QuerySettingsConfig.enableMapKeysDiscovery.testid);
 
     it('reflects a stored enableMapKeysDiscovery=false', () => {
       render(<ConfigEditor {...mockConfigEditorProps(overrides)} />);

--- a/src/views/CHConfigEditor.test.tsx
+++ b/src/views/CHConfigEditor.test.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
+import { config } from '@grafana/runtime';
 import { ConfigEditor } from './CHConfigEditor';
+import { createValidationAPI } from './CHConfigEditorHooks';
 import { mockConfigEditorProps } from '__mocks__/ConfigEditor';
 import '@testing-library/jest-dom';
 import { CHConfig, Protocol } from 'types/config';
@@ -10,7 +12,7 @@ jest.mock('@grafana/runtime', () => {
   const original = jest.requireActual('@grafana/runtime');
   return {
     ...original,
-    config: { buildInfo: { version: '10.0.0' }, secureSocksDSProxyEnabled: true },
+    config: { buildInfo: { version: '10.0.0' }, secureSocksDSProxyEnabled: true, featureToggles: {} },
   };
 });
 
@@ -143,6 +145,44 @@ describe('ConfigEditor', () => {
   it('hides the required-field error once the host is filled (no validation toggle)', () => {
     render(<ConfigEditor {...mockConfigEditorProps({ host: 'localhost' } as Partial<CHConfig>)} />);
     expect(screen.queryByText(labels.serverAddress.error)).not.toBeInTheDocument();
+  });
+
+  describe('with the clickHouseConfigValidation feature toggle enabled', () => {
+    const featureToggles = config.featureToggles as Record<string, boolean | undefined>;
+
+    beforeEach(() => {
+      featureToggles.clickHouseConfigValidation = true;
+    });
+
+    afterEach(() => {
+      delete featureToggles.clickHouseConfigValidation;
+    });
+
+    it('shows the required-field error on an empty host', () => {
+      // Before Grafana 13.1 nothing calls validate() on the local
+      // ValidationAPI, so field errors never populate. The structural empty
+      // check must still surface the inline error.
+      render(<ConfigEditor {...mockConfigEditorProps({ host: '' } as Partial<CHConfig>)} />);
+      expect(screen.getByText(labels.serverAddress.error)).toBeInTheDocument();
+    });
+
+    it('shows the required-field error on an empty port', () => {
+      render(<ConfigEditor {...mockConfigEditorProps({ host: 'localhost', port: 0 } as Partial<CHConfig>)} />);
+      expect(screen.getByText(labels.serverPort.error)).toBeInTheDocument();
+    });
+
+    it('hides the required-field error once the host is filled', () => {
+      render(<ConfigEditor {...mockConfigEditorProps({ host: 'localhost' } as Partial<CHConfig>)} />);
+      expect(screen.queryByText(labels.serverAddress.error)).not.toBeInTheDocument();
+    });
+
+    it('prefers the validation API error message when one is set', () => {
+      const validation = createValidationAPI();
+      validation.setError('host', 'Custom validation error');
+      render(<ConfigEditor {...mockConfigEditorProps({ host: '' } as Partial<CHConfig>)} validation={validation} />);
+      expect(screen.getByText('Custom validation error')).toBeInTheDocument();
+      expect(screen.queryByText(labels.serverAddress.error)).not.toBeInTheDocument();
+    });
   });
 
   it('renders single-table logs configuration', () => {

--- a/src/views/CHConfigEditor.tsx
+++ b/src/views/CHConfigEditor.tsx
@@ -96,15 +96,16 @@ export const ConfigEditor: React.FC<ConfigEditorProps> = (props) => {
 
   const fieldErrors = validation?.getErrors() ?? {};
 
-  // When the clickHouseConfigValidation feature toggle is off (the default),
-  // `validation` is undefined and `fieldErrors` is always empty — which dropped
-  // the inline required-field indicator that shipped in v4.17.0. Fall back to a
-  // structural empty check so the required host/port fields still surface an
-  // inline error on the default install, before Save & Test round-trips.
-  const hostInvalid = validation ? Boolean(fieldErrors.host) : !jsonData.host;
-  const hostError = validation ? fieldErrors.host : jsonData.host ? undefined : labels.serverAddress.error;
-  const portInvalid = validation ? Boolean(fieldErrors.port) : !jsonData.port;
-  const portError = validation ? fieldErrors.port : jsonData.port ? undefined : labels.serverPort.error;
+  // The structural empty check must run regardless of the validation plumbing:
+  // with the clickHouseConfigValidation toggle off `validation` is undefined,
+  // and with it on the local ValidationAPI only gains errors once Grafana
+  // calls validate() (13.1+). Either way an empty required host/port field
+  // must surface an inline error immediately, as it did in v4.17.0, with any
+  // API-driven error message taking precedence when present.
+  const hostInvalid = Boolean(fieldErrors.host) || !jsonData.host;
+  const hostError = fieldErrors.host || (jsonData.host ? undefined : labels.serverAddress.error);
+  const portInvalid = Boolean(fieldErrors.port) || !jsonData.port;
+  const portError = fieldErrors.port || (jsonData.port ? undefined : labels.serverPort.error);
 
   const onPortChange = (port: string) => {
     onOptionsChange({

--- a/src/views/CHConfigEditor.tsx
+++ b/src/views/CHConfigEditor.tsx
@@ -641,6 +641,7 @@ export const ConfigEditor: React.FC<ConfigEditorProps> = (props) => {
               queryTimeout={jsonData.queryTimeout}
               rowCapacityHint={jsonData.rowCapacityHint}
               validateSql={jsonData.validateSql}
+              enableMapKeysDiscovery={jsonData.enableMapKeysDiscovery}
               onDialTimeoutChange={(e) => {
                 trackingV1.trackClickhouseConfigV1QuerySettings({ dialTimeout: Number(e.currentTarget.value) });
                 onUpdateDatasourceJsonDataOption(props, 'dialTimeout')(e);

--- a/src/views/ConfigEditor.test.tsx
+++ b/src/views/ConfigEditor.test.tsx
@@ -15,6 +15,9 @@ jest.mock('./config-v2/CHConfigEditor', () => ({
 }));
 
 const setLegacyToggle = (value: boolean | undefined) => {
+  // The source reads featureToggles with optional chaining, so the helper must
+  // not assume the runtime test environment provides the map either.
+  config.featureToggles = config.featureToggles ?? ({} as typeof config.featureToggles);
   (config.featureToggles as Record<string, boolean | undefined>)['newClickhouseConfigPageDesign'] = value;
 };
 

--- a/src/views/ConfigEditor.test.tsx
+++ b/src/views/ConfigEditor.test.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { config } from '@grafana/runtime';
+import { OpenFeature, TypedInMemoryProvider } from '@openfeature/web-sdk';
+import { ConfigEditor } from './ConfigEditor';
+import { mockConfigEditorProps } from '__mocks__/ConfigEditor';
+import '@testing-library/jest-dom';
+
+jest.mock('./CHConfigEditor', () => ({
+  ConfigEditor: () => <div data-testid="config-editor-v1" />,
+}));
+
+jest.mock('./config-v2/CHConfigEditor', () => ({
+  ConfigEditor: () => <div data-testid="config-editor-v2" />,
+}));
+
+const setLegacyToggle = (value: boolean | undefined) => {
+  (config.featureToggles as Record<string, boolean | undefined>)['newClickhouseConfigPageDesign'] = value;
+};
+
+const registerProvider = (flagValue: boolean) =>
+  OpenFeature.setProviderAndWait(
+    'internal-grafana-core',
+    new TypedInMemoryProvider({
+      newClickhouseConfigPageDesign: {
+        variants: { on: true, off: false },
+        defaultVariant: flagValue ? 'on' : 'off',
+        disabled: false,
+      },
+    })
+  );
+
+describe('ConfigEditor', () => {
+  afterEach(async () => {
+    setLegacyToggle(undefined);
+    await OpenFeature.clearProviders();
+  });
+
+  it('renders the V1 editor when no OpenFeature provider is registered and the legacy toggle is unset', () => {
+    render(<ConfigEditor {...mockConfigEditorProps()} />);
+    expect(screen.getByTestId('config-editor-v1')).toBeInTheDocument();
+    expect(screen.queryByTestId('config-editor-v2')).not.toBeInTheDocument();
+  });
+
+  it('renders the V2 editor when no OpenFeature provider is registered and the legacy toggle is enabled', () => {
+    // Grafana versions before 12.3 never register an OpenFeature provider,
+    // so the legacy featureToggles map is the only signal available.
+    setLegacyToggle(true);
+    render(<ConfigEditor {...mockConfigEditorProps()} />);
+    expect(screen.getByTestId('config-editor-v2')).toBeInTheDocument();
+    expect(screen.queryByTestId('config-editor-v1')).not.toBeInTheDocument();
+  });
+
+  it('prefers the OpenFeature provider value over the legacy toggle', async () => {
+    setLegacyToggle(true);
+    await registerProvider(false);
+    render(<ConfigEditor {...mockConfigEditorProps()} />);
+    expect(screen.getByTestId('config-editor-v1')).toBeInTheDocument();
+    expect(screen.queryByTestId('config-editor-v2')).not.toBeInTheDocument();
+  });
+
+  it('renders the V2 editor when the OpenFeature provider enables the flag', async () => {
+    await registerProvider(true);
+    render(<ConfigEditor {...mockConfigEditorProps()} />);
+    expect(screen.getByTestId('config-editor-v2')).toBeInTheDocument();
+    expect(screen.queryByTestId('config-editor-v1')).not.toBeInTheDocument();
+  });
+});

--- a/src/views/ConfigEditor.tsx
+++ b/src/views/ConfigEditor.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { DataSourcePluginOptionsEditorProps } from '@grafana/data';
+import { config } from '@grafana/runtime';
 import { OpenFeature } from '@openfeature/web-sdk';
 import { CHConfig, CHSecureConfig } from 'types/config';
 import { ConfigEditor as ConfigEditorV1 } from './CHConfigEditor';
@@ -12,9 +13,16 @@ const GRAFANA_CORE_OPEN_FEATURE_DOMAIN = 'internal-grafana-core';
 export type ConfigEditorProps = DataSourcePluginOptionsEditorProps<CHConfig, CHSecureConfig>;
 
 export const ConfigEditor: React.FC<ConfigEditorProps> = (props) => {
+  // Grafana only registers an OpenFeature provider from 12.3, so on older
+  // versions the flag read falls through to the default. Passing the legacy
+  // featureToggles value as the default keeps the ini toggle working pre-12.3
+  // while still letting the provider win where one is registered.
+  const legacyToggle = Boolean(
+    (config.featureToggles as Record<string, boolean | undefined> | undefined)?.['newClickhouseConfigPageDesign']
+  );
   const useV2 = OpenFeature.getClient(GRAFANA_CORE_OPEN_FEATURE_DOMAIN).getBooleanValue(
     'newClickhouseConfigPageDesign',
-    false
+    legacyToggle
   );
   return useV2 ? <ConfigEditorV2 {...props} /> : <ConfigEditorV1 {...props} />;
 };

--- a/src/views/config-v2/DatabaseCredentialsSection.test.tsx
+++ b/src/views/config-v2/DatabaseCredentialsSection.test.tsx
@@ -80,6 +80,25 @@ describe('DatabaseCredentialsSection', () => {
       mocks: { onOptionsChange: jest.fn() },
     });
 
+    it('shows username error on blur when empty and no validation API is present', () => {
+      render(<DatabaseCredentialsSection {...emptyProps} />);
+
+      fireEvent.blur(screen.getByLabelText(/username/i));
+
+      expect(screen.getByText('Username is required')).toBeInTheDocument();
+    });
+
+    it('clears username error once the field is filled and no validation API is present', () => {
+      const { rerender } = render(<DatabaseCredentialsSection {...emptyProps} />);
+
+      fireEvent.blur(screen.getByLabelText(/username/i));
+      expect(screen.getByText('Username is required')).toBeInTheDocument();
+
+      rerender(<DatabaseCredentialsSection {...filledProps} />);
+
+      expect(screen.queryByText('Username is required')).not.toBeInTheDocument();
+    });
+
     it('shows inline error for username when validator is called with empty value', async () => {
       const validation = createMockValidation();
       render(<DatabaseCredentialsSection {...emptyProps} validation={validation} />);

--- a/src/views/config-v2/DatabaseCredentialsSection.tsx
+++ b/src/views/config-v2/DatabaseCredentialsSection.tsx
@@ -29,16 +29,18 @@ export const DatabaseCredentialsSection = (props: Props) => {
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
 
   useEffect(() => {
-    if (!validation) {
-      return;
-    }
+    // Always clear the error eagerly when the user fills in the field,
+    // regardless of whether the ValidationAPI is available.
     if (jsonData.username) {
       setFieldErrors((prev) => {
         const next = { ...prev };
         delete next.username;
         return next;
       });
-      validation.clearError('username');
+      validation?.clearError('username');
+    }
+    if (!validation) {
+      return;
     }
     return validation.registerValidation(() => {
       const errors: Record<string, string> = {};


### PR DESCRIPTION
## Type of Change

- [x] 🐛 Bug Fix

---

## Bug Fix

### What is the bug?

Four config editor defects from the v4.18.0/v4.19.0 cycles, spanning the parallel v1 and v2 editors and the flag plumbing they share, one commit each:

1. **The v1 classic-mode Map keys discovery switch ignores its stored value.** #1885 wired `enableMapKeysDiscovery` into three of the four `QuerySettingsConfig` call sites, missing the v1 classic-mode block (the default editor), so the switch always rendered checked and the setting could never be re-enabled from that UI. The missing `value` prop is now passed.
2. **The v2 Username "required" error never clears.** `onBlur` set the error unconditionally, but the clearing logic lived behind the validation API, which is absent by default, so the error persisted for the whole session after one blur on the empty field. Errors now clear eagerly based on the field value, mirroring the `ServerAndEncryptionSection` pattern from #1831.
3. **The v2 config editor became unreachable on Grafana 11.6-12.2.** #1921 replaced the legacy `config.featureToggles` read with OpenFeature, but Grafana only registers that provider from 12.3, so the no-op provider always returned false and the ini toggle stopped working on older Grafana (worked in v4.18.0, `plugin.json` still supports >=11.6.0). The legacy toggle value is now passed as the OpenFeature default, keeping 12.3+ behaviour identical.
4. **Enabling `clickHouseConfigValidation` disabled v1 inline validation entirely.** #1995's structural fallback for the host/port required errors was keyed on `validation` truthiness, but the toggle-on path creates a local no-op ValidationAPI that nothing ever invokes on Grafana < 13.1, so no inline errors appeared at all. The structural check is now unconditional.

### How to reproduce

Each fix's regression tests document the exact scenario (`CHConfigEditor.test.tsx`, `DatabaseCredentialsSection.test.tsx`, `ConfigEditor.test.tsx`). Representative example for 3: Grafana 12.2 with `feature_toggles.newClickhouseConfigPageDesign = true`; before this PR the v1 editor renders silently, after it the v2 editor renders as it did in v4.18.0.

### Environment (if no related issue)

- **ClickHouse version**: any supported
- **Grafana version**: any supported (fix 3 specific to 11.6-12.2)
- **Plugin version**: 4.19.0 and current main

---

## Please check that:

- [x] Tests for this change have been added/updated.
- [ ] Documentation has been added/updated (where applicable).

## Special notes for your reviewer

Supersedes #2059, #2060, #2061 and #2070 (same fixes, previously one PR each, closed in favour of this bundle). Commits are kept separate, one per fix.

Found by an automated audit of regressions introduced while integrating PRs across the v4.18.0 and v4.19.0 release cycles (range v4.17.0..main). Related PRs: #1885, #2014, #1769, #1831, #1995, #1921.
