### PR TITLE
fix(migration): preserve explicit queryType when pluginVersion is missing or empty

### DIFF
--- a/src/data/migration.test.ts
+++ b/src/data/migration.test.ts
@@ -342,4 +342,31 @@ describe('Query Editor Version Migration', () => {
     const migratedQuery = migrateCHQuery(v3Query);
     expect(migratedQuery).toEqual(latestQuery);
   });
+
+  it('preserves explicit queryType when pluginVersion is empty on v4 SQL query', () => {
+    const query = {
+      refId: 'A',
+      editorType: EditorType.SQL,
+      pluginVersion: '',
+      rawSql: 'SELECT now() AS time, 1 AS value',
+      queryType: QueryType.TimeSeries,
+    } as unknown as CHQuery;
+
+    const migratedQuery = migrateCHQuery(query);
+    expect(migratedQuery).toEqual(query);
+    expect(migratedQuery.queryType).toBe(QueryType.TimeSeries);
+  });
+
+  it('preserves explicit queryType when pluginVersion is undefined on v4 SQL query', () => {
+    const query = {
+      refId: 'A',
+      editorType: EditorType.SQL,
+      rawSql: 'SELECT * FROM logs',
+      queryType: QueryType.Logs,
+    } as unknown as CHQuery;
+
+    const migratedQuery = migrateCHQuery(query);
+    expect(migratedQuery).toEqual(query);
+    expect(migratedQuery.queryType).toBe(QueryType.Logs);
+  });
 });

--- a/src/data/migration.ts
+++ b/src/data/migration.ts
@@ -51,6 +51,9 @@ const migrateV3CHQuery = (savedQuery: AnyCHQuery): CHQuery => {
     return builderQuery;
   }
 
+  const isV4QueryType =
+    savedQuery.queryType && savedQuery.queryType !== 'sql' && savedQuery.queryType !== 'builder';
+
   // Raw SQL Query
   const rawSqlQuery: CHSqlQuery = {
     ...savedQuery,
@@ -59,7 +62,7 @@ const migrateV3CHQuery = (savedQuery: AnyCHQuery): CHQuery => {
     rawSql: savedQuery.rawSql || '',
     refId: savedQuery.refId || '',
     format: savedQuery.format,
-    queryType: mapGrafanaFormatToQueryType(savedQuery.format),
+    queryType: isV4QueryType ? (savedQuery.queryType as QueryType) : mapGrafanaFormatToQueryType(savedQuery.format),
     meta: {},
   };
 
@@ -174,10 +177,30 @@ const migrateV3QueryBuilderOptions = (savedOptions: AnyQueryBuilderOptions): Que
  * Checks if CHQuery is from <= v3 options.
  */
 const isV3CHQuery = (savedQuery: AnyCHQuery): boolean => {
+  // If the query was explicitly saved with v3 queryType ('sql' or 'builder'), it is v3
+  const oldQueryType = savedQuery['queryType'] === 'sql' || savedQuery['queryType'] === 'builder';
+  if (oldQueryType) {
+    return true;
+  }
+
+  // If the query already has v4 editorType, it is a v4 query
+  if (savedQuery['editorType'] === EditorType.SQL || savedQuery['editorType'] === EditorType.Builder) {
+    return false;
+  }
+
+  // If the query has a valid v4 queryType (not v3 'sql'/'builder')
+  if (
+    savedQuery['queryType'] === QueryType.Table ||
+    savedQuery['queryType'] === QueryType.TimeSeries ||
+    savedQuery['queryType'] === QueryType.Logs ||
+    savedQuery['queryType'] === QueryType.Traces
+  ) {
+    return false;
+  }
+
   // pluginVersion was added in v4
   const oldPluginVersion = !savedQuery['pluginVersion'] || !isVersionGtOrEq(savedQuery.pluginVersion, '4.0.0');
-  const oldQueryType = savedQuery['queryType'] === 'sql' || savedQuery['queryType'] === 'builder';
-  return oldPluginVersion || oldQueryType;
+  return oldPluginVersion;
 };
 
 /**


### PR DESCRIPTION
## Summary

Fixes #2119.

A v4-shaped SQL query carrying an explicit `queryType` (e.g. `timeseries` or `logs`), but no `format` and no `pluginVersion` (common in provisioned dashboards, alert rules, or programmatic Explore URLs), was previously misclassified as a v3 query by `isV3CHQuery` because `oldPluginVersion` treated any empty/absent `pluginVersion` as v3.

The SQL migration path in `migrateV3CHQuery` then rederived `queryType` using `mapGrafanaFormatToQueryType(savedQuery.format)`, which defaults to `QueryType.Table` when `format` is absent, silently overwriting and downgrading the query's explicit `queryType`.

## Changes

1. In `src/data/migration.ts`:
   - Updated `isV3CHQuery` so queries with v4 `editorType` (`sql` or `builder`) or valid v4 `queryType` values (`table`, `timeseries`, `logs`, `traces`) are recognized as v4 queries even when `pluginVersion` is missing or empty.
   - Updated `migrateV3CHQuery` to preserve valid v4 `queryType` if present when migrating raw SQL queries instead of falling back to format mapping.
2. In `src/data/migration.test.ts`:
   - Added unit tests verifying `queryType` preservation when `pluginVersion` is empty string or `undefined` on v4 SQL queries.

## Verification

- `npx jest src/data/migration.test.ts` passed 100% (11 passed).
- `npm run typecheck` (`tsc --noEmit`) passed with 0 errors.
