### PR TITLE
fix(ci): coerce dispatch inputs to booleans so push events pass validation

### DIFF
--- a/.github/workflows/bundled-image.yml
+++ b/.github/workflows/bundled-image.yml
@@ -70,6 +70,8 @@ jobs:
       id-token: write
     with:
       grafana-image: ${{ inputs.grafana-image }}
-      push-image: ${{ inputs.push-image }}
-      trigger-argo: ${{ inputs.trigger-argo }}
-      debug: ${{ inputs.debug }}
+      # On push events the inputs context is empty, and an empty string fails the called
+      # workflow's boolean type validation at startup. `== true` coerces empty to false.
+      push-image: ${{ inputs.push-image == true }}
+      trigger-argo: ${{ inputs.trigger-argo == true }}
+      debug: ${{ inputs.debug == true }}


### PR DESCRIPTION
The push trigger added in #2140 fails at workflow startup on every push to main, so no bundled build runs on merge. The caller forwards `${{ inputs.push-image }}`, `${{ inputs.trigger-argo }}`, and `${{ inputs.debug }}` to the shared pipeline, whose inputs are typed `boolean`. On a `push` event the `inputs` context is empty, each expression evaluates to an empty string, and the called workflow rejects the string-for-boolean at validation time: the run fails with no jobs ("workflow file issue"). Dispatch events are unaffected, which is why the same call site worked while the caller was dispatch-only.

`== true` coerces the empty value to a real `false` on push and passes the chosen value through on dispatch. `grafana-image` is typed `string`, so the empty value is already valid there.

Verified against the failing run: [33066297351](https://github.com/grafana/clickhouse-datasource/actions/runs/33066297351) (push, startup failure, zero jobs) vs the same shared pipeline succeeding on a `workflow_dispatch` caller minutes earlier.

Merging this is itself a push to main, so the merge doubles as the first live run of the per-merge pipeline.
