### PR TITLE
fix(adhoc): single-table sources, stateless Map keys, and pre-24.3 discovery

### DIFF
--- a/src/data/CHDatasource.test.ts
+++ b/src/data/CHDatasource.test.ts
@@ -820,7 +820,7 @@ describe('ClickHouseDatasource', () => {
       const mapKeysFrame = arrayToDataFrame([{ keys: 'http.method' }, { keys: 'http.status' }]);
       jest.spyOn(ds, 'query').mockImplementation((request) => {
         const sql = request.targets[0].rawSql ?? '';
-        if (sql.includes('arrayJoin("labels".keys)')) {
+        if (sql.includes('arrayJoin(mapKeys("labels"))')) {
           return of({ data: [mapKeysFrame] });
         }
         return of({ data: [columnsFrame] });
@@ -845,7 +845,7 @@ describe('ClickHouseDatasource', () => {
       const mapKeysFrame = arrayToDataFrame([{ keys: "weird'key" }]);
       jest.spyOn(ds, 'query').mockImplementation((request) => {
         const sql = request.targets[0].rawSql ?? '';
-        if (sql.includes('arrayJoin("labels".keys)')) {
+        if (sql.includes('arrayJoin(mapKeys("labels"))')) {
           return of({ data: [mapKeysFrame] });
         }
         return of({ data: [columnsFrame] });
@@ -878,7 +878,7 @@ describe('ClickHouseDatasource', () => {
 
       const spyOnQuery = jest.spyOn(ds, 'query').mockImplementation((request) => {
         const sql = request.targets[0].rawSql ?? '';
-        if (sql.includes('arrayJoin("labels".keys)')) {
+        if (sql.includes('arrayJoin(mapKeys("labels"))')) {
           return of({ data: [mapKeysFrame] });
         }
         if (sql.includes("labels['http.method']")) {
@@ -946,7 +946,7 @@ describe('ClickHouseDatasource', () => {
 
       jest.spyOn(ds, 'query').mockImplementation((request) => {
         const sql = request.targets[0].rawSql ?? '';
-        if (sql.includes('arrayJoin("labels".keys)')) {
+        if (sql.includes('arrayJoin(mapKeys("labels"))')) {
           return of({ data: [mapKeysFrame] });
         }
         if (sql.includes("labels['region']")) {
@@ -973,7 +973,7 @@ describe('ClickHouseDatasource', () => {
 
       const spyOnQuery = jest.spyOn(ds, 'query').mockImplementation((request) => {
         const sql = request.targets[0].rawSql ?? '';
-        if (sql.includes('arrayJoin("labels".keys)')) {
+        if (sql.includes('arrayJoin(mapKeys("labels"))')) {
           return of({ data: [mapKeysFrame] });
         }
         if (sql.includes("labels['weird\\'key']")) {
@@ -1007,7 +1007,7 @@ describe('ClickHouseDatasource', () => {
       const mapKeysFrame = arrayToDataFrame([{ keys: 'a' }]);
       jest.spyOn(ds, 'query').mockImplementation((request) => {
         const sql = request.targets[0].rawSql ?? '';
-        if (sql.includes('.keys)')) {
+        if (sql.includes('mapKeys(')) {
           return of({ data: [mapKeysFrame] });
         }
         return of({ data: [columnsFrame] });
@@ -1037,8 +1037,35 @@ describe('ClickHouseDatasource', () => {
       expect(result).toEqual(['a', 'b']);
       const sql = spy.mock.calls[0][0].targets[0].rawSql!;
       expect(sql).toBe(
-        'SELECT DISTINCT arrayJoin("labels".keys) as keys FROM (SELECT "labels" FROM "db"."events" LIMIT 100000) LIMIT 1000'
+        'SELECT DISTINCT arrayJoin(mapKeys("labels")) as keys FROM (SELECT "labels" FROM "db"."events" LIMIT 100000) LIMIT 1000'
       );
+    });
+
+    it('uses the mapKeys() function rather than the .keys sub-column so the old analyzer can resolve it', async () => {
+      // ClickHouse's old analyzer (the default before 24.3, or with
+      // allow_experimental_analyzer=0) cannot resolve `.keys` sub-columns on
+      // subquery results and fails with UNKNOWN_IDENTIFIER (code 47). Every
+      // call site swallows the error, so Map-key ad-hoc filters silently
+      // vanish on 22.7-24.2 unless the probe uses the mapKeys() function.
+      const ds = cloneDeep(mockDatasource);
+      ds.settings.jsonData.logs = {
+        defaultDatabase: 'otel',
+        defaultTable: 'otel_logs',
+        otelEnabled: false,
+        timeColumn: 'Timestamp',
+      };
+      const frame = arrayToDataFrame([{ keys: 'a' }]);
+      const spy = jest.spyOn(ds, 'query').mockImplementation(() => of({ data: [frame] }));
+
+      // Subquery-sampled path (free-form table) and time-bounded path (OTel
+      // logs table) must both avoid the sub-column syntax.
+      await ds.fetchUniqueMapKeys('labels', 'db', 'events');
+      await ds.fetchUniqueMapKeys('LogAttributes', 'otel', 'otel_logs');
+      for (const call of spy.mock.calls) {
+        const sql = call[0].targets[0].rawSql!;
+        expect(sql).not.toContain('.keys');
+        expect(sql).toContain('arrayJoin(mapKeys(');
+      }
     });
 
     it('bounds the probe to the configured logs time column when target matches OTel logs table', async () => {

--- a/src/data/CHDatasource.test.ts
+++ b/src/data/CHDatasource.test.ts
@@ -495,6 +495,105 @@ describe('ClickHouseDatasource', () => {
       expect(keys).toEqual([{ text: 'table.foo' }]);
     });
 
+    it('coerces an unset default database to the literal default on a classic datasource', async () => {
+      jest.spyOn(templateSrvMock, 'replace').mockImplementation(() => '$clickhouse_adhoc_query');
+      const frame = arrayToDataFrame([{ name: 'foo', type: 'string', table: 'table' }]);
+      const ds = cloneDeep(mockDatasource);
+      ds.settings.jsonData.defaultDatabase = undefined;
+      ds.settings.jsonData.defaultTable = undefined;
+      const spyOnQuery = jest.spyOn(ds, 'query').mockImplementation((_request) => of({ data: [frame] }));
+
+      await ds.getTagKeys();
+      const expected = { rawSql: "SELECT name, type, table FROM system.columns WHERE database IN ('default')" };
+
+      expect(spyOnQuery).toHaveBeenCalledWith(
+        expect.objectContaining({ targets: expect.arrayContaining([expect.objectContaining(expected)]) })
+      );
+    });
+
+    it('should Fetch Tags From the single-table logs source when no default database is set', async () => {
+      jest.spyOn(templateSrvMock, 'replace').mockImplementation(() => '$clickhouse_adhoc_query');
+      const frame = arrayToDataFrame([{ name: 'foo', type: 'string', table: 'otel_logs' }]);
+      const ds = cloneDeep(mockDatasource);
+      ds.settings.jsonData.defaultDatabase = undefined;
+      ds.settings.jsonData.defaultTable = undefined;
+      ds.settings.jsonData.configMode = 'single-table';
+      ds.settings.jsonData.signalType = 'logs';
+      ds.settings.jsonData.logs = { defaultDatabase: 'otel', defaultTable: 'otel_logs' };
+      const spyOnQuery = jest.spyOn(ds, 'query').mockImplementation((_request) => of({ data: [frame] }));
+
+      const keys = await ds.getTagKeys();
+      const expected = {
+        rawSql: "SELECT name, type, table FROM system.columns WHERE database IN ('otel') AND table = 'otel_logs'",
+      };
+
+      expect(spyOnQuery).toHaveBeenCalledWith(
+        expect.objectContaining({ targets: expect.arrayContaining([expect.objectContaining(expected)]) })
+      );
+
+      expect(keys).toEqual([{ text: 'otel_logs.foo' }]);
+    });
+
+    it('should Fetch Tags From the single-table traces source when no default database is set', async () => {
+      jest.spyOn(templateSrvMock, 'replace').mockImplementation(() => '$clickhouse_adhoc_query');
+      const frame = arrayToDataFrame([{ name: 'foo', type: 'string', table: 'otel_traces' }]);
+      const ds = cloneDeep(mockDatasource);
+      ds.settings.jsonData.defaultDatabase = undefined;
+      ds.settings.jsonData.defaultTable = undefined;
+      ds.settings.jsonData.configMode = 'single-table';
+      ds.settings.jsonData.signalType = 'traces';
+      ds.settings.jsonData.traces = { defaultDatabase: 'otel', defaultTable: 'otel_traces' };
+      const spyOnQuery = jest.spyOn(ds, 'query').mockImplementation((_request) => of({ data: [frame] }));
+
+      await ds.getTagKeys();
+      const expected = {
+        rawSql: "SELECT name, type, table FROM system.columns WHERE database IN ('otel') AND table = 'otel_traces'",
+      };
+
+      expect(spyOnQuery).toHaveBeenCalledWith(
+        expect.objectContaining({ targets: expect.arrayContaining([expect.objectContaining(expected)]) })
+      );
+    });
+
+    it('coerces an unset single-table logs database to the literal default', async () => {
+      jest.spyOn(templateSrvMock, 'replace').mockImplementation(() => '$clickhouse_adhoc_query');
+      const frame = arrayToDataFrame([{ name: 'foo', type: 'string', table: 'otel_logs' }]);
+      const ds = cloneDeep(mockDatasource);
+      ds.settings.jsonData.defaultDatabase = undefined;
+      ds.settings.jsonData.defaultTable = undefined;
+      ds.settings.jsonData.configMode = 'single-table';
+      ds.settings.jsonData.signalType = 'logs';
+      ds.settings.jsonData.logs = { defaultTable: 'otel_logs' };
+      const spyOnQuery = jest.spyOn(ds, 'query').mockImplementation((_request) => of({ data: [frame] }));
+
+      await ds.getTagKeys();
+      const expected = {
+        rawSql: "SELECT name, type, table FROM system.columns WHERE database IN ('default') AND table = 'otel_logs'",
+      };
+
+      expect(spyOnQuery).toHaveBeenCalledWith(
+        expect.objectContaining({ targets: expect.arrayContaining([expect.objectContaining(expected)]) })
+      );
+    });
+
+    it('prefers an explicit default database over the single-table source', async () => {
+      jest.spyOn(templateSrvMock, 'replace').mockImplementation(() => '$clickhouse_adhoc_query');
+      const frame = arrayToDataFrame([{ name: 'foo', type: 'string', table: 'table' }]);
+      const ds = cloneDeep(mockDatasource);
+      ds.settings.jsonData.defaultDatabase = 'foo';
+      ds.settings.jsonData.configMode = 'single-table';
+      ds.settings.jsonData.signalType = 'logs';
+      ds.settings.jsonData.logs = { defaultDatabase: 'otel', defaultTable: 'otel_logs' };
+      const spyOnQuery = jest.spyOn(ds, 'query').mockImplementation((_request) => of({ data: [frame] }));
+
+      await ds.getTagKeys();
+      const expected = { rawSql: "SELECT name, type, table FROM system.columns WHERE database IN ('foo')" };
+
+      expect(spyOnQuery).toHaveBeenCalledWith(
+        expect.objectContaining({ targets: expect.arrayContaining([expect.objectContaining(expected)]) })
+      );
+    });
+
     it('should Fetch Tags From Query', async () => {
       const spyOnReplace = jest.spyOn(templateSrvMock, 'replace').mockImplementation(() => 'select name from foo');
       const frame = arrayToDataFrame([{ name: 'foo' }]);

--- a/src/data/CHDatasource.test.ts
+++ b/src/data/CHDatasource.test.ts
@@ -827,11 +827,32 @@ describe('ClickHouseDatasource', () => {
       });
 
       const keys = await ds.getTagKeys();
+      // Bracket form is self-describing: applying the saved filter must not
+      // depend on the Map-column caches populated by this method (#2043).
       expect(keys).toEqual([
         { text: 'events.level' },
-        { text: 'events.labels.http.method' },
-        { text: 'events.labels.http.status' },
+        { text: "events.labels['http.method']" },
+        { text: "events.labels['http.status']" },
       ]);
+    });
+
+    it('mints bracketed keys with the map key escaped as a ClickHouse string literal', async () => {
+      jest.spyOn(templateSrvMock, 'replace').mockImplementation(() => 'db.events');
+      const ds = cloneDeep(mockDatasource);
+      ds.settings.jsonData.defaultDatabase = 'db';
+      ds.settings.jsonData.defaultTable = 'events';
+      const columnsFrame = arrayToDataFrame([{ name: 'labels', type: 'Map(String, String)', table: 'events' }]);
+      const mapKeysFrame = arrayToDataFrame([{ keys: "weird'key" }]);
+      jest.spyOn(ds, 'query').mockImplementation((request) => {
+        const sql = request.targets[0].rawSql ?? '';
+        if (sql.includes('arrayJoin("labels".keys)')) {
+          return of({ data: [mapKeysFrame] });
+        }
+        return of({ data: [columnsFrame] });
+      });
+
+      const keys = await ds.getTagKeys();
+      expect(keys).toEqual([{ text: "events.labels['weird\\'key']" }]);
     });
 
     it('falls back to a flat Map column entry when no table context is available', async () => {
@@ -868,6 +889,30 @@ describe('ClickHouseDatasource', () => {
 
       await ds.getTagKeys(); // populates the mapColumnsByTable cache
       const values = await ds.getTagValues({ key: 'events.labels.http.method' });
+      expect(values).toEqual([{ text: 'GET' }, { text: 'POST' }]);
+      expect(spyOnQuery).toHaveBeenCalledWith(
+        expect.objectContaining({
+          targets: expect.arrayContaining([
+            expect.objectContaining({
+              rawSql: "select distinct labels['http.method'] from db.events limit 1000",
+            }),
+          ]),
+        })
+      );
+    });
+
+    it('fetches values for a bracketed Map key without a prior getTagKeys call', async () => {
+      // Round-trip of a key minted by getTagKeys: the bracketed form must
+      // produce the same values SELECT with no stored state, i.e. on a
+      // fresh dashboard load where the Map-column caches are still empty
+      // (#2043).
+      jest.spyOn(templateSrvMock, 'replace').mockImplementation(() => 'db.events');
+      const ds = cloneDeep(mockDatasource);
+      ds.settings.jsonData.defaultDatabase = 'db';
+      const valuesFrame = arrayToDataFrame([{ val: 'GET' }, { val: 'POST' }]);
+      const spyOnQuery = jest.spyOn(ds, 'query').mockImplementation(() => of({ data: [valuesFrame] }));
+
+      const values = await ds.getTagValues({ key: "events.labels['http.method']" });
       expect(values).toEqual([{ text: 'GET' }, { text: 'POST' }]);
       expect(spyOnQuery).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/src/data/CHDatasource.ts
+++ b/src/data/CHDatasource.ts
@@ -1579,7 +1579,10 @@ export class Datasource
 
     // Replace each top-level Map-column entry with one entry per discovered
     // map key. If probing returned nothing (empty set, stripped by the
-    // filter), keep the original entry as a no-op fallback.
+    // filter), keep the original entry as a no-op fallback. Keys are minted
+    // in explicit bracket form (`col['key']`) so that filter application is
+    // stateless: a saved filter must render correct SQL on fresh dashboard
+    // load, before this method has run and populated the Map-column caches.
     const expandedKeyByCol = new Map<string, string[]>();
     for (const p of probed) {
       if (p.keys.length > 0) {
@@ -1601,7 +1604,7 @@ export class Datasource
         return;
       }
       for (const k of mapKeys) {
-        expanded.push({ text: `${baseText}.${k}` });
+        expanded.push({ text: `${baseText}['${escapeCHStringLiteral(k)}']` });
       }
     });
     return expanded;
@@ -1700,7 +1703,9 @@ export class Datasource
     // distinct Map values rather than stringified Map objects (which the
     // Grafana frame layer renders as `[object Object]`). The map key is
     // escaped for CH string-literal embedding so that keys containing `'`
-    // or `\` produce valid SQL.
+    // or `\` produce valid SQL. Keys minted by getTagKeys arrive already in
+    // bracket form (`mapCol['key']`, literal body pre-escaped) and pass
+    // through unchanged as valid bracket access.
     const mapAccess = this.asMapAccess(col, source);
     const selectExpr = mapAccess ? `${mapAccess.column}['${escapeCHStringLiteral(mapAccess.key)}']` : col;
 

--- a/src/data/CHDatasource.ts
+++ b/src/data/CHDatasource.ts
@@ -28,7 +28,7 @@ import {
 import { DataSourceWithBackend, getTemplateSrv } from '@grafana/runtime';
 import { trackClickhouseHealthCheckFailed } from 'tracking';
 import LogsContextPanel from 'components/LogsContextPanel';
-import { cloneDeep, isEmpty, isString } from 'lodash';
+import { cloneDeep, isString } from 'lodash';
 import otel from 'otel';
 import { createElement as createReactElement, ReactNode } from 'react';
 import { concatMap, firstValueFrom, Observable } from 'rxjs';
@@ -1608,16 +1608,38 @@ export class Datasource
   }
 
   /**
+   * Default source for ad-hoc filter key/value discovery, used when the
+   * dashboard does not define `$clickhouse_adhoc_query`. Returns a bare
+   * database name or `db.table`. Single-table mode (#1832) hides the classic
+   * Default database field in the config editor, so when that field is unset
+   * the source is derived from the configured signal's database and table
+   * (mirroring buildCompactQueryDefaults) rather than the literal 'default'
+   * database that getDefaultDatabase coerces to.
+   */
+  private getDefaultAdhocSource(): string | undefined {
+    if (!this.settings.jsonData.defaultDatabase && this.isSingleTableMode()) {
+      const isTraces = this.getSignalType() === 'traces';
+      const signalDb = isTraces ? this.getDefaultTraceDatabase() : this.getDefaultLogsDatabase();
+      const signalTable = isTraces ? this.getDefaultTraceTable() : this.getDefaultLogsTable();
+      const table = signalTable || this.getDefaultTable();
+      if (table) {
+        return `${signalDb || this.getDefaultDatabase()}.${table}`;
+      }
+    }
+    return this.getDefaultDatabase();
+  }
+
+  /**
    * The `$clickhouse_adhoc_query` template variable may resolve to a bare
    * database name or `db.table`. This returns the database component, or
    * undefined when we can't derive one (free-form SELECT variable, etc.).
    */
   private resolveAdhocDatabase(_frame: DataFrame): string | undefined {
     const source = getTemplateSrv().replace('$clickhouse_adhoc_query');
-    const defaultDatabase = this.getDefaultDatabase();
-    const raw = source === '$clickhouse_adhoc_query' ? defaultDatabase : source;
+    const defaultSource = this.getDefaultAdhocSource();
+    const raw = source === '$clickhouse_adhoc_query' ? defaultSource : source;
     if (!raw || raw.toLowerCase().startsWith('select')) {
-      return defaultDatabase;
+      return defaultSource?.split('.')[0];
     }
     return raw.includes('.') ? raw.split('.')[0] : raw;
   }
@@ -1630,7 +1652,7 @@ export class Datasource
    */
   private resolveAdhocSingleTable(): string | undefined {
     const source = getTemplateSrv().replace('$clickhouse_adhoc_query');
-    const raw = source === '$clickhouse_adhoc_query' ? this.getDefaultDatabase() : source;
+    const raw = source === '$clickhouse_adhoc_query' ? this.getDefaultAdhocSource() : source;
     if (!raw || raw.toLowerCase().startsWith('select')) {
       return undefined;
     }
@@ -1802,12 +1824,14 @@ export class Datasource
   private getTagSource() {
     // @todo https://github.com/grafana/grafana/issues/13109
     const ADHOC_VAR = '$clickhouse_adhoc_query';
-    const defaultDatabase = this.getDefaultDatabase();
     let source = getTemplateSrv().replace(ADHOC_VAR);
-    if (source === ADHOC_VAR && isEmpty(defaultDatabase)) {
-      return { type: TagType.schema, source: undefined };
+    if (source === ADHOC_VAR) {
+      const defaultSource = this.getDefaultAdhocSource();
+      if (!defaultSource) {
+        return { type: TagType.schema, source: undefined };
+      }
+      source = defaultSource;
     }
-    source = source === ADHOC_VAR ? defaultDatabase! : source;
     if (source.toLowerCase().startsWith('select')) {
       return { type: TagType.query, source };
     }

--- a/src/data/CHDatasource.ts
+++ b/src/data/CHDatasource.ts
@@ -1204,7 +1204,10 @@ export class Datasource
     const source = timeColumn
       ? `${tableIdentifier} WHERE ${escapeIdentifier(timeColumn)} >= now() - INTERVAL 6 HOUR`
       : `(SELECT ${escapedColumn} FROM ${tableIdentifier} LIMIT ${MAP_KEY_PROBE_ROW_SAMPLE})`;
-    const rawSql = `SELECT DISTINCT arrayJoin(${escapedColumn}.keys) as keys FROM ${source} LIMIT 1000`;
+    // mapKeys() rather than the `.keys` sub-column: ClickHouse's old analyzer
+    // (the default before 24.3) cannot resolve sub-columns on subquery results
+    // and fails with UNKNOWN_IDENTIFIER, silently breaking key discovery.
+    const rawSql = `SELECT DISTINCT arrayJoin(mapKeys(${escapedColumn})) as keys FROM ${source} LIMIT 1000`;
     return this.fetchData(rawSql);
   }
 

--- a/src/data/adHocFilter.test.ts
+++ b/src/data/adHocFilter.test.ts
@@ -400,4 +400,64 @@ describe('AdHocManager', () => {
       expect(val).toContain("labels[\\'a\\\\\\\\b\\']");
     });
   });
+
+  describe('self-describing bracketed Map keys (#2043)', () => {
+    it('renders a bracketed key without any setMapColumns call (table-prefixed)', () => {
+      // Saved filters must apply on a fresh dashboard load, before
+      // getTagKeys has run, because the key itself carries the Map access.
+      const ahm = new AdHocFilter();
+      const val = ahm.apply('SELECT * FROM events', [
+        { key: "events.metadata['region']", operator: '=', value: 'eu' },
+      ] as AdHocVariableFilter[]);
+      expect(val).toContain("metadata[\\'region\\'] = \\'eu\\'");
+    });
+
+    it('renders a bracketed key without any setMapColumns call (hideTableName)', () => {
+      const ahm = new AdHocFilter();
+      const val = ahm.apply('SELECT * FROM events', [
+        { key: "metadata['region']", operator: '=', value: 'eu' },
+      ] as AdHocVariableFilter[]);
+      expect(val).toContain("metadata[\\'region\\'] = \\'eu\\'");
+    });
+
+    it('renders a bracketed key whose map key contains dots', () => {
+      const ahm = new AdHocFilter();
+      const val = ahm.apply('SELECT * FROM events', [
+        { key: "events.labels['http.method']", operator: '=', value: 'GET' },
+      ] as AdHocVariableFilter[]);
+      expect(val).toContain("labels[\\'http.method\\'] = \\'GET\\'");
+    });
+
+    it('re-escapes quotes from the minted string-literal body for the outer filter string', () => {
+      // getTagKeys mints `labels['weird\'key']` for the raw map key
+      // `weird'key`. The outer additional_table_filters embedding needs the
+      // same two-layer escape as the legacy dotted form.
+      const ahm = new AdHocFilter();
+      const val = ahm.apply('SELECT * FROM events', [
+        { key: "events.labels['weird\\'key']", operator: '=', value: 'x' },
+      ] as AdHocVariableFilter[]);
+      expect(val).toContain("labels[\\'weird\\\\\\'key\\']");
+    });
+
+    it('renders a bracketed key as dot access when useJSON is set', () => {
+      const ahm = new AdHocFilter();
+      const val = ahm.apply(
+        'SELECT * FROM events',
+        [{ key: "events.metadata['region']", operator: '=', value: 'eu' }] as AdHocVariableFilter[],
+        true
+      );
+      expect(val).toContain("metadata.region = \\'eu\\'");
+    });
+
+    it('legacy dotted keys still render via the registered Map-column set', () => {
+      // Already-saved dashboards persist the dotted form; it must keep
+      // working when getTagKeys has populated the column set.
+      const ahm = new AdHocFilter();
+      ahm.setMapColumns(new Set(['metadata']));
+      const val = ahm.apply('SELECT * FROM events', [
+        { key: 'events.metadata.region', operator: '=', value: 'eu' },
+      ] as AdHocVariableFilter[]);
+      expect(val).toContain("metadata[\\'region\\'] = \\'eu\\'");
+    });
+  });
 });

--- a/src/data/adHocFilter.ts
+++ b/src/data/adHocFilter.ts
@@ -111,6 +111,17 @@ function escapeMapKeyForOuterFilter(key: string): string {
   return key.replace(/\\/g, '\\\\\\\\').replace(/'/g, "\\\\\\'");
 }
 
+// Self-describing Map access minted by getTagKeys: `MapCol['key']` or
+// `table.MapCol['key']`. The bracket content is a ClickHouse string-literal
+// body (quotes and backslashes pre-escaped with `\`).
+const BRACKET_MAP_ACCESS = /^(?:([^.[\]']+)\.)?([^.[\]']+)\['((?:[^'\\]|\\.)*)'\]$/;
+
+// Inverse of the ClickHouse string-literal escaping applied when the key was
+// minted: `\X` → `X`.
+function unescapeCHStringLiteral(s: string): string {
+  return s.replace(/\\(.)/g, '$1');
+}
+
 function escapeKey(s: string, isJSON = false, mapColumns: ReadonlySet<string> = DEFAULT_MAP_COLUMNS): string {
   // Convert arrayElement(col, 'key') → col['key']. Handled up front so the
   // dotted-path logic below doesn't see synthetic function syntax.
@@ -120,6 +131,20 @@ function escapeKey(s: string, isJSON = false, mapColumns: ReadonlySet<string> = 
       const [_, array, key] = match;
       return `${array}[\\'${escapeMapKeyForOuterFilter(key)}\\']`;
     }
+  }
+
+  // Explicit bracket form (`MapCol['key']` or `table.MapCol['key']`) is
+  // handled without consulting mapColumns, so saved filters render
+  // correctly on a fresh dashboard load, before getTagKeys has populated
+  // the Map-column cache.
+  const bracketed = s.match(BRACKET_MAP_ACCESS);
+  if (bracketed) {
+    const [, , mapCol, literalKey] = bracketed;
+    const mapKey = unescapeCHStringLiteral(literalKey);
+    if (isJSON) {
+      return `${mapCol}.${mapKey}`;
+    }
+    return `${mapCol}[\\'${escapeMapKeyForOuterFilter(mapKey)}\\']`;
   }
 
   const parts = s.split('.');

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -66,7 +66,7 @@ export interface CHConfig extends DataSourceJsonData {
   /**
    * Controls the Map-column key discovery probe that populates the filter-key
    * dropdown for `Map(...)` columns. The probe issues
-   * `SELECT DISTINCT arrayJoin(col.keys) FROM db.table LIMIT 1000` and can be
+   * `SELECT DISTINCT arrayJoin(mapKeys(col)) FROM db.table LIMIT 1000` and can be
    * expensive on large tables when the map has high key cardinality. Defaults
    * to true to preserve existing UX; operators on large OTel logs/traces tables
    * may want to disable it. See issue #1843.

--- a/tests/e2e/mapFilter.spec.ts
+++ b/tests/e2e/mapFilter.spec.ts
@@ -87,7 +87,7 @@ test.describe('Map column adhoc filters', () => {
     // the fixture has the expected distinct keys so that any future change
     // to the discovery query (e.g. sampling via a subquery) keeps surfacing
     // all map keys present in a small table.
-    await enterSql(page, 'SELECT DISTINCT arrayJoin(labels.keys) AS keys FROM e2e_test.map_events ORDER BY keys');
+    await enterSql(page, 'SELECT DISTINCT arrayJoin(mapKeys(labels)) AS keys FROM e2e_test.map_events ORDER BY keys');
 
     const { responsePromise, getBody } = await waitForQueryDataResponseWithBody(explorePage);
     await page.locator('.query-editor-row').getByRole('button', { name: 'Run Query' }).click();


### PR DESCRIPTION
## Type of Change

- [x] 🐛 Bug Fix

---

## Bug Fix

### What is the bug?

Three ad-hoc filter defects from the v4.18.0/v4.19.0 cycles (the #1793/#1885/#1993 Map-key work plus single-table mode #1832), one commit each:

1. **Key discovery ignores single-table configuration.** Discovery resolved its source solely from `jsonData.defaultDatabase` (coerced to the literal `default`), but single-table mode stores the database and table under `jsonData.logs`/`jsonData.traces` and hides the classic field, so the key dropdown listed the wrong database and picked keys never matched the compact query's FROM table. Discovery now falls back to the single-table logs (else traces) source when the classic default is unset, with `$clickhouse_adhoc_query` and explicit defaults keeping precedence.
2. **Saved Map-key filters generate wrong SQL on dashboard load.** `escapeKey` only rendered dotted Map keys as bracket access after `setMapColumns` ran, which happens exclusively inside `getTagKeys` (lazy, on dropdown open). On a fresh dashboard load every panel errored with UNKNOWN_IDENTIFIER until the user opened the filter dropdown once. Newly minted keys now use a self-describing bracket form (`table.mapcol['key']`) that applies statelessly, and legacy dotted keys keep working via the existing discovery path.
3. **Map-key discovery breaks on ClickHouse before 24.3.** The #1993 bounded probe read the `.keys` sub-column from a subquery, which the old analyzer (default before 24.3, or `allow_experimental_analyzer=0`) rejects with UNKNOWN_IDENTIFIER, and every call site swallows the error, so Map-key filters and dropdowns silently vanished on 22.7-24.2 (reproduced on 23.8 vs 24.8). The probe now uses the `mapKeys()` function, which both analyzers resolve.

### How to reproduce

Each fix's regression tests document the exact scenario (`CHDatasource.test.ts`, `adHocFilter.test.ts`). Representative example for 2: add an ad-hoc filter on a custom Map column key, save the dashboard, reload it; before this PR every panel errors until the filter key dropdown is opened once.

### Environment (if no related issue)

- **ClickHouse version**: any supported (fix 3 specific to pre-24.3 or old-analyzer configs)
- **Grafana version**: any supported
- **Plugin version**: 4.19.0 and current main

---

## Please check that:

- [x] Tests for this change have been added/updated.
- [ ] Documentation has been added/updated (where applicable).

## Special notes for your reviewer

Supersedes #2052, #2055 and #2064 (same fixes, previously one PR each, closed in favour of this bundle). Commits are kept separate, one per fix. Draft because fix 2 introduces a new user-visible key format in the ad-hoc dropdown (bracket form instead of dotted), which is a design decision worth explicit sign-off, fixes 1 and 3 are straightforward. One cross-fix interaction was resolved while bundling: fix 2's key-escaping test stubbed the probe with the pre-fix-3 SQL shape and was updated to the `mapKeys()` form.

Found by an automated audit of regressions introduced while integrating PRs across the v4.18.0 and v4.19.0 release cycles (range v4.17.0..main). Related PRs: #1793, #1885, #1993, #1832, #1841.
