### PR TITLE
ci(cron): pass run-stage to the Cloud E2E workflow for DER labelling

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -25,6 +25,11 @@ jobs:
       contents: read
       id-token: write
     with:
+      # This is the nightly Cloud E2E run, so label it with the DER run_stage vocabulary.
+      run-stage: nightly
+      # datasource-version is omitted here: the nightly tests whatever version is deployed
+      # on the shared instance, so it defaults to the commit SHA. The in-Argo promotion
+      # gate (generateBenchSuites) passes the real released version.
       pdc-network-name: datasources-pdc-network-aws-datasourcese2e
       repo-secrets: |
         DS_INSTANCE_HOST=ds-instance:host


### PR DESCRIPTION
Passes `run-stage: nightly` to the shared `playwright-cloud.yml` so the nightly Cloud E2E run is labelled with the DER `run_stage` vocabulary. `datasource-version` is left to default (the commit SHA) for the nightly, since it tests whatever is deployed on the shared instance; the in-Argo promotion gate carries the real released version.

Part of M1 test-result labelling. Depends on grafana/data-sources-ci-workflows#12 (which adds the `run-stage` input), so merge that first.
