### PR TITLE
feat(dashboards): add interval variable to control panel min interval

### DIFF
--- a/src/dashboards/__tests__/dashboards.test.ts
+++ b/src/dashboards/__tests__/dashboards.test.ts
@@ -147,4 +147,33 @@ describe('OTel dashboards', () => {
       expect(content).not.toMatch(/= '\$\{?\w+\}?'/);
     });
   });
+
+  describe('interval variable', () => {
+    type Panel = { gridPos?: unknown; interval?: string; targets?: Array<{ rawSql?: string }> };
+    type Dashboard = {
+      templating?: { list?: Array<{ name?: string; type?: string }> };
+      panels?: Array<Panel & { panels?: Panel[] }>;
+    };
+
+    const flatten = (d: Dashboard): Panel[] =>
+      (d.panels ?? []).flatMap((p) => [p, ...(p.panels ?? [])]);
+
+    it.each(otelDashboards)('%s exposes an "interval" interval variable', (filename) => {
+      const d = JSON.parse(fs.readFileSync(path.join(DASHBOARDS_DIR, filename), 'utf8')) as Dashboard;
+      const variable = d.templating?.list?.find((v) => v.name === 'interval');
+      expect(variable).toBeDefined();
+      expect(variable?.type).toBe('interval');
+    });
+
+    it.each(otelDashboards)('%s sets min interval on every $__interval_s panel', (filename) => {
+      const d = JSON.parse(fs.readFileSync(path.join(DASHBOARDS_DIR, filename), 'utf8')) as Dashboard;
+      const bucketed = flatten(d).filter((p) =>
+        (p.targets ?? []).some((t) => (t.rawSql ?? '').includes('$__interval_s'))
+      );
+      expect(bucketed.length).toBeGreaterThan(0);
+      for (const panel of bucketed) {
+        expect(panel.interval).toBe('${interval}');
+      }
+    });
+  });
 });

--- a/src/dashboards/__tests__/dashboards.test.ts
+++ b/src/dashboards/__tests__/dashboards.test.ts
@@ -175,5 +175,17 @@ describe('OTel dashboards', () => {
         expect(panel.interval).toBe('${interval}');
       }
     });
+
+    it.each(otelDashboards)('%s forwards the interval selection, not the resolved bucket', (filename) => {
+      // A data link interpolates ${interval} through to the concrete bucket size, so drilling
+      // through while "auto" is selected would pin that bucket on the target dashboard. The
+      // :text formatter forwards the selection as displayed ("auto", "30s"), which the target
+      // matches back to the same option — auto stays auto, an explicit choice stays explicit.
+      const content = fs.readFileSync(path.join(DASHBOARDS_DIR, filename), 'utf8');
+      const forwarding = content.match(/var-interval=\$\{interval[^}]*\}/g) ?? [];
+      for (const param of forwarding) {
+        expect(param).toBe('var-interval=${interval:text}');
+      }
+    });
   });
 });

--- a/src/dashboards/otel-logs-explorer.json
+++ b/src/dashboards/otel-logs-explorer.json
@@ -308,6 +308,8 @@
         "name": "interval",
         "options": [
           { "selected": true, "text": "auto", "value": "$__auto_interval_interval" },
+          { "selected": false, "text": "10s", "value": "10s" },
+          { "selected": false, "text": "30s", "value": "30s" },
           { "selected": false, "text": "1m", "value": "1m" },
           { "selected": false, "text": "5m", "value": "5m" },
           { "selected": false, "text": "10m", "value": "10m" },
@@ -317,7 +319,7 @@
           { "selected": false, "text": "12h", "value": "12h" },
           { "selected": false, "text": "1d", "value": "1d" }
         ],
-        "query": "1m,5m,10m,30m,1h,6h,12h,1d",
+        "query": "10s,30s,1m,5m,10m,30m,1h,6h,12h,1d",
         "refresh": 2,
         "type": "interval"
       },

--- a/src/dashboards/otel-logs-explorer.json
+++ b/src/dashboards/otel-logs-explorer.json
@@ -47,6 +47,7 @@
       },
       "gridPos": { "h": 5, "w": 24, "x": 0, "y": 1 },
       "id": 1,
+      "interval": "${interval}",
       "description": "Stacked log volume by SeverityText across the services and levels selected above.",
       "options": { "legend": { "displayMode": "list", "placement": "bottom", "calcs": ["sum"] }, "tooltip": { "mode": "multi" } },
       "title": "Log Volume by Level",
@@ -199,6 +200,7 @@
       },
       "gridPos": { "h": 5, "w": 24, "x": 0, "y": 12 },
       "id": 201,
+      "interval": "${interval}",
       "description": "Log volume by SeverityText for $service.",
       "options": { "legend": { "displayMode": "list", "placement": "bottom", "calcs": ["sum"] }, "tooltip": { "mode": "multi" } },
       "links": [
@@ -291,6 +293,33 @@
         "refresh": 1,
         "regex": "",
         "type": "datasource"
+      },
+      {
+        "auto": true,
+        "auto_count": 30,
+        "auto_min": "10s",
+        "current": {
+          "selected": false,
+          "text": "auto",
+          "value": "$__auto_interval_interval"
+        },
+        "hide": 0,
+        "label": "Min interval",
+        "name": "interval",
+        "options": [
+          { "selected": true, "text": "auto", "value": "$__auto_interval_interval" },
+          { "selected": false, "text": "1m", "value": "1m" },
+          { "selected": false, "text": "5m", "value": "5m" },
+          { "selected": false, "text": "10m", "value": "10m" },
+          { "selected": false, "text": "30m", "value": "30m" },
+          { "selected": false, "text": "1h", "value": "1h" },
+          { "selected": false, "text": "6h", "value": "6h" },
+          { "selected": false, "text": "12h", "value": "12h" },
+          { "selected": false, "text": "1d", "value": "1d" }
+        ],
+        "query": "1m,5m,10m,30m,1h,6h,12h,1d",
+        "refresh": 2,
+        "type": "interval"
       },
       {
         "allValue": null,

--- a/src/dashboards/otel-service-dashboard.json
+++ b/src/dashboards/otel-service-dashboard.json
@@ -85,6 +85,33 @@
         "type": "datasource"
       },
       {
+        "auto": true,
+        "auto_count": 30,
+        "auto_min": "10s",
+        "current": {
+          "selected": false,
+          "text": "auto",
+          "value": "$__auto_interval_interval"
+        },
+        "hide": 0,
+        "label": "Min interval",
+        "name": "interval",
+        "options": [
+          { "selected": true, "text": "auto", "value": "$__auto_interval_interval" },
+          { "selected": false, "text": "1m", "value": "1m" },
+          { "selected": false, "text": "5m", "value": "5m" },
+          { "selected": false, "text": "10m", "value": "10m" },
+          { "selected": false, "text": "30m", "value": "30m" },
+          { "selected": false, "text": "1h", "value": "1h" },
+          { "selected": false, "text": "6h", "value": "6h" },
+          { "selected": false, "text": "12h", "value": "12h" },
+          { "selected": false, "text": "1d", "value": "1d" }
+        ],
+        "query": "1m,5m,10m,30m,1h,6h,12h,1d",
+        "refresh": 2,
+        "type": "interval"
+      },
+      {
         "current": {},
         "datasource": {
           "type": "grafana-clickhouse-datasource",
@@ -195,6 +222,7 @@
         "y": 1
       },
       "id": 1,
+      "interval": "${interval}",
       "description": "Server spans per second for ${service}: incoming requests this service handles. The R in RED.",
       "title": "Request Rate (Server)",
       "type": "timeseries",
@@ -257,6 +285,7 @@
         "y": 1
       },
       "id": 2,
+      "interval": "${interval}",
       "description": "Fraction of Server spans for ${service} with StatusCode = 'Error'. The E in RED.",
       "title": "Error Rate (Server)",
       "type": "timeseries",
@@ -327,6 +356,7 @@
         "y": 1
       },
       "id": 3,
+      "interval": "${interval}",
       "description": "P50, P90 (solid) and P99 (dashed orange) Server span duration for ${service}. The D in RED.",
       "title": "Duration Percentiles (Server)",
       "type": "timeseries",
@@ -469,6 +499,7 @@
         "y": 16
       },
       "id": 12,
+      "interval": "${interval}",
       "description": "Client spans per second for ${service}: outgoing requests this service makes to its dependencies. The R in RED.",
       "title": "Request Rate (Client)",
       "type": "timeseries",
@@ -531,6 +562,7 @@
         "y": 16
       },
       "id": 13,
+      "interval": "${interval}",
       "description": "Fraction of Client spans for ${service} with StatusCode = 'Error'. The E in RED.",
       "title": "Error Rate (Client)",
       "type": "timeseries",
@@ -601,6 +633,7 @@
         "y": 16
       },
       "id": 14,
+      "interval": "${interval}",
       "description": "P50, P90 (solid) and P99 (dashed orange) Client span duration for ${service}. The D in RED.",
       "title": "Duration Percentiles (Client)",
       "type": "timeseries",
@@ -869,6 +902,7 @@
             "y": 42
           },
           "id": 16,
+          "interval": "${interval}",
           "description": "Internal spans per second for ${service}: in-process work (function-level instrumentation, no network).",
           "title": "Request Rate (Internal)",
           "type": "timeseries",
@@ -931,6 +965,7 @@
             "y": 42
           },
           "id": 17,
+          "interval": "${interval}",
           "description": "Fraction of Internal spans for ${service} with StatusCode = 'Error'.",
           "title": "Error Rate (Internal)",
           "type": "timeseries",
@@ -1001,6 +1036,7 @@
             "y": 42
           },
           "id": 18,
+          "interval": "${interval}",
           "description": "P50, P90 (solid) and P99 (dashed orange) Internal span duration for ${service}.",
           "title": "Duration Percentiles (Internal)",
           "type": "timeseries",
@@ -1144,6 +1180,7 @@
             "y": 57
           },
           "id": 20,
+          "interval": "${interval}",
           "description": "Async spans (Producer + Consumer) per second for ${service}: message production and consumption against queues / event buses.",
           "title": "Message Rate (Async)",
           "type": "timeseries",
@@ -1206,6 +1243,7 @@
             "y": 57
           },
           "id": 21,
+          "interval": "${interval}",
           "description": "Fraction of Async (Producer + Consumer) spans for ${service} with StatusCode = 'Error'.",
           "title": "Error Rate (Async)",
           "type": "timeseries",
@@ -1276,6 +1314,7 @@
             "y": 57
           },
           "id": 22,
+          "interval": "${interval}",
           "description": "P50, P90 (solid) and P99 (dashed orange) Async span duration for ${service}.",
           "title": "Duration Percentiles (Async)",
           "type": "timeseries",

--- a/src/dashboards/otel-service-dashboard.json
+++ b/src/dashboards/otel-service-dashboard.json
@@ -425,7 +425,7 @@
                 "value": [
                   {
                     "title": "View traces for ${__value.raw}",
-                    "url": "/d/otel-traces-explorer?var-service=${service}&var-operation=${__value.raw}&${__url_time_range}&var-datasource=${datasource}&var-interval=${interval}"
+                    "url": "/d/otel-traces-explorer?var-service=${service}&var-operation=${__value.raw}&${__url_time_range}&var-datasource=${datasource}&var-interval=${interval:text}"
                   }
                 ]
               }
@@ -702,7 +702,7 @@
                 "value": [
                   {
                     "title": "View traces for ${__value.raw}",
-                    "url": "/d/otel-traces-explorer?var-service=${service}&var-operation=${__value.raw}&${__url_time_range}&var-datasource=${datasource}&var-interval=${interval}"
+                    "url": "/d/otel-traces-explorer?var-service=${service}&var-operation=${__value.raw}&${__url_time_range}&var-datasource=${datasource}&var-interval=${interval:text}"
                   }
                 ]
               }
@@ -787,7 +787,7 @@
                 "value": [
                   {
                     "title": "View traces for ${__value.raw}",
-                    "url": "/d/otel-traces-explorer?var-service=${service}&var-operation=${__value.raw}&${__url_time_range}&var-datasource=${datasource}&var-interval=${interval}"
+                    "url": "/d/otel-traces-explorer?var-service=${service}&var-operation=${__value.raw}&${__url_time_range}&var-datasource=${datasource}&var-interval=${interval:text}"
                   }
                 ]
               }
@@ -1105,7 +1105,7 @@
                     "value": [
                       {
                         "title": "View traces for ${__value.raw}",
-                        "url": "/d/otel-traces-explorer?var-service=${service}&var-operation=${__value.raw}&${__url_time_range}&var-datasource=${datasource}&var-interval=${interval}"
+                        "url": "/d/otel-traces-explorer?var-service=${service}&var-operation=${__value.raw}&${__url_time_range}&var-datasource=${datasource}&var-interval=${interval:text}"
                       }
                     ]
                   }
@@ -1395,7 +1395,7 @@
                     "value": [
                       {
                         "title": "View traces for ${__value.raw}",
-                        "url": "/d/otel-traces-explorer?var-service=${service}&var-operation=${__value.raw}&${__url_time_range}&var-datasource=${datasource}&var-interval=${interval}"
+                        "url": "/d/otel-traces-explorer?var-service=${service}&var-operation=${__value.raw}&${__url_time_range}&var-datasource=${datasource}&var-interval=${interval:text}"
                       }
                     ]
                   }

--- a/src/dashboards/otel-service-dashboard.json
+++ b/src/dashboards/otel-service-dashboard.json
@@ -98,6 +98,8 @@
         "name": "interval",
         "options": [
           { "selected": true, "text": "auto", "value": "$__auto_interval_interval" },
+          { "selected": false, "text": "10s", "value": "10s" },
+          { "selected": false, "text": "30s", "value": "30s" },
           { "selected": false, "text": "1m", "value": "1m" },
           { "selected": false, "text": "5m", "value": "5m" },
           { "selected": false, "text": "10m", "value": "10m" },
@@ -107,7 +109,7 @@
           { "selected": false, "text": "12h", "value": "12h" },
           { "selected": false, "text": "1d", "value": "1d" }
         ],
-        "query": "1m,5m,10m,30m,1h,6h,12h,1d",
+        "query": "10s,30s,1m,5m,10m,30m,1h,6h,12h,1d",
         "refresh": 2,
         "type": "interval"
       },
@@ -423,7 +425,7 @@
                 "value": [
                   {
                     "title": "View traces for ${__value.raw}",
-                    "url": "/d/otel-traces-explorer?var-service=${service}&var-operation=${__value.raw}&${__url_time_range}&var-datasource=${datasource}"
+                    "url": "/d/otel-traces-explorer?var-service=${service}&var-operation=${__value.raw}&${__url_time_range}&var-datasource=${datasource}&var-interval=${interval}"
                   }
                 ]
               }
@@ -700,7 +702,7 @@
                 "value": [
                   {
                     "title": "View traces for ${__value.raw}",
-                    "url": "/d/otel-traces-explorer?var-service=${service}&var-operation=${__value.raw}&${__url_time_range}&var-datasource=${datasource}"
+                    "url": "/d/otel-traces-explorer?var-service=${service}&var-operation=${__value.raw}&${__url_time_range}&var-datasource=${datasource}&var-interval=${interval}"
                   }
                 ]
               }
@@ -785,7 +787,7 @@
                 "value": [
                   {
                     "title": "View traces for ${__value.raw}",
-                    "url": "/d/otel-traces-explorer?var-service=${service}&var-operation=${__value.raw}&${__url_time_range}&var-datasource=${datasource}"
+                    "url": "/d/otel-traces-explorer?var-service=${service}&var-operation=${__value.raw}&${__url_time_range}&var-datasource=${datasource}&var-interval=${interval}"
                   }
                 ]
               }
@@ -1103,7 +1105,7 @@
                     "value": [
                       {
                         "title": "View traces for ${__value.raw}",
-                        "url": "/d/otel-traces-explorer?var-service=${service}&var-operation=${__value.raw}&${__url_time_range}&var-datasource=${datasource}"
+                        "url": "/d/otel-traces-explorer?var-service=${service}&var-operation=${__value.raw}&${__url_time_range}&var-datasource=${datasource}&var-interval=${interval}"
                       }
                     ]
                   }
@@ -1393,7 +1395,7 @@
                     "value": [
                       {
                         "title": "View traces for ${__value.raw}",
-                        "url": "/d/otel-traces-explorer?var-service=${service}&var-operation=${__value.raw}&${__url_time_range}&var-datasource=${datasource}"
+                        "url": "/d/otel-traces-explorer?var-service=${service}&var-operation=${__value.raw}&${__url_time_range}&var-datasource=${datasource}&var-interval=${interval}"
                       }
                     ]
                   }

--- a/src/dashboards/otel-traces-explorer.json
+++ b/src/dashboards/otel-traces-explorer.json
@@ -91,6 +91,8 @@
         "name": "interval",
         "options": [
           { "selected": true, "text": "auto", "value": "$__auto_interval_interval" },
+          { "selected": false, "text": "10s", "value": "10s" },
+          { "selected": false, "text": "30s", "value": "30s" },
           { "selected": false, "text": "1m", "value": "1m" },
           { "selected": false, "text": "5m", "value": "5m" },
           { "selected": false, "text": "10m", "value": "10m" },
@@ -100,7 +102,7 @@
           { "selected": false, "text": "12h", "value": "12h" },
           { "selected": false, "text": "1d", "value": "1d" }
         ],
-        "query": "1m,5m,10m,30m,1h,6h,12h,1d",
+        "query": "10s,30s,1m,5m,10m,30m,1h,6h,12h,1d",
         "refresh": 2,
         "type": "interval"
       },
@@ -446,7 +448,7 @@
       "interval": "${interval}",
       "description": "Total span count for $service.",
       "options": {
-        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "reduceOptions": { "calcs": ["sum"] },
         "colorMode": "none",
         "graphMode": "area",
         "textMode": "value_and_name",

--- a/src/dashboards/otel-traces-explorer.json
+++ b/src/dashboards/otel-traces-explorer.json
@@ -78,6 +78,33 @@
         "type": "datasource"
       },
       {
+        "auto": true,
+        "auto_count": 30,
+        "auto_min": "10s",
+        "current": {
+          "selected": false,
+          "text": "auto",
+          "value": "$__auto_interval_interval"
+        },
+        "hide": 0,
+        "label": "Min interval",
+        "name": "interval",
+        "options": [
+          { "selected": true, "text": "auto", "value": "$__auto_interval_interval" },
+          { "selected": false, "text": "1m", "value": "1m" },
+          { "selected": false, "text": "5m", "value": "5m" },
+          { "selected": false, "text": "10m", "value": "10m" },
+          { "selected": false, "text": "30m", "value": "30m" },
+          { "selected": false, "text": "1h", "value": "1h" },
+          { "selected": false, "text": "6h", "value": "6h" },
+          { "selected": false, "text": "12h", "value": "12h" },
+          { "selected": false, "text": "1d", "value": "1d" }
+        ],
+        "query": "1m,5m,10m,30m,1h,6h,12h,1d",
+        "refresh": 2,
+        "type": "interval"
+      },
+      {
         "current": {},
         "datasource": {
           "type": "grafana-clickhouse-datasource",
@@ -370,6 +397,7 @@
       },
       "gridPos": { "h": 8, "w": 16, "x": 0, "y": 25 },
       "id": 301,
+      "interval": "${interval}",
       "description": "Span duration distribution over time for $service, log-scale. Sampled at 1-in-500 spans for performance.",
       "options": {
         "calculate": true,
@@ -415,6 +443,7 @@
       "fieldConfig": { "defaults": { "color": { "mode": "fixed", "fixedColor": "text" } } },
       "gridPos": { "h": 2, "w": 8, "x": 16, "y": 25 },
       "id": 302,
+      "interval": "${interval}",
       "description": "Total span count for $service.",
       "options": {
         "reduceOptions": { "calcs": ["lastNotNull"] },
@@ -441,6 +470,7 @@
       "fieldConfig": { "defaults": { "color": { "mode": "fixed", "fixedColor": "red" } } },
       "gridPos": { "h": 2, "w": 8, "x": 16, "y": 27 },
       "id": 303,
+      "interval": "${interval}",
       "description": "Error span count for $service.",
       "options": {
         "reduceOptions": { "calcs": ["sum"] },
@@ -467,6 +497,7 @@
       "fieldConfig": { "defaults": { "unit": "ms", "color": { "mode": "fixed", "fixedColor": "orange" } } },
       "gridPos": { "h": 2, "w": 8, "x": 16, "y": 29 },
       "id": 304,
+      "interval": "${interval}",
       "description": "P99 span duration for $service.",
       "options": {
         "reduceOptions": { "calcs": ["lastNotNull"] },
@@ -498,6 +529,7 @@
       "fieldConfig": { "defaults": { "unit": "ms", "color": { "mode": "fixed", "fixedColor": "blue" } } },
       "gridPos": { "h": 2, "w": 8, "x": 16, "y": 31 },
       "id": 305,
+      "interval": "${interval}",
       "description": "Mean span duration for $service.",
       "options": {
         "reduceOptions": { "calcs": ["lastNotNull"] },


### PR DESCRIPTION
## What
Adds an `interval` template variable (interval type, default `auto`) to the OpenTelemetry **Logs**, **Traces** and **Service** dashboards, and sets it as the **Min interval** query option (`"interval": "${interval}"`) on every panel that buckets by `$__interval_s`.

## Why
Lets users control the time-bucket granularity of the timeseries / heatmap / stat panels from the dashboard, instead of being locked to Grafana's auto interval derived from panel width.

## Drill-through behaviour

The five hand-built drill-through links on the service dashboard forward `&var-interval=${interval}`, which resolves to the bucket in effect when you click. So a drill-through from the default `auto` state pins that concrete bucket (for example `30s`) on the target dashboard rather than leaving it on `auto`.

`${interval:text}` does not avoid this. On scenes, `IntervalVariable` defines no `getValueText`, so the `text` formatter falls through to `getValue()` and forwards the resolved bucket anyway; and the target's `updateFromUrl` takes any non-sentinel string verbatim, so `var-interval=auto` would set a literal `auto` that is not one of its options. Forwarding the plain value at least gives the target something it can honour. The dashboard-level menu link still preserves `auto`, because `includeVars` emits the `$__auto` sentinel.

---
_Part of a small series of independent improvements to the pre-built OpenTelemetry dashboards. The dashboard-editing PRs touch overlapping lines, so whichever lands first, the others need a trivial rebase:_
- #2080 — database selector variable
- #2081 — importable `__inputs`/`__requires`
- #2082 — min-interval variable
- #2083 — multi-value quoting
- #2084 — JSON-schema logs dashboard

All commits are signed. New assertions added to `src/dashboards/__tests__/dashboards.test.ts`.

