### PR TITLE
fix(adhoc): preserve dotted column names when table names are hidden

### DIFF
--- a/src/data/CHDatasource.test.ts
+++ b/src/data/CHDatasource.test.ts
@@ -207,6 +207,7 @@ describe('ClickHouseDatasource', () => {
       // Create datasource instance with our mocked ad-hoc filter
       const ds = createInstance({});
       ds.adHocFilter = adHocFilter;
+      ds.settings.jsonData.hideTableNameInAdhocFilters = true;
 
       // Resolve variables
       const result = ds.applyTemplateVariables(query, {}, adHocFilters);
@@ -216,7 +217,7 @@ describe('ClickHouseDatasource', () => {
       expect(spyOnGetVars).toHaveBeenCalled();
 
       // Verify that apply was called with the resolved SQL
-      expect(applyFilterSpy).toHaveBeenCalledWith(resolvedSql, adHocFilters, false);
+      expect(applyFilterSpy).toHaveBeenCalledWith(resolvedSql, adHocFilters, false, true);
 
       // Verify that the final query contains the ad-hoc filters
       expect(result.rawSql).toEqual(sqlWithAdHocFilters);
@@ -268,7 +269,7 @@ describe('ClickHouseDatasource', () => {
       expect(spyOnGetVars).toHaveBeenCalled();
 
       // Verify that apply was called with the resolved SQL
-      expect(applyFilterSpy).toHaveBeenCalledWith(resolvedSql, adHocFilters, true);
+      expect(applyFilterSpy).toHaveBeenCalledWith(resolvedSql, adHocFilters, true, false);
 
       // Verify that the final query contains the ad-hoc filters
       expect(result.rawSql).toEqual(sqlWithAdHocFilters);
@@ -303,17 +304,19 @@ describe('ClickHouseDatasource', () => {
         editorType: EditorType.SQL,
       } as CHQuery;
 
-      const adHocFilters = [{ key: 'key', operator: '=', value: 'val' }];
+      const adHocFilters = [{ key: '__otel_materialized_k8s.cluster.name', operator: '=', value: 'val' }];
 
       const spyOnReplace = jest.spyOn(templateSrvMock, 'replace').mockImplementation((x) => x);
       const spyOnGetVars = jest.spyOn(templateSrvMock, 'getVariables').mockImplementation(() => []);
 
-      const result = createInstance({}).applyTemplateVariables(query, {}, adHocFilters);
+      const ds = createInstance({});
+      ds.settings.jsonData.hideTableNameInAdhocFilters = true;
+      const result = ds.applyTemplateVariables(query, {}, adHocFilters);
 
       expect(spyOnReplace).toHaveBeenCalled();
       expect(spyOnGetVars).toHaveBeenCalled();
       expect(result.rawSql).toEqual(
-        "SELECT * FROM complex_table settings additional_table_filters={'my_table': ' key = \\'val\\' '}"
+        "SELECT * FROM complex_table settings additional_table_filters={'my_table': ' `__otel_materialized_k8s.cluster.name` = \\'val\\' '}"
       );
     });
 

--- a/src/data/CHDatasource.ts
+++ b/src/data/CHDatasource.ts
@@ -535,16 +535,17 @@ export class Datasource
       }
 
       const useJSON = Boolean(templateSrvVariables.find((v) => v.name === 'clickhouse_adhoc_use_json'));
+      const hideTableNameInAdhocFilters = Boolean(this.settings.jsonData.hideTableNameInAdhocFilters);
 
       // Check if query contains $__adHocFilters macro
       const hasMacro = /\$__adHocFilters\s*\(\s*['"](.+?)['"]\s*\)/.test(rawQuery);
 
       // Apply $__adHocFilters macro before automatic filter application
-      rawQuery = this.applyAdHocFiltersMacro(rawQuery, filters, useJSON);
+      rawQuery = this.applyAdHocFiltersMacro(rawQuery, filters, useJSON, hideTableNameInAdhocFilters);
 
       // Only apply automatic filters if the macro was not used
       if (!hasMacro) {
-        rawQuery = this.adHocFilter.apply(rawQuery, filters, useJSON);
+        rawQuery = this.adHocFilter.apply(rawQuery, filters, useJSON, hideTableNameInAdhocFilters);
       }
     }
     this.skipAdHocFilter = false;
@@ -626,7 +627,12 @@ export class Datasource
     return rawQuery;
   }
 
-  applyAdHocFiltersMacro(rawQuery: string, filters: AdHocVariableFilter[], useJSON = false): string {
+  applyAdHocFiltersMacro(
+    rawQuery: string,
+    filters: AdHocVariableFilter[],
+    useJSON = false,
+    hideTableNameInAdhocFilters = false
+  ): string {
     if (!rawQuery) {
       return rawQuery;
     }
@@ -648,7 +654,7 @@ export class Datasource
         return match; // Return original if no valid table names found
       }
 
-      const filterStr = this.adHocFilter.buildFilterString(filters, useJSON);
+      const filterStr = this.adHocFilter.buildFilterString(filters, useJSON, hideTableNameInAdhocFilters);
       if (filterStr === '') {
         return 'additional_table_filters={}';
       }

--- a/src/data/adHocFilter.test.ts
+++ b/src/data/adHocFilter.test.ts
@@ -324,6 +324,19 @@ describe('AdHocManager', () => {
     expect(val).toEqual(`SELECT stuff FROM foo settings additional_table_filters={'foo' : ' key.key2 = \\'val\\' '}`);
   });
 
+  it('preserves a dotted non-Map column name when table names are hidden', () => {
+    const ahm = new AdHocFilter();
+    const val = ahm.apply(
+      'SELECT stuff FROM foo',
+      [{ key: '__otel_materialized_k8s.cluster.name', operator: '=', value: 'val' }] as AdHocVariableFilter[],
+      false,
+      true
+    );
+    expect(val).toEqual(
+      "SELECT stuff FROM foo settings additional_table_filters={'foo' : ' `__otel_materialized_k8s.cluster.name` = \\'val\\' '}"
+    );
+  });
+
   describe('schema-driven Map column detection (#1434)', () => {
     it('rewrites dotted key access for user-registered Map columns (hideTableName)', () => {
       // Mirrors the hideTableNameInAdhocFilters=true path: UI emits `col.key`

--- a/src/data/adHocFilter.ts
+++ b/src/data/adHocFilter.ts
@@ -38,7 +38,7 @@ export class AdHocFilter {
     this._mapColumns = merged;
   }
 
-  buildFilterString(adHocFilters: AdHocVariableFilter[], useJSON = false): string {
+  buildFilterString(adHocFilters: AdHocVariableFilter[], useJSON = false, hideTableNameInAdhocFilters = false): string {
     if (!adHocFilters || adHocFilters.length === 0) {
       return '';
     }
@@ -53,7 +53,7 @@ export class AdHocFilter {
 
     const filters = validFilters
       .map((f, i) => {
-        const key = escapeKey(f.key, useJSON, this._mapColumns);
+        const key = escapeKey(f.key, useJSON, this._mapColumns, hideTableNameInAdhocFilters);
         const value = escapeValueBasedOnOperator(f.value, f.operator);
         const condition = i !== validFilters.length - 1 ? (f.condition ? f.condition : 'AND') : '';
         const operator = convertOperatorToClickHouseOperator(f.operator);
@@ -69,7 +69,12 @@ export class AdHocFilter {
     return this._mapColumns;
   }
 
-  apply(sql: string, adHocFilters: AdHocVariableFilter[], useJSON = false): string {
+  apply(
+    sql: string,
+    adHocFilters: AdHocVariableFilter[],
+    useJSON = false,
+    hideTableNameInAdhocFilters = false
+  ): string {
     if (sql === '' || !adHocFilters || adHocFilters.length === 0) {
       return sql;
     }
@@ -87,7 +92,7 @@ export class AdHocFilter {
       return sql;
     }
 
-    const filters = this.buildFilterString(adHocFilters, useJSON);
+    const filters = this.buildFilterString(adHocFilters, useJSON, hideTableNameInAdhocFilters);
 
     if (filters === '') {
       return sql;
@@ -111,7 +116,17 @@ function escapeMapKeyForOuterFilter(key: string): string {
   return key.replace(/\\/g, '\\\\\\\\').replace(/'/g, "\\\\\\'");
 }
 
-function escapeKey(s: string, isJSON = false, mapColumns: ReadonlySet<string> = DEFAULT_MAP_COLUMNS): string {
+function escapeIdentifierForOuterFilter(identifier: string): string {
+  const escaped = identifier.replace(/\\/g, '\\\\\\\\').replace(/`/g, '\\\\`');
+  return `\`${escaped}\``;
+}
+
+function escapeKey(
+  s: string,
+  isJSON = false,
+  mapColumns: ReadonlySet<string> = DEFAULT_MAP_COLUMNS,
+  hideTableNameInAdhocFilters = false
+): string {
   // Convert arrayElement(col, 'key') → col['key']. Handled up front so the
   // dotted-path logic below doesn't see synthetic function syntax.
   if (s.startsWith('arrayElement(') && s.endsWith(')')) {
@@ -149,9 +164,12 @@ function escapeKey(s: string, isJSON = false, mapColumns: ReadonlySet<string> = 
     return `${mapCol}[\\'${escapeMapKeyForOuterFilter(mapKey)}\\']`;
   }
 
-  // Default: bare column, or `table.col` reference where col isn't a Map.
-  // Strip the leading table prefix if present.
-  return s.includes('.') ? s.split('.').slice(1).join('.') : s;
+  // With visible table names, strip the leading table prefix. With hidden
+  // table names, dots belong to the column name and must be quoted.
+  if (hideTableNameInAdhocFilters && s.includes('.')) {
+    return escapeIdentifierForOuterFilter(s);
+  }
+  return s.includes('.') ? parts.slice(1).join('.') : s;
 }
 
 function escapeValueBasedOnOperator(s: string, operator: string): string {


### PR DESCRIPTION
## Summary

- pass `hideTableNameInAdhocFilters` into automatic and macro ad-hoc filter formatting
- preserve and quote dotted non-Map column names when table names are hidden
- retain table-prefix stripping and Map bracket-access behavior
- add regression coverage for the formatter and both datasource paths

Fixes #2096.

## Root cause

`escapeKey()` treated the first segment of every dotted non-Map key as a table prefix. With `hideTableNameInAdhocFilters` enabled, the key has no table prefix, so the formatter dropped part of the real column name. The remaining identifier also needed quoting because ClickHouse does not allow dots in unquoted identifiers.

## Validation

- focused runtime checks for automatic filters, `$__adHocFilters(...)`, visible table prefixes, and Map keys
- TypeScript syntax transpilation of all four changed files with esbuild
- `npx --yes prettier@3.9.3 --check src/data/adHocFilter.ts src/data/CHDatasource.ts src/data/adHocFilter.test.ts src/data/CHDatasource.test.ts`
- `git diff --check`

The full Jest suite was not run locally because a fresh install resolves 1,788 packages, including Playwright and the complete plugin toolchain. No browser or full dependency install was performed.
