### PR TITLE
Bump go version in workflow

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -58,5 +58,5 @@ jobs:
       pull-requests: read
 
     with:
-      go-version: "1.26.4"
+      go-version: "1.26.5"
       golangci-lint-version: "2.10.1"


### PR DESCRIPTION
Clickhouse now requires Go 1.26.5