### PR TITLE
ci(cron): notify Slack on Cloud E2E failure

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -48,11 +48,10 @@ jobs:
     steps:
       # Intentionally pinned to @main, same as the playwright-cloud call above.
       - name: Notify Slack on failure
-        uses: grafana/data-sources-ci-workflows/.github/actions/notify-slack-failure@main
+        uses: grafana/data-sources-ci-workflows/.github/actions/notify-cloud-e2e-failure@main
         with:
-          title: Cloud E2E tests failed
           repo: ${{ github.repository }}
-          stage: nightly
+          run-stage: nightly
           ref-name: ${{ github.ref_name }}
           actor: ${{ github.actor }}
           sha: ${{ github.sha }}

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -36,3 +36,24 @@ jobs:
         DS_INSTANCE_PASSWORD=ds-instance:password
         DS_INSTANCE_PORT=ds-instance:port
         DS_INSTANCE_USERNAME=ds-instance:username
+
+  notify-slack:
+    name: Notify Slack on failure
+    needs: playwright-cloud
+    if: failure()
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      # Intentionally pinned to @main, same as the playwright-cloud call above.
+      - name: Notify Slack on failure
+        uses: grafana/data-sources-ci-workflows/.github/actions/notify-slack-failure@main
+        with:
+          title: Cloud E2E tests failed
+          repo: ${{ github.repository }}
+          stage: nightly
+          ref-name: ${{ github.ref_name }}
+          actor: ${{ github.actor }}
+          sha: ${{ github.sha }}
+          run-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}


### PR DESCRIPTION
## What
Adds a `notify-slack` job to the nightly Cloud E2E cron workflow that posts to `#grafana-ds-plugins-dev` when the `playwright-cloud` job fails, using the shared `notify-cloud-e2e-failure` composite action from `data-sources-ci-workflows`.

## Why
Serves as the reference example for the caller-owned notification pattern introduced in [grafana/data-sources-ci-workflows#15](https://github.com/grafana/data-sources-ci-workflows/pull/15): `playwright-cloud.yml` no longer notifies on failure itself, so callers that want an alert add their own job.

## Dependency
This references `grafana/data-sources-ci-workflows/.github/actions/notify-cloud-e2e-failure@main`, which doesn't exist on that repo's `main` branch yet. **This PR can't be merged until [data-sources-ci-workflows#15](https://github.com/grafana/data-sources-ci-workflows/pull/15) merges.** Opening now as draft so both can be reviewed in parallel.

## User-facing impact
None. CI-only change to the nightly cron workflow.