### PR TITLE
fix(dashboards): annotation presets, free-text search, and datasource ref fixes

### DIFF
--- a/src/dashboards/__tests__/dashboards.test.ts
+++ b/src/dashboards/__tests__/dashboards.test.ts
@@ -10,6 +10,36 @@ const otelDashboards = [
   'otel-service-dashboard.json',
 ] as const;
 
+const allDashboards = fs.readdirSync(DASHBOARDS_DIR).filter((filename) => filename.endsWith('.json'));
+
+// Built-in Grafana datasources referenced by annotations
+const builtInDatasourceUids = new Set(['grafana', '-- Grafana --']);
+
+const isRecord = (value: unknown): value is Record<string, unknown> => typeof value === 'object' && value !== null;
+
+const collectDatasourceUids = (node: unknown): string[] => {
+  if (Array.isArray(node)) {
+    return node.flatMap(collectDatasourceUids);
+  }
+  if (!isRecord(node)) {
+    return [];
+  }
+  const datasource = node.datasource;
+  const uids = isRecord(datasource) && typeof datasource.uid === 'string' ? [datasource.uid] : [];
+  return uids.concat(Object.values(node).flatMap(collectDatasourceUids));
+};
+
+describe('shipped dashboards', () => {
+  it.each(allDashboards)('%s references datasources only via variables or built-ins', (filename) => {
+    const content = fs.readFileSync(path.join(DASHBOARDS_DIR, filename), 'utf8');
+    const dashboard: unknown = JSON.parse(content);
+    const hardcodedUids = collectDatasourceUids(dashboard).filter(
+      (uid) => !uid.startsWith('${') && !builtInDatasourceUids.has(uid)
+    );
+    expect(hardcodedUids).toEqual([]);
+  });
+});
+
 describe('OTel dashboards', () => {
   describe.each(otelDashboards)('%s', (filename) => {
     const filepath = path.join(DASHBOARDS_DIR, filename);

--- a/src/dashboards/__tests__/dashboards.test.ts
+++ b/src/dashboards/__tests__/dashboards.test.ts
@@ -39,6 +39,27 @@ describe('OTel dashboards', () => {
     });
   });
 
+  describe('otel-logs-explorer.json annotations', () => {
+    // Traces-backed annotations must ship disabled so logs-only installations
+    // do not hit UNKNOWN_TABLE errors on every dashboard load.
+    it('ships traces-backed annotations disabled but not hidden', () => {
+      const filepath = path.join(DASHBOARDS_DIR, 'otel-logs-explorer.json');
+      const dashboard = JSON.parse(fs.readFileSync(filepath, 'utf8')) as {
+        annotations?: {
+          list?: Array<{ name?: string; enable?: boolean; hide?: boolean; target?: { rawSql?: string } }>;
+        };
+      };
+      const tracesAnnotations = (dashboard.annotations?.list ?? []).filter((annotation) =>
+        annotation.target?.rawSql?.includes('otel_traces')
+      );
+      expect(tracesAnnotations.length).toBeGreaterThan(0);
+      tracesAnnotations.forEach((annotation) => {
+        expect(annotation.enable).toBe(false);
+        expect(annotation.hide).toBe(false);
+      });
+    });
+  });
+
   describe('plugin.json registration', () => {
     const pluginJson = JSON.parse(fs.readFileSync(PLUGIN_JSON, 'utf8')) as {
       includes: Array<{ type: string; name: string; path: string }>;

--- a/src/dashboards/__tests__/dashboards.test.ts
+++ b/src/dashboards/__tests__/dashboards.test.ts
@@ -29,6 +29,14 @@ describe('OTel dashboards', () => {
       expect(dashboard.uid).toBeTruthy();
       expect(dashboard.title).toBeTruthy();
     });
+
+    it('does not pass the free-text search variable to hasToken', () => {
+      // hasToken() raises BAD_ARGUMENTS for needles containing whitespace or
+      // ASCII separators (e.g. 'GET /api'), so free-text search clauses must
+      // use substring matching such as positionCaseInsensitive() instead.
+      const content = fs.readFileSync(filepath, 'utf8');
+      expect(content).not.toContain('hasToken(');
+    });
   });
 
   describe('plugin.json registration', () => {

--- a/src/dashboards/cluster-analysis.json
+++ b/src/dashboards/cluster-analysis.json
@@ -1718,7 +1718,7 @@
       {
         "datasource": {
           "type": "grafana-clickhouse-datasource",
-          "uid": "y-Ka8y37k"
+          "uid": "${datasource}"
         },
         "filters": [],
         "hide": 0,

--- a/src/dashboards/otel-logs-explorer.json
+++ b/src/dashboards/otel-logs-explorer.json
@@ -260,10 +260,10 @@
       {
         "customSql": "SELECT\n  time,\n  ServiceName AS tags,\n  concat(ServiceName, ' deployed ', version, if(prev_version != '', concat(' (was ', prev_version, ')'), '')) AS text,\n  'Deployment' AS title\nFROM (\n  SELECT\n    toStartOfInterval(Timestamp, INTERVAL 30 second) AS time,\n    ServiceName,\n    topK(1)(ResourceAttributes['service.version'])[1] AS version,\n    lagInFrame(topK(1)(ResourceAttributes['service.version'])[1])\n      OVER (PARTITION BY ServiceName ORDER BY time) AS prev_version\n  FROM otel_traces\n  WHERE $__timeFilter(Timestamp)\n    AND $__conditionalAll(ServiceName IN ($service), $service)\n    AND ResourceAttributes['service.version'] != ''\n  GROUP BY ServiceName, time\n  ORDER BY ServiceName, time\n)\nWHERE prev_version != '' AND prev_version != version\nORDER BY time",
         "datasource": { "type": "grafana-clickhouse-datasource", "uid": "${datasource}" },
-        "enable": true,
+        "enable": false,
         "hide": false,
         "iconColor": "#73BF69",
-        "name": "Deployments (service.version)",
+        "name": "Deployments (service.version, requires traces)",
         "preset": "custom",
         "target": {
           "editorType": "sql",

--- a/src/dashboards/otel-logs-explorer.json
+++ b/src/dashboards/otel-logs-explorer.json
@@ -54,7 +54,7 @@
         {
           "datasource": { "type": "grafana-clickhouse-datasource", "uid": "${datasource}" },
           "editorType": "sql",
-          "rawSql": "SELECT\n  toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time,\n  SeverityText AS metric,\n  count() AS count\nFROM otel_logs\nWHERE $__timeFilter(Timestamp)\n  AND $__conditionalAll(ServiceName IN ($service), $service)\n  AND $__conditionalAll(SeverityText IN ($level_filter), $level_filter)\n  AND $__conditionalAll(hasToken(Body, '$search'), $search)\nGROUP BY time, metric\nORDER BY time",
+          "rawSql": "SELECT\n  toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time,\n  SeverityText AS metric,\n  count() AS count\nFROM otel_logs\nWHERE $__timeFilter(Timestamp)\n  AND $__conditionalAll(ServiceName IN ($service), $service)\n  AND $__conditionalAll(SeverityText IN ($level_filter), $level_filter)\n  AND $__conditionalAll(positionCaseInsensitive(Body, '$search') > 0, $search)\nGROUP BY time, metric\nORDER BY time",
           "refId": "A",
           "format": 0
         }
@@ -86,7 +86,7 @@
         {
           "datasource": { "type": "grafana-clickhouse-datasource", "uid": "${datasource}" },
           "editorType": "sql",
-          "rawSql": "SELECT\n  ServiceName AS Service,\n  count() AS Count\nFROM otel_logs\nWHERE $__timeFilter(Timestamp)\n  AND $__conditionalAll(ServiceName IN ($service), $service)\n  AND $__conditionalAll(SeverityText IN ($level_filter), $level_filter)\n  AND $__conditionalAll(hasToken(Body, '$search'), $search)\nGROUP BY Service\nORDER BY Count DESC\nLIMIT 15",
+          "rawSql": "SELECT\n  ServiceName AS Service,\n  count() AS Count\nFROM otel_logs\nWHERE $__timeFilter(Timestamp)\n  AND $__conditionalAll(ServiceName IN ($service), $service)\n  AND $__conditionalAll(SeverityText IN ($level_filter), $level_filter)\n  AND $__conditionalAll(positionCaseInsensitive(Body, '$search') > 0, $search)\nGROUP BY Service\nORDER BY Count DESC\nLIMIT 15",
           "refId": "A",
           "format": 0
         }
@@ -122,7 +122,7 @@
         {
           "datasource": { "type": "grafana-clickhouse-datasource", "uid": "${datasource}" },
           "editorType": "sql",
-          "rawSql": "SELECT\n  SeverityText AS Level,\n  count() AS Count\nFROM otel_logs\nWHERE $__timeFilter(Timestamp)\n  AND $__conditionalAll(ServiceName IN ($service), $service)\n  AND $__conditionalAll(hasToken(Body, '$search'), $search)\nGROUP BY Level\nORDER BY Count DESC",
+          "rawSql": "SELECT\n  SeverityText AS Level,\n  count() AS Count\nFROM otel_logs\nWHERE $__timeFilter(Timestamp)\n  AND $__conditionalAll(ServiceName IN ($service), $service)\n  AND $__conditionalAll(positionCaseInsensitive(Body, '$search') > 0, $search)\nGROUP BY Level\nORDER BY Count DESC",
           "refId": "A",
           "format": 0
         }
@@ -159,7 +159,7 @@
         {
           "datasource": { "type": "grafana-clickhouse-datasource", "uid": "${datasource}" },
           "editorType": "sql",
-          "rawSql": "SELECT\n  SeverityText AS Level,\n  ServiceName AS Service,\n  replaceRegexpAll(Body, '(userId|orderId|cartId|requestId|traceId|spanId|ctId)=[a-zA-Z0-9-]+', '\\1=…') AS Message,\n  count() AS Count\nFROM otel_logs\nWHERE $__timeFilter(Timestamp)\n  AND SeverityText IN ('ERROR', 'WARN', 'FATAL', 'Error', 'Warning', 'error', 'warning', 'fatal', 'CRITICAL')\n  AND $__conditionalAll(ServiceName IN ($service), $service)\n  AND $__conditionalAll(hasToken(Body, '$search'), $search)\nGROUP BY Level, Service, Message\nORDER BY Count DESC\nLIMIT 20",
+          "rawSql": "SELECT\n  SeverityText AS Level,\n  ServiceName AS Service,\n  replaceRegexpAll(Body, '(userId|orderId|cartId|requestId|traceId|spanId|ctId)=[a-zA-Z0-9-]+', '\\1=…') AS Message,\n  count() AS Count\nFROM otel_logs\nWHERE $__timeFilter(Timestamp)\n  AND SeverityText IN ('ERROR', 'WARN', 'FATAL', 'Error', 'Warning', 'error', 'warning', 'fatal', 'CRITICAL')\n  AND $__conditionalAll(ServiceName IN ($service), $service)\n  AND $__conditionalAll(positionCaseInsensitive(Body, '$search') > 0, $search)\nGROUP BY Level, Service, Message\nORDER BY Count DESC\nLIMIT 20",
           "refId": "A",
           "format": 0
         }
@@ -208,7 +208,7 @@
         {
           "datasource": { "type": "grafana-clickhouse-datasource", "uid": "${datasource}" },
           "editorType": "sql",
-          "rawSql": "SELECT\n  toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time,\n  SeverityText AS metric,\n  count() AS count\nFROM otel_logs\nWHERE $__timeFilter(Timestamp)\n  AND ServiceName = '${service}'\n  AND $__conditionalAll(SeverityText IN ($level_filter), $level_filter)\n  AND $__conditionalAll(hasToken(Body, '$search'), $search)\nGROUP BY time, metric\nORDER BY time",
+          "rawSql": "SELECT\n  toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time,\n  SeverityText AS metric,\n  count() AS count\nFROM otel_logs\nWHERE $__timeFilter(Timestamp)\n  AND ServiceName = '${service}'\n  AND $__conditionalAll(SeverityText IN ($level_filter), $level_filter)\n  AND $__conditionalAll(positionCaseInsensitive(Body, '$search') > 0, $search)\nGROUP BY time, metric\nORDER BY time",
           "refId": "A",
           "format": 0
         }
@@ -238,7 +238,7 @@
         {
           "datasource": { "type": "grafana-clickhouse-datasource", "uid": "${datasource}" },
           "editorType": "sql",
-          "rawSql": "SELECT\n  Timestamp AS timestamp,\n  Body AS body,\n  SeverityText AS level,\n  ServiceName,\n  TraceId,\n  SpanId,\n  ResourceAttributes['service.namespace'] AS namespace,\n  ResourceAttributes['k8s.pod.name'] AS k8s_pod\nFROM otel_logs\nWHERE $__timeFilter(Timestamp)\n  AND ServiceName = '${service}'\n  AND $__conditionalAll(SeverityText IN ($level_filter), $level_filter)\n  AND $__conditionalAll(hasToken(Body, '$search'), $search)\nORDER BY Timestamp DESC\nLIMIT 200",
+          "rawSql": "SELECT\n  Timestamp AS timestamp,\n  Body AS body,\n  SeverityText AS level,\n  ServiceName,\n  TraceId,\n  SpanId,\n  ResourceAttributes['service.namespace'] AS namespace,\n  ResourceAttributes['k8s.pod.name'] AS k8s_pod\nFROM otel_logs\nWHERE $__timeFilter(Timestamp)\n  AND ServiceName = '${service}'\n  AND $__conditionalAll(SeverityText IN ($level_filter), $level_filter)\n  AND $__conditionalAll(positionCaseInsensitive(Body, '$search') > 0, $search)\nORDER BY Timestamp DESC\nLIMIT 200",
           "refId": "A",
           "format": 2
         }

--- a/src/dashboards/otel-logs-explorer.json
+++ b/src/dashboards/otel-logs-explorer.json
@@ -258,12 +258,13 @@
         "type": "dashboard"
       },
       {
+        "customSql": "SELECT\n  time,\n  ServiceName AS tags,\n  concat(ServiceName, ' deployed ', version, if(prev_version != '', concat(' (was ', prev_version, ')'), '')) AS text,\n  'Deployment' AS title\nFROM (\n  SELECT\n    toStartOfInterval(Timestamp, INTERVAL 30 second) AS time,\n    ServiceName,\n    topK(1)(ResourceAttributes['service.version'])[1] AS version,\n    lagInFrame(topK(1)(ResourceAttributes['service.version'])[1])\n      OVER (PARTITION BY ServiceName ORDER BY time) AS prev_version\n  FROM otel_traces\n  WHERE $__timeFilter(Timestamp)\n    AND $__conditionalAll(ServiceName IN ($service), $service)\n    AND ResourceAttributes['service.version'] != ''\n  GROUP BY ServiceName, time\n  ORDER BY ServiceName, time\n)\nWHERE prev_version != '' AND prev_version != version\nORDER BY time",
         "datasource": { "type": "grafana-clickhouse-datasource", "uid": "${datasource}" },
         "enable": true,
         "hide": false,
         "iconColor": "#73BF69",
         "name": "Deployments (service.version)",
-        "preset": "deployment_detection",
+        "preset": "custom",
         "target": {
           "editorType": "sql",
           "rawSql": "SELECT\n  time,\n  ServiceName AS tags,\n  concat(ServiceName, ' deployed ', version, if(prev_version != '', concat(' (was ', prev_version, ')'), '')) AS text,\n  'Deployment' AS title\nFROM (\n  SELECT\n    toStartOfInterval(Timestamp, INTERVAL 30 second) AS time,\n    ServiceName,\n    topK(1)(ResourceAttributes['service.version'])[1] AS version,\n    lagInFrame(topK(1)(ResourceAttributes['service.version'])[1])\n      OVER (PARTITION BY ServiceName ORDER BY time) AS prev_version\n  FROM otel_traces\n  WHERE $__timeFilter(Timestamp)\n    AND $__conditionalAll(ServiceName IN ($service), $service)\n    AND ResourceAttributes['service.version'] != ''\n  GROUP BY ServiceName, time\n  ORDER BY ServiceName, time\n)\nWHERE prev_version != '' AND prev_version != version\nORDER BY time",

--- a/src/dashboards/otel-service-dashboard.json
+++ b/src/dashboards/otel-service-dashboard.json
@@ -49,6 +49,7 @@
         "type": "dashboard"
       },
       {
+        "customSql": "SELECT\n  time,\n  ServiceName AS tags,\n  concat(ServiceName, ' deployed ', version, if(prev_version != '', concat(' (was ', prev_version, ')'), '')) AS text,\n  'Deployment' AS title\nFROM (\n  SELECT\n    toStartOfInterval(Timestamp, INTERVAL 30 second) AS time,\n    ServiceName,\n    topK(1)(ResourceAttributes['service.version'])[1] AS version,\n    lagInFrame(topK(1)(ResourceAttributes['service.version'])[1])\n      OVER (PARTITION BY ServiceName ORDER BY time) AS prev_version\n  FROM otel_traces\n  WHERE $__timeFilter(Timestamp)\n    AND ServiceName = '${service}'\n    AND ResourceAttributes['service.version'] != ''\n  GROUP BY ServiceName, time\n  ORDER BY ServiceName, time\n)\nWHERE prev_version != '' AND prev_version != version\nORDER BY time",
         "datasource": {
           "type": "grafana-clickhouse-datasource",
           "uid": "${datasource}"
@@ -57,7 +58,7 @@
         "hide": false,
         "iconColor": "#73BF69",
         "name": "Deployments (service.version)",
-        "preset": "deployment_detection",
+        "preset": "custom",
         "rawQuery": "SELECT\n  time,\n  ServiceName AS tags,\n  concat(ServiceName, ' deployed ', version, if(prev_version != '', concat(' (was ', prev_version, ')'), '')) AS text,\n  'Deployment' AS title\nFROM (\n  SELECT\n    toStartOfInterval(Timestamp, INTERVAL 30 second) AS time,\n    ServiceName,\n    topK(1)(ResourceAttributes['service.version'])[1] AS version,\n    lagInFrame(topK(1)(ResourceAttributes['service.version'])[1])\n      OVER (PARTITION BY ServiceName ORDER BY time) AS prev_version\n  FROM otel_traces\n  WHERE $__timeFilter(Timestamp)\n    AND ServiceName = '${service}'\n    AND ResourceAttributes['service.version'] != ''\n  GROUP BY ServiceName, time\n  ORDER BY ServiceName, time\n)\nWHERE prev_version != '' AND prev_version != version\nORDER BY time",
         "target": {
           "editorType": "sql",

--- a/src/dashboards/otel-service-dashboard.json
+++ b/src/dashboards/otel-service-dashboard.json
@@ -205,7 +205,7 @@
             "uid": "${datasource}"
           },
           "editorType": "sql",
-          "rawSql": "SELECT toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time, count() / $__interval_s AS rps FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND SpanKind = 'Server' AND $__conditionalAll(SpanName IN ($operation), $operation) AND $__conditionalAll(hasToken(SpanName, '$search'), $search) GROUP BY time ORDER BY time",
+          "rawSql": "SELECT toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time, count() / $__interval_s AS rps FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND SpanKind = 'Server' AND $__conditionalAll(SpanName IN ($operation), $operation) AND $__conditionalAll(positionCaseInsensitive(SpanName, '$search') > 0, $search) GROUP BY time ORDER BY time",
           "refId": "A",
           "format": 0
         }
@@ -267,7 +267,7 @@
             "uid": "${datasource}"
           },
           "editorType": "sql",
-          "rawSql": "SELECT toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time, countIf(StatusCode IN ('Error', 'STATUS_CODE_ERROR')) / count() AS error_rate FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND SpanKind = 'Server' AND $__conditionalAll(SpanName IN ($operation), $operation) AND $__conditionalAll(hasToken(SpanName, '$search'), $search) GROUP BY time ORDER BY time",
+          "rawSql": "SELECT toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time, countIf(StatusCode IN ('Error', 'STATUS_CODE_ERROR')) / count() AS error_rate FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND SpanKind = 'Server' AND $__conditionalAll(SpanName IN ($operation), $operation) AND $__conditionalAll(positionCaseInsensitive(SpanName, '$search') > 0, $search) GROUP BY time ORDER BY time",
           "refId": "A",
           "format": 0
         }
@@ -337,7 +337,7 @@
             "uid": "${datasource}"
           },
           "editorType": "sql",
-          "rawSql": "SELECT toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time, quantile(0.5)(Duration) AS p50, quantile(0.9)(Duration) AS p90, quantile(0.99)(Duration) AS p99 FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND SpanKind = 'Server' AND $__conditionalAll(SpanName IN ($operation), $operation) AND $__conditionalAll(hasToken(SpanName, '$search'), $search) GROUP BY time ORDER BY time",
+          "rawSql": "SELECT toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time, quantile(0.5)(Duration) AS p50, quantile(0.9)(Duration) AS p90, quantile(0.99)(Duration) AS p99 FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND SpanKind = 'Server' AND $__conditionalAll(SpanName IN ($operation), $operation) AND $__conditionalAll(positionCaseInsensitive(SpanName, '$search') > 0, $search) GROUP BY time ORDER BY time",
           "refId": "A",
           "format": 0
         }
@@ -421,7 +421,7 @@
             "uid": "${datasource}"
           },
           "editorType": "sql",
-          "rawSql": "SELECT SpanName AS Operation, count() AS Count, quantile(0.5)(Duration) AS P50, quantile(0.99)(Duration) AS P99 FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND SpanKind = 'Server' AND $__conditionalAll(SpanName IN ($operation), $operation) AND $__conditionalAll(hasToken(SpanName, '$search'), $search) GROUP BY SpanName ORDER BY P99 DESC LIMIT 20",
+          "rawSql": "SELECT SpanName AS Operation, count() AS Count, quantile(0.5)(Duration) AS P50, quantile(0.99)(Duration) AS P99 FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND SpanKind = 'Server' AND $__conditionalAll(SpanName IN ($operation), $operation) AND $__conditionalAll(positionCaseInsensitive(SpanName, '$search') > 0, $search) GROUP BY SpanName ORDER BY P99 DESC LIMIT 20",
           "refId": "A",
           "format": 1
         }
@@ -479,7 +479,7 @@
             "uid": "${datasource}"
           },
           "editorType": "sql",
-          "rawSql": "SELECT toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time, count() / $__interval_s AS rps FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND SpanKind = 'Client' AND $__conditionalAll(SpanName IN ($operation), $operation) AND $__conditionalAll(hasToken(SpanName, '$search'), $search) GROUP BY time ORDER BY time",
+          "rawSql": "SELECT toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time, count() / $__interval_s AS rps FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND SpanKind = 'Client' AND $__conditionalAll(SpanName IN ($operation), $operation) AND $__conditionalAll(positionCaseInsensitive(SpanName, '$search') > 0, $search) GROUP BY time ORDER BY time",
           "refId": "A",
           "format": 0
         }
@@ -541,7 +541,7 @@
             "uid": "${datasource}"
           },
           "editorType": "sql",
-          "rawSql": "SELECT toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time, countIf(StatusCode IN ('Error', 'STATUS_CODE_ERROR')) / count() AS error_rate FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND SpanKind = 'Client' AND $__conditionalAll(SpanName IN ($operation), $operation) AND $__conditionalAll(hasToken(SpanName, '$search'), $search) GROUP BY time ORDER BY time",
+          "rawSql": "SELECT toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time, countIf(StatusCode IN ('Error', 'STATUS_CODE_ERROR')) / count() AS error_rate FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND SpanKind = 'Client' AND $__conditionalAll(SpanName IN ($operation), $operation) AND $__conditionalAll(positionCaseInsensitive(SpanName, '$search') > 0, $search) GROUP BY time ORDER BY time",
           "refId": "A",
           "format": 0
         }
@@ -611,7 +611,7 @@
             "uid": "${datasource}"
           },
           "editorType": "sql",
-          "rawSql": "SELECT toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time, quantile(0.5)(Duration) AS p50, quantile(0.9)(Duration) AS p90, quantile(0.99)(Duration) AS p99 FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND SpanKind = 'Client' AND $__conditionalAll(SpanName IN ($operation), $operation) AND $__conditionalAll(hasToken(SpanName, '$search'), $search) GROUP BY time ORDER BY time",
+          "rawSql": "SELECT toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time, quantile(0.5)(Duration) AS p50, quantile(0.9)(Duration) AS p90, quantile(0.99)(Duration) AS p99 FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND SpanKind = 'Client' AND $__conditionalAll(SpanName IN ($operation), $operation) AND $__conditionalAll(positionCaseInsensitive(SpanName, '$search') > 0, $search) GROUP BY time ORDER BY time",
           "refId": "A",
           "format": 0
         }
@@ -695,7 +695,7 @@
             "uid": "${datasource}"
           },
           "editorType": "sql",
-          "rawSql": "SELECT SpanName AS Operation, count() AS Count, quantile(0.5)(Duration) AS P50, quantile(0.99)(Duration) AS P99 FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND SpanKind = 'Client' AND $__conditionalAll(SpanName IN ($operation), $operation) AND $__conditionalAll(hasToken(SpanName, '$search'), $search) GROUP BY SpanName ORDER BY P99 DESC LIMIT 20",
+          "rawSql": "SELECT SpanName AS Operation, count() AS Count, quantile(0.5)(Duration) AS P50, quantile(0.99)(Duration) AS P99 FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND SpanKind = 'Client' AND $__conditionalAll(SpanName IN ($operation), $operation) AND $__conditionalAll(positionCaseInsensitive(SpanName, '$search') > 0, $search) GROUP BY SpanName ORDER BY P99 DESC LIMIT 20",
           "refId": "A",
           "format": 1
         }
@@ -780,7 +780,7 @@
             "uid": "${datasource}"
           },
           "editorType": "sql",
-          "rawSql": "SELECT SpanName AS Operation, SpanKind AS Kind, StatusMessage AS Error, count() AS Count, max(Timestamp) AS \"Last Seen\" FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND StatusCode IN ('Error', 'STATUS_CODE_ERROR') AND $__conditionalAll(hasToken(SpanName, '$search'), $search) GROUP BY SpanName, SpanKind, StatusMessage ORDER BY Count DESC LIMIT 20",
+          "rawSql": "SELECT SpanName AS Operation, SpanKind AS Kind, StatusMessage AS Error, count() AS Count, max(Timestamp) AS \"Last Seen\" FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND StatusCode IN ('Error', 'STATUS_CODE_ERROR') AND $__conditionalAll(positionCaseInsensitive(SpanName, '$search') > 0, $search) GROUP BY SpanName, SpanKind, StatusMessage ORDER BY Count DESC LIMIT 20",
           "refId": "A",
           "format": 1
         }
@@ -822,7 +822,7 @@
             "uid": "${datasource}"
           },
           "editorType": "sql",
-          "rawSql": "SELECT Timestamp AS timestamp, Body AS body, SeverityText AS level, ServiceName, TraceId, SpanId FROM otel_logs WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND $__conditionalAll(hasToken(Body, '$search'), $search) ORDER BY Timestamp DESC LIMIT 200",
+          "rawSql": "SELECT Timestamp AS timestamp, Body AS body, SeverityText AS level, ServiceName, TraceId, SpanId FROM otel_logs WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND $__conditionalAll(positionCaseInsensitive(Body, '$search') > 0, $search) ORDER BY Timestamp DESC LIMIT 200",
           "refId": "A",
           "format": 2
         }
@@ -879,7 +879,7 @@
                 "uid": "${datasource}"
               },
               "editorType": "sql",
-              "rawSql": "SELECT toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time, count() / $__interval_s AS rps FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND SpanKind = 'Internal' AND $__conditionalAll(SpanName IN ($operation), $operation) AND $__conditionalAll(hasToken(SpanName, '$search'), $search) GROUP BY time ORDER BY time",
+              "rawSql": "SELECT toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time, count() / $__interval_s AS rps FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND SpanKind = 'Internal' AND $__conditionalAll(SpanName IN ($operation), $operation) AND $__conditionalAll(positionCaseInsensitive(SpanName, '$search') > 0, $search) GROUP BY time ORDER BY time",
               "refId": "A",
               "format": 0
             }
@@ -941,7 +941,7 @@
                 "uid": "${datasource}"
               },
               "editorType": "sql",
-              "rawSql": "SELECT toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time, countIf(StatusCode IN ('Error', 'STATUS_CODE_ERROR')) / count() AS error_rate FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND SpanKind = 'Internal' AND $__conditionalAll(SpanName IN ($operation), $operation) AND $__conditionalAll(hasToken(SpanName, '$search'), $search) GROUP BY time ORDER BY time",
+              "rawSql": "SELECT toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time, countIf(StatusCode IN ('Error', 'STATUS_CODE_ERROR')) / count() AS error_rate FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND SpanKind = 'Internal' AND $__conditionalAll(SpanName IN ($operation), $operation) AND $__conditionalAll(positionCaseInsensitive(SpanName, '$search') > 0, $search) GROUP BY time ORDER BY time",
               "refId": "A",
               "format": 0
             }
@@ -1011,7 +1011,7 @@
                 "uid": "${datasource}"
               },
               "editorType": "sql",
-              "rawSql": "SELECT toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time, quantile(0.5)(Duration) AS p50, quantile(0.9)(Duration) AS p90, quantile(0.99)(Duration) AS p99 FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND SpanKind = 'Internal' AND $__conditionalAll(SpanName IN ($operation), $operation) AND $__conditionalAll(hasToken(SpanName, '$search'), $search) GROUP BY time ORDER BY time",
+              "rawSql": "SELECT toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time, quantile(0.5)(Duration) AS p50, quantile(0.9)(Duration) AS p90, quantile(0.99)(Duration) AS p99 FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND SpanKind = 'Internal' AND $__conditionalAll(SpanName IN ($operation), $operation) AND $__conditionalAll(positionCaseInsensitive(SpanName, '$search') > 0, $search) GROUP BY time ORDER BY time",
               "refId": "A",
               "format": 0
             }
@@ -1095,7 +1095,7 @@
                 "uid": "${datasource}"
               },
               "editorType": "sql",
-              "rawSql": "SELECT SpanName AS Operation, count() AS Count, quantile(0.5)(Duration) AS P50, quantile(0.99)(Duration) AS P99 FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND SpanKind = 'Internal' AND $__conditionalAll(SpanName IN ($operation), $operation) AND $__conditionalAll(hasToken(SpanName, '$search'), $search) GROUP BY SpanName ORDER BY P99 DESC LIMIT 20",
+              "rawSql": "SELECT SpanName AS Operation, count() AS Count, quantile(0.5)(Duration) AS P50, quantile(0.99)(Duration) AS P99 FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND SpanKind = 'Internal' AND $__conditionalAll(SpanName IN ($operation), $operation) AND $__conditionalAll(positionCaseInsensitive(SpanName, '$search') > 0, $search) GROUP BY SpanName ORDER BY P99 DESC LIMIT 20",
               "refId": "A",
               "format": 1
             }
@@ -1154,7 +1154,7 @@
                 "uid": "${datasource}"
               },
               "editorType": "sql",
-              "rawSql": "SELECT toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time, count() / $__interval_s AS rps FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND SpanKind IN ('Producer', 'Consumer') AND $__conditionalAll(SpanName IN ($operation), $operation) AND $__conditionalAll(hasToken(SpanName, '$search'), $search) GROUP BY time ORDER BY time",
+              "rawSql": "SELECT toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time, count() / $__interval_s AS rps FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND SpanKind IN ('Producer', 'Consumer') AND $__conditionalAll(SpanName IN ($operation), $operation) AND $__conditionalAll(positionCaseInsensitive(SpanName, '$search') > 0, $search) GROUP BY time ORDER BY time",
               "refId": "A",
               "format": 0
             }
@@ -1216,7 +1216,7 @@
                 "uid": "${datasource}"
               },
               "editorType": "sql",
-              "rawSql": "SELECT toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time, countIf(StatusCode IN ('Error', 'STATUS_CODE_ERROR')) / count() AS error_rate FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND SpanKind IN ('Producer', 'Consumer') AND $__conditionalAll(SpanName IN ($operation), $operation) AND $__conditionalAll(hasToken(SpanName, '$search'), $search) GROUP BY time ORDER BY time",
+              "rawSql": "SELECT toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time, countIf(StatusCode IN ('Error', 'STATUS_CODE_ERROR')) / count() AS error_rate FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND SpanKind IN ('Producer', 'Consumer') AND $__conditionalAll(SpanName IN ($operation), $operation) AND $__conditionalAll(positionCaseInsensitive(SpanName, '$search') > 0, $search) GROUP BY time ORDER BY time",
               "refId": "A",
               "format": 0
             }
@@ -1286,7 +1286,7 @@
                 "uid": "${datasource}"
               },
               "editorType": "sql",
-              "rawSql": "SELECT toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time, quantile(0.5)(Duration) AS p50, quantile(0.9)(Duration) AS p90, quantile(0.99)(Duration) AS p99 FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND SpanKind IN ('Producer', 'Consumer') AND $__conditionalAll(SpanName IN ($operation), $operation) AND $__conditionalAll(hasToken(SpanName, '$search'), $search) GROUP BY time ORDER BY time",
+              "rawSql": "SELECT toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time, quantile(0.5)(Duration) AS p50, quantile(0.9)(Duration) AS p90, quantile(0.99)(Duration) AS p99 FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND SpanKind IN ('Producer', 'Consumer') AND $__conditionalAll(SpanName IN ($operation), $operation) AND $__conditionalAll(positionCaseInsensitive(SpanName, '$search') > 0, $search) GROUP BY time ORDER BY time",
               "refId": "A",
               "format": 0
             }
@@ -1382,7 +1382,7 @@
                 "uid": "${datasource}"
               },
               "editorType": "sql",
-              "rawSql": "SELECT SpanName AS Operation, SpanKind AS Kind, count() AS Count, quantile(0.5)(Duration) AS P50, quantile(0.99)(Duration) AS P99 FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND SpanKind IN ('Producer', 'Consumer') AND $__conditionalAll(SpanName IN ($operation), $operation) AND $__conditionalAll(hasToken(SpanName, '$search'), $search) GROUP BY SpanName, SpanKind ORDER BY P99 DESC LIMIT 20",
+              "rawSql": "SELECT SpanName AS Operation, SpanKind AS Kind, count() AS Count, quantile(0.5)(Duration) AS P50, quantile(0.99)(Duration) AS P99 FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND SpanKind IN ('Producer', 'Consumer') AND $__conditionalAll(SpanName IN ($operation), $operation) AND $__conditionalAll(positionCaseInsensitive(SpanName, '$search') > 0, $search) GROUP BY SpanName, SpanKind ORDER BY P99 DESC LIMIT 20",
               "refId": "A",
               "format": 1
             }

--- a/src/dashboards/otel-traces-explorer.json
+++ b/src/dashboards/otel-traces-explorer.json
@@ -334,7 +334,7 @@
           },
           "editorType": "sql",
           "format": 1,
-          "rawSql": "SELECT\n  TraceId,\n  any(ServiceName) AS Service,\n  any(SpanName) AS RootOperation,\n  min(Timestamp) AS Time,\n  max(Duration) AS Duration,\n  count() AS Spans,\n  anyIf(StatusCode, StatusCode IN ('Error', 'STATUS_CODE_ERROR')) AS Status\nFROM otel_traces\nWHERE $__timeFilter(Timestamp)\n  AND $__conditionalAll(ServiceName IN ($service), $service)\n  AND $__conditionalAll(SpanName IN ($operation), $operation)\n  AND $__conditionalAll(StatusCode IN ($status), $status)\n  AND $__conditionalAll(hasToken(SpanName, '$search'), $search)\nGROUP BY TraceId\nHAVING $__conditionalAll(max(Duration) >= toUInt64($min_duration) * 1000000, $min_duration)\nORDER BY Time DESC\nLIMIT 200",
+          "rawSql": "SELECT\n  TraceId,\n  any(ServiceName) AS Service,\n  any(SpanName) AS RootOperation,\n  min(Timestamp) AS Time,\n  max(Duration) AS Duration,\n  count() AS Spans,\n  anyIf(StatusCode, StatusCode IN ('Error', 'STATUS_CODE_ERROR')) AS Status\nFROM otel_traces\nWHERE $__timeFilter(Timestamp)\n  AND $__conditionalAll(ServiceName IN ($service), $service)\n  AND $__conditionalAll(SpanName IN ($operation), $operation)\n  AND $__conditionalAll(StatusCode IN ($status), $status)\n  AND $__conditionalAll(positionCaseInsensitive(SpanName, '$search') > 0, $search)\nGROUP BY TraceId\nHAVING $__conditionalAll(max(Duration) >= toUInt64($min_duration) * 1000000, $min_duration)\nORDER BY Time DESC\nLIMIT 200",
           "refId": "A"
         }
       ]
@@ -405,7 +405,7 @@
           },
           "editorType": "sql",
           "format": 0,
-          "rawSql": "SELECT\n  toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time,\n  Duration / 1000000 AS duration_ms\nFROM otel_traces\nWHERE $__timeFilter(Timestamp)\n  AND ServiceName IN (${service:singlequote}) AND $__conditionalAll(hasToken(SpanName, '$search'), $search)\n  AND cityHash64(SpanId) % 500 = 0\nORDER BY time",
+          "rawSql": "SELECT\n  toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time,\n  Duration / 1000000 AS duration_ms\nFROM otel_traces\nWHERE $__timeFilter(Timestamp)\n  AND ServiceName IN (${service:singlequote}) AND $__conditionalAll(positionCaseInsensitive(SpanName, '$search') > 0, $search)\n  AND cityHash64(SpanId) % 500 = 0\nORDER BY time",
           "refId": "A"
         }
       ]
@@ -431,7 +431,7 @@
       "targets": [{
         "datasource": { "type": "grafana-clickhouse-datasource", "uid": "${datasource}" },
         "editorType": "sql",
-        "rawSql": "SELECT toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time, count() AS Spans FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName IN (${service:singlequote}) AND $__conditionalAll(hasToken(SpanName, '$search'), $search) GROUP BY time ORDER BY time",
+        "rawSql": "SELECT toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time, count() AS Spans FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName IN (${service:singlequote}) AND $__conditionalAll(positionCaseInsensitive(SpanName, '$search') > 0, $search) GROUP BY time ORDER BY time",
         "refId": "A",
         "format": 1
       }]
@@ -457,7 +457,7 @@
       "targets": [{
         "datasource": { "type": "grafana-clickhouse-datasource", "uid": "${datasource}" },
         "editorType": "sql",
-        "rawSql": "SELECT toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time, countIf(StatusCode IN ('Error', 'STATUS_CODE_ERROR')) AS Errors FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName IN (${service:singlequote}) AND $__conditionalAll(hasToken(SpanName, '$search'), $search) GROUP BY time ORDER BY time",
+        "rawSql": "SELECT toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time, countIf(StatusCode IN ('Error', 'STATUS_CODE_ERROR')) AS Errors FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName IN (${service:singlequote}) AND $__conditionalAll(positionCaseInsensitive(SpanName, '$search') > 0, $search) GROUP BY time ORDER BY time",
         "refId": "A",
         "format": 1
       }]
@@ -488,7 +488,7 @@
           },
           "editorType": "sql",
           "format": 0,
-          "rawSql": "SELECT\n  toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time,\n  quantile(0.99)(Duration) / 1000000 AS p99_ms\nFROM otel_traces\nWHERE $__timeFilter(Timestamp)\n  AND ServiceName IN (${service:singlequote}) AND $__conditionalAll(hasToken(SpanName, '$search'), $search)\nGROUP BY time\nORDER BY time",
+          "rawSql": "SELECT\n  toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time,\n  quantile(0.99)(Duration) / 1000000 AS p99_ms\nFROM otel_traces\nWHERE $__timeFilter(Timestamp)\n  AND ServiceName IN (${service:singlequote}) AND $__conditionalAll(positionCaseInsensitive(SpanName, '$search') > 0, $search)\nGROUP BY time\nORDER BY time",
           "refId": "A"
         }
       ]
@@ -514,7 +514,7 @@
       "targets": [{
         "datasource": { "type": "grafana-clickhouse-datasource", "uid": "${datasource}" },
         "editorType": "sql",
-        "rawSql": "SELECT toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time, avg(Duration) / 1000000 AS \"Avg Duration\" FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName IN (${service:singlequote}) AND $__conditionalAll(hasToken(SpanName, '$search'), $search) GROUP BY time ORDER BY time",
+        "rawSql": "SELECT toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time, avg(Duration) / 1000000 AS \"Avg Duration\" FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName IN (${service:singlequote}) AND $__conditionalAll(positionCaseInsensitive(SpanName, '$search') > 0, $search) GROUP BY time ORDER BY time",
         "refId": "A",
         "format": 1
       }]
@@ -642,7 +642,7 @@
           },
           "editorType": "sql",
           "format": 1,
-          "rawSql": "SELECT\n  SpanName AS Operation,\n  count() AS Count,\n  countIf(StatusCode IN ('Error', 'STATUS_CODE_ERROR')) AS Errors,\n  round(countIf(StatusCode IN ('Error', 'STATUS_CODE_ERROR')) / count() * 100, 2) AS \"Error %\",\n  quantile(0.5)(Duration) AS P50,\n  quantile(0.99)(Duration) AS P99,\n  anyIf(if(StatusMessage != '', StatusMessage, SpanAttributes['http.status_code']), StatusCode IN ('Error', 'STATUS_CODE_ERROR')) AS \"Top Error\"\nFROM otel_traces\nWHERE $__timeFilter(Timestamp)\n  AND ServiceName IN (${service:singlequote}) AND $__conditionalAll(hasToken(SpanName, '$search'), $search)\nGROUP BY Operation\nORDER BY Count DESC\nLIMIT 15",
+          "rawSql": "SELECT\n  SpanName AS Operation,\n  count() AS Count,\n  countIf(StatusCode IN ('Error', 'STATUS_CODE_ERROR')) AS Errors,\n  round(countIf(StatusCode IN ('Error', 'STATUS_CODE_ERROR')) / count() * 100, 2) AS \"Error %\",\n  quantile(0.5)(Duration) AS P50,\n  quantile(0.99)(Duration) AS P99,\n  anyIf(if(StatusMessage != '', StatusMessage, SpanAttributes['http.status_code']), StatusCode IN ('Error', 'STATUS_CODE_ERROR')) AS \"Top Error\"\nFROM otel_traces\nWHERE $__timeFilter(Timestamp)\n  AND ServiceName IN (${service:singlequote}) AND $__conditionalAll(positionCaseInsensitive(SpanName, '$search') > 0, $search)\nGROUP BY Operation\nORDER BY Count DESC\nLIMIT 15",
           "refId": "A"
         }
       ]

--- a/src/dashboards/otel-traces-explorer.json
+++ b/src/dashboards/otel-traces-explorer.json
@@ -42,6 +42,7 @@
         "type": "dashboard"
       },
       {
+        "customSql": "SELECT\n  time,\n  ServiceName AS tags,\n  concat(ServiceName, ' deployed ', version, if(prev_version != '', concat(' (was ', prev_version, ')'), '')) AS text,\n  'Deployment' AS title\nFROM (\n  SELECT\n    toStartOfInterval(Timestamp, INTERVAL 30 second) AS time,\n    ServiceName,\n    topK(1)(ResourceAttributes['service.version'])[1] AS version,\n    lagInFrame(topK(1)(ResourceAttributes['service.version'])[1])\n      OVER (PARTITION BY ServiceName ORDER BY time) AS prev_version\n  FROM otel_traces\n  WHERE $__timeFilter(Timestamp)\n    AND $__conditionalAll(ServiceName IN ($service), $service)\n    AND ResourceAttributes['service.version'] != ''\n  GROUP BY ServiceName, time\n  ORDER BY ServiceName, time\n)\nWHERE prev_version != '' AND prev_version != version\nORDER BY time",
         "datasource": {
           "type": "grafana-clickhouse-datasource",
           "uid": "${datasource}"
@@ -50,7 +51,7 @@
         "hide": false,
         "iconColor": "#73BF69",
         "name": "Deployments (service.version)",
-        "preset": "deployment_detection",
+        "preset": "custom",
         "rawQuery": "SELECT\n  time,\n  ServiceName AS tags,\n  concat(ServiceName, ' deployed ', version, if(prev_version != '', concat(' (was ', prev_version, ')'), '')) AS text,\n  'Deployment' AS title\nFROM (\n  SELECT\n    toStartOfInterval(Timestamp, INTERVAL 30 second) AS time,\n    ServiceName,\n    topK(1)(ResourceAttributes['service.version'])[1] AS version,\n    lagInFrame(topK(1)(ResourceAttributes['service.version'])[1])\n      OVER (PARTITION BY ServiceName ORDER BY time) AS prev_version\n  FROM otel_traces\n  WHERE $__timeFilter(Timestamp)\n    AND $__conditionalAll(ServiceName IN ($service), $service)\n    AND ResourceAttributes['service.version'] != ''\n  GROUP BY ServiceName, time\n  ORDER BY ServiceName, time\n)\nWHERE prev_version != '' AND prev_version != version\nORDER BY time",
         "target": {
           "editorType": "sql",

--- a/src/data/CHAnnotationSupport.test.tsx
+++ b/src/data/CHAnnotationSupport.test.tsx
@@ -220,6 +220,67 @@ describe('createAnnotationSupport: prepareAnnotation', () => {
     const result = support.prepareAnnotation?.({ name: 'empty', enable: true, iconColor: 'red' });
     expect(result?.target).toBeUndefined();
   });
+
+  it('migrates an unknown preset id to custom and seeds customSql from the target SQL', () => {
+    // Early bundled dashboards shipped 'deployment_detection', a preset id
+    // unknown to the editor. Without the migration, switching the unmatched Type
+    // select to Custom SQL would overwrite the query with an empty stash.
+    const result = support.prepareAnnotation?.({
+      name: 'Deployments (service.version)',
+      enable: true,
+      iconColor: '#73BF69',
+      preset: 'deployment_detection',
+      target: { refId: 'anno', pluginVersion: '', editorType: EditorType.SQL, rawSql: 'SELECT 3 AS time' },
+    });
+    expect(result?.preset).toBe('custom');
+    expect(result?.customSql).toBe('SELECT 3 AS time');
+    expect(result?.target?.rawSql).toBe('SELECT 3 AS time');
+  });
+
+  it('seeds customSql from a legacy rawQuery when migrating an unknown preset', () => {
+    const result = support.prepareAnnotation?.({
+      name: 'legacy-preset',
+      enable: true,
+      iconColor: 'red',
+      preset: 'deployment_detection',
+      rawQuery: 'SELECT 4 AS time',
+    });
+    expect(result?.preset).toBe('custom');
+    expect(result?.customSql).toBe('SELECT 4 AS time');
+    expect(result?.target?.rawSql).toBe('SELECT 4 AS time');
+  });
+
+  it('keeps an existing customSql stash when migrating an unknown preset', () => {
+    const result = support.prepareAnnotation?.({
+      name: 'stashed',
+      enable: true,
+      iconColor: 'red',
+      preset: 'deployment_detection',
+      customSql: 'SELECT stashed AS time',
+      target: { refId: 'anno', pluginVersion: '', editorType: EditorType.SQL, rawSql: 'SELECT 5 AS time' },
+    });
+    expect(result?.preset).toBe('custom');
+    expect(result?.customSql).toBe('SELECT stashed AS time');
+  });
+
+  it.each(['custom', 'change_detection'])('leaves the known %s preset untouched', (preset) => {
+    const result = support.prepareAnnotation?.({
+      name: 'known',
+      enable: true,
+      iconColor: 'red',
+      preset,
+      target: { refId: 'anno', pluginVersion: '', editorType: EditorType.SQL, rawSql: 'SELECT 6 AS time' },
+    });
+    expect(result?.preset).toBe(preset);
+    expect(result?.customSql).toBeUndefined();
+    expect(result?.target?.rawSql).toBe('SELECT 6 AS time');
+  });
+
+  it('does not add a preset to an annotation that has none', () => {
+    const result = support.prepareAnnotation?.({ name: 'bare', enable: true, iconColor: 'red' });
+    expect(result?.preset).toBeUndefined();
+    expect(result?.customSql).toBeUndefined();
+  });
 });
 
 describe('createAnnotationSupport: getDefaultQuery', () => {

--- a/src/data/CHAnnotationSupport.tsx
+++ b/src/data/CHAnnotationSupport.tsx
@@ -348,13 +348,22 @@ export function createAnnotationSupport(datasource: Datasource): AnnotationSuppo
       // it into the modern target shape once. `rawQuery` is read via the
       // AnnotationQuery index signature, so no cast is needed.
       const legacyRawQuery: string | undefined = json?.rawQuery;
-      if (legacyRawQuery && !json?.target?.rawSql) {
+      const prepared: CHAnnotationQuery =
+        legacyRawQuery && !json?.target?.rawSql ? { ...json, target: buildTarget(json.target, legacyRawQuery) } : json;
+
+      // Dashboards may carry a preset id unknown to this editor (early
+      // bundled dashboards shipped 'deployment_detection'). Migrate it to
+      // 'custom' and seed the customSql stash from the shipped SQL, otherwise
+      // the preset round trip would overwrite the query with an empty string.
+      const preset: string | undefined = prepared.preset;
+      if (preset !== undefined && preset !== 'custom' && preset !== 'change_detection') {
         return {
-          ...json,
-          target: buildTarget(json.target, legacyRawQuery),
+          ...prepared,
+          preset: 'custom',
+          customSql: prepared.customSql || prepared.target?.rawSql || legacyRawQuery || '',
         };
       }
-      return json;
+      return prepared;
     },
 
     getDefaultQuery: (): Partial<CHQuery> => ({


### PR DESCRIPTION
## Type of Change

- [x] 🐛 Bug Fix

---

## Bug Fix

### What is the bug?

Four defects in the shipped dashboards (the #1869 OTel dashboards and the long-standing cluster analysis dashboard), one commit each:

1. **Deployment annotations don't round-trip the editor.** The three OTel dashboards shipped annotations with `"preset": "deployment_detection"`, an id the #1922 annotation editor does not recognise: the Type select rendered unmatched, picking "Custom SQL" wiped the shipped query, and picking "Change Detection" rewrote it without the `$service` scoping. The dashboards now ship `"preset": "custom"` with `customSql`, and `prepareAnnotation` defensively migrates unknown preset ids for already-imported dashboards.
2. **Free-text search throws on realistic input.** The Search variable fed `hasToken()`, which raises BAD_ARGUMENTS for any needle containing whitespace or separators, so searching "GET /api" errored every panel carrying the clause. All occurrences now use `positionCaseInsensitive(...) > 0`.
3. **The Logs Explorer errors on logs-only installations.** Its deployment annotation queries `otel_traces` and shipped enabled, so a logs-only pipeline (a core audience for a logs dashboard) saw a persistent UNKNOWN_TABLE error on every refresh. The annotation now ships disabled with a "requires traces" note in its name, one click to enable for users who have traces.
4. **Cluster analysis ad-hoc filters are dead on import.** The `filters` ad-hoc variable was pinned to a hardcoded datasource uid from the original author's instance while every panel queries via `${datasource}`, so filters resolved no keys and were never applied. It now references `${datasource}`, completing the sweep #1896 started for data-analysis.json.

### How to reproduce

1. Import the OpenTelemetry Traces Explorer, open Dashboard settings > Annotations > Deployments: the Type select shows no selection, and selecting "Custom SQL" empties the query (fix 1).
2. Type "GET /api" into the Search box of any OTel dashboard: panels error with ClickHouse code 36 (fix 2).
3. Import the Logs Explorer on a logs-only install: annotation error on every refresh (fix 3).
4. Import Cluster Analysis: the Filters picker offers no keys and filters are ignored (fix 4).

### Environment (if no related issue)

- **ClickHouse version**: any supported
- **Grafana version**: any supported
- **Plugin version**: 4.19.0 and current main

---

## Please check that:

- [x] Tests for this change have been added/updated.
- [ ] Documentation has been added/updated (where applicable).

## Special notes for your reviewer

Supersedes #2067, #2068, #2071 and #2072 (same fixes, previously one PR each, closed in favour of this bundle). Commits are kept separate, one per fix. Fix 4 predates the audited range (the uid dates from the 2.x era) but completes the defect class #1896 fixed in-range for data-analysis.json.

Found by an automated audit of regressions introduced while integrating PRs across the v4.18.0 and v4.19.0 release cycles (range v4.17.0..main). Related PRs: #1869, #1922, #1896.
