### PR TITLE
ci: ship every merge to dev0 through the bundled pipeline

### DIFF
--- a/.github/workflows/bundled-image.yml
+++ b/.github/workflows/bundled-image.yml
@@ -8,10 +8,10 @@
 # unchanged in every plugin repo that adopts bundled images. Keep it that way: anything that has to
 # differ per repo belongs in the shared workflow's defaults, not copied into three callers.
 #
-# Manual dispatch only, deliberately. Bundled delivery is being rolled out to the pilot data
-# sources one step at a time, and a push trigger would build an image for every commit to main
-# before the rollout is proven. When the push trigger is added it wants a paths filter, so a
-# docs-only or test-only commit does not rebuild the image.
+# Push events ship every merge to main to the dev0 wave through the shared pipeline: the
+# build is pushed and the `<plugin-id>-dev` rollout is triggered, gated and benched. The
+# paths filter keeps docs- and test-only commits from rebuilding the image. Manual dispatch
+# keeps the explicit inputs and targets the full rollout.
 #
 # Note on the app grant:
 # The shared workflow reads the Grafana base image from one line of a private infrastructure repo.
@@ -22,6 +22,12 @@
 name: Plugins - Bundled image
 
 on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - "**/*.md"
+      - docs/**
+      - tests/**
   workflow_dispatch:
     inputs:
       grafana-image:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -58,7 +58,7 @@ jobs:
     secrets: inherit
 
   publish-dev:
-    name: Publish to Dev Catalog and Deploy
+    name: Publish to Dev Catalog
     needs: cicd
     # Normal pushes to main (no release cut) publish the latest build to the dev
     # catalog. Skipped when release-please cut a release, since cicd already
@@ -76,3 +76,7 @@ jobs:
     with:
       go-version: '1.26.5'
       golangci-lint-version: '2.10.1'
+      # The backend ships to dev0 per merge through the bundled pipeline
+      # (bundled-image.yml), so this job publishes the frontend to the dev catalog
+      # and does not also trigger the backend rollout.
+      deploy: false


### PR DESCRIPTION
Ships every merge to main to the dev0 wave through the bundled pipeline, and stops the dev-catalog job from also rolling out the backend.

- `bundled-image.yml` gains a `push:` trigger with a paths filter, so docs- and test-only commits do not rebuild the image. On a push the shared pipeline builds, pushes, and triggers the dev rollout: dev0 only, through the version gate, with the bench suite per merge. Manual dispatch is unchanged and keeps targeting the full rollout.
- `publish-dev` in `push.yml` passes `deploy: false`. The dev-catalog publish still carries the full plugin, backend included. The input only skips the catalog job's backend rollout, which now arrives through the bundled pipeline instead.

This ends the two-writers contention on the dev0 waves entry for this repo: after this, only the bundled pipeline writes it.

Built on shared-pipeline changes, all merged:

- https://github.com/grafana/data-sources-ci-workflows/pull/25 adds the `deploy` input to cd-dev.
- https://github.com/grafana/data-sources-ci-workflows/pull/26 adds the push semantics: a push builds, pushes, and triggers the dev rollout.
- https://github.com/grafana/data-sources-ci-workflows/pull/27 moves the base-image token to the app that holds the read access, with the matching access change applied internally.

The per-merge bench suite and the queue of one on the dev rollout are configured internally and are live.

ClickHouse goes first per the rollout plan. A week's soak here precedes the same change in elasticsearch and cloudwatch.
