### PR TITLE
fix(logs): apply log message search to logs volume and sample queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Apply the log message search to the logs volume and logs sample queries, so the volume histogram matches the filtered log list (#2092)
+
 ## 4.20.0
 
 ### Features

--- a/src/data/CHDatasource.test.ts
+++ b/src/data/CHDatasource.test.ts
@@ -1477,22 +1477,6 @@ describe('ClickHouseDatasource', () => {
         expect(result).toBeDefined();
         expect(result?.rawSql).not.toContain('LIKE');
       });
-
-      it('should use the configured LogMessage column name for non-OTel tables', () => {
-        jest.spyOn(logs, 'getTimeFieldRoundingClause').mockReturnValue('toStartOfInterval("ts", INTERVAL 1 DAY)');
-        const result = datasource.getSupplementaryLogsVolumeQuery(request, {
-          ...query,
-          builderOptions: {
-            ...query.builderOptions,
-            columns: [
-              { name: 'ts', hint: ColumnHint.Time },
-              { name: 'message', hint: ColumnHint.LogMessage },
-            ],
-            meta: { logMessageLike: 'oops' },
-          },
-        });
-        expect(result?.rawSql).toContain("( message LIKE '%oops%' )");
-      });
     });
 
     describe('getSupplementaryLogsSampleQuery', () => {
@@ -1653,21 +1637,6 @@ describe('ClickHouseDatasource', () => {
         }) as CHBuilderQuery;
         expect(result).toBeDefined();
         expect(result.rawSql).not.toContain('LIKE');
-      });
-
-      it('should use the configured LogMessage column name for non-OTel tables', () => {
-        const result = datasource.getSupplementaryLogsSampleQuery({
-          ...query,
-          builderOptions: {
-            ...query.builderOptions,
-            columns: [
-              { name: 'ts', hint: ColumnHint.Time },
-              { name: 'message', hint: ColumnHint.LogMessage },
-            ],
-            meta: { logMessageLike: 'oops' },
-          },
-        }) as CHBuilderQuery;
-        expect(result.rawSql).toContain("( message LIKE '%oops%' )");
       });
     });
 

--- a/src/data/CHDatasource.test.ts
+++ b/src/data/CHDatasource.test.ts
@@ -1418,6 +1418,81 @@ describe('ClickHouseDatasource', () => {
             `ORDER BY time ASC`
         );
       });
+
+      it('should apply the log message search using the real column name', () => {
+        jest
+          .spyOn(logs, 'getTimeFieldRoundingClause')
+          .mockReturnValue('toStartOfInterval("created_at", INTERVAL 1 DAY)');
+        const result = datasource.getSupplementaryLogsVolumeQuery(request, {
+          ...query,
+          builderOptions: {
+            ...query.builderOptions,
+            columns: [
+              { name: 'created_at', hint: ColumnHint.Time },
+              { name: 'Body', hint: ColumnHint.LogMessage },
+            ],
+            meta: { logMessageLike: 'found' },
+          },
+        });
+        expect(result?.rawSql).toEqual(
+          'SELECT toStartOfInterval("created_at", INTERVAL 1 DAY) as "time", count(*) as logs ' +
+            'FROM "default"."logs" ' +
+            "WHERE ( Body LIKE '%found%' ) " +
+            'GROUP BY time ' +
+            'ORDER BY time ASC'
+        );
+        // real column name, not the "body" alias that the volume query never projects
+        expect(result?.rawSql).not.toContain('body LIKE');
+      });
+
+      it('should not apply a message filter when meta.logMessageLike is unset', () => {
+        jest
+          .spyOn(logs, 'getTimeFieldRoundingClause')
+          .mockReturnValue('toStartOfInterval("created_at", INTERVAL 1 DAY)');
+        const result = datasource.getSupplementaryLogsVolumeQuery(request, {
+          ...query,
+          builderOptions: {
+            ...query.builderOptions,
+            columns: [
+              { name: 'created_at', hint: ColumnHint.Time },
+              { name: 'Body', hint: ColumnHint.LogMessage },
+            ],
+          },
+        });
+        expect(result?.rawSql).not.toContain('LIKE');
+      });
+
+      it('should not apply a message filter when there is no log message column', () => {
+        jest
+          .spyOn(logs, 'getTimeFieldRoundingClause')
+          .mockReturnValue('toStartOfInterval("created_at", INTERVAL 1 DAY)');
+        const result = datasource.getSupplementaryLogsVolumeQuery(request, {
+          ...query,
+          builderOptions: {
+            ...query.builderOptions,
+            columns: [{ name: 'created_at', hint: ColumnHint.Time }],
+            meta: { logMessageLike: 'found' },
+          },
+        });
+        expect(result).toBeDefined();
+        expect(result?.rawSql).not.toContain('LIKE');
+      });
+
+      it('should use the configured LogMessage column name for non-OTel tables', () => {
+        jest.spyOn(logs, 'getTimeFieldRoundingClause').mockReturnValue('toStartOfInterval("ts", INTERVAL 1 DAY)');
+        const result = datasource.getSupplementaryLogsVolumeQuery(request, {
+          ...query,
+          builderOptions: {
+            ...query.builderOptions,
+            columns: [
+              { name: 'ts', hint: ColumnHint.Time },
+              { name: 'message', hint: ColumnHint.LogMessage },
+            ],
+            meta: { logMessageLike: 'oops' },
+          },
+        });
+        expect(result?.rawSql).toContain("( message LIKE '%oops%' )");
+      });
     });
 
     describe('getSupplementaryLogsSampleQuery', () => {
@@ -1522,6 +1597,77 @@ describe('ClickHouseDatasource', () => {
         const result = datasource.getSupplementaryLogsSampleQuery(timeSeriesQuery);
         expect(result).toBeDefined();
         expect((result as CHBuilderQuery).builderOptions.queryType).toBe(QueryType.Logs);
+      });
+
+      it('should apply the log message search using the real column name', () => {
+        const result = datasource.getSupplementaryLogsSampleQuery({
+          ...query,
+          builderOptions: {
+            ...query.builderOptions,
+            columns: [
+              { name: 'created_at', hint: ColumnHint.Time },
+              { name: 'level', hint: ColumnHint.LogLevel },
+              { name: 'Body', hint: ColumnHint.LogMessage },
+            ],
+            meta: { logMessageLike: 'found' },
+          },
+        }) as CHBuilderQuery;
+        expect(result).toBeDefined();
+        expect(result.rawSql).toContain("( Body LIKE '%found%' )");
+        // real column name, not the "body" alias
+        expect(result.rawSql).not.toContain('body LIKE');
+        const appended = result.builderOptions.filters?.find((f) => f.key === 'Body');
+        expect(appended).toMatchObject({
+          key: 'Body',
+          operator: FilterOperator.Like,
+          value: 'found',
+          type: 'string',
+          filterType: 'custom',
+          condition: 'AND',
+        });
+      });
+
+      it('should not apply a message filter when meta.logMessageLike is unset', () => {
+        const result = datasource.getSupplementaryLogsSampleQuery({
+          ...query,
+          builderOptions: {
+            ...query.builderOptions,
+            columns: [
+              { name: 'created_at', hint: ColumnHint.Time },
+              { name: 'Body', hint: ColumnHint.LogMessage },
+            ],
+          },
+        }) as CHBuilderQuery;
+        expect(result).toBeDefined();
+        expect(result.rawSql).not.toContain('LIKE');
+      });
+
+      it('should not apply a message filter when there is no log message column', () => {
+        const result = datasource.getSupplementaryLogsSampleQuery({
+          ...query,
+          builderOptions: {
+            ...query.builderOptions,
+            columns: [{ name: 'created_at', hint: ColumnHint.Time }],
+            meta: { logMessageLike: 'found' },
+          },
+        }) as CHBuilderQuery;
+        expect(result).toBeDefined();
+        expect(result.rawSql).not.toContain('LIKE');
+      });
+
+      it('should use the configured LogMessage column name for non-OTel tables', () => {
+        const result = datasource.getSupplementaryLogsSampleQuery({
+          ...query,
+          builderOptions: {
+            ...query.builderOptions,
+            columns: [
+              { name: 'ts', hint: ColumnHint.Time },
+              { name: 'message', hint: ColumnHint.LogMessage },
+            ],
+            meta: { logMessageLike: 'oops' },
+          },
+        }) as CHBuilderQuery;
+        expect(result.rawSql).toContain("( message LIKE '%oops%' )");
       });
     });
 

--- a/src/data/CHDatasource.ts
+++ b/src/data/CHDatasource.ts
@@ -393,12 +393,14 @@ export class Datasource
     const filters = (query.builderOptions.filters?.slice() || []).map((f) => {
       // In order for a hinted filter to work, the hinted column must be SELECTed OR provide "key"
       // For this histogram query the "level" column isn't selected, so we must find the original column name
-      if (f.hint && !f.key) {
-        const originalColumn = getColumnByHint(query.builderOptions, f.hint);
-        f.key = originalColumn?.alias || originalColumn?.name || '';
+      // Clone so resolving the key does not write it back into the user's query filters.
+      const next = { ...f };
+      if (next.hint && !next.key) {
+        const originalColumn = getColumnByHint(query.builderOptions, next.hint);
+        next.key = originalColumn?.alias || originalColumn?.name || '';
       }
 
-      return f;
+      return next;
     });
 
     const messageFilter = this.getLogMessageSearchFilter(query.builderOptions);

--- a/src/data/CHDatasource.ts
+++ b/src/data/CHDatasource.ts
@@ -312,6 +312,36 @@ export class Datasource
     return [SupplementaryQueryType.LogsVolume, SupplementaryQueryType.LogsSample];
   }
 
+  /**
+   * Builds a message search filter from meta.logMessageLike so the supplementary logs volume and
+   * sample queries apply the same message search as the main logs query.
+   *
+   * The filter uses an explicit key with the LogMessage column's real name, not a ColumnHint and
+   * not the "body" alias. A hinted filter only resolves when its column is selected (see the
+   * hint-to-key resolution in the callers), and the volume query does not project the LogMessage
+   * column, so an explicit real-name key is what resolves in both supplementary queries.
+   */
+  private getLogMessageSearchFilter(builderOptions: QueryBuilderOptions): StringFilter | undefined {
+    const logMessageLike = builderOptions.meta?.logMessageLike;
+    if (!logMessageLike) {
+      return undefined;
+    }
+
+    const logMessageColumn = getColumnByHint(builderOptions, ColumnHint.LogMessage);
+    if (!logMessageColumn) {
+      return undefined;
+    }
+
+    return {
+      condition: 'AND',
+      key: logMessageColumn.name,
+      type: 'string',
+      filterType: 'custom',
+      operator: FilterOperator.Like,
+      value: logMessageLike,
+    };
+  }
+
   getSupplementaryLogsVolumeQuery(logsVolumeRequest: DataQueryRequest<CHQuery>, query: CHQuery): CHQuery | undefined {
     if (
       query.editorType !== EditorType.Builder ||
@@ -371,6 +401,11 @@ export class Datasource
       return f;
     });
 
+    const messageFilter = this.getLogMessageSearchFilter(query.builderOptions);
+    if (messageFilter) {
+      filters.push(messageFilter);
+    }
+
     const logVolumeSqlBuilderOptions: QueryBuilderOptions = {
       database: query.builderOptions.database,
       table: query.builderOptions.table,
@@ -417,6 +452,11 @@ export class Datasource
       }
       return { ...f };
     });
+
+    const messageFilter = this.getLogMessageSearchFilter(query.builderOptions);
+    if (messageFilter) {
+      filters.push(messageFilter);
+    }
 
     const defaultColumns = Array.from(this.getDefaultLogsColumns(), ([hint, name]) => ({ hint, name }));
 


### PR DESCRIPTION
## Summary

The log message search box in the Explore logs view is applied to the main logs query but not to the supplementary **logs volume** histogram or **logs sample** queries. `getSupplementaryLogsVolumeQuery` and `getSupplementaryLogsSampleQuery` both rebuild `QueryBuilderOptions` from `filters`/`columns`/`aggregates` without carrying `meta`, and `meta.logMessageLike` is where the message search lives. The result is a histogram that shows bars while the filtered sample list is empty.

This applies the same message search to both supplementary queries as an explicit `LIKE` filter on the LogMessage column.

## Changes

- Add a private `getLogMessageSearchFilter` helper that builds a `FilterOperator.Like` filter from `meta.logMessageLike` on the LogMessage column, or returns nothing when the search is empty or no LogMessage column is configured.
- Append that filter in `getSupplementaryLogsVolumeQuery` and `getSupplementaryLogsSampleQuery`.
- Unit tests for both builders (message applied, message unset, no LogMessage column).

## Why

The filter targets the LogMessage column's real name (for example `Body`), not the `body` alias the main query uses in its SELECT. The volume query does not project that alias, so an alias-based predicate would not resolve there. The real column name resolves in both the main and the supplementary queries.

## Local verification

Reproduced against the public ClickHouse demo (`sql-clickhouse.clickhouse.com`, `otel_v2.otel_logs`) in Explore: query type Logs, filter `SeverityText LIKE error`, message search `found`. In this dataset "found" only appears in info-level bodies, so the error-level sample is empty. Confirmed the generated SQL before and after against the demo (last 1 hour):

| Query | Predicate | Rows |
| ----- | --------- | ---- |
| Logs sample (what the user sees) | `error AND Body LIKE '%found%'` | 0 |
| Logs volume, before | `error` only | 562 |
| Logs volume, after (this PR) | `error AND Body LIKE '%found%'` | 0 |

After the change the histogram matches the sample list. With a term that does appear in error bodies (`failed`) the sample and the volume query return the same non-zero count (207), so the fix narrows the histogram rather than blanking it.

## Test plan

- [x] npx jest (full suite, 998 passed)
- [x] npx tsc --noEmit
- [x] npx eslint
- [x] npx prettier --check
- [x] npm run spellcheck

Please add the `changelog` label so this surfaces in the next release notes.
