### PR TITLE
refactor(adhoc): remove unreachable empty default-database check in getTagSource

### DIFF
--- a/src/data/CHDatasource.test.ts
+++ b/src/data/CHDatasource.test.ts
@@ -460,16 +460,16 @@ describe('ClickHouseDatasource', () => {
   });
 
   describe('Tag Keys', () => {
-    it('should Fetch Default Tags When No Second AdHoc Variable', async () => {
+    it('should Fetch Tags From The Literal Default Database When None Is Configured', async () => {
       const spyOnReplace = jest.spyOn(templateSrvMock, 'replace').mockImplementation(() => '$clickhouse_adhoc_query');
       const ds = cloneDeep(mockDatasource);
+      ds.settings.jsonData.defaultDatabase = undefined;
       const frame = arrayToDataFrame([{ name: 'foo', type: 'string', table: 'table' }]);
-      jest.spyOn(ds, 'getDefaultDatabase').mockImplementation(() => undefined!); // Disable default DB
       const spyOnQuery = jest.spyOn(ds, 'query').mockImplementation((_request) => of({ data: [frame] }));
 
       const keys = await ds.getTagKeys();
       expect(spyOnReplace).toHaveBeenCalled();
-      const expected = { rawSql: 'SELECT name, type, table FROM system.columns' };
+      const expected = { rawSql: "SELECT name, type, table FROM system.columns WHERE database IN ('default')" };
 
       expect(spyOnQuery).toHaveBeenCalledWith(
         expect.objectContaining({ targets: expect.arrayContaining([expect.objectContaining(expected)]) })

--- a/src/data/CHDatasource.ts
+++ b/src/data/CHDatasource.ts
@@ -28,7 +28,7 @@ import {
 import { DataSourceWithBackend, getTemplateSrv } from '@grafana/runtime';
 import { trackClickhouseHealthCheckFailed } from 'tracking';
 import LogsContextPanel from 'components/LogsContextPanel';
-import { cloneDeep, isEmpty, isString } from 'lodash';
+import { cloneDeep, isString } from 'lodash';
 import otel from 'otel';
 import { createElement as createReactElement, ReactNode } from 'react';
 import { concatMap, firstValueFrom, Observable } from 'rxjs';
@@ -1752,12 +1752,6 @@ export class Datasource
     const tagSource = this.getTagSource();
     this.skipAdHocFilter = true;
 
-    if (tagSource.source === undefined) {
-      const rawSql = 'SELECT name, type, table FROM system.columns';
-      const results = await this.runQuery({ rawSql });
-      return { type: TagType.schema, frame: results };
-    }
-
     if (tagSource.type === TagType.query) {
       // Check if the query contains the $__adhoc_column macro
       if (tagSource.source.includes('$__adhoc_column')) {
@@ -1802,12 +1796,10 @@ export class Datasource
   private getTagSource() {
     // @todo https://github.com/grafana/grafana/issues/13109
     const ADHOC_VAR = '$clickhouse_adhoc_query';
-    const defaultDatabase = this.getDefaultDatabase();
     let source = getTemplateSrv().replace(ADHOC_VAR);
-    if (source === ADHOC_VAR && isEmpty(defaultDatabase)) {
-      return { type: TagType.schema, source: undefined };
+    if (source === ADHOC_VAR) {
+      source = this.getDefaultDatabase();
     }
-    source = source === ADHOC_VAR ? defaultDatabase! : source;
     if (source.toLowerCase().startsWith('select')) {
       return { type: TagType.query, source };
     }


### PR DESCRIPTION
<!-- To surface this PR in the changelog add the label: changelog -->

## Type of Change

- [x] 🧹 Refactor / Chore

---

## What is this change?

Follow-up cleanup from a review discussion on #2079 (https://github.com/grafana/clickhouse-datasource/pull/2079#discussion_r3673836488).

`getTagSource()` guarded the unresolved `$clickhouse_adhoc_query` case with `isEmpty(defaultDatabase)`, but `getDefaultDatabase()` falls back to the literal `'default'` and never returns an empty value, so the guard could never fire. This removes:

- the unreachable `isEmpty(defaultDatabase)` branch in `getTagSource()` (and the now redundant non-null assertion on `defaultDatabase`)
- the downstream `tagSource.source === undefined` branch in `fetchTags()`, which was only reachable from that guard and would otherwise become a compile error once the guard is gone
- the now unused `isEmpty` lodash import

The one test that exercised the removed branch did so by mocking `getDefaultDatabase()` to return `undefined`, a state the real method cannot produce. It has been reworked to pin the actual fallback behaviour: with no default database configured, tag keys are fetched from the literal `default` database.

**User-facing impact: none.** The removed branches were unreachable in production, so behaviour is unchanged.

---

## Please check that:

- [x] Tests for this change have been added/updated.
- [ ] Documentation has been added/updated (where applicable).

## Special notes for your reviewer

This touches the same region of `getTagSource()` as the open PR #2079, so whichever lands second will need a small conflict resolution. In #2079's version the equivalent dead check is `if (!defaultSource)` after `getDefaultAdhocSource()`, which falls back to `getDefaultDatabase()` the same way.
