### PR TITLE
Fix error categorization tracking bug

### DIFF
--- a/src/data/CHDatasource.test.ts
+++ b/src/data/CHDatasource.test.ts
@@ -8,7 +8,7 @@ import {
   toDataFrame,
   TypedVariableModel,
 } from '@grafana/data';
-import { DataSourceWithBackend } from '@grafana/runtime';
+import { DataSourceWithBackend, HealthCheckError, HealthStatus } from '@grafana/runtime';
 import { DataQuery } from '@grafana/schema';
 import { mockDatasource } from '__mocks__/datasource';
 import { cloneDeep } from 'lodash';
@@ -45,6 +45,7 @@ const templateSrvMock = { replace: jest.fn(), getVariables: jest.fn(), getAdhocF
 jest.mock('@grafana/runtime', () => ({
   ...(jest.requireActual('@grafana/runtime') as unknown as object),
   getTemplateSrv: () => templateSrvMock,
+  reportInteraction: jest.fn(),
 }));
 
 const createInstance = ({ queryResponse }: Partial<InstanceConfig> = {}) => {
@@ -3468,6 +3469,33 @@ describe('ClickHouseDatasource', () => {
       }) as CHBuilderQuery;
 
       expect(result.builderOptions.filters).toHaveLength(0);
+    });
+  });
+
+  describe('testDatasource', () => {
+    it('resolves with success when the health check passes', async () => {
+      const ds = cloneDeep(mockDatasource);
+      jest.spyOn(ds, 'callHealthCheck').mockResolvedValue({ status: HealthStatus.OK, message: 'ok', details: {} });
+
+      await expect(ds.testDatasource()).resolves.toEqual({ status: 'success', message: 'ok' });
+    });
+
+    // Grafana core records the test_datasource_clicked success flag from
+    // whether testDatasource rejects. A returned error-status object counts
+    // as success, so a failed health check MUST reject (see PR #1776 fallout).
+    it('rejects when the health check fails so core records success=false', async () => {
+      const ds = cloneDeep(mockDatasource);
+      jest.spyOn(ds, 'callHealthCheck').mockResolvedValue({
+        status: HealthStatus.Error,
+        message: '[auth] code: 516, authentication failed',
+        details: {},
+      });
+
+      await expect(ds.testDatasource()).rejects.toMatchObject({
+        status: 'error',
+        message: expect.stringContaining('Auth error'),
+        error: expect.any(HealthCheckError),
+      });
     });
   });
 });

--- a/src/data/CHDatasource.ts
+++ b/src/data/CHDatasource.ts
@@ -27,7 +27,7 @@ import {
   ToggleFilterAction,
   TypedVariableModel,
 } from '@grafana/data';
-import { DataSourceWithBackend, getTemplateSrv } from '@grafana/runtime';
+import { DataSourceWithBackend, getTemplateSrv, HealthCheckError } from '@grafana/runtime';
 import { trackClickhouseHealthCheckFailed } from 'tracking';
 import LogsContextPanel from 'components/LogsContextPanel';
 import { cloneDeep, isString } from 'lodash';
@@ -2139,10 +2139,16 @@ export class Datasource
       const detail = result.message.replace(/^\[\w+\]\s*/, '');
       const hint = getConnectionErrorHint(category, detail);
       const label = category === 'tls' ? 'TLS' : category.charAt(0).toUpperCase() + category.slice(1);
-      return {
+      const message = hint ? `${label} error [${detail}]: ${hint}` : result.message;
+      // Rejecting on failure is load-bearing: Grafana core sets the success
+      // flag on its test_datasource_clicked event from whether this promise
+      // rejects, matching the base DataSourceWithBackend behavior. Returning
+      // an error-status object here records failed tests as successes.
+      return Promise.reject({
         status: 'error',
-        message: hint ? `${label} error [${detail}]: ${hint}` : result.message,
-      };
+        message,
+        error: new HealthCheckError(message, result.details),
+      });
     }
     return { status: 'success', message: result.message };
   }

--- a/src/data/CHDatasource.ts
+++ b/src/data/CHDatasource.ts
@@ -2140,10 +2140,8 @@ export class Datasource
       const hint = getConnectionErrorHint(category, detail);
       const label = category === 'tls' ? 'TLS' : category.charAt(0).toUpperCase() + category.slice(1);
       const message = hint ? `${label} error [${detail}]: ${hint}` : result.message;
-      // Rejecting on failure is load-bearing: Grafana core sets the success
-      // flag on its test_datasource_clicked event from whether this promise
-      // rejects, matching the base DataSourceWithBackend behavior. Returning
-      // an error-status object here records failed tests as successes.
+      // This must reject on failure. If we return the error instead,
+      // Grafana treats the test as successful in its analytics.
       return Promise.reject({
         status: 'error',
         message,


### PR DESCRIPTION
This PR fixes a bug that inflated the success flag on the `grafana_ds_test_datasource_clicked` tracking event. With the addition of error categorization in #1776 (v4.18.0), the `testDatasource` override returned health check errors instead of throwing them. Grafana core records the event's success flag from whether the promise rejects, so failed health checks were being recorded as successes. Errors are now thrown again so failures are counted correctly.

Note: User-facing behavior is unchanged, the error message and hints always displayed correctly; only the analytics were wrong. 