### PR TITLE
test(e2e): raise cloud-run timeouts to fix nightly cron flakiness

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -11,12 +11,30 @@ import type { PluginOptions } from '@grafana/plugin-e2e';
 // dotenv.config({ path: path.resolve(__dirname, '.env') });
 
 /**
+ * GRAFANA_URL is set only by the Cloud cron workflow (.github/workflows/cron.yml),
+ * which runs the suite against a shared Grafana Cloud dev instance.
+ */
+const isCloudRun = !!process.env.GRAFANA_URL;
+
+/**
  * See https://playwright.dev/docs/test-configuration.
  */
 export default defineConfig<PluginOptions>({
   testDir: './tests/e2e',
   /* Run tests in files in parallel */
   fullyParallel: true,
+  /*
+   * Timeout ceilings are raised for Cloud runs. Each test gets a fresh browser
+   * context, so on the shared Cloud instance every test re-downloads the plugin
+   * bundle and Monaco assets. When the instance is busy that first paint can
+   * exceed Playwright's 5s expect default, which made the query editor rendering
+   * tests flake on the nightly cron. These are polling ceilings, not sleeps, so
+   * fast runs are unaffected.
+   */
+  timeout: isCloudRun ? 90_000 : 30_000,
+  expect: {
+    timeout: isCloudRun ? 30_000 : 5_000,
+  },
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
@@ -37,7 +55,12 @@ export default defineConfig<PluginOptions>({
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
-    video: 'on',
+    /*
+     * Recording video for every test makes fully-parallel local runs CPU-bound
+     * enough to cause spurious 30s timeouts. Keep full recording on CI (single
+     * worker) and record only failures locally.
+     */
+    video: process.env.CI ? 'on' : 'retain-on-failure',
   },
 
   /* Configure projects for major browsers */


### PR DESCRIPTION
## Type of Change

- [x] 🧹 Refactor / Chore

---

## Refactor / Chore

### What changed?

Raises the Playwright test and expect ceilings to 90s and 30s for Cloud runs only, keyed on `GRAFANA_URL`. Local runs also stop recording video for passing tests.

### Why?

The nightly [Scheduled Cloud E2E](https://github.com/grafana/clickhouse-datasource/actions/workflows/cron.yml) cron kept failing on the query editor rendering tests. Each test gets a fresh browser context, so on the shared Cloud instance every test re-downloads the plugin bundle and the Monaco assets. When the instance is busy, that first paint exceeds Playwright's 5s expect default and the test fails through both retries. Local runs never see it, because the local container serves the assets.

The raised values are polling ceilings rather than sleeps, so a fast run finishes just as quickly. Recording video for every test made fully-parallel local runs CPU-bound enough to cause spurious timeouts of their own, so local runs now record failures only. CI keeps full recording, because it runs a single worker.

---

## Special notes for your reviewer

This is the first of three PRs splitting #2044, which is 56 files and has not attracted a review in a month. It is the config-only flakiness fix, taken from that branch unchanged, and it stands alone. The other two carry the shared-helper extraction plus spec regrouping, and the new coverage.

Test-only, no user-facing change. `tsc --noEmit` is clean and `playwright test --list` still collects 84 tests in 18 files.
