### PR TITLE
fix(query): surface frontend query processing errors instead of hanging panels

### DIFF
--- a/cspell.config.json
+++ b/cspell.config.json
@@ -16,6 +16,7 @@
   "words": [
     "aggregatable",
     "aheads",
+    "alertbox",
     "ASOF",
     "apikey",
     "buildinfo",

--- a/src/data/CHDatasource.test.ts
+++ b/src/data/CHDatasource.test.ts
@@ -2,6 +2,7 @@ import {
   arrayToDataFrame,
   CoreApp,
   DataQueryRequest,
+  LoadingState,
   SupplementaryQueryType,
   TimeRange,
   toDataFrame,
@@ -11,7 +12,7 @@ import { DataSourceWithBackend } from '@grafana/runtime';
 import { DataQuery } from '@grafana/schema';
 import { mockDatasource } from '__mocks__/datasource';
 import { cloneDeep } from 'lodash';
-import { of } from 'rxjs';
+import { lastValueFrom, of, throwError } from 'rxjs';
 import {
   BuilderMode,
   ColumnHint,
@@ -1412,6 +1413,51 @@ describe('ClickHouseDatasource', () => {
         ],
         timezone: 'UTC',
       });
+    });
+
+    // Regression guards for #1931: a crash during frontend response
+    // processing must produce a visible error response, not an unshaped
+    // throw that leaves the panel spinning forever.
+    it('emits an error response when response transformation throws', async () => {
+      const instance = cloneDeep(mockDatasource);
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      // A frame with no `fields` makes the trace/log link transforms throw,
+      // same crash class as the TypeError fixed by #1920.
+      jest
+        .spyOn(DataSourceWithBackend.prototype, 'query')
+        .mockImplementation((_request) => of({ data: [{ refId: '1' }] } as any));
+
+      const response = await lastValueFrom(
+        instance.query({
+          targets: [{ refId: '1' }] as DataQuery[],
+          timezone: 'UTC',
+        } as any)
+      );
+
+      expect(response.state).toBe(LoadingState.Error);
+      expect(response.data).toEqual([]);
+      expect(response.errors?.[0]?.message).toBeTruthy();
+      consoleSpy.mockRestore();
+    });
+
+    it('emits an error response when the backend query observable errors', async () => {
+      const instance = cloneDeep(mockDatasource);
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      jest
+        .spyOn(DataSourceWithBackend.prototype, 'query')
+        .mockImplementation((_request) => throwError(() => ({ data: { message: 'connection refused' } })));
+
+      const response = await lastValueFrom(
+        instance.query({
+          targets: [{ refId: '1' }] as DataQuery[],
+          timezone: 'UTC',
+        } as any)
+      );
+
+      expect(response.state).toBe(LoadingState.Error);
+      expect(response.data).toEqual([]);
+      expect(response.errors?.[0]?.message).toBe('connection refused');
+      consoleSpy.mockRestore();
     });
   });
 

--- a/src/data/CHDatasource.ts
+++ b/src/data/CHDatasource.ts
@@ -2,6 +2,7 @@ import {
   AdHocVariableFilter,
   DataFrame,
   DataFrameView,
+  DataQueryError,
   DataQueryRequest,
   DataQueryResponse,
   DataSourceInstanceSettings,
@@ -13,6 +14,7 @@ import {
   Field,
   getTimeZone,
   getTimeZoneInfo,
+  LoadingState,
   LogRowContextOptions,
   LogRowContextQueryDirection,
   LogRowModel,
@@ -31,7 +33,7 @@ import LogsContextPanel from 'components/LogsContextPanel';
 import { cloneDeep, isString } from 'lodash';
 import otel from 'otel';
 import { createElement as createReactElement, ReactNode } from 'react';
-import { concatMap, firstValueFrom, Observable } from 'rxjs';
+import { catchError, concatMap, firstValueFrom, Observable, of } from 'rxjs';
 import { CHConfig, ConfigMode, SignalType } from 'types/config';
 import {
   AggregateColumn,
@@ -1477,6 +1479,16 @@ export class Datasource
             return { ...transformed, data: splitLogsVolumeFrames(transformed.data, Datasource.logVolumePrefix) };
           }
           return transformed;
+        }),
+        // Without this, a throw during response transformation escapes the
+        // observable unshaped and the panel spins forever instead of showing
+        // an error (#1931).
+        catchError((err) => {
+          console.error('ClickHouse query failed:', err);
+          const error: DataQueryError = {
+            message: this.extractQueryErrorMessage(err) || 'Query failed. Check the browser console for details.',
+          };
+          return of<DataQueryResponse>({ data: [], state: LoadingState.Error, error, errors: [error] });
         })
       );
   }

--- a/src/views/CHQueryEditor.test.tsx
+++ b/src/views/CHQueryEditor.test.tsx
@@ -60,6 +60,27 @@ describe('Query Editor', () => {
     expect(screen.getByText('SELECT * FROM table')).toBeInTheDocument();
   });
 
+  it('renders an error alert instead of crashing when the editor throws (#1931)', () => {
+    // Suppress React's error-boundary console noise for the intentional throw.
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const datasource = newMockDatasource();
+    jest.spyOn(datasource, 'isSingleTableMode').mockImplementation(() => {
+      throw new Error('render crash');
+    });
+
+    render(
+      <CHQueryEditor
+        query={{ pluginVersion: '', rawSql: 'SELECT 1', refId: 'A', editorType: EditorType.SQL }}
+        onChange={jest.fn()}
+        onRunQuery={jest.fn()}
+        datasource={datasource}
+      />
+    );
+
+    expect(screen.getByText('ClickHouse query editor failed to load')).toBeInTheDocument();
+    consoleSpy.mockRestore();
+  });
+
   it('Should not sync builder options when editorType remains SQL', () => {
     const builderOptions = {
       database: 'db2',

--- a/src/views/CHQueryEditor.tsx
+++ b/src/views/CHQueryEditor.tsx
@@ -3,7 +3,7 @@ import { QueryEditorProps } from '@grafana/data';
 import { Datasource } from 'data/CHDatasource';
 import { EditorTypeSwitcher } from 'components/queryBuilder/EditorTypeSwitcher';
 import { styles } from 'styles';
-import { Button, ConfirmModal, InlineFieldRow, Stack } from '@grafana/ui';
+import { Button, ConfirmModal, ErrorBoundaryAlert, InlineFieldRow, Stack } from '@grafana/ui';
 import { CHBuilderQuery, CHQuery, EditorType } from 'types/sql';
 import { CHConfig } from 'types/config';
 import { QueryBuilder } from 'components/queryBuilder/QueryBuilder';
@@ -38,9 +38,19 @@ const removeSpanLinkQueryField = (query: CHQuery): CHQuery => {
 };
 
 /**
- * Top level query editor component
+ * Top level query editor component.
+ * Wrapped in an error boundary so a crash while rendering the editor surfaces
+ * an alert instead of breaking the panel edit view (#1931).
  */
 export const CHQueryEditor = (props: CHQueryEditorProps) => {
+  return (
+    <ErrorBoundaryAlert title="ClickHouse query editor failed to load" style="alertbox">
+      <CHQueryEditorContent {...props} />
+    </ErrorBoundaryAlert>
+  );
+};
+
+const CHQueryEditorContent = (props: CHQueryEditorProps) => {
   const { datasource, query: savedQuery, onChange, onRunQuery } = props;
   // Fold a span-link injected trace id into the builder options before rendering, so the
   // editor shows the linked trace and the first propagated change keeps targeting it once


### PR DESCRIPTION
- Add `catchError` to the `query()` pipe so a throw during response transformation emits a visible error response instead of leaving panels/variables loading forever
- Wrap `CHQueryEditor` in `ErrorBoundaryAlert` so an editor render crash shows a plugin-scoped alert instead of a broken edit view
- Checks: lint, typecheck, full jest (995 passed) pass; verified live in Grafana 12.2 with an injected transform crash (before/after screenshots below)

Screenshot:
<img width="2724" height="671" alt="image" src="https://github.com/user-attachments/assets/f94119ae-83a7-426c-80b5-7971f67d2f82" />
<img width="2724" height="637" alt="image" src="https://github.com/user-attachments/assets/9f739b41-aea4-439b-8343-5962a4bc5145" />


Closes #1931