### PR TITLE
ci: Receive publish-catalog dispatch for lockstep catalog publishing

### DIFF
--- a/.github/workflows/catalog-publish.yml
+++ b/.github/workflows/catalog-publish.yml
@@ -1,0 +1,25 @@
+name: Catalog publish (coupled)
+run-name: Publish ${{ github.event.client_payload.plugin_version }} to ${{ github.event.client_payload.environment }}
+
+on:
+  repository_dispatch:
+    types: [publish-catalog]
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v11.1.0
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+      pull-requests: read
+    with:
+      branch: ${{ github.event.client_payload.ref }}
+      environment: ${{ github.event.client_payload.environment }}
+      scopes: ${{ github.event.client_payload.environment == 'prod' && 'grafana_cloud' || 'universal' }}
+      run-playwright: false
+      github-draft-release: false
+      trigger-argo: false


### PR DESCRIPTION
Adds `catalog-publish.yml` (repository_dispatch: publish-catalog) that publishes the full plugin via `plugin-ci-workflows/cd.yml` at the dispatched ref/env/scope, with `trigger-argo: false`. The deployment_tools post-wave hook drives it. First live dispatch may surface GATB/WIF publish-auth allowlists to add.

Part of the [bigger](https://github.com/grafana/data-sources/issues/742) effort to move data sources to bundled docker images.
