### PR TITLE
feat(dashboards): add JSON-schema OTel logs dashboard

### DIFF
--- a/docs/sources/dashboards.md
+++ b/docs/sources/dashboards.md
@@ -21,9 +21,9 @@ review_date: 2026-08-12
 
 # ClickHouse OpenTelemetry dashboards
 
-The plugin ships three pre-built dashboards for OpenTelemetry data stored in ClickHouse. Together they cover top-down log exploration, service topology and trace search, and a single-service deep dive that ties RED metrics, errors, logs, and trace detail into one view.
+The plugin ships four pre-built dashboards for OpenTelemetry data stored in ClickHouse. Three cover top-down log exploration, service topology and trace search, and a single-service deep dive that ties RED metrics, errors, logs, and trace detail into one view; a fourth is a variant of the logs explorer for tables that store OTel attributes as the native JSON type.
 
-The three dashboards link to each other via dashboard data links: clicking a service or operation in one dashboard preserves the time range and datasource and lands you on the matching view in another.
+The core three dashboards link to each other via dashboard data links: clicking a service or operation in one dashboard preserves the time range and datasource and lands you on the matching view in another.
 
 ## Required schema
 
@@ -51,6 +51,10 @@ Both per-service panels have an **Open in Explore** link in the panel header tha
 Filter variables: **Service** (multi, defaults to top 10 by volume), **Level** (multi), **Search** (textbox; passes through to `positionCaseInsensitive(Body, ...)`, a case-insensitive substring match).
 
 Annotations: deployment markers derived from `service.version` changes in `otel_traces` over 30-second buckets.
+
+## OpenTelemetry Logs Explorer (JSON schema)
+
+A variant of the OpenTelemetry Logs Explorer for deployments where the `otel_logs` attribute columns (`ResourceAttributes`, `LogAttributes`, `ScopeAttributes`) use ClickHouse's native `JSON` type instead of `Map(String, String)` — the ClickStack schema. The panels are identical except that the Log Samples panel reads attributes with JSON path access (for example `ResourceAttributes.service.namespace::String`) instead of Map key access. Because the two access styles are not interchangeable within a single query, this ships as a separate dashboard rather than a mode of the Map dashboard. The deployment annotation reads `otel_traces`, which is left as `Map`.
 
 ## OpenTelemetry Traces Explorer
 

--- a/docs/sources/dashboards.md
+++ b/docs/sources/dashboards.md
@@ -29,10 +29,14 @@ The core three dashboards link to each other via dashboard data links: clicking 
 
 The dashboards expect the standard table layout produced by the [ClickHouse exporter for the OpenTelemetry Collector](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/clickhouseexporter):
 
-- A logs table named `otel_logs` in the data source's default database.
-- A traces table named `otel_traces` in the data source's default database.
+- A logs table named `otel_logs`.
+- A traces table named `otel_traces`.
 
-Both tables are referenced by their bare names in raw SQL, so the data source's **Default database** setting needs to point at the database that holds them. If you renamed the OTel exporter tables, the dashboards do not pick the new names up automatically; either restore the standard names or duplicate the dashboards and edit the SQL.
+The three Map-schema dashboards (Logs Explorer, Traces Explorer, and the single-service deep dive) reference both tables by their bare names in raw SQL, so the data source's **Default database** setting needs to point at the database that holds them.
+
+The JSON-schema Logs Explorer instead exposes a **Database** selector variable and qualifies its queries as `${database}.otel_logs`, so it can run against any database without changing the data source default. Its panels only need `otel_logs`; the `otel_traces` table is required solely by the optional deployment annotation, which is **disabled by default**, so a logs-only database works out of the box.
+
+If you renamed the OTel exporter tables, the dashboards do not pick the new names up automatically; either restore the standard names or duplicate the dashboards and edit the SQL.
 
 The dashboards rely on the columns the exporter ships with: `Timestamp`, `Body`, `SeverityText`, `ServiceName`, `TraceId`, `SpanId`, `ResourceAttributes` for logs; `TraceId`, `ServiceName`, `SpanName`, `Timestamp`, `Duration`, `StatusCode`, `SpanKind`, `ParentSpanId`, `SpanAttributes`, `ResourceAttributes` for traces.
 

--- a/src/dashboards/__tests__/dashboards.test.ts
+++ b/src/dashboards/__tests__/dashboards.test.ts
@@ -107,4 +107,43 @@ describe('OTel dashboards', () => {
       expect(fs.existsSync(filepath)).toBe(true);
     });
   });
+
+  describe('JSON-schema logs dashboard', () => {
+    const JSON_DASHBOARD = 'otel-logs-explorer-json.json';
+    const filepath = path.join(DASHBOARDS_DIR, JSON_DASHBOARD);
+
+    it('is registered in plugin.json with a distinct uid/title', () => {
+      const pluginJson = JSON.parse(fs.readFileSync(PLUGIN_JSON, 'utf8')) as {
+        includes: Array<{ type: string; path: string }>;
+      };
+      expect(
+        pluginJson.includes.find((i) => i.type === 'dashboard' && i.path === `dashboards/${JSON_DASHBOARD}`)
+      ).toBeDefined();
+
+      const dashboard = JSON.parse(fs.readFileSync(filepath, 'utf8')) as { uid?: string; title?: string };
+      expect(dashboard.uid).toBe('otel-logs-explorer-json');
+      expect(dashboard.title).toContain('JSON');
+    });
+
+    it('reads otel_logs attributes with JSON (dot) access, not Map (bracket)', () => {
+      const content = fs.readFileSync(filepath, 'utf8');
+      expect(content).toContain('ResourceAttributes.service.namespace::String');
+      expect(content).toContain('ResourceAttributes.k8s.pod.name::String');
+      expect(content).not.toContain("ResourceAttributes['service.namespace']");
+      expect(content).not.toContain("ResourceAttributes['k8s.pod.name']");
+    });
+
+    it('keeps Map (bracket) access for otel_traces in the deployment annotation', () => {
+      // otel_traces is still Map(String,String); only otel_logs uses the JSON schema.
+      const content = fs.readFileSync(filepath, 'utf8');
+      expect(content).toContain("ResourceAttributes['service.version']");
+    });
+
+    it('quotes template variables in SQL', () => {
+      // Same guard as the other bundled dashboards ($__... macros excluded).
+      const content = fs.readFileSync(filepath, 'utf8');
+      expect(content).not.toMatch(/IN \(\$\{?(?!__)\w+\}?\)/);
+      expect(content).not.toMatch(/= '\$\{?\w+\}?'/);
+    });
+  });
 });

--- a/src/dashboards/__tests__/dashboards.test.ts
+++ b/src/dashboards/__tests__/dashboards.test.ts
@@ -6,6 +6,7 @@ const PLUGIN_JSON = path.join(__dirname, '..', '..', 'plugin.json');
 
 const otelDashboards = [
   'otel-logs-explorer.json',
+  'otel-logs-explorer-json.json',
   'otel-traces-explorer.json',
   'otel-service-dashboard.json',
 ] as const;

--- a/src/dashboards/otel-logs-explorer-json.json
+++ b/src/dashboards/otel-logs-explorer-json.json
@@ -1,0 +1,456 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_GRAFANA_CLICKHOUSE_DATASOURCE",
+      "label": "ClickHouse",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "grafana-clickhouse-datasource",
+      "pluginName": "ClickHouse"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "9.0.1"
+    },
+    {
+      "type": "datasource",
+      "id": "grafana-clickhouse-datasource",
+      "name": "ClickHouse",
+      "version": "2.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "bargauge",
+      "name": "Bar gauge",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "logs",
+      "name": "Logs",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "piechart",
+      "name": "Pie chart",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "table",
+      "name": "Table",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
+  "description": "Explore OpenTelemetry logs in ClickHouse where attribute columns use the native JSON type (ClickStack schema) instead of Map. Top services with per-service log volume and samples.",
+  "editable": true,
+  "graphTooltip": 2,
+  "id": null,
+  "links": [
+    {
+      "asDropdown": true,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": ["clickhouse", "otel"],
+      "title": "OpenTelemetry Dashboards",
+      "type": "dashboards"
+    }
+  ],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "id": 100,
+      "title": "Overview",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "grafana-clickhouse-datasource", "uid": "${datasource}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "bars",
+            "fillOpacity": 80,
+            "stacking": { "mode": "normal" },
+            "lineWidth": 0,
+            "pointSize": 5,
+            "showPoints": "never"
+          }
+        },
+        "overrides": [
+          { "matcher": { "id": "byRegexp", "options": "/fatal|FATAL/i" }, "properties": [{ "id": "displayName", "value": "fatal" }, { "id": "color", "value": { "fixedColor": "#C4162A", "mode": "fixed" } }] },
+          { "matcher": { "id": "byRegexp", "options": "/error|Error/i" }, "properties": [{ "id": "displayName", "value": "error" }, { "id": "color", "value": { "fixedColor": "#F2495C", "mode": "fixed" } }] },
+          { "matcher": { "id": "byRegexp", "options": "/warn|Warning/i" }, "properties": [{ "id": "displayName", "value": "warning" }, { "id": "color", "value": { "fixedColor": "#FF9830", "mode": "fixed" } }] },
+          { "matcher": { "id": "byRegexp", "options": "/info|Information/i" }, "properties": [{ "id": "displayName", "value": "info" }, { "id": "color", "value": { "fixedColor": "#73BF69", "mode": "fixed" } }] },
+          { "matcher": { "id": "byRegexp", "options": "/debug|Debug/i" }, "properties": [{ "id": "displayName", "value": "debug" }, { "id": "color", "value": { "fixedColor": "#5794F2", "mode": "fixed" } }] },
+          { "matcher": { "id": "byRegexp", "options": "/(?:^count )?TRACE$|(?:^count )?Trace$/i" }, "properties": [{ "id": "displayName", "value": "trace" }, { "id": "color", "value": { "fixedColor": "#B877D9", "mode": "fixed" } }] }
+        ]
+      },
+      "gridPos": { "h": 5, "w": 24, "x": 0, "y": 1 },
+      "id": 1,
+      "interval": "${interval}",
+      "description": "Stacked log volume by SeverityText across the services and levels selected above.",
+      "options": { "legend": { "displayMode": "list", "placement": "bottom", "calcs": ["sum"] }, "tooltip": { "mode": "multi" } },
+      "title": "Log Volume by Level",
+      "targets": [
+        {
+          "datasource": { "type": "grafana-clickhouse-datasource", "uid": "${datasource}" },
+          "editorType": "sql",
+          "rawSql": "SELECT\n  toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time,\n  SeverityText AS metric,\n  count() AS count\nFROM ${database}.otel_logs\nWHERE $__timeFilter(Timestamp)\n  AND $__conditionalAll(ServiceName IN (${service:singlequote}), $service)\n  AND $__conditionalAll(SeverityText IN (${level_filter:singlequote}), $level_filter)\n  AND $__conditionalAll(hasToken(Body, '$search'), $search)\nGROUP BY time, metric\nORDER BY time",
+          "refId": "A",
+          "format": 0
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "grafana-clickhouse-datasource", "uid": "${datasource}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "thresholds": { "steps": [{ "color": "green", "value": null }, { "color": "yellow", "value": 1000 }, { "color": "red", "value": 10000 }] }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 5, "w": 7, "x": 0, "y": 6 },
+      "id": 2,
+      "description": "Log volume per service in the current time range, honoring the Service, Level, and Search filters. Highest-volume first, up to 15.",
+      "options": {
+        "displayMode": "gradient",
+        "orientation": "horizontal",
+        "reduceOptions": { "calcs": ["sum"], "fields": "/Count/", "values": true },
+        "showUnfilled": true,
+        "minVizHeight": 16,
+        "minVizWidth": 80
+      },
+      "title": "Services",
+      "targets": [
+        {
+          "datasource": { "type": "grafana-clickhouse-datasource", "uid": "${datasource}" },
+          "editorType": "sql",
+          "rawSql": "SELECT\n  ServiceName AS Service,\n  count() AS Count\nFROM ${database}.otel_logs\nWHERE $__timeFilter(Timestamp)\n  AND $__conditionalAll(ServiceName IN (${service:singlequote}), $service)\n  AND $__conditionalAll(SeverityText IN (${level_filter:singlequote}), $level_filter)\n  AND $__conditionalAll(hasToken(Body, '$search'), $search)\nGROUP BY Service\nORDER BY Count DESC\nLIMIT 15",
+          "refId": "A",
+          "format": 0
+        }
+      ],
+      "type": "bargauge"
+    },
+    {
+      "datasource": { "type": "grafana-clickhouse-datasource", "uid": "${datasource}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" }
+        },
+        "overrides": [
+          { "matcher": { "id": "byRegexp", "options": "/fatal|FATAL/" }, "properties": [{ "id": "color", "value": { "fixedColor": "#C4162A", "mode": "fixed" } }] },
+          { "matcher": { "id": "byRegexp", "options": "/error|Error/" }, "properties": [{ "id": "color", "value": { "fixedColor": "#F2495C", "mode": "fixed" } }] },
+          { "matcher": { "id": "byRegexp", "options": "/warn|Warning/" }, "properties": [{ "id": "color", "value": { "fixedColor": "#FF9830", "mode": "fixed" } }] },
+          { "matcher": { "id": "byRegexp", "options": "/info|Information/" }, "properties": [{ "id": "color", "value": { "fixedColor": "#73BF69", "mode": "fixed" } }] },
+          { "matcher": { "id": "byRegexp", "options": "/debug|Debug/" }, "properties": [{ "id": "color", "value": { "fixedColor": "#5794F2", "mode": "fixed" } }] },
+          { "matcher": { "id": "byRegexp", "options": "/TRACE|Trace/" }, "properties": [{ "id": "color", "value": { "fixedColor": "#B877D9", "mode": "fixed" } }] }
+        ]
+      },
+      "gridPos": { "h": 5, "w": 5, "x": 7, "y": 6 },
+      "id": 4,
+      "description": "Share of log lines by SeverityText. Useful for spotting unusual error spikes at a glance.",
+      "options": {
+        "legend": { "displayMode": "list", "placement": "right", "values": ["value"] },
+        "pieType": "donut",
+        "reduceOptions": { "calcs": ["sum"], "fields": "/Count/", "values": true },
+        "tooltip": { "mode": "single" }
+      },
+      "title": "Level Distribution",
+      "targets": [
+        {
+          "datasource": { "type": "grafana-clickhouse-datasource", "uid": "${datasource}" },
+          "editorType": "sql",
+          "rawSql": "SELECT\n  SeverityText AS Level,\n  count() AS Count\nFROM ${database}.otel_logs\nWHERE $__timeFilter(Timestamp)\n  AND $__conditionalAll(ServiceName IN (${service:singlequote}), $service)\n  AND $__conditionalAll(hasToken(Body, '$search'), $search)\nGROUP BY Level\nORDER BY Count DESC",
+          "refId": "A",
+          "format": 0
+        }
+      ],
+      "type": "piechart"
+    },
+    {
+      "datasource": { "type": "grafana-clickhouse-datasource", "uid": "${datasource}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "align": "auto",
+            "filterable": false,
+            "inspect": true
+          }
+        },
+        "overrides": [
+          { "matcher": { "id": "byName", "options": "Count" }, "properties": [{ "id": "custom.width", "value": 70 }] },
+          { "matcher": { "id": "byName", "options": "Level" }, "properties": [{ "id": "custom.width", "value": 60 }] },
+          { "matcher": { "id": "byName", "options": "Service" }, "properties": [{ "id": "custom.width", "value": 100 }] }
+        ]
+      },
+      "gridPos": { "h": 5, "w": 12, "x": 12, "y": 6 },
+      "id": 3,
+      "description": "Most frequent ERROR / WARN / FATAL bodies across the selected services. Common id-style tokens (userId, traceId, etc.) are stripped before grouping so similar messages cluster.",
+      "options": {
+        "showHeader": true,
+        "sortBy": [{ "displayName": "Count", "desc": true }],
+        "footer": { "show": false }
+      },
+      "title": "Top Error Messages",
+      "targets": [
+        {
+          "datasource": { "type": "grafana-clickhouse-datasource", "uid": "${datasource}" },
+          "editorType": "sql",
+          "rawSql": "SELECT\n  SeverityText AS Level,\n  ServiceName AS Service,\n  replaceRegexpAll(Body, '(userId|orderId|cartId|requestId|traceId|spanId|ctId)=[a-zA-Z0-9-]+', '\\1=…') AS Message,\n  count() AS Count\nFROM ${database}.otel_logs\nWHERE $__timeFilter(Timestamp)\n  AND SeverityText IN ('ERROR', 'WARN', 'FATAL', 'Error', 'Warning', 'error', 'warning', 'fatal', 'CRITICAL')\n  AND $__conditionalAll(ServiceName IN (${service:singlequote}), $service)\n  AND $__conditionalAll(hasToken(Body, '$search'), $search)\nGROUP BY Level, Service, Message\nORDER BY Count DESC\nLIMIT 20",
+          "refId": "A",
+          "format": 0
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 11 },
+      "id": 200,
+      "repeat": "service",
+      "repeatDirection": "v",
+      "title": "$service",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "grafana-clickhouse-datasource", "uid": "${datasource}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "bars",
+            "fillOpacity": 80,
+            "stacking": { "mode": "normal" },
+            "lineWidth": 0,
+            "showPoints": "never"
+          }
+        },
+        "overrides": [
+          { "matcher": { "id": "byRegexp", "options": "/fatal|FATAL/i" }, "properties": [{ "id": "displayName", "value": "fatal" }, { "id": "color", "value": { "fixedColor": "#C4162A", "mode": "fixed" } }] },
+          { "matcher": { "id": "byRegexp", "options": "/error|Error/i" }, "properties": [{ "id": "displayName", "value": "error" }, { "id": "color", "value": { "fixedColor": "#F2495C", "mode": "fixed" } }] },
+          { "matcher": { "id": "byRegexp", "options": "/warn|Warning/i" }, "properties": [{ "id": "displayName", "value": "warning" }, { "id": "color", "value": { "fixedColor": "#FF9830", "mode": "fixed" } }] },
+          { "matcher": { "id": "byRegexp", "options": "/info|Information/i" }, "properties": [{ "id": "displayName", "value": "info" }, { "id": "color", "value": { "fixedColor": "#73BF69", "mode": "fixed" } }] },
+          { "matcher": { "id": "byRegexp", "options": "/debug|Debug/i" }, "properties": [{ "id": "displayName", "value": "debug" }, { "id": "color", "value": { "fixedColor": "#5794F2", "mode": "fixed" } }] },
+          { "matcher": { "id": "byRegexp", "options": "/(?:^count )?TRACE$|(?:^count )?Trace$/i" }, "properties": [{ "id": "displayName", "value": "trace" }, { "id": "color", "value": { "fixedColor": "#B877D9", "mode": "fixed" } }] }
+        ]
+      },
+      "gridPos": { "h": 5, "w": 24, "x": 0, "y": 12 },
+      "id": 201,
+      "interval": "${interval}",
+      "description": "Log volume by SeverityText for $service.",
+      "options": { "legend": { "displayMode": "list", "placement": "bottom", "calcs": ["sum"] }, "tooltip": { "mode": "multi" } },
+      "links": [
+      ],
+      "title": "Log Volume: $service",
+      "targets": [
+        {
+          "datasource": { "type": "grafana-clickhouse-datasource", "uid": "${datasource}" },
+          "editorType": "sql",
+          "rawSql": "SELECT\n  toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time,\n  SeverityText AS metric,\n  count() AS count\nFROM ${database}.otel_logs\nWHERE $__timeFilter(Timestamp)\n  AND ServiceName = ${service:singlequote}\n  AND $__conditionalAll(SeverityText IN (${level_filter:singlequote}), $level_filter)\n  AND $__conditionalAll(hasToken(Body, '$search'), $search)\nGROUP BY time, metric\nORDER BY time",
+          "refId": "A",
+          "format": 0
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "grafana-clickhouse-datasource", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": {}, "overrides": [] },
+      "gridPos": { "h": 14, "w": 24, "x": 0, "y": 17 },
+      "id": 202,
+      "description": "Recent log lines for $service. Click a row to expand attributes. JSON-shaped bodies are pretty-printed.",
+      "options": {
+        "showTime": true,
+        "showLabels": true,
+        "showCommonLabels": false,
+        "wrapLogMessage": true,
+        "prettifyLogMessage": true,
+        "enableLogDetails": true,
+        "dedupStrategy": "none",
+        "sortOrder": "Descending"
+      },
+      "links": [
+      ],
+      "title": "Log Samples: $service",
+      "targets": [
+        {
+          "datasource": { "type": "grafana-clickhouse-datasource", "uid": "${datasource}" },
+          "editorType": "sql",
+          "rawSql": "SELECT\n  Timestamp AS timestamp,\n  Body AS body,\n  SeverityText AS level,\n  ServiceName,\n  TraceId,\n  SpanId,\n  ResourceAttributes.service.namespace::String AS namespace,\n  ResourceAttributes.k8s.pod.name::String AS k8s_pod\nFROM ${database}.otel_logs\nWHERE $__timeFilter(Timestamp)\n  AND ServiceName = ${service:singlequote}\n  AND $__conditionalAll(SeverityText IN (${level_filter:singlequote}), $level_filter)\n  AND $__conditionalAll(hasToken(Body, '$search'), $search)\nORDER BY Timestamp DESC\nLIMIT 200",
+          "refId": "A",
+          "format": 2
+        }
+      ],
+      "type": "logs"
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      },
+      {
+        "datasource": { "type": "grafana-clickhouse-datasource", "uid": "${datasource}" },
+        "enable": true,
+        "hide": false,
+        "iconColor": "#73BF69",
+        "name": "Deployments (service.version)",
+        "preset": "deployment_detection",
+        "target": {
+          "editorType": "sql",
+          "rawSql": "SELECT\n  time,\n  ServiceName AS tags,\n  concat(ServiceName, ' deployed ', version, if(prev_version != '', concat(' (was ', prev_version, ')'), '')) AS text,\n  'Deployment' AS title\nFROM (\n  SELECT\n    toStartOfInterval(Timestamp, INTERVAL 30 second) AS time,\n    ServiceName,\n    topK(1)(ResourceAttributes['service.version'])[1] AS version,\n    lagInFrame(topK(1)(ResourceAttributes['service.version'])[1])\n      OVER (PARTITION BY ServiceName ORDER BY time) AS prev_version\n  FROM ${database}.otel_traces\n  WHERE $__timeFilter(Timestamp)\n    AND $__conditionalAll(ServiceName IN (${service:singlequote}), $service)\n    AND ResourceAttributes['service.version'] != ''\n  GROUP BY ServiceName, time\n  ORDER BY ServiceName, time\n)\nWHERE prev_version != '' AND prev_version != version\nORDER BY time",
+          "refId": "anno",
+          "format": 1
+        }
+      }
+    ]
+  },
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": ["clickhouse", "otel", "logs"],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "ClickHouse",
+          "value": "${DS_GRAFANA_CLICKHOUSE_DATASOURCE}"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "grafana-clickhouse-datasource",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      },
+      {
+        "current": {},
+        "datasource": { "type": "grafana-clickhouse-datasource", "uid": "${datasource}" },
+        "definition": "",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Database",
+        "multi": false,
+        "name": "database",
+        "options": [],
+        "query": {
+          "editorType": "sql",
+          "rawSql": "SELECT DISTINCT database FROM system.tables WHERE name = 'otel_logs' ORDER BY database"
+        },
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "auto": true,
+        "auto_count": 30,
+        "auto_min": "10s",
+        "current": {
+          "selected": false,
+          "text": "auto",
+          "value": "$__auto_interval_interval"
+        },
+        "hide": 0,
+        "label": "Min interval",
+        "name": "interval",
+        "options": [
+          { "selected": true, "text": "auto", "value": "$__auto_interval_interval" },
+          { "selected": false, "text": "1m", "value": "1m" },
+          { "selected": false, "text": "5m", "value": "5m" },
+          { "selected": false, "text": "10m", "value": "10m" },
+          { "selected": false, "text": "30m", "value": "30m" },
+          { "selected": false, "text": "1h", "value": "1h" },
+          { "selected": false, "text": "6h", "value": "6h" },
+          { "selected": false, "text": "12h", "value": "12h" },
+          { "selected": false, "text": "1d", "value": "1d" }
+        ],
+        "query": "1m,5m,10m,30m,1h,6h,12h,1d",
+        "refresh": 2,
+        "type": "interval"
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": { "type": "grafana-clickhouse-datasource", "uid": "${datasource}" },
+        "definition": "",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Service",
+        "multi": true,
+        "name": "service",
+        "options": [],
+        "query": {
+          "editorType": "sql",
+          "rawSql": "SELECT ServiceName FROM ${database}.otel_logs WHERE $__timeFilter(Timestamp) GROUP BY ServiceName ORDER BY count() DESC LIMIT 10"
+        },
+        "refresh": 2,
+        "regex": "",
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": { "type": "grafana-clickhouse-datasource", "uid": "${datasource}" },
+        "definition": "",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Level",
+        "multi": true,
+        "name": "level_filter",
+        "options": [],
+        "query": {
+          "editorType": "sql",
+          "rawSql": "SELECT DISTINCT SeverityText FROM ${database}.otel_logs WHERE $__timeFilter(Timestamp) ORDER BY SeverityText"
+        },
+        "refresh": 2,
+        "regex": "",
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": { "selected": false, "text": "", "value": "" },
+        "hide": 0,
+        "label": "Search",
+        "name": "search",
+        "options": [{ "selected": true, "text": "", "value": "" }],
+        "query": "",
+        "type": "textbox"
+      }
+    ]
+  },
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "",
+  "title": "OpenTelemetry Logs Explorer (JSON schema)",
+  "uid": "otel-logs-explorer-json"
+}

--- a/src/dashboards/otel-logs-explorer-json.json
+++ b/src/dashboards/otel-logs-explorer-json.json
@@ -355,7 +355,7 @@
       {
         "current": {},
         "datasource": { "type": "grafana-clickhouse-datasource", "uid": "${datasource}" },
-        "definition": "",
+        "definition": "SELECT DISTINCT database FROM system.columns WHERE table = 'otel_logs' AND name = 'ResourceAttributes' AND startsWith(type, 'JSON') ORDER BY database",
         "hide": 0,
         "includeAll": false,
         "label": "Database",
@@ -364,7 +364,7 @@
         "options": [],
         "query": {
           "editorType": "sql",
-          "rawSql": "SELECT DISTINCT database FROM system.tables WHERE name = 'otel_logs' ORDER BY database"
+          "rawSql": "SELECT DISTINCT database FROM system.columns WHERE table = 'otel_logs' AND name = 'ResourceAttributes' AND startsWith(type, 'JSON') ORDER BY database"
         },
         "refresh": 1,
         "regex": "",

--- a/src/dashboards/otel-logs-explorer-json.json
+++ b/src/dashboards/otel-logs-explorer-json.json
@@ -109,7 +109,7 @@
         {
           "datasource": { "type": "grafana-clickhouse-datasource", "uid": "${datasource}" },
           "editorType": "sql",
-          "rawSql": "SELECT\n  toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time,\n  SeverityText AS metric,\n  count() AS count\nFROM ${database}.otel_logs\nWHERE $__timeFilter(Timestamp)\n  AND $__conditionalAll(ServiceName IN (${service:singlequote}), $service)\n  AND $__conditionalAll(SeverityText IN (${level_filter:singlequote}), $level_filter)\n  AND $__conditionalAll(hasToken(Body, '$search'), $search)\nGROUP BY time, metric\nORDER BY time",
+          "rawSql": "SELECT\n  toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time,\n  SeverityText AS metric,\n  count() AS count\nFROM ${database}.otel_logs\nWHERE $__timeFilter(Timestamp)\n  AND $__conditionalAll(ServiceName IN (${service:singlequote}), $service)\n  AND $__conditionalAll(SeverityText IN (${level_filter:singlequote}), $level_filter)\n  AND $__conditionalAll(positionCaseInsensitive(Body, '$search') > 0, $search)\nGROUP BY time, metric\nORDER BY time",
           "refId": "A",
           "format": 0
         }
@@ -141,7 +141,7 @@
         {
           "datasource": { "type": "grafana-clickhouse-datasource", "uid": "${datasource}" },
           "editorType": "sql",
-          "rawSql": "SELECT\n  ServiceName AS Service,\n  count() AS Count\nFROM ${database}.otel_logs\nWHERE $__timeFilter(Timestamp)\n  AND $__conditionalAll(ServiceName IN (${service:singlequote}), $service)\n  AND $__conditionalAll(SeverityText IN (${level_filter:singlequote}), $level_filter)\n  AND $__conditionalAll(hasToken(Body, '$search'), $search)\nGROUP BY Service\nORDER BY Count DESC\nLIMIT 15",
+          "rawSql": "SELECT\n  ServiceName AS Service,\n  count() AS Count\nFROM ${database}.otel_logs\nWHERE $__timeFilter(Timestamp)\n  AND $__conditionalAll(ServiceName IN (${service:singlequote}), $service)\n  AND $__conditionalAll(SeverityText IN (${level_filter:singlequote}), $level_filter)\n  AND $__conditionalAll(positionCaseInsensitive(Body, '$search') > 0, $search)\nGROUP BY Service\nORDER BY Count DESC\nLIMIT 15",
           "refId": "A",
           "format": 0
         }
@@ -177,7 +177,7 @@
         {
           "datasource": { "type": "grafana-clickhouse-datasource", "uid": "${datasource}" },
           "editorType": "sql",
-          "rawSql": "SELECT\n  SeverityText AS Level,\n  count() AS Count\nFROM ${database}.otel_logs\nWHERE $__timeFilter(Timestamp)\n  AND $__conditionalAll(ServiceName IN (${service:singlequote}), $service)\n  AND $__conditionalAll(hasToken(Body, '$search'), $search)\nGROUP BY Level\nORDER BY Count DESC",
+          "rawSql": "SELECT\n  SeverityText AS Level,\n  count() AS Count\nFROM ${database}.otel_logs\nWHERE $__timeFilter(Timestamp)\n  AND $__conditionalAll(ServiceName IN (${service:singlequote}), $service)\n  AND $__conditionalAll(positionCaseInsensitive(Body, '$search') > 0, $search)\nGROUP BY Level\nORDER BY Count DESC",
           "refId": "A",
           "format": 0
         }
@@ -214,7 +214,7 @@
         {
           "datasource": { "type": "grafana-clickhouse-datasource", "uid": "${datasource}" },
           "editorType": "sql",
-          "rawSql": "SELECT\n  SeverityText AS Level,\n  ServiceName AS Service,\n  replaceRegexpAll(Body, '(userId|orderId|cartId|requestId|traceId|spanId|ctId)=[a-zA-Z0-9-]+', '\\1=…') AS Message,\n  count() AS Count\nFROM ${database}.otel_logs\nWHERE $__timeFilter(Timestamp)\n  AND SeverityText IN ('ERROR', 'WARN', 'FATAL', 'Error', 'Warning', 'error', 'warning', 'fatal', 'CRITICAL')\n  AND $__conditionalAll(ServiceName IN (${service:singlequote}), $service)\n  AND $__conditionalAll(hasToken(Body, '$search'), $search)\nGROUP BY Level, Service, Message\nORDER BY Count DESC\nLIMIT 20",
+          "rawSql": "SELECT\n  SeverityText AS Level,\n  ServiceName AS Service,\n  replaceRegexpAll(Body, '(userId|orderId|cartId|requestId|traceId|spanId|ctId)=[a-zA-Z0-9-]+', '\\1=…') AS Message,\n  count() AS Count\nFROM ${database}.otel_logs\nWHERE $__timeFilter(Timestamp)\n  AND SeverityText IN ('ERROR', 'WARN', 'FATAL', 'Error', 'Warning', 'error', 'warning', 'fatal', 'CRITICAL')\n  AND $__conditionalAll(ServiceName IN (${service:singlequote}), $service)\n  AND $__conditionalAll(positionCaseInsensitive(Body, '$search') > 0, $search)\nGROUP BY Level, Service, Message\nORDER BY Count DESC\nLIMIT 20",
           "refId": "A",
           "format": 0
         }
@@ -264,7 +264,7 @@
         {
           "datasource": { "type": "grafana-clickhouse-datasource", "uid": "${datasource}" },
           "editorType": "sql",
-          "rawSql": "SELECT\n  toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time,\n  SeverityText AS metric,\n  count() AS count\nFROM ${database}.otel_logs\nWHERE $__timeFilter(Timestamp)\n  AND ServiceName = ${service:singlequote}\n  AND $__conditionalAll(SeverityText IN (${level_filter:singlequote}), $level_filter)\n  AND $__conditionalAll(hasToken(Body, '$search'), $search)\nGROUP BY time, metric\nORDER BY time",
+          "rawSql": "SELECT\n  toStartOfInterval(Timestamp, INTERVAL $__interval_s second) AS time,\n  SeverityText AS metric,\n  count() AS count\nFROM ${database}.otel_logs\nWHERE $__timeFilter(Timestamp)\n  AND ServiceName = ${service:singlequote}\n  AND $__conditionalAll(SeverityText IN (${level_filter:singlequote}), $level_filter)\n  AND $__conditionalAll(positionCaseInsensitive(Body, '$search') > 0, $search)\nGROUP BY time, metric\nORDER BY time",
           "refId": "A",
           "format": 0
         }
@@ -294,7 +294,7 @@
         {
           "datasource": { "type": "grafana-clickhouse-datasource", "uid": "${datasource}" },
           "editorType": "sql",
-          "rawSql": "SELECT\n  Timestamp AS timestamp,\n  Body AS body,\n  SeverityText AS level,\n  ServiceName,\n  TraceId,\n  SpanId,\n  ResourceAttributes.service.namespace::String AS namespace,\n  ResourceAttributes.k8s.pod.name::String AS k8s_pod\nFROM ${database}.otel_logs\nWHERE $__timeFilter(Timestamp)\n  AND ServiceName = ${service:singlequote}\n  AND $__conditionalAll(SeverityText IN (${level_filter:singlequote}), $level_filter)\n  AND $__conditionalAll(hasToken(Body, '$search'), $search)\nORDER BY Timestamp DESC\nLIMIT 200",
+          "rawSql": "SELECT\n  Timestamp AS timestamp,\n  Body AS body,\n  SeverityText AS level,\n  ServiceName,\n  TraceId,\n  SpanId,\n  ResourceAttributes.service.namespace::String AS namespace,\n  ResourceAttributes.k8s.pod.name::String AS k8s_pod\nFROM ${database}.otel_logs\nWHERE $__timeFilter(Timestamp)\n  AND ServiceName = ${service:singlequote}\n  AND $__conditionalAll(SeverityText IN (${level_filter:singlequote}), $level_filter)\n  AND $__conditionalAll(positionCaseInsensitive(Body, '$search') > 0, $search)\nORDER BY Timestamp DESC\nLIMIT 200",
           "refId": "A",
           "format": 2
         }
@@ -314,12 +314,13 @@
         "type": "dashboard"
       },
       {
+        "customSql": "SELECT\n  time,\n  ServiceName AS tags,\n  concat(ServiceName, ' deployed ', version, if(prev_version != '', concat(' (was ', prev_version, ')'), '')) AS text,\n  'Deployment' AS title\nFROM (\n  SELECT\n    toStartOfInterval(Timestamp, INTERVAL 30 second) AS time,\n    ServiceName,\n    topK(1)(ResourceAttributes['service.version'])[1] AS version,\n    lagInFrame(topK(1)(ResourceAttributes['service.version'])[1])\n      OVER (PARTITION BY ServiceName ORDER BY time) AS prev_version\n  FROM ${database}.otel_traces\n  WHERE $__timeFilter(Timestamp)\n    AND $__conditionalAll(ServiceName IN (${service:singlequote}), $service)\n    AND ResourceAttributes['service.version'] != ''\n  GROUP BY ServiceName, time\n  ORDER BY ServiceName, time\n)\nWHERE prev_version != '' AND prev_version != version\nORDER BY time",
         "datasource": { "type": "grafana-clickhouse-datasource", "uid": "${datasource}" },
-        "enable": true,
+        "enable": false,
         "hide": false,
         "iconColor": "#73BF69",
-        "name": "Deployments (service.version)",
-        "preset": "deployment_detection",
+        "name": "Deployments (service.version, requires traces)",
+        "preset": "custom",
         "target": {
           "editorType": "sql",
           "rawSql": "SELECT\n  time,\n  ServiceName AS tags,\n  concat(ServiceName, ' deployed ', version, if(prev_version != '', concat(' (was ', prev_version, ')'), '')) AS text,\n  'Deployment' AS title\nFROM (\n  SELECT\n    toStartOfInterval(Timestamp, INTERVAL 30 second) AS time,\n    ServiceName,\n    topK(1)(ResourceAttributes['service.version'])[1] AS version,\n    lagInFrame(topK(1)(ResourceAttributes['service.version'])[1])\n      OVER (PARTITION BY ServiceName ORDER BY time) AS prev_version\n  FROM ${database}.otel_traces\n  WHERE $__timeFilter(Timestamp)\n    AND $__conditionalAll(ServiceName IN (${service:singlequote}), $service)\n    AND ResourceAttributes['service.version'] != ''\n  GROUP BY ServiceName, time\n  ORDER BY ServiceName, time\n)\nWHERE prev_version != '' AND prev_version != version\nORDER BY time",

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -33,6 +33,11 @@
     },
     {
       "type": "dashboard",
+      "name": "OpenTelemetry Logs Explorer (JSON schema)",
+      "path": "dashboards/otel-logs-explorer-json.json"
+    },
+    {
+      "type": "dashboard",
       "name": "OpenTelemetry Traces Explorer",
       "path": "dashboards/otel-traces-explorer.json"
     },


### PR DESCRIPTION
## What
Adds `otel-logs-explorer-json.json`, a variant of the OpenTelemetry Logs Explorer for ClickHouse tables that store OTel attributes with the native **JSON** type (the ClickStack schema) instead of `Map(String, String)`. Registered in `plugin.json` alongside the Map-schema dashboard.

## Why a separate dashboard
The two schemas need different attribute-access syntax and **cannot be served by one static query**: on a JSON column `ResourceAttributes.service.namespace` reads the nested path, whereas the Map form `ResourceAttributes['service.namespace']` errors on a JSON column (`ILLEGAL_TYPE_OF_ARGUMENT`). ClickHouse can't branch on column type inside a static query, so a duplicate is the clean option.

- Only the **Log Samples** panel reads `otel_logs` attributes; it uses dot access with a `::String` cast (validated against a live ClickHouse 26.2 JSON table).
- The deployment annotation reads `otel_traces`, which remains `Map`, so its access is left unchanged.
- The dashboard mirrors the improved Map edition (database selector, importable inputs, interval variable, consistent quoting).

---
_Part of a small series of independent improvements to the pre-built OpenTelemetry dashboards. The dashboard-editing PRs touch overlapping lines, so whichever lands first, the others need a trivial rebase:_
- #2080 — database selector variable
- #2081 — importable `__inputs`/`__requires`
- #2082 — min-interval variable
- #2083 — multi-value quoting
- #2084 — JSON-schema logs dashboard

All commits are signed. New assertions added to `src/dashboards/__tests__/dashboards.test.ts`.
