### PR TITLE
test(e2e): default Playwright video off

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -56,11 +56,12 @@ export default defineConfig<PluginOptions>({
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
     /*
-     * Recording video for every test makes fully-parallel local runs CPU-bound
-     * enough to cause spurious 30s timeouts. Keep full recording on CI (single
-     * worker) and record only failures locally.
+     * Recording video makes fully-parallel local runs CPU-bound enough to cause spurious
+     * timeouts, and no workflow keeps the output, so nothing reads it. `retain-on-failure`
+     * would not help: it records for every test and only deletes the passing ones, so it
+     * costs the same to run. Pass `--video=retain-on-failure` when a failure needs one.
      */
-    video: process.env.CI ? 'on' : 'retain-on-failure',
+    video: 'off',
   },
 
   /* Configure projects for major browsers */


### PR DESCRIPTION
## Type of Change

- [x] 🧹 Refactor / Chore

---

## Refactor / Chore

### What changed?

`video: 'off'` for Playwright, replacing #2121's `process.env.CI ? 'on' : 'retain-on-failure'`.

### Why?

Following @aangelisc's point on #2121 that video should default off. Two things make it clearer than a preference:

**Nothing keeps the output.** There is no `upload-playwright-artifacts` in `push.yml`, and `playwright-cloud.yml` retains nothing either, so every video recorded on CI is discarded unread. Across a six-version matrix that is a lot of encoding for no diagnostic value.

**`retain-on-failure` would not have helped.** Playwright records video for every test and then deletes the ones from passing runs, so it costs the same to run as `on`. The local half of #2121 therefore did not fix the CPU-bound flakiness it was meant to fix. Only `off` does that.

`--video=retain-on-failure` on the command line covers the case where a specific failure needs one.

---

## Special notes for your reviewer

`trace: 'on-first-retry'` and `screenshot: 'only-on-failure'` are unchanged. Those two are cheap on the happy path, because neither records anything for a passing first attempt.

Test-only, no user-facing change. `tsc --noEmit` and prettier clean, and `playwright test --list` still collects 84 tests in 18 files.
