### PR TITLE
chore(e2e): bump @grafana/plugin-e2e to 3.11.0 and drop dashboardNewLayouts workaround

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,6 @@ services:
       # OFREP interception (>=3.5.0), but we also disable it at the server level so
       # that manual `docker-compose up` + browsing doesn't trigger the onboarding modal.
       - GF_FEATURE_TOGGLES_splashScreen=false
-      - GF_FEATURE_TOGGLES_dashboardNewLayouts=false
       - GF_FEATURE_TOGGLES_newClickhouseConfigPageDesign=true
       - GF_FEATURE_TOGGLES_clickHouseConfigValidation=true
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "@axe-core/playwright": "4.12.1",
         "@babel/core": "8.0.1",
         "@grafana/eslint-config": "8.2.0",
-        "@grafana/plugin-e2e": "3.10.0",
+        "@grafana/plugin-e2e": "3.11.0",
         "@grafana/sign-plugin": "3.3.3",
         "@grafana/tsconfig": "2.2.0",
         "@playwright/test": "1.61.1",
@@ -2217,15 +2217,13 @@
       }
     },
     "node_modules/@grafana/e2e-selectors": {
-      "version": "13.1.0-25644485979",
-      "resolved": "https://registry.npmjs.org/@grafana/e2e-selectors/-/e2e-selectors-13.1.0-25644485979.tgz",
-      "integrity": "sha512-2H+veZBayawey47iUTb5N69QK5KYHxzspe8uaauvLH7aSsjeyzH6nFubLkOVxz1JUOVtVrwOaH+libUwSaPMXw==",
+      "version": "13.2.0-30594044109",
+      "resolved": "https://registry.npmjs.org/@grafana/e2e-selectors/-/e2e-selectors-13.2.0-30594044109.tgz",
+      "integrity": "sha512-CRN0CTsSkAC3qQvufbR7duUzSX2Jfgc/g5ap+eSrjcFcS+vAVUDGfQVLK6y5ojN+B0gATNIbmVlCGngQxmm+eA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "semver": "^7.7.0",
-        "tslib": "2.8.1",
-        "typescript": "6.0.2"
+        "semver": "^7.7.0"
       }
     },
     "node_modules/@grafana/e2e-selectors/node_modules/semver": {
@@ -2239,20 +2237,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/@grafana/e2e-selectors/node_modules/typescript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
-      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "node_modules/@grafana/eslint-config": {
@@ -2314,13 +2298,13 @@
       }
     },
     "node_modules/@grafana/plugin-e2e": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@grafana/plugin-e2e/-/plugin-e2e-3.10.0.tgz",
-      "integrity": "sha512-KvIC4klLuDdgT9Go61yY+Mm/8+8zSqF4lqhlMomBl53h9gx4PPYjoVRdK9e272oVJqlpgy42z7+OxHrs7IYY2g==",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/@grafana/plugin-e2e/-/plugin-e2e-3.11.0.tgz",
+      "integrity": "sha512-kStVAbkmuQzgMaYwzm1leRGG+vRzuFj2JgojKeLFwPyZhL80OyVLC4L96ePmx2PZGmUXA9enMtMG8YqBx3uJdw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@grafana/e2e-selectors": "13.1.0-25644485979",
+        "@grafana/e2e-selectors": "13.2.0-30594044109",
         "yaml": "^2.3.4"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@axe-core/playwright": "4.12.1",
     "@babel/core": "8.0.1",
     "@grafana/eslint-config": "8.2.0",
-    "@grafana/plugin-e2e": "3.10.0",
+    "@grafana/plugin-e2e": "3.11.0",
     "@grafana/sign-plugin": "3.3.3",
     "@grafana/tsconfig": "2.2.0",
     "@playwright/test": "1.61.1",


### PR DESCRIPTION
- Bump `@grafana/plugin-e2e` 3.10.0 -> 3.11.0, which fixes the panel-edit selectors against Grafana nightly's new dashboard layout
- Revert the temporary `GF_FEATURE_TOGGLES_dashboardNewLayouts=false` e2e workaround from docker-compose
- Verification: the nightly e2e CI job on this PR exercises the removed toggle path