### PR TITLE
ci: add a dispatch-only caller for the bundled image pipeline

### DIFF
--- a/.github/workflows/bundled-image.yml
+++ b/.github/workflows/bundled-image.yml
@@ -1,12 +1,17 @@
 # Description:
 # Thin caller for the shared bundled-image pipeline in grafana/data-sources-ci-workflows, which
-# builds the plugin, bakes it onto the Grafana base image the dev0 wave runs, boot-smokes the
-# result, and pushes it to this repo's own prod GAR.
+# builds the plugin, bakes it onto the Grafana base image the first rollout wave runs, boot-smokes
+# the result, and pushes it to this repository's own registry.
+#
+# This file carries no value specific to this repository. The shared workflow derives the plugin id
+# and version from the build, and the registry from the repository name, so the same file works
+# unchanged in every plugin repo that adopts bundled images. Keep it that way: anything that has to
+# differ per repo belongs in the shared workflow's defaults, not copied into three callers.
 #
 # Manual dispatch only, deliberately. Bundled delivery is being rolled out to the pilot data
-# sources one step at a time, and a push trigger would start building an image for every commit
-# to main before the rollout is proven. Add the push trigger once the first dispatched runs are
-# consistently green.
+# sources one step at a time, and a push trigger would build an image for every commit to main
+# before the rollout is proven. When the push trigger is added it wants a paths filter, so a
+# docs-only or test-only commit does not rebuild the image.
 #
 # Note on the app grant:
 # The shared workflow reads the Grafana base image from one line of a private infrastructure repo.
@@ -21,12 +26,12 @@ on:
     inputs:
       grafana-image:
         description: >-
-          Grafana base image to bundle onto. Leave empty to read the dev0 wave's current image.
+          Grafana base image to bundle onto. Leave empty to read the first wave's current image.
         type: string
         required: false
         default: ""
       push-image:
-        description: Push the image to the GAR once the smoke test passes.
+        description: Push the image to the registry once the smoke test passes.
         type: boolean
         required: false
         default: false
@@ -35,10 +40,18 @@ on:
         type: boolean
         required: false
         default: false
+      debug:
+        description: >-
+          Build a debug image. It is tagged with a -debug suffix and pushed under a separate
+          debug/ path, which keeps it out of the rollout.
+        type: boolean
+        required: false
+        default: false
 
 permissions: {}
 
 concurrency:
+  # Never cancel a run in flight. A cancelled run can leave a half-pushed image behind.
   group: bundled-image-${{ github.ref }}
   cancel-in-progress: false
 
@@ -50,9 +63,7 @@ jobs:
       contents: read
       id-token: write
     with:
-      # Created by adding this repo to the bundled-image source repos in the infrastructure
-      # terraform. The name is derived from the repo name, so it changes only if the repo is renamed.
-      gar-repository: docker-clickhouse-datasource-prod
       grafana-image: ${{ inputs.grafana-image }}
       push-image: ${{ inputs.push-image }}
       trigger-argo: ${{ inputs.trigger-argo }}
+      debug: ${{ inputs.debug }}

--- a/.github/workflows/bundled-image.yml
+++ b/.github/workflows/bundled-image.yml
@@ -1,0 +1,58 @@
+# Description:
+# Thin caller for the shared bundled-image pipeline in grafana/data-sources-ci-workflows, which
+# builds the plugin, bakes it onto the Grafana base image the dev0 wave runs, boot-smokes the
+# result, and pushes it to this repo's own prod GAR.
+#
+# Manual dispatch only, deliberately. Bundled delivery is being rolled out to the pilot data
+# sources one step at a time, and a push trigger would start building an image for every commit
+# to main before the rollout is proven. Add the push trigger once the first dispatched runs are
+# consistently green.
+#
+# Note on the app grant:
+# The shared workflow reads the Grafana base image from one line of a private infrastructure repo.
+# The token for that read is granted against THIS file's path, because the broker keys on the
+# top-level caller rather than on the shared workflow it calls. Until that grant applies, pass
+# grafana-image explicitly and the lookup is skipped.
+
+name: Plugins - Bundled image
+
+on:
+  workflow_dispatch:
+    inputs:
+      grafana-image:
+        description: >-
+          Grafana base image to bundle onto. Leave empty to read the dev0 wave's current image.
+        type: string
+        required: false
+        default: ""
+      push-image:
+        description: Push the image to the GAR once the smoke test passes.
+        type: boolean
+        required: false
+        default: false
+      trigger-argo:
+        description: Submit the Argo rollout after a successful push.
+        type: boolean
+        required: false
+        default: false
+
+permissions: {}
+
+concurrency:
+  group: bundled-image-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  bundled-image:
+    name: Build and push
+    uses: grafana/data-sources-ci-workflows/.github/workflows/cd-bundled.yml@main
+    permissions:
+      contents: read
+      id-token: write
+    with:
+      # Created by adding this repo to the bundled-image source repos in the infrastructure
+      # terraform. The name is derived from the repo name, so it changes only if the repo is renamed.
+      gar-repository: docker-clickhouse-datasource-prod
+      grafana-image: ${{ inputs.grafana-image }}
+      push-image: ${{ inputs.push-image }}
+      trigger-argo: ${{ inputs.trigger-argo }}


### PR DESCRIPTION
Adds a manual-dispatch caller for the shared bundled-image pipeline. That pipeline builds and signs the plugin, bakes it onto the Grafana base image the first rollout wave runs, boot-smokes the resulting image, and pushes it to this repository's own container registry.

The file carries no value specific to this repository. The shared workflow derives the plugin id and version from the build, and the registry name from the repository name, so the same file works unchanged in every plugin repo that adopts bundled images. Anything that has to differ per repo belongs in the shared workflow's defaults rather than copied into three callers.

Dispatch only, and `push-image` and `trigger-argo` both default to false, so a first run builds and smoke-tests without publishing anything and without starting a rollout. A push trigger belongs here once dispatched runs are consistently green, and it wants a paths filter so that a docs-only commit does not rebuild the image.

### Status

Everything the pipeline needs is in place: the shared workflow has merged, the container registry exists, and the grant that lets the build read the base image is applied. A dispatch now runs end to end.

Intended sequence from here:

1. Dry run with the defaults, which builds and smoke-tests without pushing.
2. `push-image: true`, which pushes the smoke-tested image to the registry.
3. `trigger-argo: true`, which starts the first bundled rollout. Hold this step until the wave verification fix for bundled images lands (tracked internally), so the first rollout is gated meaningfully rather than waved through.

### Supersedes #2130

Same goal, written with @sasklacz's version as the reference. Kept from it: the `debug` input, and the paths-filter idea, recorded in a comment for when the push trigger arrives. Left out: the `repository_dispatch` trigger, because nothing dispatches `rebase-plugin-image` yet, so it would be a receiver with no sender. The same now applies to #2131's `publish-catalog` receiver: per-wave catalog publishing is switched off for this repo, because the release pipeline publishes one universally scoped version per release, so that receiver would also have no sender here.
