### PR TITLE
fix(dashboards): quote template variables in bundled dashboards

### DIFF
--- a/src/dashboards/__tests__/dashboards.test.ts
+++ b/src/dashboards/__tests__/dashboards.test.ts
@@ -159,11 +159,13 @@ describe('OTel dashboards', () => {
     it.each(allDashboards)('%s quotes template variables in SQL', (filename) => {
       const content = fs.readFileSync(path.join(DASHBOARDS_DIR, filename), 'utf8');
       // Template variables must be interpolated with :singlequote, not bare. The datasource's
-      // default formatter quotes multi-value selections ('a','b') but does not escape a single
-      // quote inside a value, and leaves single-value selections unquoted; :singlequote does
-      // both. ($__... macros are excluded.)
-      expect(content).not.toMatch(/IN \(\$\{?(?!__)\w+\}?\)/);
-      expect(content).not.toMatch(/= '\$\{?\w+\}?'/);
+      // default formatter (CHDatasource.format) already renders a multi-value selection as
+      // 'a','b', but it does not escape a single quote inside a value, so a value such as
+      // bob's-service produces invalid SQL. :singlequote escapes the quote; the plain formatter
+      // does not. Dashboards mix uppercase IN and lowercase in, so match case-insensitively.
+      // ($__... macros are excluded.)
+      expect(content).not.toMatch(/IN \(\$\{?(?!__)\w+\}?\)/i);
+      expect(content).not.toMatch(/= '\$\{?\w+\}?'/i);
     });
   });
 });

--- a/src/dashboards/__tests__/dashboards.test.ts
+++ b/src/dashboards/__tests__/dashboards.test.ts
@@ -147,4 +147,23 @@ describe('OTel dashboards', () => {
       expect(content).not.toMatch(/= '\$\{?\w+\}?'/);
     });
   });
+
+  describe('template variable quoting', () => {
+    // Guard every bundled dashboard, so a bare interpolation added to any of them is caught.
+    const allDashboards = (
+      JSON.parse(fs.readFileSync(PLUGIN_JSON, 'utf8')) as { includes: Array<{ type: string; path: string }> }
+    ).includes
+      .filter((i) => i.type === 'dashboard')
+      .map((i) => path.basename(i.path));
+
+    it.each(allDashboards)('%s quotes template variables in SQL', (filename) => {
+      const content = fs.readFileSync(path.join(DASHBOARDS_DIR, filename), 'utf8');
+      // Template variables must be interpolated with :singlequote, not bare. The datasource's
+      // default formatter quotes multi-value selections ('a','b') but does not escape a single
+      // quote inside a value, and leaves single-value selections unquoted; :singlequote does
+      // both. ($__... macros are excluded.)
+      expect(content).not.toMatch(/IN \(\$\{?(?!__)\w+\}?\)/);
+      expect(content).not.toMatch(/= '\$\{?\w+\}?'/);
+    });
+  });
 });

--- a/src/dashboards/data-analysis.json
+++ b/src/dashboards/data-analysis.json
@@ -331,7 +331,7 @@
             }
           },
           "queryType": "sql",
-          "rawSql": "SELECT  sum(total_rows) as \"Total rows\" FROM system.tables WHERE database IN (${database}) AND name IN (${table})",
+          "rawSql": "SELECT  sum(total_rows) as \"Total rows\" FROM system.tables WHERE database IN (${database:singlequote}) AND name IN (${table:singlequote})",
           "refId": "A"
         }
       ],
@@ -399,7 +399,7 @@
             }
           },
           "queryType": "sql",
-          "rawSql": "SELECT count() as \"Total columns\" FROM system.columns WHERE database IN (${database}) AND table IN (${table})",
+          "rawSql": "SELECT count() as \"Total columns\" FROM system.columns WHERE database IN (${database:singlequote}) AND table IN (${table:singlequote})",
           "refId": "A"
         }
       ],
@@ -690,7 +690,7 @@
             }
           },
           "queryType": "sql",
-          "rawSql": "SELECT concatAssumeInjective(table.database, '.', name) as name,\n       table_stats.total_rows as total_rows\nFROM system.tables table\n         LEFT JOIN ( SELECT table,\n       database,\n       sum(rows)                  as total_rows\nFROM system.parts\nWHERE table IN (${table}) AND active AND database IN (${database}) \nGROUP BY table, database\n ) AS table_stats ON table.name = table_stats.table AND table.database = table_stats.database\nORDER BY total_rows DESC\nLIMIT 10",
+          "rawSql": "SELECT concatAssumeInjective(table.database, '.', name) as name,\n       table_stats.total_rows as total_rows\nFROM system.tables table\n         LEFT JOIN ( SELECT table,\n       database,\n       sum(rows)                  as total_rows\nFROM system.parts\nWHERE table IN (${table:singlequote}) AND active AND database IN (${database:singlequote}) \nGROUP BY table, database\n ) AS table_stats ON table.name = table_stats.table AND table.database = table_stats.database\nORDER BY total_rows DESC\nLIMIT 10",
           "refId": "A"
         }
       ],
@@ -774,7 +774,7 @@
             }
           },
           "queryType": "sql",
-          "rawSql": "SELECT concatAssumeInjective(table.database, '.', name) as name,\n       col_stats.col_count as total_columns\nFROM system.tables table\n         LEFT JOIN (SELECT database, table, count() as col_count FROM system.columns  GROUP BY table, database) as col_stats\n                   ON table.name = col_stats.table AND col_stats.database = table.database\nWHERE database IN (${database}) AND name != '' AND table IN (${table}) AND name != '' ORDER BY total_columns DESC LIMIT 10;\n",
+          "rawSql": "SELECT concatAssumeInjective(table.database, '.', name) as name,\n       col_stats.col_count as total_columns\nFROM system.tables table\n         LEFT JOIN (SELECT database, table, count() as col_count FROM system.columns  GROUP BY table, database) as col_stats\n                   ON table.name = col_stats.table AND col_stats.database = table.database\nWHERE database IN (${database:singlequote}) AND name != '' AND table IN (${table:singlequote}) AND name != '' ORDER BY total_columns DESC LIMIT 10;\n",
           "refId": "A"
         }
       ],
@@ -878,7 +878,7 @@
             }
           },
           "queryType": "sql",
-          "rawSql": "SELECT engine, count() \"Number of databases\" FROM system.databases WHERE name IN (${database}) GROUP BY engine ",
+          "rawSql": "SELECT engine, count() \"Number of databases\" FROM system.databases WHERE name IN (${database:singlequote}) GROUP BY engine ",
           "refId": "A"
         }
       ],
@@ -981,7 +981,7 @@
             }
           },
           "queryType": "sql",
-          "rawSql": "SELECT engine, count() \"Number of tables\" FROM system.tables WHERE database IN (${database}) AND notLike(engine,'System%')  AND name IN (${table}) GROUP BY engine ORDER BY count() DESC",
+          "rawSql": "SELECT engine, count() \"Number of tables\" FROM system.tables WHERE database IN (${database:singlequote}) AND notLike(engine,'System%')  AND name IN (${table:singlequote}) GROUP BY engine ORDER BY count() DESC",
           "refId": "A"
         }
       ],
@@ -1180,7 +1180,7 @@
           },
           "pluginVersion": "4.10.2",
           "queryType": "table",
-          "rawSql": "SELECT name,\n       engine,\n       tables,\n       partitions,\n       parts,\n       bytes_on_disk            \"disk_size\",\n       col_count,\n       total_rows,\n       data_uncompressed_bytes as \"uncompressed_size\"\nFROM system.databases db\n         LEFT JOIN ( SELECT database,\n                            uniq(table)                   \"tables\",\n                            uniq(table, partition)        \"partitions\",\n                            count()                    AS parts,\n                            sum(bytes_on_disk)            \"bytes_on_disk\",\n                            sum(data_uncompressed_bytes) as \"data_uncompressed_bytes\",\n                            sum(rows) as total_rows,\n                            max(col_count) as \"col_count\"\n                     FROM system.parts AS parts\n                               JOIN (SELECT database, count() as col_count\n                                         FROM system.columns\n                                         WHERE database IN (${database}) AND table IN (${table})\n                                         GROUP BY database) as col_stats\n                                        ON parts.database = col_stats.database\n                     WHERE database IN (${database}) AND active AND table IN (${table})\n                     GROUP BY database) AS db_stats ON db.name = db_stats.database\nWHERE database IN (${database}) AND lower(name) != 'information_schema'\nORDER BY bytes_on_disk DESC\nLIMIT 10;",
+          "rawSql": "SELECT name,\n       engine,\n       tables,\n       partitions,\n       parts,\n       bytes_on_disk            \"disk_size\",\n       col_count,\n       total_rows,\n       data_uncompressed_bytes as \"uncompressed_size\"\nFROM system.databases db\n         LEFT JOIN ( SELECT database,\n                            uniq(table)                   \"tables\",\n                            uniq(table, partition)        \"partitions\",\n                            count()                    AS parts,\n                            sum(bytes_on_disk)            \"bytes_on_disk\",\n                            sum(data_uncompressed_bytes) as \"data_uncompressed_bytes\",\n                            sum(rows) as total_rows,\n                            max(col_count) as \"col_count\"\n                     FROM system.parts AS parts\n                               JOIN (SELECT database, count() as col_count\n                                         FROM system.columns\n                                         WHERE database IN (${database:singlequote}) AND table IN (${table:singlequote})\n                                         GROUP BY database) as col_stats\n                                        ON parts.database = col_stats.database\n                     WHERE database IN (${database:singlequote}) AND active AND table IN (${table:singlequote})\n                     GROUP BY database) AS db_stats ON db.name = db_stats.database\nWHERE database IN (${database:singlequote}) AND lower(name) != 'information_schema'\nORDER BY bytes_on_disk DESC\nLIMIT 10;",
           "refId": "A"
         }
       ],
@@ -1562,7 +1562,7 @@
           },
           "pluginVersion": "4.10.2",
           "queryType": "table",
-          "rawSql": "SELECT name,\n       table.database,\n       engine,\n       partitions,\n       parts,\n       bytes_on_disk            \"disk_size\",\n       col_count,\n       table_stats.total_rows,\n       data_uncompressed_bytes as \"uncompressed_size\"\nFROM system.tables table\n         LEFT JOIN ( SELECT table,\n       database,\n       uniq(table, partition)        \"partitions\",\n       count()                    AS parts,\n       sum(bytes_on_disk)            \"bytes_on_disk\",\n       sum(data_uncompressed_bytes) as \"data_uncompressed_bytes\",\n       sum(rows)                  as total_rows,\n                            max(col_count) as col_count\nFROM system.parts as parts\n         LEFT JOIN (SELECT database, table, count() as col_count FROM system.columns GROUP BY table, database) as col_stats\n                   ON parts.table = col_stats.table AND col_stats.database = parts.database\nWHERE active\nGROUP BY table, database\n ) AS table_stats ON table.name = table_stats.table AND table.database = table_stats.database\nWHERE database IN (${database}) AND lower(name) != 'information_schema' AND table IN (${table})\nORDER BY bytes_on_disk DESC\nLIMIT 1000",
+          "rawSql": "SELECT name,\n       table.database,\n       engine,\n       partitions,\n       parts,\n       bytes_on_disk            \"disk_size\",\n       col_count,\n       table_stats.total_rows,\n       data_uncompressed_bytes as \"uncompressed_size\"\nFROM system.tables table\n         LEFT JOIN ( SELECT table,\n       database,\n       uniq(table, partition)        \"partitions\",\n       count()                    AS parts,\n       sum(bytes_on_disk)            \"bytes_on_disk\",\n       sum(data_uncompressed_bytes) as \"data_uncompressed_bytes\",\n       sum(rows)                  as total_rows,\n                            max(col_count) as col_count\nFROM system.parts as parts\n         LEFT JOIN (SELECT database, table, count() as col_count FROM system.columns GROUP BY table, database) as col_stats\n                   ON parts.table = col_stats.table AND col_stats.database = parts.database\nWHERE active\nGROUP BY table, database\n ) AS table_stats ON table.name = table_stats.table AND table.database = table_stats.database\nWHERE database IN (${database:singlequote}) AND lower(name) != 'information_schema' AND table IN (${table:singlequote})\nORDER BY bytes_on_disk DESC\nLIMIT 1000",
           "refId": "A"
         }
       ],
@@ -1786,7 +1786,7 @@
             }
           },
           "queryType": "sql",
-          "rawSql": "SELECT database, table, partition_id, name, disk, level FROM system.detached_parts WHERE database IN (${database}) AND table IN (${table})",
+          "rawSql": "SELECT database, table, partition_id, name, disk, level FROM system.detached_parts WHERE database IN (${database:singlequote}) AND table IN (${table:singlequote})",
           "refId": "A"
         }
       ],
@@ -1915,7 +1915,7 @@
             }
           },
           "queryType": "sql",
-          "rawSql": "SELECT modification_time as timestamp, concatAssumeInjective(database, '.', table) as table, rows FROM system.parts parts WHERE parts.database IN ($database) AND parts.table IN (${table})  AND $__timeFilter(modification_time) ORDER BY modification_time ASC",
+          "rawSql": "SELECT modification_time as timestamp, concatAssumeInjective(database, '.', table) as table, rows FROM system.parts parts WHERE parts.database IN (${database:singlequote}) AND parts.table IN (${table:singlequote})  AND $__timeFilter(modification_time) ORDER BY modification_time ASC",
           "refId": "A"
         }
       ],
@@ -2022,7 +2022,7 @@
             }
           },
           "queryType": "sql",
-          "rawSql": "SELECT concatAssumeInjective(database, '.', table) as dbTable, count() \"partitions\", sum(part_count) \"parts\", max(part_count) \"max_parts_per_partition\"\nFROM ( SELECT database, table, count() \"part_count\"\n       FROM system.parts\n       WHERE database IN (${database}) AND active AND table IN (${table})\n       GROUP BY database, table, partition ) partitions\nGROUP BY database, table\nORDER BY max_parts_per_partition DESC\nLIMIT 10",
+          "rawSql": "SELECT concatAssumeInjective(database, '.', table) as dbTable, count() \"partitions\", sum(part_count) \"parts\", max(part_count) \"max_parts_per_partition\"\nFROM ( SELECT database, table, count() \"part_count\"\n       FROM system.parts\n       WHERE database IN (${database:singlequote}) AND active AND table IN (${table:singlequote})\n       GROUP BY database, table, partition ) partitions\nGROUP BY database, table\nORDER BY max_parts_per_partition DESC\nLIMIT 10",
           "refId": "A"
         }
       ],
@@ -2261,7 +2261,7 @@
             }
           },
           "queryType": "sql",
-          "rawSql": "SELECT database, table, partition_id, modification_time, name, part_type, active, level, disk_name, path, marks, rows, bytes_on_disk, refcount, min_block_number, max_block_number FROM system.parts WHERE database IN (${database}) AND table IN (${table})  AND modification_time > now() - INTERVAL 3 MINUTE ORDER BY modification_time DESC",
+          "rawSql": "SELECT database, table, partition_id, modification_time, name, part_type, active, level, disk_name, path, marks, rows, bytes_on_disk, refcount, min_block_number, max_block_number FROM system.parts WHERE database IN (${database:singlequote}) AND table IN (${table:singlequote})  AND modification_time > now() - INTERVAL 3 MINUTE ORDER BY modification_time DESC",
           "refId": "A"
         }
       ],
@@ -2344,13 +2344,13 @@
           "type": "grafana-clickhouse-datasource",
           "uid": "${datasource}"
         },
-        "definition": "SELECT name FROM system.tables WHERE database IN (${database})",
+        "definition": "SELECT name FROM system.tables WHERE database IN (${database:singlequote})",
         "includeAll": true,
         "label": "Table",
         "multi": true,
         "name": "table",
         "options": [],
-        "query": "SELECT name FROM system.tables WHERE database IN (${database})",
+        "query": "SELECT name FROM system.tables WHERE database IN (${database:singlequote})",
         "refresh": 1,
         "regex": "",
         "type": "query"

--- a/src/dashboards/otel-logs-explorer.json
+++ b/src/dashboards/otel-logs-explorer.json
@@ -54,7 +54,7 @@
         {
           "datasource": { "type": "grafana-clickhouse-datasource", "uid": "${datasource}" },
           "editorType": "sql",
-          "rawSql": "SELECT\n  toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time,\n  SeverityText AS metric,\n  count() AS count\nFROM otel_logs\nWHERE $__timeFilter(Timestamp)\n  AND $__conditionalAll(ServiceName IN ($service), $service)\n  AND $__conditionalAll(SeverityText IN ($level_filter), $level_filter)\n  AND $__conditionalAll(positionCaseInsensitive(Body, '$search') > 0, $search)\nGROUP BY time, metric\nORDER BY time",
+          "rawSql": "SELECT\n  toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time,\n  SeverityText AS metric,\n  count() AS count\nFROM otel_logs\nWHERE $__timeFilter(Timestamp)\n  AND $__conditionalAll(ServiceName IN (${service:singlequote}), $service)\n  AND $__conditionalAll(SeverityText IN (${level_filter:singlequote}), $level_filter)\n  AND $__conditionalAll(positionCaseInsensitive(Body, '$search') > 0, $search)\nGROUP BY time, metric\nORDER BY time",
           "refId": "A",
           "format": 0
         }
@@ -86,7 +86,7 @@
         {
           "datasource": { "type": "grafana-clickhouse-datasource", "uid": "${datasource}" },
           "editorType": "sql",
-          "rawSql": "SELECT\n  ServiceName AS Service,\n  count() AS Count\nFROM otel_logs\nWHERE $__timeFilter(Timestamp)\n  AND $__conditionalAll(ServiceName IN ($service), $service)\n  AND $__conditionalAll(SeverityText IN ($level_filter), $level_filter)\n  AND $__conditionalAll(positionCaseInsensitive(Body, '$search') > 0, $search)\nGROUP BY Service\nORDER BY Count DESC\nLIMIT 15",
+          "rawSql": "SELECT\n  ServiceName AS Service,\n  count() AS Count\nFROM otel_logs\nWHERE $__timeFilter(Timestamp)\n  AND $__conditionalAll(ServiceName IN (${service:singlequote}), $service)\n  AND $__conditionalAll(SeverityText IN (${level_filter:singlequote}), $level_filter)\n  AND $__conditionalAll(positionCaseInsensitive(Body, '$search') > 0, $search)\nGROUP BY Service\nORDER BY Count DESC\nLIMIT 15",
           "refId": "A",
           "format": 0
         }
@@ -122,7 +122,7 @@
         {
           "datasource": { "type": "grafana-clickhouse-datasource", "uid": "${datasource}" },
           "editorType": "sql",
-          "rawSql": "SELECT\n  SeverityText AS Level,\n  count() AS Count\nFROM otel_logs\nWHERE $__timeFilter(Timestamp)\n  AND $__conditionalAll(ServiceName IN ($service), $service)\n  AND $__conditionalAll(positionCaseInsensitive(Body, '$search') > 0, $search)\nGROUP BY Level\nORDER BY Count DESC",
+          "rawSql": "SELECT\n  SeverityText AS Level,\n  count() AS Count\nFROM otel_logs\nWHERE $__timeFilter(Timestamp)\n  AND $__conditionalAll(ServiceName IN (${service:singlequote}), $service)\n  AND $__conditionalAll(positionCaseInsensitive(Body, '$search') > 0, $search)\nGROUP BY Level\nORDER BY Count DESC",
           "refId": "A",
           "format": 0
         }
@@ -159,7 +159,7 @@
         {
           "datasource": { "type": "grafana-clickhouse-datasource", "uid": "${datasource}" },
           "editorType": "sql",
-          "rawSql": "SELECT\n  SeverityText AS Level,\n  ServiceName AS Service,\n  replaceRegexpAll(Body, '(userId|orderId|cartId|requestId|traceId|spanId|ctId)=[a-zA-Z0-9-]+', '\\1=…') AS Message,\n  count() AS Count\nFROM otel_logs\nWHERE $__timeFilter(Timestamp)\n  AND SeverityText IN ('ERROR', 'WARN', 'FATAL', 'Error', 'Warning', 'error', 'warning', 'fatal', 'CRITICAL')\n  AND $__conditionalAll(ServiceName IN ($service), $service)\n  AND $__conditionalAll(positionCaseInsensitive(Body, '$search') > 0, $search)\nGROUP BY Level, Service, Message\nORDER BY Count DESC\nLIMIT 20",
+          "rawSql": "SELECT\n  SeverityText AS Level,\n  ServiceName AS Service,\n  replaceRegexpAll(Body, '(userId|orderId|cartId|requestId|traceId|spanId|ctId)=[a-zA-Z0-9-]+', '\\1=…') AS Message,\n  count() AS Count\nFROM otel_logs\nWHERE $__timeFilter(Timestamp)\n  AND SeverityText IN ('ERROR', 'WARN', 'FATAL', 'Error', 'Warning', 'error', 'warning', 'fatal', 'CRITICAL')\n  AND $__conditionalAll(ServiceName IN (${service:singlequote}), $service)\n  AND $__conditionalAll(positionCaseInsensitive(Body, '$search') > 0, $search)\nGROUP BY Level, Service, Message\nORDER BY Count DESC\nLIMIT 20",
           "refId": "A",
           "format": 0
         }
@@ -208,7 +208,7 @@
         {
           "datasource": { "type": "grafana-clickhouse-datasource", "uid": "${datasource}" },
           "editorType": "sql",
-          "rawSql": "SELECT\n  toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time,\n  SeverityText AS metric,\n  count() AS count\nFROM otel_logs\nWHERE $__timeFilter(Timestamp)\n  AND ServiceName = '${service}'\n  AND $__conditionalAll(SeverityText IN ($level_filter), $level_filter)\n  AND $__conditionalAll(positionCaseInsensitive(Body, '$search') > 0, $search)\nGROUP BY time, metric\nORDER BY time",
+          "rawSql": "SELECT\n  toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time,\n  SeverityText AS metric,\n  count() AS count\nFROM otel_logs\nWHERE $__timeFilter(Timestamp)\n  AND ServiceName = ${service:singlequote}\n  AND $__conditionalAll(SeverityText IN (${level_filter:singlequote}), $level_filter)\n  AND $__conditionalAll(positionCaseInsensitive(Body, '$search') > 0, $search)\nGROUP BY time, metric\nORDER BY time",
           "refId": "A",
           "format": 0
         }
@@ -238,7 +238,7 @@
         {
           "datasource": { "type": "grafana-clickhouse-datasource", "uid": "${datasource}" },
           "editorType": "sql",
-          "rawSql": "SELECT\n  Timestamp AS timestamp,\n  Body AS body,\n  SeverityText AS level,\n  ServiceName,\n  TraceId,\n  SpanId,\n  ResourceAttributes['service.namespace'] AS namespace,\n  ResourceAttributes['k8s.pod.name'] AS k8s_pod\nFROM otel_logs\nWHERE $__timeFilter(Timestamp)\n  AND ServiceName = '${service}'\n  AND $__conditionalAll(SeverityText IN ($level_filter), $level_filter)\n  AND $__conditionalAll(positionCaseInsensitive(Body, '$search') > 0, $search)\nORDER BY Timestamp DESC\nLIMIT 200",
+          "rawSql": "SELECT\n  Timestamp AS timestamp,\n  Body AS body,\n  SeverityText AS level,\n  ServiceName,\n  TraceId,\n  SpanId,\n  ResourceAttributes['service.namespace'] AS namespace,\n  ResourceAttributes['k8s.pod.name'] AS k8s_pod\nFROM otel_logs\nWHERE $__timeFilter(Timestamp)\n  AND ServiceName = ${service:singlequote}\n  AND $__conditionalAll(SeverityText IN (${level_filter:singlequote}), $level_filter)\n  AND $__conditionalAll(positionCaseInsensitive(Body, '$search') > 0, $search)\nORDER BY Timestamp DESC\nLIMIT 200",
           "refId": "A",
           "format": 2
         }
@@ -258,7 +258,7 @@
         "type": "dashboard"
       },
       {
-        "customSql": "SELECT\n  time,\n  ServiceName AS tags,\n  concat(ServiceName, ' deployed ', version, if(prev_version != '', concat(' (was ', prev_version, ')'), '')) AS text,\n  'Deployment' AS title\nFROM (\n  SELECT\n    toStartOfInterval(Timestamp, INTERVAL 30 second) AS time,\n    ServiceName,\n    topK(1)(ResourceAttributes['service.version'])[1] AS version,\n    lagInFrame(topK(1)(ResourceAttributes['service.version'])[1])\n      OVER (PARTITION BY ServiceName ORDER BY time) AS prev_version\n  FROM otel_traces\n  WHERE $__timeFilter(Timestamp)\n    AND $__conditionalAll(ServiceName IN ($service), $service)\n    AND ResourceAttributes['service.version'] != ''\n  GROUP BY ServiceName, time\n  ORDER BY ServiceName, time\n)\nWHERE prev_version != '' AND prev_version != version\nORDER BY time",
+        "customSql": "SELECT\n  time,\n  ServiceName AS tags,\n  concat(ServiceName, ' deployed ', version, if(prev_version != '', concat(' (was ', prev_version, ')'), '')) AS text,\n  'Deployment' AS title\nFROM (\n  SELECT\n    toStartOfInterval(Timestamp, INTERVAL 30 second) AS time,\n    ServiceName,\n    topK(1)(ResourceAttributes['service.version'])[1] AS version,\n    lagInFrame(topK(1)(ResourceAttributes['service.version'])[1])\n      OVER (PARTITION BY ServiceName ORDER BY time) AS prev_version\n  FROM otel_traces\n  WHERE $__timeFilter(Timestamp)\n    AND $__conditionalAll(ServiceName IN (${service:singlequote}), $service)\n    AND ResourceAttributes['service.version'] != ''\n  GROUP BY ServiceName, time\n  ORDER BY ServiceName, time\n)\nWHERE prev_version != '' AND prev_version != version\nORDER BY time",
         "datasource": { "type": "grafana-clickhouse-datasource", "uid": "${datasource}" },
         "enable": false,
         "hide": false,
@@ -267,7 +267,7 @@
         "preset": "custom",
         "target": {
           "editorType": "sql",
-          "rawSql": "SELECT\n  time,\n  ServiceName AS tags,\n  concat(ServiceName, ' deployed ', version, if(prev_version != '', concat(' (was ', prev_version, ')'), '')) AS text,\n  'Deployment' AS title\nFROM (\n  SELECT\n    toStartOfInterval(Timestamp, INTERVAL 30 second) AS time,\n    ServiceName,\n    topK(1)(ResourceAttributes['service.version'])[1] AS version,\n    lagInFrame(topK(1)(ResourceAttributes['service.version'])[1])\n      OVER (PARTITION BY ServiceName ORDER BY time) AS prev_version\n  FROM otel_traces\n  WHERE $__timeFilter(Timestamp)\n    AND $__conditionalAll(ServiceName IN ($service), $service)\n    AND ResourceAttributes['service.version'] != ''\n  GROUP BY ServiceName, time\n  ORDER BY ServiceName, time\n)\nWHERE prev_version != '' AND prev_version != version\nORDER BY time",
+          "rawSql": "SELECT\n  time,\n  ServiceName AS tags,\n  concat(ServiceName, ' deployed ', version, if(prev_version != '', concat(' (was ', prev_version, ')'), '')) AS text,\n  'Deployment' AS title\nFROM (\n  SELECT\n    toStartOfInterval(Timestamp, INTERVAL 30 second) AS time,\n    ServiceName,\n    topK(1)(ResourceAttributes['service.version'])[1] AS version,\n    lagInFrame(topK(1)(ResourceAttributes['service.version'])[1])\n      OVER (PARTITION BY ServiceName ORDER BY time) AS prev_version\n  FROM otel_traces\n  WHERE $__timeFilter(Timestamp)\n    AND $__conditionalAll(ServiceName IN (${service:singlequote}), $service)\n    AND ResourceAttributes['service.version'] != ''\n  GROUP BY ServiceName, time\n  ORDER BY ServiceName, time\n)\nWHERE prev_version != '' AND prev_version != version\nORDER BY time",
           "refId": "anno",
           "format": 1
         }

--- a/src/dashboards/otel-service-dashboard.json
+++ b/src/dashboards/otel-service-dashboard.json
@@ -49,7 +49,7 @@
         "type": "dashboard"
       },
       {
-        "customSql": "SELECT\n  time,\n  ServiceName AS tags,\n  concat(ServiceName, ' deployed ', version, if(prev_version != '', concat(' (was ', prev_version, ')'), '')) AS text,\n  'Deployment' AS title\nFROM (\n  SELECT\n    toStartOfInterval(Timestamp, INTERVAL 30 second) AS time,\n    ServiceName,\n    topK(1)(ResourceAttributes['service.version'])[1] AS version,\n    lagInFrame(topK(1)(ResourceAttributes['service.version'])[1])\n      OVER (PARTITION BY ServiceName ORDER BY time) AS prev_version\n  FROM otel_traces\n  WHERE $__timeFilter(Timestamp)\n    AND ServiceName = '${service}'\n    AND ResourceAttributes['service.version'] != ''\n  GROUP BY ServiceName, time\n  ORDER BY ServiceName, time\n)\nWHERE prev_version != '' AND prev_version != version\nORDER BY time",
+        "customSql": "SELECT\n  time,\n  ServiceName AS tags,\n  concat(ServiceName, ' deployed ', version, if(prev_version != '', concat(' (was ', prev_version, ')'), '')) AS text,\n  'Deployment' AS title\nFROM (\n  SELECT\n    toStartOfInterval(Timestamp, INTERVAL 30 second) AS time,\n    ServiceName,\n    topK(1)(ResourceAttributes['service.version'])[1] AS version,\n    lagInFrame(topK(1)(ResourceAttributes['service.version'])[1])\n      OVER (PARTITION BY ServiceName ORDER BY time) AS prev_version\n  FROM otel_traces\n  WHERE $__timeFilter(Timestamp)\n    AND ServiceName = ${service:singlequote}\n    AND ResourceAttributes['service.version'] != ''\n  GROUP BY ServiceName, time\n  ORDER BY ServiceName, time\n)\nWHERE prev_version != '' AND prev_version != version\nORDER BY time",
         "datasource": {
           "type": "grafana-clickhouse-datasource",
           "uid": "${datasource}"
@@ -59,11 +59,11 @@
         "iconColor": "#73BF69",
         "name": "Deployments (service.version)",
         "preset": "custom",
-        "rawQuery": "SELECT\n  time,\n  ServiceName AS tags,\n  concat(ServiceName, ' deployed ', version, if(prev_version != '', concat(' (was ', prev_version, ')'), '')) AS text,\n  'Deployment' AS title\nFROM (\n  SELECT\n    toStartOfInterval(Timestamp, INTERVAL 30 second) AS time,\n    ServiceName,\n    topK(1)(ResourceAttributes['service.version'])[1] AS version,\n    lagInFrame(topK(1)(ResourceAttributes['service.version'])[1])\n      OVER (PARTITION BY ServiceName ORDER BY time) AS prev_version\n  FROM otel_traces\n  WHERE $__timeFilter(Timestamp)\n    AND ServiceName = '${service}'\n    AND ResourceAttributes['service.version'] != ''\n  GROUP BY ServiceName, time\n  ORDER BY ServiceName, time\n)\nWHERE prev_version != '' AND prev_version != version\nORDER BY time",
+        "rawQuery": "SELECT\n  time,\n  ServiceName AS tags,\n  concat(ServiceName, ' deployed ', version, if(prev_version != '', concat(' (was ', prev_version, ')'), '')) AS text,\n  'Deployment' AS title\nFROM (\n  SELECT\n    toStartOfInterval(Timestamp, INTERVAL 30 second) AS time,\n    ServiceName,\n    topK(1)(ResourceAttributes['service.version'])[1] AS version,\n    lagInFrame(topK(1)(ResourceAttributes['service.version'])[1])\n      OVER (PARTITION BY ServiceName ORDER BY time) AS prev_version\n  FROM otel_traces\n  WHERE $__timeFilter(Timestamp)\n    AND ServiceName = ${service:singlequote}\n    AND ResourceAttributes['service.version'] != ''\n  GROUP BY ServiceName, time\n  ORDER BY ServiceName, time\n)\nWHERE prev_version != '' AND prev_version != version\nORDER BY time",
         "target": {
           "editorType": "sql",
           "format": 1,
-          "rawSql": "SELECT\n  time,\n  ServiceName AS tags,\n  concat(ServiceName, ' deployed ', version, if(prev_version != '', concat(' (was ', prev_version, ')'), '')) AS text,\n  'Deployment' AS title\nFROM (\n  SELECT\n    toStartOfInterval(Timestamp, INTERVAL 30 second) AS time,\n    ServiceName,\n    topK(1)(ResourceAttributes['service.version'])[1] AS version,\n    lagInFrame(topK(1)(ResourceAttributes['service.version'])[1])\n      OVER (PARTITION BY ServiceName ORDER BY time) AS prev_version\n  FROM otel_traces\n  WHERE $__timeFilter(Timestamp)\n    AND ServiceName = '${service}'\n    AND ResourceAttributes['service.version'] != ''\n  GROUP BY ServiceName, time\n  ORDER BY ServiceName, time\n)\nWHERE prev_version != '' AND prev_version != version\nORDER BY time"
+          "rawSql": "SELECT\n  time,\n  ServiceName AS tags,\n  concat(ServiceName, ' deployed ', version, if(prev_version != '', concat(' (was ', prev_version, ')'), '')) AS text,\n  'Deployment' AS title\nFROM (\n  SELECT\n    toStartOfInterval(Timestamp, INTERVAL 30 second) AS time,\n    ServiceName,\n    topK(1)(ResourceAttributes['service.version'])[1] AS version,\n    lagInFrame(topK(1)(ResourceAttributes['service.version'])[1])\n      OVER (PARTITION BY ServiceName ORDER BY time) AS prev_version\n  FROM otel_traces\n  WHERE $__timeFilter(Timestamp)\n    AND ServiceName = ${service:singlequote}\n    AND ResourceAttributes['service.version'] != ''\n  GROUP BY ServiceName, time\n  ORDER BY ServiceName, time\n)\nWHERE prev_version != '' AND prev_version != version\nORDER BY time"
         }
       }
     ]
@@ -113,7 +113,7 @@
           "type": "grafana-clickhouse-datasource",
           "uid": "${datasource}"
         },
-        "definition": "SELECT DISTINCT SpanName FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' ORDER BY SpanName",
+        "definition": "SELECT DISTINCT SpanName FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = ${service:singlequote} ORDER BY SpanName",
         "hide": 0,
         "includeAll": true,
         "allValue": null,
@@ -123,7 +123,7 @@
         "options": [],
         "query": {
           "editorType": "sql",
-          "rawSql": "SELECT DISTINCT SpanName FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' ORDER BY SpanName"
+          "rawSql": "SELECT DISTINCT SpanName FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = ${service:singlequote} ORDER BY SpanName"
         },
         "refresh": 2,
         "regex": "",
@@ -205,7 +205,7 @@
             "uid": "${datasource}"
           },
           "editorType": "sql",
-          "rawSql": "SELECT toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time, count() / $__interval_s AS rps FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND SpanKind = 'Server' AND $__conditionalAll(SpanName IN ($operation), $operation) AND $__conditionalAll(positionCaseInsensitive(SpanName, '$search') > 0, $search) GROUP BY time ORDER BY time",
+          "rawSql": "SELECT toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time, count() / $__interval_s AS rps FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = ${service:singlequote} AND SpanKind = 'Server' AND $__conditionalAll(SpanName IN (${operation:singlequote}), $operation) AND $__conditionalAll(positionCaseInsensitive(SpanName, '$search') > 0, $search) GROUP BY time ORDER BY time",
           "refId": "A",
           "format": 0
         }
@@ -267,7 +267,7 @@
             "uid": "${datasource}"
           },
           "editorType": "sql",
-          "rawSql": "SELECT toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time, countIf(StatusCode IN ('Error', 'STATUS_CODE_ERROR')) / count() AS error_rate FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND SpanKind = 'Server' AND $__conditionalAll(SpanName IN ($operation), $operation) AND $__conditionalAll(positionCaseInsensitive(SpanName, '$search') > 0, $search) GROUP BY time ORDER BY time",
+          "rawSql": "SELECT toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time, countIf(StatusCode IN ('Error', 'STATUS_CODE_ERROR')) / count() AS error_rate FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = ${service:singlequote} AND SpanKind = 'Server' AND $__conditionalAll(SpanName IN (${operation:singlequote}), $operation) AND $__conditionalAll(positionCaseInsensitive(SpanName, '$search') > 0, $search) GROUP BY time ORDER BY time",
           "refId": "A",
           "format": 0
         }
@@ -337,7 +337,7 @@
             "uid": "${datasource}"
           },
           "editorType": "sql",
-          "rawSql": "SELECT toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time, quantile(0.5)(Duration) AS p50, quantile(0.9)(Duration) AS p90, quantile(0.99)(Duration) AS p99 FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND SpanKind = 'Server' AND $__conditionalAll(SpanName IN ($operation), $operation) AND $__conditionalAll(positionCaseInsensitive(SpanName, '$search') > 0, $search) GROUP BY time ORDER BY time",
+          "rawSql": "SELECT toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time, quantile(0.5)(Duration) AS p50, quantile(0.9)(Duration) AS p90, quantile(0.99)(Duration) AS p99 FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = ${service:singlequote} AND SpanKind = 'Server' AND $__conditionalAll(SpanName IN (${operation:singlequote}), $operation) AND $__conditionalAll(positionCaseInsensitive(SpanName, '$search') > 0, $search) GROUP BY time ORDER BY time",
           "refId": "A",
           "format": 0
         }
@@ -421,7 +421,7 @@
             "uid": "${datasource}"
           },
           "editorType": "sql",
-          "rawSql": "SELECT SpanName AS Operation, count() AS Count, quantile(0.5)(Duration) AS P50, quantile(0.99)(Duration) AS P99 FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND SpanKind = 'Server' AND $__conditionalAll(SpanName IN ($operation), $operation) AND $__conditionalAll(positionCaseInsensitive(SpanName, '$search') > 0, $search) GROUP BY SpanName ORDER BY P99 DESC LIMIT 20",
+          "rawSql": "SELECT SpanName AS Operation, count() AS Count, quantile(0.5)(Duration) AS P50, quantile(0.99)(Duration) AS P99 FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = ${service:singlequote} AND SpanKind = 'Server' AND $__conditionalAll(SpanName IN (${operation:singlequote}), $operation) AND $__conditionalAll(positionCaseInsensitive(SpanName, '$search') > 0, $search) GROUP BY SpanName ORDER BY P99 DESC LIMIT 20",
           "refId": "A",
           "format": 1
         }
@@ -479,7 +479,7 @@
             "uid": "${datasource}"
           },
           "editorType": "sql",
-          "rawSql": "SELECT toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time, count() / $__interval_s AS rps FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND SpanKind = 'Client' AND $__conditionalAll(SpanName IN ($operation), $operation) AND $__conditionalAll(positionCaseInsensitive(SpanName, '$search') > 0, $search) GROUP BY time ORDER BY time",
+          "rawSql": "SELECT toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time, count() / $__interval_s AS rps FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = ${service:singlequote} AND SpanKind = 'Client' AND $__conditionalAll(SpanName IN (${operation:singlequote}), $operation) AND $__conditionalAll(positionCaseInsensitive(SpanName, '$search') > 0, $search) GROUP BY time ORDER BY time",
           "refId": "A",
           "format": 0
         }
@@ -541,7 +541,7 @@
             "uid": "${datasource}"
           },
           "editorType": "sql",
-          "rawSql": "SELECT toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time, countIf(StatusCode IN ('Error', 'STATUS_CODE_ERROR')) / count() AS error_rate FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND SpanKind = 'Client' AND $__conditionalAll(SpanName IN ($operation), $operation) AND $__conditionalAll(positionCaseInsensitive(SpanName, '$search') > 0, $search) GROUP BY time ORDER BY time",
+          "rawSql": "SELECT toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time, countIf(StatusCode IN ('Error', 'STATUS_CODE_ERROR')) / count() AS error_rate FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = ${service:singlequote} AND SpanKind = 'Client' AND $__conditionalAll(SpanName IN (${operation:singlequote}), $operation) AND $__conditionalAll(positionCaseInsensitive(SpanName, '$search') > 0, $search) GROUP BY time ORDER BY time",
           "refId": "A",
           "format": 0
         }
@@ -611,7 +611,7 @@
             "uid": "${datasource}"
           },
           "editorType": "sql",
-          "rawSql": "SELECT toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time, quantile(0.5)(Duration) AS p50, quantile(0.9)(Duration) AS p90, quantile(0.99)(Duration) AS p99 FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND SpanKind = 'Client' AND $__conditionalAll(SpanName IN ($operation), $operation) AND $__conditionalAll(positionCaseInsensitive(SpanName, '$search') > 0, $search) GROUP BY time ORDER BY time",
+          "rawSql": "SELECT toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time, quantile(0.5)(Duration) AS p50, quantile(0.9)(Duration) AS p90, quantile(0.99)(Duration) AS p99 FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = ${service:singlequote} AND SpanKind = 'Client' AND $__conditionalAll(SpanName IN (${operation:singlequote}), $operation) AND $__conditionalAll(positionCaseInsensitive(SpanName, '$search') > 0, $search) GROUP BY time ORDER BY time",
           "refId": "A",
           "format": 0
         }
@@ -695,7 +695,7 @@
             "uid": "${datasource}"
           },
           "editorType": "sql",
-          "rawSql": "SELECT SpanName AS Operation, count() AS Count, quantile(0.5)(Duration) AS P50, quantile(0.99)(Duration) AS P99 FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND SpanKind = 'Client' AND $__conditionalAll(SpanName IN ($operation), $operation) AND $__conditionalAll(positionCaseInsensitive(SpanName, '$search') > 0, $search) GROUP BY SpanName ORDER BY P99 DESC LIMIT 20",
+          "rawSql": "SELECT SpanName AS Operation, count() AS Count, quantile(0.5)(Duration) AS P50, quantile(0.99)(Duration) AS P99 FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = ${service:singlequote} AND SpanKind = 'Client' AND $__conditionalAll(SpanName IN (${operation:singlequote}), $operation) AND $__conditionalAll(positionCaseInsensitive(SpanName, '$search') > 0, $search) GROUP BY SpanName ORDER BY P99 DESC LIMIT 20",
           "refId": "A",
           "format": 1
         }
@@ -780,7 +780,7 @@
             "uid": "${datasource}"
           },
           "editorType": "sql",
-          "rawSql": "SELECT SpanName AS Operation, SpanKind AS Kind, StatusMessage AS Error, count() AS Count, max(Timestamp) AS \"Last Seen\" FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND StatusCode IN ('Error', 'STATUS_CODE_ERROR') AND $__conditionalAll(positionCaseInsensitive(SpanName, '$search') > 0, $search) GROUP BY SpanName, SpanKind, StatusMessage ORDER BY Count DESC LIMIT 20",
+          "rawSql": "SELECT SpanName AS Operation, SpanKind AS Kind, StatusMessage AS Error, count() AS Count, max(Timestamp) AS \"Last Seen\" FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = ${service:singlequote} AND StatusCode IN ('Error', 'STATUS_CODE_ERROR') AND $__conditionalAll(positionCaseInsensitive(SpanName, '$search') > 0, $search) GROUP BY SpanName, SpanKind, StatusMessage ORDER BY Count DESC LIMIT 20",
           "refId": "A",
           "format": 1
         }
@@ -822,7 +822,7 @@
             "uid": "${datasource}"
           },
           "editorType": "sql",
-          "rawSql": "SELECT Timestamp AS timestamp, Body AS body, SeverityText AS level, ServiceName, TraceId, SpanId FROM otel_logs WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND $__conditionalAll(positionCaseInsensitive(Body, '$search') > 0, $search) ORDER BY Timestamp DESC LIMIT 200",
+          "rawSql": "SELECT Timestamp AS timestamp, Body AS body, SeverityText AS level, ServiceName, TraceId, SpanId FROM otel_logs WHERE $__timeFilter(Timestamp) AND ServiceName = ${service:singlequote} AND $__conditionalAll(positionCaseInsensitive(Body, '$search') > 0, $search) ORDER BY Timestamp DESC LIMIT 200",
           "refId": "A",
           "format": 2
         }
@@ -879,7 +879,7 @@
                 "uid": "${datasource}"
               },
               "editorType": "sql",
-              "rawSql": "SELECT toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time, count() / $__interval_s AS rps FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND SpanKind = 'Internal' AND $__conditionalAll(SpanName IN ($operation), $operation) AND $__conditionalAll(positionCaseInsensitive(SpanName, '$search') > 0, $search) GROUP BY time ORDER BY time",
+              "rawSql": "SELECT toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time, count() / $__interval_s AS rps FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = ${service:singlequote} AND SpanKind = 'Internal' AND $__conditionalAll(SpanName IN (${operation:singlequote}), $operation) AND $__conditionalAll(positionCaseInsensitive(SpanName, '$search') > 0, $search) GROUP BY time ORDER BY time",
               "refId": "A",
               "format": 0
             }
@@ -941,7 +941,7 @@
                 "uid": "${datasource}"
               },
               "editorType": "sql",
-              "rawSql": "SELECT toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time, countIf(StatusCode IN ('Error', 'STATUS_CODE_ERROR')) / count() AS error_rate FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND SpanKind = 'Internal' AND $__conditionalAll(SpanName IN ($operation), $operation) AND $__conditionalAll(positionCaseInsensitive(SpanName, '$search') > 0, $search) GROUP BY time ORDER BY time",
+              "rawSql": "SELECT toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time, countIf(StatusCode IN ('Error', 'STATUS_CODE_ERROR')) / count() AS error_rate FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = ${service:singlequote} AND SpanKind = 'Internal' AND $__conditionalAll(SpanName IN (${operation:singlequote}), $operation) AND $__conditionalAll(positionCaseInsensitive(SpanName, '$search') > 0, $search) GROUP BY time ORDER BY time",
               "refId": "A",
               "format": 0
             }
@@ -1011,7 +1011,7 @@
                 "uid": "${datasource}"
               },
               "editorType": "sql",
-              "rawSql": "SELECT toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time, quantile(0.5)(Duration) AS p50, quantile(0.9)(Duration) AS p90, quantile(0.99)(Duration) AS p99 FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND SpanKind = 'Internal' AND $__conditionalAll(SpanName IN ($operation), $operation) AND $__conditionalAll(positionCaseInsensitive(SpanName, '$search') > 0, $search) GROUP BY time ORDER BY time",
+              "rawSql": "SELECT toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time, quantile(0.5)(Duration) AS p50, quantile(0.9)(Duration) AS p90, quantile(0.99)(Duration) AS p99 FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = ${service:singlequote} AND SpanKind = 'Internal' AND $__conditionalAll(SpanName IN (${operation:singlequote}), $operation) AND $__conditionalAll(positionCaseInsensitive(SpanName, '$search') > 0, $search) GROUP BY time ORDER BY time",
               "refId": "A",
               "format": 0
             }
@@ -1095,7 +1095,7 @@
                 "uid": "${datasource}"
               },
               "editorType": "sql",
-              "rawSql": "SELECT SpanName AS Operation, count() AS Count, quantile(0.5)(Duration) AS P50, quantile(0.99)(Duration) AS P99 FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND SpanKind = 'Internal' AND $__conditionalAll(SpanName IN ($operation), $operation) AND $__conditionalAll(positionCaseInsensitive(SpanName, '$search') > 0, $search) GROUP BY SpanName ORDER BY P99 DESC LIMIT 20",
+              "rawSql": "SELECT SpanName AS Operation, count() AS Count, quantile(0.5)(Duration) AS P50, quantile(0.99)(Duration) AS P99 FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = ${service:singlequote} AND SpanKind = 'Internal' AND $__conditionalAll(SpanName IN (${operation:singlequote}), $operation) AND $__conditionalAll(positionCaseInsensitive(SpanName, '$search') > 0, $search) GROUP BY SpanName ORDER BY P99 DESC LIMIT 20",
               "refId": "A",
               "format": 1
             }
@@ -1154,7 +1154,7 @@
                 "uid": "${datasource}"
               },
               "editorType": "sql",
-              "rawSql": "SELECT toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time, count() / $__interval_s AS rps FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND SpanKind IN ('Producer', 'Consumer') AND $__conditionalAll(SpanName IN ($operation), $operation) AND $__conditionalAll(positionCaseInsensitive(SpanName, '$search') > 0, $search) GROUP BY time ORDER BY time",
+              "rawSql": "SELECT toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time, count() / $__interval_s AS rps FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = ${service:singlequote} AND SpanKind IN ('Producer', 'Consumer') AND $__conditionalAll(SpanName IN (${operation:singlequote}), $operation) AND $__conditionalAll(positionCaseInsensitive(SpanName, '$search') > 0, $search) GROUP BY time ORDER BY time",
               "refId": "A",
               "format": 0
             }
@@ -1216,7 +1216,7 @@
                 "uid": "${datasource}"
               },
               "editorType": "sql",
-              "rawSql": "SELECT toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time, countIf(StatusCode IN ('Error', 'STATUS_CODE_ERROR')) / count() AS error_rate FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND SpanKind IN ('Producer', 'Consumer') AND $__conditionalAll(SpanName IN ($operation), $operation) AND $__conditionalAll(positionCaseInsensitive(SpanName, '$search') > 0, $search) GROUP BY time ORDER BY time",
+              "rawSql": "SELECT toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time, countIf(StatusCode IN ('Error', 'STATUS_CODE_ERROR')) / count() AS error_rate FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = ${service:singlequote} AND SpanKind IN ('Producer', 'Consumer') AND $__conditionalAll(SpanName IN (${operation:singlequote}), $operation) AND $__conditionalAll(positionCaseInsensitive(SpanName, '$search') > 0, $search) GROUP BY time ORDER BY time",
               "refId": "A",
               "format": 0
             }
@@ -1286,7 +1286,7 @@
                 "uid": "${datasource}"
               },
               "editorType": "sql",
-              "rawSql": "SELECT toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time, quantile(0.5)(Duration) AS p50, quantile(0.9)(Duration) AS p90, quantile(0.99)(Duration) AS p99 FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND SpanKind IN ('Producer', 'Consumer') AND $__conditionalAll(SpanName IN ($operation), $operation) AND $__conditionalAll(positionCaseInsensitive(SpanName, '$search') > 0, $search) GROUP BY time ORDER BY time",
+              "rawSql": "SELECT toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time, quantile(0.5)(Duration) AS p50, quantile(0.9)(Duration) AS p90, quantile(0.99)(Duration) AS p99 FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = ${service:singlequote} AND SpanKind IN ('Producer', 'Consumer') AND $__conditionalAll(SpanName IN (${operation:singlequote}), $operation) AND $__conditionalAll(positionCaseInsensitive(SpanName, '$search') > 0, $search) GROUP BY time ORDER BY time",
               "refId": "A",
               "format": 0
             }
@@ -1382,7 +1382,7 @@
                 "uid": "${datasource}"
               },
               "editorType": "sql",
-              "rawSql": "SELECT SpanName AS Operation, SpanKind AS Kind, count() AS Count, quantile(0.5)(Duration) AS P50, quantile(0.99)(Duration) AS P99 FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = '${service}' AND SpanKind IN ('Producer', 'Consumer') AND $__conditionalAll(SpanName IN ($operation), $operation) AND $__conditionalAll(positionCaseInsensitive(SpanName, '$search') > 0, $search) GROUP BY SpanName, SpanKind ORDER BY P99 DESC LIMIT 20",
+              "rawSql": "SELECT SpanName AS Operation, SpanKind AS Kind, count() AS Count, quantile(0.5)(Duration) AS P50, quantile(0.99)(Duration) AS P99 FROM otel_traces WHERE $__timeFilter(Timestamp) AND ServiceName = ${service:singlequote} AND SpanKind IN ('Producer', 'Consumer') AND $__conditionalAll(SpanName IN (${operation:singlequote}), $operation) AND $__conditionalAll(positionCaseInsensitive(SpanName, '$search') > 0, $search) GROUP BY SpanName, SpanKind ORDER BY P99 DESC LIMIT 20",
               "refId": "A",
               "format": 1
             }

--- a/src/dashboards/otel-traces-explorer.json
+++ b/src/dashboards/otel-traces-explorer.json
@@ -42,7 +42,7 @@
         "type": "dashboard"
       },
       {
-        "customSql": "SELECT\n  time,\n  ServiceName AS tags,\n  concat(ServiceName, ' deployed ', version, if(prev_version != '', concat(' (was ', prev_version, ')'), '')) AS text,\n  'Deployment' AS title\nFROM (\n  SELECT\n    toStartOfInterval(Timestamp, INTERVAL 30 second) AS time,\n    ServiceName,\n    topK(1)(ResourceAttributes['service.version'])[1] AS version,\n    lagInFrame(topK(1)(ResourceAttributes['service.version'])[1])\n      OVER (PARTITION BY ServiceName ORDER BY time) AS prev_version\n  FROM otel_traces\n  WHERE $__timeFilter(Timestamp)\n    AND $__conditionalAll(ServiceName IN ($service), $service)\n    AND ResourceAttributes['service.version'] != ''\n  GROUP BY ServiceName, time\n  ORDER BY ServiceName, time\n)\nWHERE prev_version != '' AND prev_version != version\nORDER BY time",
+        "customSql": "SELECT\n  time,\n  ServiceName AS tags,\n  concat(ServiceName, ' deployed ', version, if(prev_version != '', concat(' (was ', prev_version, ')'), '')) AS text,\n  'Deployment' AS title\nFROM (\n  SELECT\n    toStartOfInterval(Timestamp, INTERVAL 30 second) AS time,\n    ServiceName,\n    topK(1)(ResourceAttributes['service.version'])[1] AS version,\n    lagInFrame(topK(1)(ResourceAttributes['service.version'])[1])\n      OVER (PARTITION BY ServiceName ORDER BY time) AS prev_version\n  FROM otel_traces\n  WHERE $__timeFilter(Timestamp)\n    AND $__conditionalAll(ServiceName IN (${service:singlequote}), $service)\n    AND ResourceAttributes['service.version'] != ''\n  GROUP BY ServiceName, time\n  ORDER BY ServiceName, time\n)\nWHERE prev_version != '' AND prev_version != version\nORDER BY time",
         "datasource": {
           "type": "grafana-clickhouse-datasource",
           "uid": "${datasource}"
@@ -52,11 +52,11 @@
         "iconColor": "#73BF69",
         "name": "Deployments (service.version)",
         "preset": "custom",
-        "rawQuery": "SELECT\n  time,\n  ServiceName AS tags,\n  concat(ServiceName, ' deployed ', version, if(prev_version != '', concat(' (was ', prev_version, ')'), '')) AS text,\n  'Deployment' AS title\nFROM (\n  SELECT\n    toStartOfInterval(Timestamp, INTERVAL 30 second) AS time,\n    ServiceName,\n    topK(1)(ResourceAttributes['service.version'])[1] AS version,\n    lagInFrame(topK(1)(ResourceAttributes['service.version'])[1])\n      OVER (PARTITION BY ServiceName ORDER BY time) AS prev_version\n  FROM otel_traces\n  WHERE $__timeFilter(Timestamp)\n    AND $__conditionalAll(ServiceName IN ($service), $service)\n    AND ResourceAttributes['service.version'] != ''\n  GROUP BY ServiceName, time\n  ORDER BY ServiceName, time\n)\nWHERE prev_version != '' AND prev_version != version\nORDER BY time",
+        "rawQuery": "SELECT\n  time,\n  ServiceName AS tags,\n  concat(ServiceName, ' deployed ', version, if(prev_version != '', concat(' (was ', prev_version, ')'), '')) AS text,\n  'Deployment' AS title\nFROM (\n  SELECT\n    toStartOfInterval(Timestamp, INTERVAL 30 second) AS time,\n    ServiceName,\n    topK(1)(ResourceAttributes['service.version'])[1] AS version,\n    lagInFrame(topK(1)(ResourceAttributes['service.version'])[1])\n      OVER (PARTITION BY ServiceName ORDER BY time) AS prev_version\n  FROM otel_traces\n  WHERE $__timeFilter(Timestamp)\n    AND $__conditionalAll(ServiceName IN (${service:singlequote}), $service)\n    AND ResourceAttributes['service.version'] != ''\n  GROUP BY ServiceName, time\n  ORDER BY ServiceName, time\n)\nWHERE prev_version != '' AND prev_version != version\nORDER BY time",
         "target": {
           "editorType": "sql",
           "format": 1,
-          "rawSql": "SELECT\n  time,\n  ServiceName AS tags,\n  concat(ServiceName, ' deployed ', version, if(prev_version != '', concat(' (was ', prev_version, ')'), '')) AS text,\n  'Deployment' AS title\nFROM (\n  SELECT\n    toStartOfInterval(Timestamp, INTERVAL 30 second) AS time,\n    ServiceName,\n    topK(1)(ResourceAttributes['service.version'])[1] AS version,\n    lagInFrame(topK(1)(ResourceAttributes['service.version'])[1])\n      OVER (PARTITION BY ServiceName ORDER BY time) AS prev_version\n  FROM otel_traces\n  WHERE $__timeFilter(Timestamp)\n    AND $__conditionalAll(ServiceName IN ($service), $service)\n    AND ResourceAttributes['service.version'] != ''\n  GROUP BY ServiceName, time\n  ORDER BY ServiceName, time\n)\nWHERE prev_version != '' AND prev_version != version\nORDER BY time"
+          "rawSql": "SELECT\n  time,\n  ServiceName AS tags,\n  concat(ServiceName, ' deployed ', version, if(prev_version != '', concat(' (was ', prev_version, ')'), '')) AS text,\n  'Deployment' AS title\nFROM (\n  SELECT\n    toStartOfInterval(Timestamp, INTERVAL 30 second) AS time,\n    ServiceName,\n    topK(1)(ResourceAttributes['service.version'])[1] AS version,\n    lagInFrame(topK(1)(ResourceAttributes['service.version'])[1])\n      OVER (PARTITION BY ServiceName ORDER BY time) AS prev_version\n  FROM otel_traces\n  WHERE $__timeFilter(Timestamp)\n    AND $__conditionalAll(ServiceName IN (${service:singlequote}), $service)\n    AND ResourceAttributes['service.version'] != ''\n  GROUP BY ServiceName, time\n  ORDER BY ServiceName, time\n)\nWHERE prev_version != '' AND prev_version != version\nORDER BY time"
         }
       }
     ]
@@ -105,7 +105,7 @@
           "type": "grafana-clickhouse-datasource",
           "uid": "${datasource}"
         },
-        "definition": "SELECT DISTINCT SpanName FROM otel_traces WHERE $__timeFilter(Timestamp) AND $__conditionalAll(ServiceName IN ($service), $service) ORDER BY SpanName LIMIT 200",
+        "definition": "SELECT DISTINCT SpanName FROM otel_traces WHERE $__timeFilter(Timestamp) AND $__conditionalAll(ServiceName IN (${service:singlequote}), $service) ORDER BY SpanName LIMIT 200",
         "hide": 0,
         "includeAll": true,
         "allValue": null,
@@ -115,7 +115,7 @@
         "options": [],
         "query": {
           "editorType": "sql",
-          "rawSql": "SELECT DISTINCT SpanName FROM otel_traces WHERE $__timeFilter(Timestamp) AND $__conditionalAll(ServiceName IN ($service), $service) ORDER BY SpanName LIMIT 200"
+          "rawSql": "SELECT DISTINCT SpanName FROM otel_traces WHERE $__timeFilter(Timestamp) AND $__conditionalAll(ServiceName IN (${service:singlequote}), $service) ORDER BY SpanName LIMIT 200"
         },
         "refresh": 2,
         "sort": 0,
@@ -334,7 +334,7 @@
           },
           "editorType": "sql",
           "format": 1,
-          "rawSql": "SELECT\n  TraceId,\n  any(ServiceName) AS Service,\n  any(SpanName) AS RootOperation,\n  min(Timestamp) AS Time,\n  max(Duration) AS Duration,\n  count() AS Spans,\n  anyIf(StatusCode, StatusCode IN ('Error', 'STATUS_CODE_ERROR')) AS Status\nFROM otel_traces\nWHERE $__timeFilter(Timestamp)\n  AND $__conditionalAll(ServiceName IN ($service), $service)\n  AND $__conditionalAll(SpanName IN ($operation), $operation)\n  AND $__conditionalAll(StatusCode IN ($status), $status)\n  AND $__conditionalAll(positionCaseInsensitive(SpanName, '$search') > 0, $search)\nGROUP BY TraceId\nHAVING $__conditionalAll(max(Duration) >= toUInt64($min_duration) * 1000000, $min_duration)\nORDER BY Time DESC\nLIMIT 200",
+          "rawSql": "SELECT\n  TraceId,\n  any(ServiceName) AS Service,\n  any(SpanName) AS RootOperation,\n  min(Timestamp) AS Time,\n  max(Duration) AS Duration,\n  count() AS Spans,\n  anyIf(StatusCode, StatusCode IN ('Error', 'STATUS_CODE_ERROR')) AS Status\nFROM otel_traces\nWHERE $__timeFilter(Timestamp)\n  AND $__conditionalAll(ServiceName IN (${service:singlequote}), $service)\n  AND $__conditionalAll(SpanName IN (${operation:singlequote}), $operation)\n  AND $__conditionalAll(StatusCode IN (${status:singlequote}), $status)\n  AND $__conditionalAll(positionCaseInsensitive(SpanName, '$search') > 0, $search)\nGROUP BY TraceId\nHAVING $__conditionalAll(max(Duration) >= toUInt64($min_duration) * 1000000, $min_duration)\nORDER BY Time DESC\nLIMIT 200",
           "refId": "A"
         }
       ]

--- a/src/dashboards/query-analysis.json
+++ b/src/dashboards/query-analysis.json
@@ -138,7 +138,7 @@
             }
           },
           "queryType": "sql",
-          "rawSql": "SELECT count() as \"Total queries\" FROM system.query_log WHERE type in ($type) AND initial_user IN (${user:singlequote}) AND query_kind IN (${query_kind:singlequote}) AND $__timeFilter(event_time) ",
+          "rawSql": "SELECT count() as \"Total queries\" FROM system.query_log WHERE type in (${type:singlequote}) AND initial_user IN (${user:singlequote}) AND query_kind IN (${query_kind:singlequote}) AND $__timeFilter(event_time) ",
           "refId": "A"
         }
       ],
@@ -220,7 +220,7 @@
             }
           },
           "queryType": "sql",
-          "rawSql": "SELECT avg(memory_usage) as \"Avg query memory\", $__timeInterval(query_start_time) as time FROM system.query_log WHERE type in ($type) AND initial_user IN (${user:singlequote}) AND query_kind IN (${query_kind:singlequote}) AND $__timeFilter(event_time) GROUP BY time ORDER BY time",
+          "rawSql": "SELECT avg(memory_usage) as \"Avg query memory\", $__timeInterval(query_start_time) as time FROM system.query_log WHERE type in (${type:singlequote}) AND initial_user IN (${user:singlequote}) AND query_kind IN (${query_kind:singlequote}) AND $__timeFilter(event_time) GROUP BY time ORDER BY time",
           "refId": "A"
         }
       ],
@@ -308,7 +308,7 @@
             }
           },
           "queryType": "sql",
-          "rawSql": "SELECT query_duration_ms as \"Query time\" FROM system.query_log WHERE type in ($type) AND initial_user IN (${user:singlequote}) AND query_kind IN (${query_kind:singlequote}) AND $__timeFilter(event_time) LIMIT 1000;",
+          "rawSql": "SELECT query_duration_ms as \"Query time\" FROM system.query_log WHERE type in (${type:singlequote}) AND initial_user IN (${user:singlequote}) AND query_kind IN (${query_kind:singlequote}) AND $__timeFilter(event_time) LIMIT 1000;",
           "refId": "A"
         }
       ],
@@ -380,7 +380,7 @@
             }
           },
           "queryType": "sql",
-          "rawSql": "SELECT initial_user, count() as c FROM system.query_log WHERE type in ($type) AND initial_user IN (${user:singlequote}) AND query_kind IN (${query_kind:singlequote}) GROUP BY initial_user LIMIT 100;\n",
+          "rawSql": "SELECT initial_user, count() as c FROM system.query_log WHERE type in (${type:singlequote}) AND initial_user IN (${user:singlequote}) AND query_kind IN (${query_kind:singlequote}) GROUP BY initial_user LIMIT 100;\n",
           "refId": "A"
         }
       ],
@@ -463,7 +463,7 @@
             }
           },
           "queryType": "sql",
-          "rawSql": "SELECT avg(query_duration_ms) as \"Avg query time\", $__timeInterval(query_start_time) as time FROM system.query_log WHERE type in ($type) AND initial_user IN (${user:singlequote}) AND query_kind IN (${query_kind:singlequote}) AND $__timeFilter(event_time) GROUP BY time ORDER BY time",
+          "rawSql": "SELECT avg(query_duration_ms) as \"Avg query time\", $__timeInterval(query_start_time) as time FROM system.query_log WHERE type in (${type:singlequote}) AND initial_user IN (${user:singlequote}) AND query_kind IN (${query_kind:singlequote}) AND $__timeFilter(event_time) GROUP BY time ORDER BY time",
           "refId": "A"
         }
       ],
@@ -562,7 +562,7 @@
             }
           },
           "queryType": "sql",
-          "rawSql": "SELECT $__timeInterval(query_start_time) as time,\n       any(normalizeQuery(query)) AS normalized_query,\n       count() as c\nFROM system.query_log\nWHERE type != 'QueryStart'\n  AND $__timeFilter(event_time)\n  AND initial_user IN (${user:singlequote})\n   AND query_kind IN (${query_kind:singlequote})\n  AND normalized_query_hash IN (SELECT normalized_query_hash\n                                FROM system.query_log\n                                WHERE type in ($type) AND $__timeFilter(event_time) AND query_kind IN (${query_kind:singlequote})\n                                GROUP BY normalized_query_hash\n                                ORDER BY count() DESC\n                                LIMIT 5)\nGROUP BY normalized_query_hash, time\nORDER BY time",
+          "rawSql": "SELECT $__timeInterval(query_start_time) as time,\n       any(normalizeQuery(query)) AS normalized_query,\n       count() as c\nFROM system.query_log\nWHERE type != 'QueryStart'\n  AND $__timeFilter(event_time)\n  AND initial_user IN (${user:singlequote})\n   AND query_kind IN (${query_kind:singlequote})\n  AND normalized_query_hash IN (SELECT normalized_query_hash\n                                FROM system.query_log\n                                WHERE type in (${type:singlequote}) AND $__timeFilter(event_time) AND query_kind IN (${query_kind:singlequote})\n                                GROUP BY normalized_query_hash\n                                ORDER BY count() DESC\n                                LIMIT 5)\nGROUP BY normalized_query_hash, time\nORDER BY time",
           "refId": "A"
         }
       ],
@@ -670,7 +670,7 @@
             }
           },
           "queryType": "sql",
-          "rawSql": "SELECT $__timeInterval(query_start_time) as time,\n       any(normalizeQuery(query)) AS normalized_query,\n       avg(query_duration_ms) as avg_query_duration\nFROM system.query_log\nWHERE type != 'QueryStart'\n  AND $__timeFilter(event_time)\n  AND type in ($type) AND initial_user IN (${user:singlequote}) AND query_kind IN (${query_kind:singlequote})\n  AND normalized_query_hash IN (SELECT normalized_query_hash\n                                FROM system.query_log\n                                WHERE type in ($type) AND initial_user IN (${user:singlequote}) AND query_kind IN (${query_kind:singlequote}) AND $__timeFilter(event_time)\n                                GROUP BY normalized_query_hash\n                                ORDER BY avg(query_duration_ms) DESC\n                                LIMIT 10)\nGROUP BY normalized_query_hash, time\nORDER BY time",
+          "rawSql": "SELECT $__timeInterval(query_start_time) as time,\n       any(normalizeQuery(query)) AS normalized_query,\n       avg(query_duration_ms) as avg_query_duration\nFROM system.query_log\nWHERE type != 'QueryStart'\n  AND $__timeFilter(event_time)\n  AND type in (${type:singlequote}) AND initial_user IN (${user:singlequote}) AND query_kind IN (${query_kind:singlequote})\n  AND normalized_query_hash IN (SELECT normalized_query_hash\n                                FROM system.query_log\n                                WHERE type in (${type:singlequote}) AND initial_user IN (${user:singlequote}) AND query_kind IN (${query_kind:singlequote}) AND $__timeFilter(event_time)\n                                GROUP BY normalized_query_hash\n                                ORDER BY avg(query_duration_ms) DESC\n                                LIMIT 10)\nGROUP BY normalized_query_hash, time\nORDER BY time",
           "refId": "A"
         }
       ],
@@ -1382,7 +1382,7 @@
             }
           },
           "queryType": "sql",
-          "rawSql": "SELECT query_start_time, type, query_duration_ms, initial_user, substring(query_id,1, 8) as query_id, query_kind, normalizeQuery(query) AS normalized_query, concat( toString(read_rows), ' rows / ', formatReadableSize(read_bytes) ) AS read, concat( toString(written_rows), ' rows / ', formatReadableSize(written_bytes) ) AS written, concat( toString(result_rows), ' rows / ', formatReadableSize(result_bytes) ) AS result, memory_usage FROM system.query_log WHERE type in ($type) AND initial_user IN (${user:singlequote}) AND query_kind IN (${query_kind:singlequote}) AND $__timeFilter(event_time) ORDER BY query_duration_ms DESC LIMIT  1000",
+          "rawSql": "SELECT query_start_time, type, query_duration_ms, initial_user, substring(query_id,1, 8) as query_id, query_kind, normalizeQuery(query) AS normalized_query, concat( toString(read_rows), ' rows / ', formatReadableSize(read_bytes) ) AS read, concat( toString(written_rows), ' rows / ', formatReadableSize(written_bytes) ) AS written, concat( toString(result_rows), ' rows / ', formatReadableSize(result_bytes) ) AS result, memory_usage FROM system.query_log WHERE type in (${type:singlequote}) AND initial_user IN (${user:singlequote}) AND query_kind IN (${query_kind:singlequote}) AND $__timeFilter(event_time) ORDER BY query_duration_ms DESC LIMIT  1000",
           "refId": "A"
         }
       ],

--- a/src/dashboards/query-analysis.json
+++ b/src/dashboards/query-analysis.json
@@ -138,7 +138,7 @@
             }
           },
           "queryType": "sql",
-          "rawSql": "SELECT count() as \"Total queries\" FROM system.query_log WHERE type in ($type) AND initial_user IN ($user) AND query_kind IN ($query_kind) AND $__timeFilter(event_time) ",
+          "rawSql": "SELECT count() as \"Total queries\" FROM system.query_log WHERE type in ($type) AND initial_user IN (${user:singlequote}) AND query_kind IN (${query_kind:singlequote}) AND $__timeFilter(event_time) ",
           "refId": "A"
         }
       ],
@@ -220,7 +220,7 @@
             }
           },
           "queryType": "sql",
-          "rawSql": "SELECT avg(memory_usage) as \"Avg query memory\", $__timeInterval(query_start_time) as time FROM system.query_log WHERE type in ($type) AND initial_user IN ($user) AND query_kind IN ($query_kind) AND $__timeFilter(event_time) GROUP BY time ORDER BY time",
+          "rawSql": "SELECT avg(memory_usage) as \"Avg query memory\", $__timeInterval(query_start_time) as time FROM system.query_log WHERE type in ($type) AND initial_user IN (${user:singlequote}) AND query_kind IN (${query_kind:singlequote}) AND $__timeFilter(event_time) GROUP BY time ORDER BY time",
           "refId": "A"
         }
       ],
@@ -308,7 +308,7 @@
             }
           },
           "queryType": "sql",
-          "rawSql": "SELECT query_duration_ms as \"Query time\" FROM system.query_log WHERE type in ($type) AND initial_user IN ($user) AND query_kind IN ($query_kind) AND $__timeFilter(event_time) LIMIT 1000;",
+          "rawSql": "SELECT query_duration_ms as \"Query time\" FROM system.query_log WHERE type in ($type) AND initial_user IN (${user:singlequote}) AND query_kind IN (${query_kind:singlequote}) AND $__timeFilter(event_time) LIMIT 1000;",
           "refId": "A"
         }
       ],
@@ -380,7 +380,7 @@
             }
           },
           "queryType": "sql",
-          "rawSql": "SELECT initial_user, count() as c FROM system.query_log WHERE type in ($type) AND initial_user IN ($user) AND query_kind IN ($query_kind) GROUP BY initial_user LIMIT 100;\n",
+          "rawSql": "SELECT initial_user, count() as c FROM system.query_log WHERE type in ($type) AND initial_user IN (${user:singlequote}) AND query_kind IN (${query_kind:singlequote}) GROUP BY initial_user LIMIT 100;\n",
           "refId": "A"
         }
       ],
@@ -463,7 +463,7 @@
             }
           },
           "queryType": "sql",
-          "rawSql": "SELECT avg(query_duration_ms) as \"Avg query time\", $__timeInterval(query_start_time) as time FROM system.query_log WHERE type in ($type) AND initial_user IN ($user) AND query_kind IN ($query_kind) AND $__timeFilter(event_time) GROUP BY time ORDER BY time",
+          "rawSql": "SELECT avg(query_duration_ms) as \"Avg query time\", $__timeInterval(query_start_time) as time FROM system.query_log WHERE type in ($type) AND initial_user IN (${user:singlequote}) AND query_kind IN (${query_kind:singlequote}) AND $__timeFilter(event_time) GROUP BY time ORDER BY time",
           "refId": "A"
         }
       ],
@@ -562,7 +562,7 @@
             }
           },
           "queryType": "sql",
-          "rawSql": "SELECT $__timeInterval(query_start_time) as time,\n       any(normalizeQuery(query)) AS normalized_query,\n       count() as c\nFROM system.query_log\nWHERE type != 'QueryStart'\n  AND $__timeFilter(event_time)\n  AND initial_user IN ($user)\n   AND query_kind IN ($query_kind)\n  AND normalized_query_hash IN (SELECT normalized_query_hash\n                                FROM system.query_log\n                                WHERE type in ($type) AND $__timeFilter(event_time) AND query_kind IN ($query_kind)\n                                GROUP BY normalized_query_hash\n                                ORDER BY count() DESC\n                                LIMIT 5)\nGROUP BY normalized_query_hash, time\nORDER BY time",
+          "rawSql": "SELECT $__timeInterval(query_start_time) as time,\n       any(normalizeQuery(query)) AS normalized_query,\n       count() as c\nFROM system.query_log\nWHERE type != 'QueryStart'\n  AND $__timeFilter(event_time)\n  AND initial_user IN (${user:singlequote})\n   AND query_kind IN (${query_kind:singlequote})\n  AND normalized_query_hash IN (SELECT normalized_query_hash\n                                FROM system.query_log\n                                WHERE type in ($type) AND $__timeFilter(event_time) AND query_kind IN (${query_kind:singlequote})\n                                GROUP BY normalized_query_hash\n                                ORDER BY count() DESC\n                                LIMIT 5)\nGROUP BY normalized_query_hash, time\nORDER BY time",
           "refId": "A"
         }
       ],
@@ -670,7 +670,7 @@
             }
           },
           "queryType": "sql",
-          "rawSql": "SELECT $__timeInterval(query_start_time) as time,\n       any(normalizeQuery(query)) AS normalized_query,\n       avg(query_duration_ms) as avg_query_duration\nFROM system.query_log\nWHERE type != 'QueryStart'\n  AND $__timeFilter(event_time)\n  AND type in ($type) AND initial_user IN ($user) AND query_kind IN ($query_kind)\n  AND normalized_query_hash IN (SELECT normalized_query_hash\n                                FROM system.query_log\n                                WHERE type in ($type) AND initial_user IN ($user) AND query_kind IN ($query_kind) AND $__timeFilter(event_time)\n                                GROUP BY normalized_query_hash\n                                ORDER BY avg(query_duration_ms) DESC\n                                LIMIT 10)\nGROUP BY normalized_query_hash, time\nORDER BY time",
+          "rawSql": "SELECT $__timeInterval(query_start_time) as time,\n       any(normalizeQuery(query)) AS normalized_query,\n       avg(query_duration_ms) as avg_query_duration\nFROM system.query_log\nWHERE type != 'QueryStart'\n  AND $__timeFilter(event_time)\n  AND type in ($type) AND initial_user IN (${user:singlequote}) AND query_kind IN (${query_kind:singlequote})\n  AND normalized_query_hash IN (SELECT normalized_query_hash\n                                FROM system.query_log\n                                WHERE type in ($type) AND initial_user IN (${user:singlequote}) AND query_kind IN (${query_kind:singlequote}) AND $__timeFilter(event_time)\n                                GROUP BY normalized_query_hash\n                                ORDER BY avg(query_duration_ms) DESC\n                                LIMIT 10)\nGROUP BY normalized_query_hash, time\nORDER BY time",
           "refId": "A"
         }
       ],
@@ -774,7 +774,7 @@
             }
           },
           "queryType": "sql",
-          "rawSql": "SELECT $__timeInterval(query_start_time) as time, initial_user as user, count() as \"number of queries by\"\nFROM system.query_log\nWHERE query_kind IN ($query_kind) AND type IN ($type) AND $__timeFilter(event_time) AND initial_user IN (\n  SELECT initial_user\nFROM system.query_log\nWHERE query_kind IN ($query_kind) AND type IN ($type) AND $__timeFilter(event_time)\nGROUP BY initial_user\nORDER BY count() as c DESC\nLIMIT 10\n)\nGROUP BY initial_user, time\nORDER BY time;",
+          "rawSql": "SELECT $__timeInterval(query_start_time) as time, initial_user as user, count() as \"number of queries by\"\nFROM system.query_log\nWHERE query_kind IN (${query_kind:singlequote}) AND type IN (${type:singlequote}) AND $__timeFilter(event_time) AND initial_user IN (\n  SELECT initial_user\nFROM system.query_log\nWHERE query_kind IN (${query_kind:singlequote}) AND type IN (${type:singlequote}) AND $__timeFilter(event_time)\nGROUP BY initial_user\nORDER BY count() as c DESC\nLIMIT 10\n)\nGROUP BY initial_user, time\nORDER BY time;",
           "refId": "A"
         }
       ],
@@ -1382,7 +1382,7 @@
             }
           },
           "queryType": "sql",
-          "rawSql": "SELECT query_start_time, type, query_duration_ms, initial_user, substring(query_id,1, 8) as query_id, query_kind, normalizeQuery(query) AS normalized_query, concat( toString(read_rows), ' rows / ', formatReadableSize(read_bytes) ) AS read, concat( toString(written_rows), ' rows / ', formatReadableSize(written_bytes) ) AS written, concat( toString(result_rows), ' rows / ', formatReadableSize(result_bytes) ) AS result, memory_usage FROM system.query_log WHERE type in ($type) AND initial_user IN ($user) AND query_kind IN ($query_kind) AND $__timeFilter(event_time) ORDER BY query_duration_ms DESC LIMIT  1000",
+          "rawSql": "SELECT query_start_time, type, query_duration_ms, initial_user, substring(query_id,1, 8) as query_id, query_kind, normalizeQuery(query) AS normalized_query, concat( toString(read_rows), ' rows / ', formatReadableSize(read_bytes) ) AS read, concat( toString(written_rows), ' rows / ', formatReadableSize(written_bytes) ) AS written, concat( toString(result_rows), ' rows / ', formatReadableSize(result_bytes) ) AS result, memory_usage FROM system.query_log WHERE type in ($type) AND initial_user IN (${user:singlequote}) AND query_kind IN (${query_kind:singlequote}) AND $__timeFilter(event_time) ORDER BY query_duration_ms DESC LIMIT  1000",
           "refId": "A"
         }
       ],


### PR DESCRIPTION
## What
Interpolate template variables with the `:singlequote` format option instead of the bare form, across all bundled dashboards that filter on variables in raw SQL:

- **OpenTelemetry Logs / Traces / Service:** `service`, `level_filter`, `operation`, `status` in `IN (...)`, and `= '${service}'`.
- **Data Analysis:** `database`, `table` in `IN (...)`.
- **Query Analysis:** `query_kind`, `type`, `user` in `IN (...)`.

## Why
The datasource's default variable formatter (`format` in `src/data/CHDatasource.ts`) quotes a multi-value selection as `'a','b'`, but it does **not** escape a single quote inside a value, and it leaves a single-value selection **unquoted**. So:

- A value containing a single quote (e.g. a service named `o'brien-service`) interpolates to `IN ('o'brien-service')` — invalid SQL.
- A single-value variable used in `IN (...)` (e.g. `IN (${database})` in Data Analysis) interpolates to `IN (mydb)` — unquoted, also invalid.

`${var:singlequote}` uses Grafana's built-in formatter, which quotes **and** escapes embedded quotes, fixing both cases. Several panels already used `:singlequote`, so this also makes the quoting consistent.

A regression test in `dashboards.test.ts` asserts no bare `IN ($var)` / `IN (${var})` or `= '${var}'` remains in these dashboards (excluding `$__` macros).

---
_Part of a small series of independent improvements to the pre-built dashboards:_
- #2080 — database selector variable
- #2081 — importable `__inputs`/`__requires`
- #2082 — min-interval variable
- #2083 — template variable quoting (this PR)
- #2084 — JSON-schema logs dashboard

All commits are signed.
