### PR TITLE
feat(dashboards): make OTel dashboards importable via datasource input

### DIFF
--- a/src/dashboards/__tests__/dashboards.test.ts
+++ b/src/dashboards/__tests__/dashboards.test.ts
@@ -147,4 +147,27 @@ describe('OTel dashboards', () => {
       expect(content).not.toMatch(/= '\$\{?\w+\}?'/);
     });
   });
+
+  describe('importable', () => {
+    it.each(otelDashboards)('%s declares a datasource __input so import prompts for one', (filename) => {
+      const dashboard = JSON.parse(fs.readFileSync(path.join(DASHBOARDS_DIR, filename), 'utf8')) as {
+        __inputs?: Array<{ name?: string; type?: string; pluginId?: string }>;
+      };
+      const dsInput = dashboard.__inputs?.find((i) => i.type === 'datasource');
+      expect(dsInput).toBeDefined();
+      expect(dsInput?.pluginId).toBe('grafana-clickhouse-datasource');
+    });
+
+    it.each(otelDashboards)('%s wires the datasource variable to the __input', (filename) => {
+      // On UI import Grafana substitutes the input token into current.value, so the datasource
+      // the user picks in the import prompt becomes the variable's selection.
+      const dashboard = JSON.parse(fs.readFileSync(path.join(DASHBOARDS_DIR, filename), 'utf8')) as {
+        __inputs?: Array<{ name?: string }>;
+        templating?: { list?: Array<{ type?: string; current?: { value?: string } }> };
+      };
+      const inputName = dashboard.__inputs?.[0]?.name;
+      const dsVar = dashboard.templating?.list?.find((v) => v.type === 'datasource');
+      expect(dsVar?.current?.value).toBe(`\${${inputName}}`);
+    });
+  });
 });

--- a/src/dashboards/__tests__/dashboards.test.ts
+++ b/src/dashboards/__tests__/dashboards.test.ts
@@ -162,10 +162,10 @@ describe('OTel dashboards', () => {
       // On UI import Grafana substitutes the input token into current.value, so the datasource
       // the user picks in the import prompt becomes the variable's selection.
       const dashboard = JSON.parse(fs.readFileSync(path.join(DASHBOARDS_DIR, filename), 'utf8')) as {
-        __inputs?: Array<{ name?: string }>;
+        __inputs?: Array<{ name?: string; type?: string }>;
         templating?: { list?: Array<{ type?: string; current?: { value?: string } }> };
       };
-      const inputName = dashboard.__inputs?.[0]?.name;
+      const inputName = dashboard.__inputs?.find((i) => i.type === 'datasource')?.name;
       const dsVar = dashboard.templating?.list?.find((v) => v.type === 'datasource');
       expect(dsVar?.current?.value).toBe(`\${${inputName}}`);
     });

--- a/src/dashboards/otel-logs-explorer.json
+++ b/src/dashboards/otel-logs-explorer.json
@@ -14,13 +14,13 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "9.0.1"
+      "version": ">=11.6.0-0"
     },
     {
       "type": "datasource",
       "id": "grafana-clickhouse-datasource",
       "name": "ClickHouse",
-      "version": "2.0.0"
+      "version": "4.20.0"
     },
     {
       "type": "panel",
@@ -335,8 +335,8 @@
     "list": [
       {
         "current": {
-          "selected": false,
-          "text": "ClickHouse",
+          "selected": true,
+          "text": "",
           "value": "${DS_GRAFANA_CLICKHOUSE_DATASOURCE}"
         },
         "hide": 0,

--- a/src/dashboards/otel-logs-explorer.json
+++ b/src/dashboards/otel-logs-explorer.json
@@ -1,4 +1,58 @@
 {
+  "__inputs": [
+    {
+      "name": "DS_GRAFANA_CLICKHOUSE_DATASOURCE",
+      "label": "ClickHouse",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "grafana-clickhouse-datasource",
+      "pluginName": "ClickHouse"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "9.0.1"
+    },
+    {
+      "type": "datasource",
+      "id": "grafana-clickhouse-datasource",
+      "name": "ClickHouse",
+      "version": "2.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "bargauge",
+      "name": "Bar gauge",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "logs",
+      "name": "Logs",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "piechart",
+      "name": "Pie chart",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "table",
+      "name": "Table",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
   "description": "Explore OpenTelemetry logs in ClickHouse. Top services with per-service log volume and samples.",
   "editable": true,
   "graphTooltip": 2,
@@ -280,7 +334,11 @@
   "templating": {
     "list": [
       {
-        "current": {},
+        "current": {
+          "selected": false,
+          "text": "ClickHouse",
+          "value": "${DS_GRAFANA_CLICKHOUSE_DATASOURCE}"
+        },
         "hide": 0,
         "includeAll": false,
         "label": "Datasource",

--- a/src/dashboards/otel-service-dashboard.json
+++ b/src/dashboards/otel-service-dashboard.json
@@ -14,13 +14,13 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "9.0.1"
+      "version": ">=11.6.0-0"
     },
     {
       "type": "datasource",
       "id": "grafana-clickhouse-datasource",
       "name": "ClickHouse",
-      "version": "2.0.0"
+      "version": "4.20.0"
     },
     {
       "type": "panel",
@@ -114,8 +114,8 @@
     "list": [
       {
         "current": {
-          "selected": false,
-          "text": "ClickHouse",
+          "selected": true,
+          "text": "",
           "value": "${DS_GRAFANA_CLICKHOUSE_DATASOURCE}"
         },
         "hide": 0,

--- a/src/dashboards/otel-service-dashboard.json
+++ b/src/dashboards/otel-service-dashboard.json
@@ -1,4 +1,46 @@
 {
+  "__inputs": [
+    {
+      "name": "DS_GRAFANA_CLICKHOUSE_DATASOURCE",
+      "label": "ClickHouse",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "grafana-clickhouse-datasource",
+      "pluginName": "ClickHouse"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "9.0.1"
+    },
+    {
+      "type": "datasource",
+      "id": "grafana-clickhouse-datasource",
+      "name": "ClickHouse",
+      "version": "2.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "logs",
+      "name": "Logs",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "table",
+      "name": "Table",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
   "title": "OpenTelemetry Service Dashboard",
   "uid": "otel-service-dashboard",
   "description": "Single-service deep dive: RED metrics and slowest operations broken out by SpanKind (Server, Client, Internal, Async), with errors and recent logs side by side. Click a service in Traces Explorer to land here.",
@@ -71,7 +113,11 @@
   "templating": {
     "list": [
       {
-        "current": {},
+        "current": {
+          "selected": false,
+          "text": "ClickHouse",
+          "value": "${DS_GRAFANA_CLICKHOUSE_DATASOURCE}"
+        },
         "hide": 0,
         "includeAll": false,
         "label": "Data Source",

--- a/src/dashboards/otel-traces-explorer.json
+++ b/src/dashboards/otel-traces-explorer.json
@@ -14,13 +14,13 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "9.0.1"
+      "version": ">=11.6.0-0"
     },
     {
       "type": "datasource",
       "id": "grafana-clickhouse-datasource",
       "name": "ClickHouse",
-      "version": "2.0.0"
+      "version": "4.20.0"
     },
     {
       "type": "panel",
@@ -113,8 +113,8 @@
     "list": [
       {
         "current": {
-          "selected": false,
-          "text": "ClickHouse",
+          "selected": true,
+          "text": "",
           "value": "${DS_GRAFANA_CLICKHOUSE_DATASOURCE}"
         },
         "hide": 0,

--- a/src/dashboards/otel-traces-explorer.json
+++ b/src/dashboards/otel-traces-explorer.json
@@ -1,4 +1,52 @@
 {
+  "__inputs": [
+    {
+      "name": "DS_GRAFANA_CLICKHOUSE_DATASOURCE",
+      "label": "ClickHouse",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "grafana-clickhouse-datasource",
+      "pluginName": "ClickHouse"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "9.0.1"
+    },
+    {
+      "type": "datasource",
+      "id": "grafana-clickhouse-datasource",
+      "name": "ClickHouse",
+      "version": "2.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "heatmap",
+      "name": "Heatmap",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "nodeGraph",
+      "name": "Node Graph",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "table",
+      "name": "Table",
+      "version": ""
+    }
+  ],
   "title": "OpenTelemetry Traces Explorer",
   "uid": "otel-traces-explorer",
   "description": "Explore OpenTelemetry traces with service topology, per-service drill-downs, and trace search. Click services, operations, or TraceIds to navigate.",
@@ -64,7 +112,11 @@
   "templating": {
     "list": [
       {
-        "current": {},
+        "current": {
+          "selected": false,
+          "text": "ClickHouse",
+          "value": "${DS_GRAFANA_CLICKHOUSE_DATASOURCE}"
+        },
         "hide": 0,
         "includeAll": false,
         "label": "Data Source",


### PR DESCRIPTION
## What
Adds an `__inputs` datasource entry (`DS_GRAFANA_CLICKHOUSE_DATASOURCE`) plus `__requires` to the OpenTelemetry **Logs**, **Traces** and **Service** dashboards, and wires the existing `datasource` template variable's default to that input.

## Why
With a non-empty `__inputs` block Grafana prompts for a ClickHouse datasource when the dashboard JSON is imported, instead of silently binding to whichever datasource happens to resolve (this matches the pattern already used by `system-dashboards.json`). The `${datasource}` template variable is preserved, so the in-dashboard datasource switcher still works after import.

---
_Part of a small series of independent improvements to the pre-built OpenTelemetry dashboards. The dashboard-editing PRs touch overlapping lines, so whichever lands first, the others need a trivial rebase:_
- #2080 — database selector variable
- #2081 — importable `__inputs`/`__requires`
- #2082 — min-interval variable
- #2083 — multi-value quoting
- #2084 — JSON-schema logs dashboard

All commits are signed. New assertions added to `src/dashboards/__tests__/dashboards.test.ts`.



BEGIN_COMMIT_OVERRIDE
feat(dashboards): make OTel dashboards importable via datasource input (#2081)
END_COMMIT_OVERRIDE
