### PR TITLE
Support JSON-typed columns in ad-hoc filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - Add Forward OAuth Identity authentication: forward the signed-in Grafana user's OAuth token to ClickHouse Cloud as a JWT so queries are attributed to the real user instead of a shared service account. Requires a verified TLS connection. Alert and other backend queries have no signed-in user and are blocked by default; enable **Allow service account fallback** to let them run with the configured username/password (#1987)
+- Support JSON-typed columns (e.g. the OTel JSON schema's `LogAttributes`/`ResourceAttributes`) in ad-hoc filters: JSON sub-paths are discovered for the key dropdown and rendered as backtick-quoted dot-access cast to `Nullable(String)`, so every filter operator works and values read back over the native protocol. Keys are minted in a stateless self-describing form (building on #2079), so a saved JSON filter applies correctly on a fresh dashboard load (#2094)
 
 ### Fixes
 

--- a/src/data/CHDatasource.test.ts
+++ b/src/data/CHDatasource.test.ts
@@ -1024,6 +1024,95 @@ describe('ClickHouseDatasource', () => {
     });
   });
 
+  describe('JSON type ad-hoc filters (#2094)', () => {
+    it('expands JSON-typed columns into self-describing backtick path keys', async () => {
+      jest.spyOn(templateSrvMock, 'replace').mockImplementation(() => 'db.events');
+      const ds = cloneDeep(mockDatasource);
+      ds.settings.jsonData.defaultDatabase = 'db';
+      ds.settings.jsonData.defaultTable = 'events';
+      const columnsFrame = arrayToDataFrame([
+        { name: 'level', type: 'String', table: 'events' },
+        { name: 'ResourceAttributes', type: 'JSON', table: 'events' },
+      ]);
+      // fetchUniqueJSONPathsForAdhoc → distinct JSON paths for ResourceAttributes.
+      const pathsFrame = arrayToDataFrame([{ path: 'k8s.pod' }, { path: 'level' }]);
+      jest.spyOn(ds, 'query').mockImplementation((request) => {
+        const sql = request.targets[0].rawSql ?? '';
+        if (sql.includes('JSONAllPaths("ResourceAttributes")')) {
+          return of({ data: [pathsFrame] });
+        }
+        return of({ data: [columnsFrame] });
+      });
+
+      const keys = await ds.getTagKeys();
+      // Each level backtick-quoted: the key is self-describing, so escapeKey
+      // renders cast JSON access with no JSON-column cache.
+      expect(keys).toEqual([
+        { text: 'events.level' },
+        { text: 'events.ResourceAttributes.`k8s`.`pod`' },
+        { text: 'events.ResourceAttributes.`level`' },
+      ]);
+    });
+
+    it('reads a companion <col>Keys array column instead of JSONAllPaths when present', async () => {
+      jest.spyOn(templateSrvMock, 'replace').mockImplementation(() => 'db.events');
+      const ds = cloneDeep(mockDatasource);
+      ds.settings.jsonData.defaultDatabase = 'db';
+      ds.settings.jsonData.defaultTable = 'events';
+      const columnsFrame = arrayToDataFrame([
+        { name: 'ResourceAttributes', type: 'JSON', table: 'events' },
+        { name: 'ResourceAttributesKeys', type: 'Array(String)', table: 'events' },
+      ]);
+      const pathsFrame = arrayToDataFrame([{ path: 'service.name' }]);
+      const spyOnQuery = jest.spyOn(ds, 'query').mockImplementation((request) => {
+        const sql = request.targets[0].rawSql ?? '';
+        if (sql.includes('arrayJoin("ResourceAttributesKeys")')) {
+          return of({ data: [pathsFrame] });
+        }
+        return of({ data: [columnsFrame] });
+      });
+
+      const keys = await ds.getTagKeys();
+      expect(keys).toContainEqual({ text: 'events.ResourceAttributes.`service`.`name`' });
+      // Discovery read the companion array column, not JSONAllPaths.
+      const probedSql = spyOnQuery.mock.calls
+        .map((c) => (c[0] as any).targets[0].rawSql as string)
+        .find((s) => s.includes('arrayJoin('));
+      expect(probedSql).toContain('arrayJoin("ResourceAttributesKeys")');
+      expect(probedSql).not.toContain('JSONAllPaths');
+    });
+
+    it('fetches values for a minted JSON key with the cast, no prior getTagKeys call', async () => {
+      // Stateless round-trip: on a fresh dashboard load (caches empty) the
+      // value SELECT must still cast the JSON sub-path — an uncast Dynamic path
+      // reads back all-null over the native protocol.
+      jest.spyOn(templateSrvMock, 'replace').mockImplementation(() => 'db.events');
+      const ds = cloneDeep(mockDatasource);
+      ds.settings.jsonData.defaultDatabase = 'db';
+      const columnsFrame = arrayToDataFrame([{ name: 'ResourceAttributes', type: 'JSON', table: 'events' }]);
+      const valuesFrame = arrayToDataFrame([{ val: 'api' }]);
+      const spyOnQuery = jest.spyOn(ds, 'query').mockImplementation((request) => {
+        const sql = request.targets[0].rawSql ?? '';
+        if (sql.includes('::Nullable(String)')) {
+          return of({ data: [valuesFrame] });
+        }
+        return of({ data: [columnsFrame] });
+      });
+
+      const values = await ds.getTagValues({ key: 'events.ResourceAttributes.`k8s`.`pod`' });
+      expect(values).toEqual([{ text: 'api' }]);
+      expect(spyOnQuery).toHaveBeenCalledWith(
+        expect.objectContaining({
+          targets: expect.arrayContaining([
+            expect.objectContaining({
+              rawSql: 'select distinct ResourceAttributes.`k8s`.`pod`::Nullable(String) from db.events limit 1000',
+            }),
+          ]),
+        })
+      );
+    });
+  });
+
   describe('fetchUniqueMapKeys probe (#1843)', () => {
     it('bounds the probe to a row-sampled subquery for free-form tables (no time column known)', async () => {
       // Without a known time column the probe can't prune by partition, so it

--- a/src/data/CHDatasource.test.ts
+++ b/src/data/CHDatasource.test.ts
@@ -1111,6 +1111,38 @@ describe('ClickHouseDatasource', () => {
         })
       );
     });
+
+    it('casts a LEGACY dotted JSON key on a cold cache (pins ensureAttributeColumnCache)', async () => {
+      // A minted backtick key self-describes and casts with no cache, so it
+      // can't catch a broken warm-up. A legacy dotted key (`col.path`, from an
+      // already-saved dashboard) resolves JSON-ness only via the column cache,
+      // which getTagKeys hasn't populated on a fresh load — ensureAttributeColumnCache
+      // must warm it, else the sub-path is emitted uncast (Dynamic → all-null).
+      jest.spyOn(templateSrvMock, 'replace').mockImplementation(() => 'db.events');
+      const ds = cloneDeep(mockDatasource);
+      ds.settings.jsonData.defaultDatabase = 'db';
+      const columnsFrame = arrayToDataFrame([{ name: 'ResourceAttributes', type: 'JSON', table: 'events' }]);
+      const valuesFrame = arrayToDataFrame([{ val: 'api' }]);
+      const spyOnQuery = jest.spyOn(ds, 'query').mockImplementation((request) => {
+        const sql = request.targets[0].rawSql ?? '';
+        if (sql.includes('::Nullable(String)')) {
+          return of({ data: [valuesFrame] });
+        }
+        return of({ data: [columnsFrame] });
+      });
+
+      const values = await ds.getTagValues({ key: 'events.ResourceAttributes.k8s.pod' });
+      expect(values).toEqual([{ text: 'api' }]);
+      expect(spyOnQuery).toHaveBeenCalledWith(
+        expect.objectContaining({
+          targets: expect.arrayContaining([
+            expect.objectContaining({
+              rawSql: 'select distinct ResourceAttributes.`k8s`.`pod`::Nullable(String) from db.events limit 1000',
+            }),
+          ]),
+        })
+      );
+    });
   });
 
   describe('fetchUniqueMapKeys probe (#1843)', () => {

--- a/src/data/CHDatasource.ts
+++ b/src/data/CHDatasource.ts
@@ -95,6 +95,9 @@ const TRACE_TIMESTAMP_TABLE_REQUIRED_COLUMNS = ['Start', 'End', 'TraceId'];
 // Row cap for the Map-key discovery probe on free-form tables (no known time
 // column to prune by). Bounds the scan to a sample instead of the whole column.
 const MAP_KEY_PROBE_ROW_SAMPLE = 100000;
+// Recent-data window used to bound attribute-discovery/value probes on a table
+// with a known time column, so they prune instead of scanning the full column.
+const ADHOC_PROBE_TIME_WINDOW = 'INTERVAL 6 HOUR';
 
 function getAttributeColumnByDisplayPrefix(
   builderOptions: QueryBuilderOptions,
@@ -1212,7 +1215,7 @@ export class Datasource
     const tableIdentifier = `${escapeIdentifier(db)}.${escapeIdentifier(table)}`;
     const timeColumn = this.getMapKeyProbeTimeColumn(db, table);
     const source = timeColumn
-      ? `${tableIdentifier} WHERE ${escapeIdentifier(timeColumn)} >= now() - INTERVAL 6 HOUR`
+      ? `${tableIdentifier} WHERE ${escapeIdentifier(timeColumn)} >= now() - ${ADHOC_PROBE_TIME_WINDOW}`
       : `(SELECT ${escapedColumn} FROM ${tableIdentifier} LIMIT ${MAP_KEY_PROBE_ROW_SAMPLE})`;
     // mapKeys() rather than the `.keys` sub-column: ClickHouse's old analyzer
     // (the default before 24.3) cannot resolve sub-columns on subquery results
@@ -1250,7 +1253,7 @@ export class Datasource
       : `arrayJoin(JSONAllPaths(${escapeIdentifier(jsonColumn)}))`;
     const projected = keysColumn ? escapeIdentifier(keysColumn) : escapeIdentifier(jsonColumn);
     const source = timeColumn
-      ? `${tableIdentifier} WHERE ${escapeIdentifier(timeColumn)} >= now() - INTERVAL 6 HOUR`
+      ? `${tableIdentifier} WHERE ${escapeIdentifier(timeColumn)} >= now() - ${ADHOC_PROBE_TIME_WINDOW}`
       : `(SELECT ${projected} FROM ${tableIdentifier} LIMIT ${MAP_KEY_PROBE_ROW_SAMPLE})`;
     const rawSql = `SELECT DISTINCT ${pathExpr} as path FROM ${source} LIMIT 1000`;
     return this.fetchData(rawSql);
@@ -1771,7 +1774,9 @@ export class Datasource
     } else {
       // When hideTableNameInAdhocFilters is false, key is 'table.column' format (e.g., 'foo.bar')
       const [table, ...colParts] = key.split('.');
-      col = colParts.join('.');
+      // A single-segment key (no `table.` prefix) leaves colParts empty; fall
+      // back to the whole key so we never emit `select distinct  from …`.
+      col = colParts.length ? colParts.join('.') : key;
       source = from?.includes('.') ? `${from.split('.')[0]}.${table}` : table;
     }
 
@@ -1801,8 +1806,11 @@ export class Datasource
     if (set) {
       return set;
     }
-    const tableKnown = this.mapColumnsByTable.has(tableKey) || this.jsonColumnsByTable.has(tableKey);
-    if (tableKnown) {
+    // "Known" means the table's schema was fetched — NOT that it has attribute
+    // columns. A fetched table with no Map/JSON column is absent from both
+    // caches, but must still return an empty set (not the cross-table union),
+    // otherwise a same-named column from another table would misclassify it.
+    if (this.attributeSchemaFetched.has(tableKey)) {
       return EMPTY_COLUMN_SET;
     }
     return cache === this.mapColumnsByTable ? this.getFlatMapColumnSet() : this.getFlatJSONColumnSet();
@@ -1968,7 +1976,10 @@ export class Datasource
         const parts = key.split('.');
         // Strip a leading `<table>.` prefix (present unless hideTableName) before
         // resolving the column against the per-table attribute caches.
-        const col = parts[0] === bareTable ? parts.slice(1).join('.') : key;
+        // Only strip a leading `<table>.` prefix; a single-segment key that
+        // equals the table name must stay as the column (else the substitution
+        // becomes empty and yields `SELECT  FROM <table>`).
+        const col = parts.length > 1 && parts[0] === bareTable ? parts.slice(1).join('.') : key;
         columnExpr = this.buildAdhocColumnExpr(col, from);
       }
       // Use a function replacer so `$`-sequences in columnExpr (e.g. a Map key

--- a/src/data/CHDatasource.ts
+++ b/src/data/CHDatasource.ts
@@ -63,6 +63,7 @@ import {
   TIME_FIELD_ALIAS,
 } from './logs';
 import { escapeIdentifier, generateSql, getColumnByHint, logAliasToColumnHints } from './sqlGenerator';
+import { buildJSONPathAccess, mintJSONAdhocKey, parseJSONAdhocKey } from './jsonPath';
 import { labelsFieldName, transformQueryResponseWithTraceAndLogLinks } from './utils';
 import { CHVariableSupport } from './CHVariableSupport';
 import { createAnnotationSupport } from './CHAnnotationSupport';
@@ -225,6 +226,13 @@ export class Datasource
   // `asMapAccess()` strips any `db.` prefix from the lookup source so callers
   // can pass either form.
   private mapColumnsByTable: Map<string, Set<string>> = new Map();
+  // JSON-typed columns; same keying/lifecycle as `mapColumnsByTable`. Not
+  // republished to AdHocFilter — JSON keys carry their type in the minted
+  // backtick form, so escapeKey renders them statelessly.
+  private jsonColumnsByTable: Map<string, Set<string>> = new Map();
+  // Bare table names whose Map/JSON column kinds are already resolved — avoids
+  // redundant system.columns lookups.
+  private attributeSchemaFetched: Set<string> = new Set();
   private static readonly TRACE_TIMESTAMP_TABLE_CACHE_TTL_MS = 30 * 1000;
   // Caches the in-flight or resolved existence check for the `<table>_trace_id_ts`
   // companion, keyed by the qualified companion table name (`${database}.${table}${suffix}`)
@@ -1220,6 +1228,34 @@ export class Datasource
     return this.fetchData(rawSql);
   }
 
+  /**
+   * JSON-path discovery for adhoc tag-key expansion. Twin of `fetchUniqueMapKeys`:
+   * same discovery toggle and bounding (time-window on the known OTel table, else
+   * a row sample) since `JSONAllPaths` over a full column is a scan. Reads a
+   * companion `<col>Keys` array column directly when present.
+   */
+  async fetchUniqueJSONPathsForAdhoc(
+    jsonColumn: string,
+    db: string,
+    table: string,
+    keysColumn?: string
+  ): Promise<string[]> {
+    if (!this.isMapKeysDiscoveryEnabled()) {
+      return [];
+    }
+    const tableIdentifier = `${escapeIdentifier(db)}.${escapeIdentifier(table)}`;
+    const timeColumn = this.getMapKeyProbeTimeColumn(db, table);
+    const pathExpr = keysColumn
+      ? `arrayJoin(${escapeIdentifier(keysColumn)})`
+      : `arrayJoin(JSONAllPaths(${escapeIdentifier(jsonColumn)}))`;
+    const projected = keysColumn ? escapeIdentifier(keysColumn) : escapeIdentifier(jsonColumn);
+    const source = timeColumn
+      ? `${tableIdentifier} WHERE ${escapeIdentifier(timeColumn)} >= now() - INTERVAL 6 HOUR`
+      : `(SELECT ${projected} FROM ${tableIdentifier} LIMIT ${MAP_KEY_PROBE_ROW_SAMPLE})`;
+    const rawSql = `SELECT DISTINCT ${pathExpr} as path FROM ${source} LIMIT 1000`;
+    return this.fetchData(rawSql);
+  }
+
   async fetchDistinctValues(column: string, db: string, table: string): Promise<Array<string | number | boolean>> {
     const escapedColumn = escapeIdentifier(column);
     const rawSql = `SELECT DISTINCT ${escapedColumn} FROM ${escapeIdentifier(db)}.${escapeIdentifier(table)} WHERE ${escapedColumn} IS NOT NULL LIMIT 1000`;
@@ -1533,71 +1569,74 @@ export class Datasource
       text: hideTableName ? item[0] : `${item[2]}.${item[0]}`,
     }));
 
-    // Collect Map columns per-table and populate both the datasource cache
-    // (consumed by fetchTagValuesFromSchema) and the AdHocFilter cache
-    // (consumed by escapeKey). Done regardless of whether Map expansion is
-    // feasible for this context — the caches are used even when expansion
-    // bails out.
+    // Classify attribute columns per-table into the datasource caches (used by
+    // fetchTagValuesFromSchema) and, below, the AdHocFilter caches (used by
+    // escapeKey), even when expansion bails out. A column is at most one kind.
     this.mapColumnsByTable = new Map();
+    this.jsonColumnsByTable = new Map();
     const mapCols: Array<{ name: string; table: string }> = [];
+    const jsonCols: Array<{ name: string; table: string }> = [];
+    const columnNamesByTable = new Map<string, Set<string>>();
     view.forEach((item) => {
-      if (isMapColumnType(item[1])) {
-        const tableKey = item[2];
-        let set = this.mapColumnsByTable.get(tableKey);
-        if (!set) {
-          set = new Set<string>();
-          this.mapColumnsByTable.set(tableKey, set);
-        }
-        set.add(item[0]);
-        mapCols.push({ name: item[0], table: item[2] });
+      const name = item[0];
+      const colType = item[1];
+      const table = item[2];
+      this.addColumnToTableCache(columnNamesByTable, table, name);
+      if (isMapColumnType(colType)) {
+        this.addColumnToTableCache(this.mapColumnsByTable, table, name);
+        mapCols.push({ name, table });
+      } else if (isJSONColumnType(colType)) {
+        this.addColumnToTableCache(this.jsonColumnsByTable, table, name);
+        jsonCols.push({ name, table });
       }
     });
+    // Every table classified above is now "known" — the lazy value-fetch path
+    // (ensureAttributeColumnCache) uses this to avoid re-querying their schema.
+    this.attributeSchemaFetched = new Set(columnNamesByTable.keys());
+    this.publishAttributeColumnsToFilter();
 
-    // Republish the flattened Map-column set to the AdHocFilter so its
-    // escapeKey can disambiguate `col.key` references.
-    const allMapCols = new Set<string>();
-    for (const set of this.mapColumnsByTable.values()) {
-      for (const c of set) {
-        allMapCols.add(c);
-      }
-    }
-    this.adHocFilter.setMapColumns(allMapCols);
-
-    // Map-key expansion only runs when the adhoc context points at a
-    // specific `db.table` — otherwise we'd need to probe every table in a
-    // database, which is too expensive to do on every dashboard render.
-    // The same opt-out that disables the per-filter probe also short-circuits
-    // this fan-out, so disabling the setting kills *all* probe traffic.
+    // Key/path expansion only runs against a specific `db.table` — probing every
+    // table in a database on each render is too expensive. The discovery opt-out
+    // short-circuits this fan-out too.
     const db = this.resolveAdhocDatabase(frame);
     const singleTable = this.resolveAdhocSingleTable();
-    if (!db || !singleTable || mapCols.length === 0 || !this.isMapKeysDiscoveryEnabled()) {
+    if (!db || !singleTable || (mapCols.length === 0 && jsonCols.length === 0) || !this.isMapKeysDiscoveryEnabled()) {
       return keys;
     }
 
-    // Only probe Map columns that belong to the targeted table.
-    const probeTargets = mapCols.filter((c) => c.table === singleTable);
-    if (probeTargets.length === 0) {
+    // Only probe attribute columns that belong to the targeted table.
+    const mapProbe = mapCols.filter((c) => c.table === singleTable);
+    const jsonProbe = jsonCols.filter((c) => c.table === singleTable);
+    if (mapProbe.length === 0 && jsonProbe.length === 0) {
       return keys;
     }
 
-    const probed = await Promise.all(
-      probeTargets.map(async (c) => {
+    const columnNames = columnNamesByTable.get(singleTable) ?? new Set<string>();
+    const probed = await Promise.all([
+      ...mapProbe.map(async (c) => {
         try {
-          const mapKeys = await this.fetchUniqueMapKeys(c.name, db, c.table);
-          return { col: c, keys: mapKeys };
+          return { col: c, keys: await this.fetchUniqueMapKeys(c.name, db, c.table) };
         } catch (ex) {
           console.warn(`Failed to fetch map keys for ${db}.${c.table}.${c.name}:`, ex);
           return { col: c, keys: [] as string[] };
         }
-      })
-    );
+      }),
+      ...jsonProbe.map(async (c) => {
+        // A companion `<col>Keys` array column, when present, is a cheaper
+        // path source than introspecting the JSON via JSONAllPaths.
+        const keysColumn = columnNames.has(`${c.name}Keys`) ? `${c.name}Keys` : undefined;
+        try {
+          return { col: c, keys: await this.fetchUniqueJSONPathsForAdhoc(c.name, db, c.table, keysColumn) };
+        } catch (ex) {
+          console.warn(`Failed to fetch JSON paths for ${db}.${c.table}.${c.name}:`, ex);
+          return { col: c, keys: [] as string[] };
+        }
+      }),
+    ]);
 
-    // Replace each top-level Map-column entry with one entry per discovered
-    // map key. If probing returned nothing (empty set, stripped by the
-    // filter), keep the original entry as a no-op fallback. Keys are minted
-    // in explicit bracket form (`col['key']`) so that filter application is
-    // stateless: a saved filter must render correct SQL on fresh dashboard
-    // load, before this method has run and populated the Map-column caches.
+    // Replace each attribute-column entry with one per discovered key/path
+    // (minted self-describing so filter application stays stateless); if probing
+    // returned nothing, keep the original entry as a no-op fallback.
     const expandedKeyByCol = new Map<string, string[]>();
     for (const p of probed) {
       if (p.keys.length > 0) {
@@ -1613,13 +1652,18 @@ export class Datasource
       const col = item[0];
       const table = item[2];
       const baseText = hideTableName ? col : `${table}.${col}`;
-      const mapKeys = expandedKeyByCol.get(col);
-      if (!mapKeys || table !== singleTable) {
+      const subKeys = expandedKeyByCol.get(col);
+      if (!subKeys || table !== singleTable) {
         expanded.push({ text: baseText });
         return;
       }
-      for (const k of mapKeys) {
-        expanded.push({ text: `${baseText}['${escapeCHStringLiteral(k)}']` });
+      // JSON columns mint the self-describing backtick path form; Map columns
+      // keep #2079's stateless bracket form.
+      const isJsonCol = this.jsonColumnsByTable.get(singleTable)?.has(col) ?? false;
+      for (const k of subKeys) {
+        expanded.push({
+          text: isJsonCol ? mintJSONAdhocKey(baseText, k) : `${baseText}['${escapeCHStringLiteral(k)}']`,
+        });
       }
     });
     return expanded;
@@ -1656,7 +1700,16 @@ export class Datasource
     const source = getTemplateSrv().replace('$clickhouse_adhoc_query');
     const defaultSource = this.getDefaultAdhocSource();
     const raw = source === '$clickhouse_adhoc_query' ? defaultSource : source;
-    if (!raw || raw.toLowerCase().startsWith('select')) {
+    if (!raw) {
+      return defaultSource?.split('.')[0];
+    }
+    if (raw.toLowerCase().startsWith('select')) {
+      // Query-mode ($__adhoc_column): use the FROM-clause database (the same
+      // table fetchTags queries), else the configured default.
+      const table = this.extractTableNameFromQuery(raw);
+      if (table && table.includes('.')) {
+        return table.split('.')[0];
+      }
       return defaultSource?.split('.')[0];
     }
     return raw.includes('.') ? raw.split('.')[0] : raw;
@@ -1671,8 +1724,17 @@ export class Datasource
   private resolveAdhocSingleTable(): string | undefined {
     const source = getTemplateSrv().replace('$clickhouse_adhoc_query');
     const raw = source === '$clickhouse_adhoc_query' ? this.getDefaultAdhocSource() : source;
-    if (!raw || raw.toLowerCase().startsWith('select')) {
+    if (!raw) {
       return undefined;
+    }
+    if (raw.toLowerCase().startsWith('select')) {
+      // Query-mode ($__adhoc_column): the FROM table (first one, best-effort for
+      // joins — the same table fetchTags queries).
+      const table = this.extractTableNameFromQuery(raw);
+      if (!table) {
+        return undefined;
+      }
+      return table.includes('.') ? table.split('.')[1] : table;
     }
     return raw.includes('.') ? raw.split('.')[1] : undefined;
   }
@@ -1713,17 +1775,11 @@ export class Datasource
       source = from?.includes('.') ? `${from.split('.')[0]}.${table}` : table;
     }
 
-    // If `col` is of the form `<mapCol>.<mapKey>` and <mapCol> is known to
-    // be a Map-typed column, rewrite to bracket-access so the SELECT pulls
-    // distinct Map values rather than stringified Map objects (which the
-    // Grafana frame layer renders as `[object Object]`). The map key is
-    // escaped for CH string-literal embedding so that keys containing `'`
-    // or `\` produce valid SQL. Keys minted by getTagKeys arrive already in
-    // bracket form (`mapCol['key']`, literal body pre-escaped) and pass
-    // through unchanged as valid bracket access.
-    const mapAccess = this.asMapAccess(col, source);
-    const selectExpr = mapAccess ? `${mapAccess.column}['${escapeCHStringLiteral(mapAccess.key)}']` : col;
-
+    // Warm the Map/JSON caches for this table in case getTagKeys hasn't run
+    // (e.g. editing a saved filter value on a restored dashboard) so JSON paths
+    // are cast rather than emitted uncast (Dynamic → all-null).
+    await this.ensureAttributeColumnCache(source);
+    const selectExpr = this.buildAdhocColumnExpr(col, source);
     const rawSql = `select distinct ${selectExpr} from ${source} limit 1000`;
     const frame = await this.runQuery({ rawSql });
     if (frame.fields?.length === 0) {
@@ -1731,6 +1787,107 @@ export class Datasource
     }
     const field = frame.fields[0];
     return this.fieldValuesToMetricFindValues(field);
+  }
+
+  /**
+   * Resolve a table's attribute-column set from the per-table cache. An ABSENT
+   * entry for a known table means "no columns of this kind", not "unknown", so
+   * return an empty set — the cross-table union would let a same-named column
+   * from another table (e.g. `logs.attrs` JSON vs `events.attrs` Map)
+   * misclassify. The union is used only when the table is entirely unknown.
+   */
+  private attributeColumnsForTable(cache: Map<string, Set<string>>, tableKey: string): ReadonlySet<string> {
+    const set = cache.get(tableKey);
+    if (set) {
+      return set;
+    }
+    const tableKnown = this.mapColumnsByTable.has(tableKey) || this.jsonColumnsByTable.has(tableKey);
+    if (tableKnown) {
+      return EMPTY_COLUMN_SET;
+    }
+    return cache === this.mapColumnsByTable ? this.getFlatMapColumnSet() : this.getFlatJSONColumnSet();
+  }
+
+  /**
+   * Build the SQL column expression for an ad-hoc value lookup: JSON → cast
+   * backtick access (an uncast `Dynamic` sub-path reads all-null over the native
+   * protocol), Map → bracket access, else the column as-is. Shared by schema-mode
+   * and query-mode ($__adhoc_column) so both emit identical, cast-correct access.
+   */
+  private buildAdhocColumnExpr(col: string, source: string): string {
+    // Self-describing JSON key minted by getTagKeys: the backtick form carries
+    // its own type, so it casts with no column cache.
+    const mintedJSON = parseJSONAdhocKey(col);
+    if (mintedJSON) {
+      return buildJSONPathAccess(mintedJSON.column, mintedJSON.path);
+    }
+    // Legacy dotted JSON key (`col.path`): resolved via the per-table cache.
+    const jsonAccess = this.asJSONAccess(col, source);
+    if (jsonAccess) {
+      return buildJSONPathAccess(jsonAccess.column, jsonAccess.path);
+    }
+    const mapAccess = this.asMapAccess(col, source);
+    if (mapAccess) {
+      return `${mapAccess.column}['${escapeCHStringLiteral(mapAccess.key)}']`;
+    }
+    return col;
+  }
+
+  private addColumnToTableCache(cache: Map<string, Set<string>>, table: string, name: string) {
+    let set = cache.get(table);
+    if (!set) {
+      set = new Set<string>();
+      cache.set(table, set);
+    }
+    set.add(name);
+  }
+
+  /**
+   * Publish only the flattened Map-column set to the AdHocFilter, so escapeKey
+   * can disambiguate a legacy dotted `col.key` Map reference (and honor the
+   * `clickhouse_adhoc_use_json` opt-in). JSON keys carry their type in the
+   * minted backtick form, so escapeKey renders them statelessly — nothing to
+   * publish.
+   */
+  private publishAttributeColumnsToFilter() {
+    this.adHocFilter.setMapColumns(this.getFlatMapColumnSet());
+  }
+
+  /**
+   * Populate the Map/JSON column-kind caches for `source`'s table. getTagKeys
+   * normally fills these, but Grafana can call getTagValues first (e.g. editing
+   * a saved filter's value on a restored dashboard); on a cold cache the value
+   * SELECT would emit an uncast JSON sub-path (`Dynamic` → all-null), so resolve
+   * the table's column kinds lazily here.
+   */
+  private async ensureAttributeColumnCache(source: string): Promise<void> {
+    const table = source.includes('.') ? source.split('.')[1] : source;
+    if (!table || this.attributeSchemaFetched.has(table)) {
+      return;
+    }
+    const db = source.includes('.') ? source.split('.')[0] : this.getDefaultDatabase();
+    // Mark fetched up front so concurrent value lookups don't double-probe.
+    this.attributeSchemaFetched.add(table);
+    try {
+      this.skipAdHocFilter = true;
+      const rawSql = `SELECT name, type FROM system.columns WHERE database = '${db}' AND table = '${table}'`;
+      const frame = await this.runQuery({ rawSql });
+      const view = new DataFrameView<{ 0: string; 1: string }>(frame);
+      view.forEach((item) => {
+        const name = item[0];
+        const colType = item[1];
+        if (isMapColumnType(colType)) {
+          this.addColumnToTableCache(this.mapColumnsByTable, table, name);
+        } else if (isJSONColumnType(colType)) {
+          this.addColumnToTableCache(this.jsonColumnsByTable, table, name);
+        }
+      });
+      this.publishAttributeColumnsToFilter();
+    } catch (ex) {
+      // Allow a later retry rather than caching the failure.
+      this.attributeSchemaFetched.delete(table);
+      console.warn(`Failed to resolve attribute column kinds for ${db}.${table}:`, ex);
+    }
   }
 
   /**
@@ -1746,7 +1903,7 @@ export class Datasource
     }
     const parts = col.split('.');
     const tableKey = source.includes('.') ? source.split('.')[1] : source;
-    const mapCols = this.mapColumnsByTable.get(tableKey) ?? this.getFlatMapColumnSet();
+    const mapCols = this.attributeColumnsForTable(this.mapColumnsByTable, tableKey);
     if (!mapCols.has(parts[0])) {
       return undefined;
     }
@@ -1763,13 +1920,61 @@ export class Datasource
     return flat;
   }
 
+  /**
+   * JSON twin of `asMapAccess`: returns `{column, path}` when the leading
+   * segment of a dotted tag key refers to a JSON-typed column in the given
+   * source. The source may be `db.table` or a bare table name.
+   */
+  private asJSONAccess(col: string, source: string): { column: string; path: string } | undefined {
+    if (!col.includes('.')) {
+      return undefined;
+    }
+    const parts = col.split('.');
+    const tableKey = source.includes('.') ? source.split('.')[1] : source;
+    const jsonCols = this.attributeColumnsForTable(this.jsonColumnsByTable, tableKey);
+    if (!jsonCols.has(parts[0])) {
+      return undefined;
+    }
+    return { column: parts[0], path: parts.slice(1).join('.') };
+  }
+
+  private getFlatJSONColumnSet(): Set<string> {
+    const flat = new Set<string>();
+    for (const set of this.jsonColumnsByTable.values()) {
+      for (const c of set) {
+        flat.add(c);
+      }
+    }
+    return flat;
+  }
+
   private async fetchTagValuesFromQuery(key: string): Promise<MetricFindValue[]> {
     const tagSource = this.getTagSource();
 
     // Check if the query contains the $__adhoc_column macro
     if (tagSource.source && tagSource.source.includes('$__adhoc_column')) {
-      // Replace the macro with the actual column name
-      const queryWithColumn = tagSource.source.replace(/\$__adhoc_column/g, key);
+      // Substitute the selected key with a cast-correct column expression, not
+      // the raw dotted key. A JSON sub-path (e.g. `ResourceAttributes.k8s.pod.name`)
+      // is `Dynamic` and reads back as all-null over Grafana's native protocol
+      // unless cast to Nullable(String); Map keys need bracket access. The table
+      // comes from the query's own FROM clause (same one used for key discovery).
+      const from = this.extractTableNameFromQuery(tagSource.source);
+      let columnExpr = key;
+      if (from) {
+        // Warm the caches for the query's table so a JSON path is cast even when
+        // getTagKeys hasn't populated them yet (cold-cache value fetch).
+        await this.ensureAttributeColumnCache(from);
+        const bareTable = from.includes('.') ? from.split('.')[1] : from;
+        const parts = key.split('.');
+        // Strip a leading `<table>.` prefix (present unless hideTableName) before
+        // resolving the column against the per-table attribute caches.
+        const col = parts[0] === bareTable ? parts.slice(1).join('.') : key;
+        columnExpr = this.buildAdhocColumnExpr(col, from);
+      }
+      // Use a function replacer so `$`-sequences in columnExpr (e.g. a Map key
+      // like `a$&b`) are inserted literally rather than interpreted by
+      // String.replace as `$&`/`$1`/`$'` replacement patterns.
+      const queryWithColumn = tagSource.source.replace(/\$__adhoc_column/g, () => columnExpr);
       this.skipAdHocFilter = true;
       const frame = await this.runQuery({ rawSql: queryWithColumn });
 
@@ -1806,7 +2011,15 @@ export class Datasource
         // Extract table name from the query and get column list from system.columns
         const tableName = this.extractTableNameFromQuery(tagSource.source);
         if (tableName) {
-          this.adHocFilter.setTargetTableFromQuery(tagSource.source.replace(/\$__adhoc_column/g, '*'));
+          try {
+            this.adHocFilter.setTargetTableFromQuery(tagSource.source.replace(/\$__adhoc_column/g, '*'));
+          } catch (ex) {
+            // getTable() uses a pgsql AST parser that can't parse some valid
+            // ClickHouse SQL (e.g. backtick-quoted identifiers). Don't let that
+            // abort key discovery — apply() re-derives the target table from the
+            // actual panel query when _targetTable is unset.
+            console.warn('Could not derive adhoc target table from tag query:', ex);
+          }
 
           // Parse database.table format
           const parts = tableName.split('.');
@@ -1830,9 +2043,13 @@ export class Datasource
   }
 
   private extractTableNameFromQuery(query: string): string | null {
-    // Try to extract table name from FROM clause
-    // Supports formats: FROM table, FROM database.table, FROM "database"."table"
-    const fromMatch = query.match(/FROM\s+(?:"?(\w+)"?\.)?"?(\w+)"?/i);
+    // Best-effort table extraction from the first FROM clause. Supports bare,
+    // double-quoted, and backtick-quoted identifiers, optionally
+    // database-qualified: `FROM t`, `FROM db.t`, `FROM "db"."t"`, `` FROM `db`.`t` ``.
+    // Quoted identifiers are common in ClickHouse; not matching them left the
+    // table unresolved, which silently dropped the JSON `::Nullable(String)`
+    // cast. Joins/subqueries/CTEs still resolve to the first FROM token only.
+    const fromMatch = query.match(/FROM\s+(?:["`]?(\w+)["`]?\.)?["`]?(\w+)["`]?/i);
     if (fromMatch) {
       const database = fromMatch[1];
       const table = fromMatch[2];
@@ -2192,6 +2409,22 @@ function isMapColumnType(type: string | undefined): boolean {
   }
   return /^(?:Nullable\(|LowCardinality\()?Map\(/.test(type);
 }
+
+/**
+ * Returns true when a ClickHouse type string describes a JSON column. Matches
+ * the modern `JSON` / `Nullable(JSON)` / `LowCardinality(JSON)` forms as well
+ * as the legacy `Object('json')` type, case-insensitively.
+ */
+function isJSONColumnType(type: string | undefined): boolean {
+  if (!type) {
+    return false;
+  }
+  return /^(?:Nullable\(|LowCardinality\()?(?:JSON|Object\('json'\))/i.test(type);
+}
+
+// Shared empty set returned when a table is known to have no attribute columns
+// of a given kind — avoids per-call allocation.
+const EMPTY_COLUMN_SET: ReadonlySet<string> = new Set();
 
 // Escape a string for embedding inside a single-quoted ClickHouse string
 // literal: backslash and single quote are the only characters that need

--- a/src/data/adHocFilter.test.ts
+++ b/src/data/adHocFilter.test.ts
@@ -484,5 +484,19 @@ describe('AdHocManager', () => {
       ] as AdHocVariableFilter[]);
       expect(val).toContain("ResourceAttributes.`level`::Nullable(String) = \\'error\\'");
     });
+
+    it('escapes a quote in a JSON path segment for the outer filter string', () => {
+      // The rendered access is embedded inside the single-quoted
+      // additional_table_filters string, so a `'` in a path segment must be
+      // escaped over the whole expression — otherwise it breaks the string.
+      // Pins the outer-escape layer (buildJSONAccessForOuterFilter); an empty
+      // implementation would emit the un-escaped `` `a'b` `` form and fail here.
+      const ahm = new AdHocFilter();
+      const val = ahm.apply('SELECT * FROM otel_logs', [
+        { key: "otel_logs.ResourceAttributes.`a'b`", operator: '=', value: 'v' },
+      ] as AdHocVariableFilter[]);
+      expect(val).toContain("ResourceAttributes.`a\\'b`::Nullable(String)");
+      expect(val).not.toContain("`a'b`");
+    });
   });
 });

--- a/src/data/adHocFilter.test.ts
+++ b/src/data/adHocFilter.test.ts
@@ -258,10 +258,12 @@ describe('AdHocManager', () => {
     const ahm = new AdHocFilter();
     const result = ahm.apply(
       'SELECT * FROM foo',
-      [{ key: "ResourceAttributes.cloud.region'", operator: '=', value: 'test' }] as AdHocVariableFilter[],
+      [{ key: 'ResourceAttributes.cloud.region', operator: '=', value: 'test' }] as AdHocVariableFilter[],
       true
     );
-    expect(result).toContain('ResourceAttributes.cloud.region');
+    // useJSON forces JSON dot-access on the default OTel column, cast to
+    // Nullable(String) — an uncast Dynamic sub-path reads back all-null.
+    expect(result).toContain('ResourceAttributes.`cloud`.`region`::Nullable(String)');
   });
 
   describe('buildFilterString', () => {
@@ -446,7 +448,7 @@ describe('AdHocManager', () => {
         [{ key: "events.metadata['region']", operator: '=', value: 'eu' }] as AdHocVariableFilter[],
         true
       );
-      expect(val).toContain("metadata.region = \\'eu\\'");
+      expect(val).toContain("metadata.`region`::Nullable(String) = \\'eu\\'");
     });
 
     it('legacy dotted keys still render via the registered Map-column set', () => {
@@ -458,6 +460,29 @@ describe('AdHocManager', () => {
         { key: 'events.metadata.region', operator: '=', value: 'eu' },
       ] as AdHocVariableFilter[]);
       expect(val).toContain("metadata[\\'region\\'] = \\'eu\\'");
+    });
+  });
+
+  describe('self-describing JSON keys (#2094)', () => {
+    // getTagKeys mints JSON sub-paths in a backtick form (`col.`seg`.`seg``).
+    // escapeKey renders them cast to Nullable(String) with NO column cache, so
+    // a saved JSON filter applies correctly on a fresh dashboard load.
+    it('renders a minted JSON key statelessly (no setMapColumns/setJSONColumns)', () => {
+      const ahm = new AdHocFilter();
+      const val = ahm.apply('SELECT * FROM otel_logs', [
+        { key: 'otel_logs.ResourceAttributes.`k8s`.`pod`.`name`', operator: '=', value: 'api' },
+      ] as AdHocVariableFilter[]);
+      expect(val).toContain(
+        "ResourceAttributes.`k8s`.`pod`.`name`::Nullable(String) = \\'api\\'"
+      );
+    });
+
+    it('renders a single-segment minted JSON key with hideTableName-style key', () => {
+      const ahm = new AdHocFilter();
+      const val = ahm.apply('SELECT * FROM otel_logs', [
+        { key: 'ResourceAttributes.`level`', operator: '=', value: 'error' },
+      ] as AdHocVariableFilter[]);
+      expect(val).toContain("ResourceAttributes.`level`::Nullable(String) = \\'error\\'");
     });
   });
 });

--- a/src/data/adHocFilter.ts
+++ b/src/data/adHocFilter.ts
@@ -1,5 +1,6 @@
 import { AdHocVariableFilter } from '@grafana/data';
 import { getTable } from './ast';
+import { buildJSONPathAccess, parseJSONAdhocKey } from './jsonPath';
 
 // OTel-standard Map columns. Retained as a fallback so behavior does not
 // regress when schema info has not been populated (e.g. in tests that
@@ -11,10 +12,15 @@ export class AdHocFilter {
   private _mapColumns: ReadonlySet<string> = DEFAULT_MAP_COLUMNS;
 
   setTargetTableFromQuery(query: string) {
-    this._targetTable = getTable(query);
-    if (this._targetTable === '') {
+    // Reset first so that if getTable() throws (its pgsql AST can't parse some
+    // valid ClickHouse SQL, e.g. backtick identifiers) we don't retain a stale
+    // table from a previous query — apply() then re-derives from the panel SQL.
+    this._targetTable = '';
+    const table = getTable(query);
+    if (table === '') {
       throw new Error('Failed to get table from adhoc query.');
     }
+    this._targetTable = table;
   }
 
   /**
@@ -122,6 +128,14 @@ function unescapeCHStringLiteral(s: string): string {
   return s.replace(/\\(.)/g, '$1');
 }
 
+// `buildJSONPathAccess` output embedded inside the single-quoted
+// `additional_table_filters` string needs one further layer of string escaping
+// (`'` → `\'`, `\` → `\\`) over the whole expression.
+function buildJSONAccessForOuterFilter(col: string, path: string): string {
+  const expr = buildJSONPathAccess(col, path);
+  return expr.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+}
+
 function escapeKey(s: string, isJSON = false, mapColumns: ReadonlySet<string> = DEFAULT_MAP_COLUMNS): string {
   // Convert arrayElement(col, 'key') → col['key']. Handled up front so the
   // dotted-path logic below doesn't see synthetic function syntax.
@@ -142,9 +156,17 @@ function escapeKey(s: string, isJSON = false, mapColumns: ReadonlySet<string> = 
     const [, , mapCol, literalKey] = bracketed;
     const mapKey = unescapeCHStringLiteral(literalKey);
     if (isJSON) {
-      return `${mapCol}.${mapKey}`;
+      return buildJSONAccessForOuterFilter(mapCol, mapKey);
     }
     return `${mapCol}[\\'${escapeMapKeyForOuterFilter(mapKey)}\\']`;
+  }
+
+  // Stateless JSON path form minted by getTagKeys (`col.`seg``): the backtick
+  // form is itself the signal, so it renders with no column cache (mirrors the
+  // Map bracket form above).
+  const jsonKey = parseJSONAdhocKey(s);
+  if (jsonKey) {
+    return buildJSONAccessForOuterFilter(jsonKey.column, jsonKey.path);
   }
 
   const parts = s.split('.');
@@ -157,7 +179,7 @@ function escapeKey(s: string, isJSON = false, mapColumns: ReadonlySet<string> = 
     const mapCol = parts[1];
     const mapKey = parts.slice(2).join('.');
     if (isJSON) {
-      return `${mapCol}.${mapKey}`;
+      return buildJSONAccessForOuterFilter(mapCol, mapKey);
     }
     return `${mapCol}[\\'${escapeMapKeyForOuterFilter(mapKey)}\\']`;
   }
@@ -169,7 +191,7 @@ function escapeKey(s: string, isJSON = false, mapColumns: ReadonlySet<string> = 
     const mapCol = parts[0];
     const mapKey = parts.slice(1).join('.');
     if (isJSON) {
-      return s;
+      return buildJSONAccessForOuterFilter(mapCol, mapKey);
     }
     return `${mapCol}[\\'${escapeMapKeyForOuterFilter(mapKey)}\\']`;
   }

--- a/src/data/jsonPath.test.ts
+++ b/src/data/jsonPath.test.ts
@@ -1,0 +1,98 @@
+import {
+  buildJSONPathAccess,
+  escapeJSONPathSegment,
+  mintJSONAdhocKey,
+  parseJSONAdhocKey,
+  unescapeJSONPathSegment,
+} from './jsonPath';
+
+describe('escapeJSONPathSegment', () => {
+  it('leaves plain segments unchanged', () => {
+    expect(escapeJSONPathSegment('k8s')).toBe('k8s');
+  });
+
+  it('escapes a backtick so it cannot close the identifier', () => {
+    expect(escapeJSONPathSegment('a`b')).toBe('a\\`b');
+  });
+
+  it('escapes a backslash', () => {
+    expect(escapeJSONPathSegment('a\\b')).toBe('a\\\\b');
+  });
+
+  it('escapes backslash before backtick (no double-escaping)', () => {
+    expect(escapeJSONPathSegment('a\\`b')).toBe('a\\\\\\`b');
+  });
+});
+
+describe('buildJSONPathAccess', () => {
+  it('builds a single-segment cast access', () => {
+    expect(buildJSONPathAccess('attrs', 'level')).toBe('attrs.`level`::Nullable(String)');
+  });
+
+  it('splits a dotted path into backtick-quoted segments', () => {
+    expect(buildJSONPathAccess('attrs', 'k8s.pod.name')).toBe('attrs.`k8s`.`pod`.`name`::Nullable(String)');
+  });
+
+  it('escapes backticks in a segment to prevent identifier break-out', () => {
+    expect(buildJSONPathAccess('attrs', 'a`b')).toBe('attrs.`a\\`b`::Nullable(String)');
+  });
+});
+
+describe('mintJSONAdhocKey / parseJSONAdhocKey round-trip', () => {
+  it('mints a single-segment backtick key', () => {
+    expect(mintJSONAdhocKey('ResourceAttributes', 'level')).toBe('ResourceAttributes.`level`');
+  });
+
+  it('mints a nested path with one backtick group per level', () => {
+    expect(mintJSONAdhocKey('ResourceAttributes', 'k8s.pod.name')).toBe(
+      'ResourceAttributes.`k8s`.`pod`.`name`'
+    );
+  });
+
+  it('preserves a table prefix in the base text', () => {
+    expect(mintJSONAdhocKey('otel_logs.ResourceAttributes', 'level')).toBe(
+      'otel_logs.ResourceAttributes.`level`'
+    );
+  });
+
+  it('parses a minted key back to column + raw path (prefix dropped)', () => {
+    expect(parseJSONAdhocKey('ResourceAttributes.`k8s`.`pod`.`name`')).toEqual({
+      column: 'ResourceAttributes',
+      path: 'k8s.pod.name',
+    });
+  });
+
+  it('drops a table prefix when parsing', () => {
+    expect(parseJSONAdhocKey('otel_logs.ResourceAttributes.`level`')).toEqual({
+      column: 'ResourceAttributes',
+      path: 'level',
+    });
+  });
+
+  it('round-trips a segment containing a backtick', () => {
+    const key = mintJSONAdhocKey('attrs', 'a`b');
+    expect(parseJSONAdhocKey(key)).toEqual({ column: 'attrs', path: 'a`b' });
+  });
+
+  it('feeds parsed output straight into buildJSONPathAccess', () => {
+    const parsed = parseJSONAdhocKey(mintJSONAdhocKey('attrs', 'k8s.pod'))!;
+    expect(buildJSONPathAccess(parsed.column, parsed.path)).toBe('attrs.`k8s`.`pod`::Nullable(String)');
+  });
+
+  it('returns undefined for a Map bracket key', () => {
+    expect(parseJSONAdhocKey("LogAttributes['level']")).toBeUndefined();
+  });
+
+  it('returns undefined for a bare/legacy dotted key', () => {
+    expect(parseJSONAdhocKey('ResourceAttributes.level')).toBeUndefined();
+    expect(parseJSONAdhocKey('ServiceName')).toBeUndefined();
+  });
+});
+
+describe('unescapeJSONPathSegment', () => {
+  it('is the inverse of escapeJSONPathSegment', () => {
+    for (const s of ['plain', 'a`b', 'a\\b', 'a\\`b']) {
+      expect(unescapeJSONPathSegment(escapeJSONPathSegment(s))).toBe(s);
+    }
+  });
+});

--- a/src/data/jsonPath.test.ts
+++ b/src/data/jsonPath.test.ts
@@ -36,6 +36,17 @@ describe('buildJSONPathAccess', () => {
   it('escapes backticks in a segment to prevent identifier break-out', () => {
     expect(buildJSONPathAccess('attrs', 'a`b')).toBe('attrs.`a\\`b`::Nullable(String)');
   });
+
+  it('leaves a plain (optionally dotted) column identifier unquoted', () => {
+    expect(buildJSONPathAccess('ResourceAttributes', 'x')).toBe('ResourceAttributes.`x`::Nullable(String)');
+    expect(buildJSONPathAccess('a.b', 'x')).toBe('a.b.`x`::Nullable(String)');
+  });
+
+  it('backtick-quotes a column that is not a plain identifier', () => {
+    // A typed/unusual ad-hoc key must not splice arbitrary text into the
+    // expression — the column becomes a single (quoted) identifier.
+    expect(buildJSONPathAccess("a) OR 1=1--", 'x')).toBe('`a) OR 1=1--`.`x`::Nullable(String)');
+  });
 });
 
 describe('mintJSONAdhocKey / parseJSONAdhocKey round-trip', () => {

--- a/src/data/jsonPath.ts
+++ b/src/data/jsonPath.ts
@@ -16,8 +16,9 @@ export function escapeJSONPathSegment(segment: string): string {
  * The `Nullable(String)` cast is required: JSON sub-paths are `Dynamic`, which
  * `IN` / `NOT IN` reject with ILLEGAL_TYPE_OF_ARGUMENT, and an uncast sub-path
  * also reads all-null over Grafana's native protocol. The cast still preserves
- * the `IS NULL` signal for missing paths. `column` is emitted verbatim (a
- * trusted `system.columns` name); only the path segments are escaped.
+ * the `IS NULL` signal for missing paths. Only the path segments are escaped;
+ * `column` is emitted as-is, so the caller is responsible for passing a valid
+ * column identifier.
  */
 export function buildJSONPathAccess(column: string, path: string): string {
   const segments = path

--- a/src/data/jsonPath.ts
+++ b/src/data/jsonPath.ts
@@ -9,6 +9,18 @@ export function escapeJSONPathSegment(segment: string): string {
   return segment.replace(/\\/g, '\\\\').replace(/`/g, '\\`');
 }
 
+// Emit a column identifier as-is when it's a plain (optionally dotted)
+// identifier; otherwise backtick-quote it (escaping backticks/backslashes). Most
+// callers pass a schema column name and see no change, but an ad-hoc filter key
+// can be typed/unusual — quoting keeps the generated SQL well-formed instead of
+// splicing arbitrary text into the expression.
+function quoteColumnIfUnsafe(column: string): string {
+  if (/^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)*$/.test(column)) {
+    return column;
+  }
+  return '`' + column.replace(/\\/g, '\\\\').replace(/`/g, '\\`') + '`';
+}
+
 /**
  * Build a JSON sub-path access expression, e.g.
  * `buildJSONPathAccess('attrs', 'a.b')` → ``attrs.`a`.`b`::Nullable(String)``.
@@ -16,16 +28,16 @@ export function escapeJSONPathSegment(segment: string): string {
  * The `Nullable(String)` cast is required: JSON sub-paths are `Dynamic`, which
  * `IN` / `NOT IN` reject with ILLEGAL_TYPE_OF_ARGUMENT, and an uncast sub-path
  * also reads all-null over Grafana's native protocol. The cast still preserves
- * the `IS NULL` signal for missing paths. Only the path segments are escaped;
- * `column` is emitted as-is, so the caller is responsible for passing a valid
- * column identifier.
+ * the `IS NULL` signal for missing paths. Path segments are backtick-escaped and
+ * the column is quoted unless it's a plain (optionally dotted) identifier, so an
+ * unusual/typed key still yields valid SQL.
  */
 export function buildJSONPathAccess(column: string, path: string): string {
   const segments = path
     .split('.')
     .map((segment) => '`' + escapeJSONPathSegment(segment) + '`')
     .join('.');
-  return `${column}.${segments}::Nullable(String)`;
+  return `${quoteColumnIfUnsafe(column)}.${segments}::Nullable(String)`;
 }
 
 // Inverse of escapeJSONPathSegment: `\X` → `X`.

--- a/src/data/jsonPath.ts
+++ b/src/data/jsonPath.ts
@@ -1,0 +1,73 @@
+// Shared construction of ClickHouse JSON sub-path access expressions, so the
+// query builder (sqlGenerator), the adhoc filter builder (adHocFilter) and
+// adhoc tag-value fetching (CHDatasource) don't drift on quoting/escaping/cast.
+
+// Backslash-escape backslashes and backticks so a segment can't close the
+// backtick identifier early (invalid SQL, and an injection vector when the
+// segment comes from data or user input).
+export function escapeJSONPathSegment(segment: string): string {
+  return segment.replace(/\\/g, '\\\\').replace(/`/g, '\\`');
+}
+
+/**
+ * Build a JSON sub-path access expression, e.g.
+ * `buildJSONPathAccess('attrs', 'a.b')` → ``attrs.`a`.`b`::Nullable(String)``.
+ *
+ * The `Nullable(String)` cast is required: JSON sub-paths are `Dynamic`, which
+ * `IN` / `NOT IN` reject with ILLEGAL_TYPE_OF_ARGUMENT, and an uncast sub-path
+ * also reads all-null over Grafana's native protocol. The cast still preserves
+ * the `IS NULL` signal for missing paths. `column` is emitted verbatim (a
+ * trusted `system.columns` name); only the path segments are escaped.
+ */
+export function buildJSONPathAccess(column: string, path: string): string {
+  const segments = path
+    .split('.')
+    .map((segment) => '`' + escapeJSONPathSegment(segment) + '`')
+    .join('.');
+  return `${column}.${segments}::Nullable(String)`;
+}
+
+// Inverse of escapeJSONPathSegment: `\X` → `X`.
+export function unescapeJSONPathSegment(segment: string): string {
+  return segment.replace(/\\(.)/g, '$1');
+}
+
+/**
+ * Mint a self-describing ad-hoc filter key for a JSON sub-path, e.g.
+ * `('ResourceAttributes', 'k8s.pod.name')` → ``ResourceAttributes.`k8s`.`pod`.`name` ``.
+ *
+ * The backtick form is what makes JSON keys stateless (like #2079's Map
+ * bracket form): `escapeKey` and the tag-value path recognize it via
+ * `parseJSONAdhocKey` and render it with no Map/JSON column cache, so a saved
+ * filter applies on a fresh dashboard load. The cast is applied at render time
+ * by `buildJSONPathAccess`, not baked into the stored key (it would show in the
+ * dropdown).
+ */
+export function mintJSONAdhocKey(baseText: string, path: string): string {
+  const segments = path
+    .split('.')
+    .map((segment) => '`' + escapeJSONPathSegment(segment) + '`')
+    .join('.');
+  return `${baseText}.${segments}`;
+}
+
+// Optional `table.` prefix, the JSON column, then one or more backtick-quoted
+// path segments. The segment body allows escaped chars so a `\`` can't end the
+// match early.
+const JSON_ADHOC_KEY = /^(?:[^.`]+\.)?([^.`]+)((?:\.`(?:[^`\\]|\\.)*`)+)$/;
+
+/**
+ * Parse a key minted by `mintJSONAdhocKey` back into `{ column, path }` (any
+ * `table.` prefix is dropped). Returns `undefined` for keys not in the backtick
+ * JSON form (Map bracket, bare column, legacy dotted), so callers can fall
+ * through to the existing handling.
+ */
+export function parseJSONAdhocKey(s: string): { column: string; path: string } | undefined {
+  const m = s.match(JSON_ADHOC_KEY);
+  if (!m) {
+    return undefined;
+  }
+  const column = m[1];
+  const segments = [...m[2].matchAll(/`((?:[^`\\]|\\.)*)`/g)].map((seg) => unescapeJSONPathSegment(seg[1]));
+  return { column, path: segments.join('.') };
+}

--- a/src/data/sqlGenerator.ts
+++ b/src/data/sqlGenerator.ts
@@ -14,6 +14,7 @@ import {
   TimeUnit,
 } from 'types/queryBuilder';
 import otel from 'otel';
+import { buildJSONPathAccess } from './jsonPath';
 
 /**
  * Generates a SQL string for the given QueryBuilderOptions
@@ -884,15 +885,11 @@ const getFilters = (options: QueryBuilderOptions): string => {
       const valueType = type.match(/Map\(\s*.+\s*,\s*(.+)\s*\)/)?.[1]?.trim() || 'String';
       type = valueType;
     } else if (filter.mapKey && type.startsWith('JSON')) {
-      const escapedJSONPaths = filter.mapKey
-        .split('.')
-        .map((p) => `\`${p}\``)
-        .join('.');
       // JSON path extraction returns Dynamic, which ClickHouse's `IN` / `NOT IN` reject
-      // with ILLEGAL_TYPE_OF_ARGUMENT. Cast to Nullable(String) so every filter operator
-      // works — `IS NULL` still detects missing keys (a plain ::String cast would swallow
-      // that signal), and `=` / `!=` / `LIKE` are unaffected.
-      column = `${column}.${escapedJSONPaths}::Nullable(String)`;
+      // with ILLEGAL_TYPE_OF_ARGUMENT. buildJSONPathAccess casts to Nullable(String) so
+      // every filter operator works — `IS NULL` still detects missing keys (a plain
+      // ::String cast would swallow that signal), and `=` / `!=` / `LIKE` are unaffected.
+      column = buildJSONPathAccess(column, filter.mapKey);
       // Update type so filter value generation routes through the string-aware branches.
       type = 'String';
     }

--- a/src/labels.ts
+++ b/src/labels.ts
@@ -183,12 +183,12 @@ export default {
           tooltip: 'Validate SQL in the editor.',
         },
         enableMapKeysDiscovery: {
-          label: 'Suggest Map keys in filter editor',
+          label: 'Suggest Map keys and JSON paths in filter editor',
           testid: 'data-testid enable-map-keys-discovery-switch',
           tooltip:
-            'When enabled, the filter editor probes Map(...) columns for distinct keys to populate the key-suggestion dropdown. ' +
-            'On large tables with high-cardinality maps this probe can scan billions of rows. ' +
-            'Disable to suppress the probe — operators can still type Map keys manually. Defaults to enabled.',
+            'When enabled, the filter editor probes Map(...) and JSON columns for distinct keys/paths to populate the key-suggestion dropdown. ' +
+            'On large tables with high-cardinality maps or JSON this probe can scan billions of rows. ' +
+            'Disable to suppress the probe — operators can still type Map keys and JSON paths manually. Defaults to enabled.',
         },
       },
       TracesConfig: {

--- a/tests/e2e/jsonAdhocFilter.spec.ts
+++ b/tests/e2e/jsonAdhocFilter.spec.ts
@@ -1,0 +1,164 @@
+import { expect, test, ExplorePage } from '@grafana/plugin-e2e';
+import { Page } from '@playwright/test';
+
+const PLUGIN_TYPE = 'grafana-clickhouse-datasource';
+
+const isCloudRun = !!process.env.GRAFANA_URL;
+
+const CLOUD_DEFAULT_UID = 'clickhouse-native-ds-m';
+const LOCAL_DEFAULT_UID = 'clickhouse-e2e';
+const DATASOURCE_UID = process.env.DS_E2E_UID || (isCloudRun ? CLOUD_DEFAULT_UID : LOCAL_DEFAULT_UID);
+
+// Time range that fully covers the seed fixture data in tests/e2e/fixtures/seed.sql
+const FIXTURE_FROM_ISO = '2024-03-15T09:45:00.000Z';
+const FIXTURE_TO_ISO = '2024-03-15T10:15:00.000Z';
+
+function exploreUrl(from = FIXTURE_FROM_ISO, to = FIXTURE_TO_ISO): string {
+  const query = {
+    refId: 'A',
+    datasource: { type: PLUGIN_TYPE, uid: DATASOURCE_UID },
+    editorType: 'sql',
+    pluginVersion: '',
+    rawSql: '',
+  };
+  const panes = JSON.stringify({
+    explore: {
+      datasource: DATASOURCE_UID,
+      queries: [query],
+      range: { from, to },
+    },
+  });
+  return `/explore?orgId=1&schemaVersion=1&panes=${encodeURIComponent(panes)}`;
+}
+
+async function enterSql(page: Page, sql: string) {
+  const editor = page.getByRole('code');
+  await editor.click();
+  await page.keyboard.press('ControlOrMeta+a');
+  await page.keyboard.type(sql);
+}
+
+async function waitForQueryDataResponseWithBody(explorePage: ExplorePage) {
+  let body: Record<string, unknown> | null = null;
+  const responsePromise = explorePage.waitForQueryDataResponse(async (r) => {
+    if (!r.ok()) {
+      return false;
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const b: any = await r.json().catch(() => null);
+    if (!Array.isArray(b?.results?.A?.frames)) {
+      return false;
+    }
+    body = b as Record<string, unknown>;
+    return true;
+  });
+  return { responsePromise, getBody: () => body };
+}
+
+// ---------------------------------------------------------------------------
+// JSON-typed adhoc filter regression guards
+//
+// Unit tests in src/data/adHocFilter.test.ts cover the SQL shape escapeKey()
+// emits when a dotted key references a JSON column, and unit tests in
+// src/data/CHDatasource.test.ts cover getTagKeys() JSON-path expansion and the
+// fetchTagValuesFromSchema() rewrite. Those tests can't confirm ClickHouse
+// actually accepts the resulting SQL strings — only E2E can.
+//
+// The filter-application predicate shape (`col.`path`::Nullable(String) = ...`)
+// is identical between the query-builder and the adhoc path and is already
+// exercised by jsonFilter.spec.ts. The tests below cover the two shapes unique
+// to the adhoc path: JSON-path discovery (fetchUniqueJSONPathsForAdhoc) and the
+// distinct-value listing (fetchTagValuesFromSchema), run against the
+// e2e_test.json_events fixture.
+// ---------------------------------------------------------------------------
+
+test.describe('JSON column adhoc filters', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  test.beforeEach(() => {
+    test.skip(
+      isCloudRun,
+      'Fixture-data tests depend on e2e_test.json_events seeded by tests/e2e/fixtures/seed.sql via the local e2e-data-loader Docker service, which is not available on Cloud.'
+    );
+  });
+
+  test('JSONAllPaths discovery query returns distinct paths', async ({ page, explorePage }) => {
+    await page.goto(exploreUrl());
+    // Shape emitted by fetchUniqueJSONPathsForAdhoc(), which getTagKeys()
+    // invokes when it sees a JSON-typed column. Nested keys are returned as
+    // flattened dot-paths (`http.status_code`).
+    await enterSql(page, 'SELECT DISTINCT arrayJoin(JSONAllPaths(attributes)) AS path FROM e2e_test.json_events ORDER BY path');
+
+    const { responsePromise, getBody } = await waitForQueryDataResponseWithBody(explorePage);
+    await page.locator('.query-editor-row').getByRole('button', { name: 'Run Query' }).click();
+    await responsePromise;
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const frames = (getBody() as any)?.results?.A?.frames;
+    expect(frames?.length).toBeGreaterThan(0);
+    expect(frames[0]?.data?.values?.[0]).toEqual(['http.status_code', 'level', 'user_id']);
+  });
+
+  test('dot-access cast values query returns distinct values', async ({ page, explorePage }) => {
+    await page.goto(exploreUrl());
+    // Shape emitted by fetchTagValuesFromSchema() after rewriting a dotted key
+    // like `json_events.attributes.level` into JSON dot-access with the
+    // Nullable(String) cast. The previous behavior (`SELECT DISTINCT attributes`)
+    // returned whole JSON objects, rendered as `[object Object]`.
+    await enterSql(
+      page,
+      'SELECT DISTINCT attributes.`level`::Nullable(String) AS v FROM e2e_test.json_events ORDER BY v'
+    );
+
+    const { responsePromise, getBody } = await waitForQueryDataResponseWithBody(explorePage);
+    await page.locator('.query-editor-row').getByRole('button', { name: 'Run Query' }).click();
+    await responsePromise;
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const frames = (getBody() as any)?.results?.A?.frames;
+    expect(frames?.length).toBeGreaterThan(0);
+    expect(frames[0]?.data?.values?.[0]).toEqual(['error', 'info', 'warn']);
+  });
+
+  test('nested dot-access cast values query returns distinct values', async ({ page, explorePage }) => {
+    await page.goto(exploreUrl());
+    // Nested path shape (`attributes.`http`.`status_code`::Nullable(String)`)
+    // emitted by fetchTagValuesFromSchema() for a discovered nested path.
+    await enterSql(
+      page,
+      'SELECT DISTINCT attributes.`http`.`status_code`::Nullable(String) AS v FROM e2e_test.json_events ORDER BY v'
+    );
+
+    const { responsePromise, getBody } = await waitForQueryDataResponseWithBody(explorePage);
+    await page.locator('.query-editor-row').getByRole('button', { name: 'Run Query' }).click();
+    await responsePromise;
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const frames = (getBody() as any)?.results?.A?.frames;
+    expect(frames?.length).toBeGreaterThan(0);
+    expect(frames[0]?.data?.values?.[0]).toEqual(['200', '400', '504']);
+  });
+
+  test('dot-access cast JSON filter returns matching rows', async ({ page, explorePage }) => {
+    await page.goto(exploreUrl());
+    // The predicate shape escapeKey() emits inside additional_table_filters for
+    // an adhoc JSON filter. Unit tests cover the full `additional_table_filters`
+    // wrapper; we avoid typing `{` through Monaco (it auto-closes and mangles
+    // the SQL). This covers the half unit tests can't: ClickHouse executing the
+    // cast predicate end-to-end.
+    await enterSql(
+      page,
+      "SELECT timestamp FROM e2e_test.json_events WHERE attributes.`level`::Nullable(String) = 'info' ORDER BY timestamp"
+    );
+
+    const { responsePromise, getBody } = await waitForQueryDataResponseWithBody(explorePage);
+    await page.locator('.query-editor-row').getByRole('button', { name: 'Run Query' }).click();
+    await responsePromise;
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const frames = (getBody() as any)?.results?.A?.frames;
+    expect(frames?.length).toBeGreaterThan(0);
+    // Fixture has two 'info' rows.
+    expect(frames[0]?.data?.values?.[0]?.length).toBe(2);
+  });
+});


### PR DESCRIPTION
## Type of Change

- [x] 🚀 Feature

---

## Feature

### What is this feature?

Ad-hoc filter (and filter-variable) support for ClickHouse **`JSON`-typed columns**, paralleling the existing `Map(...)` support.

- **Key discovery**: `getTagKeys` expands a `JSON` column into one selectable key per discovered path (via `JSONAllPaths`, or a companion `<col>Keys` array column when present, bounded by the existing `enableMapKeysDiscovery` toggle).
- **Value listing**: distinct values for a JSON path are listed via cast dot-access (`col.`a`.`b`::Nullable(String)`).
- **Filter emission**: ad-hoc filters emit JSON dot-access per column type, coexisting with `Map` columns on the same table, in both the automatic `additional_table_filters` path and the `$__adHocFilters` macro.
- Works in both **schema mode** (`$clickhouse_adhoc_query` = `db.table`) and **query mode** (`$clickhouse_adhoc_query` = a custom `SELECT ... $__adhoc_column ... FROM db.table WHERE ...`), so scoped value dropdowns and JSON path discovery work together.

JSON path access is built by a single shared helper (`src/data/jsonPath.ts`) now used by the query builder, the ad-hoc filter builder, and tag-value fetching, so all three stay consistent.

### Why is this feature needed?

The newer OpenTelemetry ClickHouse schema stores `LogAttributes`/`ResourceAttributes`/`ScopeAttributes` as `JSON` (not `Map`). On that schema, ad-hoc filters previously showed only the bare column, couldn't list per-path values, and the filter SQL was invalid: JSON sub-paths are `Dynamic`, which `IN`/`NOT IN` reject and which read back all-null over the native protocol without a `::Nullable(String)` cast.

### Who is this feature for?

Users running the OTel JSON schema (or any table with `JSON` columns) who want to filter dashboards on JSON attributes via ad-hoc filters.

### How to test this feature

1. Point the datasource at a ClickHouse table with a `JSON` column (e.g. an OTel `otel_logs` with `LogAttributes JSON`).
2. Add an **Ad hoc filters** dashboard variable for the datasource, plus a `clickhouse_adhoc_query` variable set to `db.otel_logs`.
3. Open the ad-hoc filter key dropdown → JSON paths appear (e.g. `LogAttributes.k8s.container.name`); pick a key → the value dropdown lists distinct values; apply → the panel filters.
4. (Query mode) set `clickhouse_adhoc_query` to `SELECT DISTINCT $__adhoc_column FROM db.otel_logs WHERE ServiceName = '$service'` with a `$service` variable → the same works with values scoped to the selected service.

---

## Please check that:

- [x] Tests for this change have been added/updated.
- [x] Documentation has been added/updated (where applicable).

## Special notes for your reviewer

- The change is TypeScript-only (frontend datasource); the Go backend already maps `JSON`/`Nullable(JSON)` to `FieldTypeJSON`.
- Cross-table safety: JSON/Map classification is resolved **per table**; a column name typed differently across tables (JSON in one, Map in another) is kept out of the global `escapeKey` JSON set so it retains prior Map behavior.
- Verified end-to-end against a live OTel JSON dataset, including SQL-injection probing of JSON path segments and Map keys (escaping is layered correctly for both the plain value SELECT and the nested `additional_table_filters` string).

### Known pre-existing follow-ups (not addressed here, planned separately)

- On initial dashboard load, a saved filter on a JSON column can hit the panel-apply path before column kinds are resolved and emit Map-bracket access → `ILLEGAL_TYPE_OF_ARGUMENT` (pre-existing on `main`; mitigated today by the `clickhouse_adhoc_use_json` variable). Needs synchronous/eager schema resolution.
- The ad-hoc value SELECT is unbounded (no time window), unlike key discovery.
- Non-`IN` filter values aren't escaped for interior quotes (pre-existing).
