### PR TITLE
ci: trigger the full bundled rollout when a release is published

### DIFF
--- a/.github/workflows/bundled-image.yml
+++ b/.github/workflows/bundled-image.yml
@@ -10,8 +10,10 @@
 #
 # Push events ship every merge to main to the dev0 wave through the shared pipeline: the
 # build is pushed and the `<plugin-id>-dev` rollout is triggered, gated and benched. The
-# paths filter keeps docs- and test-only commits from rebuilding the image. Manual dispatch
-# keeps the explicit inputs and targets the full rollout.
+# paths filter keeps docs- and test-only commits from rebuilding the image. A published
+# release builds from the tag and triggers the full rollout, so merging a release PR
+# delivers it to Cloud. Manual dispatch keeps the explicit inputs, targets the full
+# rollout, and stays as the fallback.
 #
 # Note on the app grant:
 # The shared workflow reads the Grafana base image from one line of a private infrastructure repo.
@@ -22,6 +24,8 @@
 name: Plugins - Bundled image
 
 on:
+  release:
+    types: [published]
   push:
     branches: [main]
     paths-ignore:


### PR DESCRIPTION
Completes this caller's trigger ladder: pushes ship to dev0 (#2140), and a published release now builds from the tag, pushes the image, and submits the full rollout (dev0 through prod, with the prod0 approval hold). Merging a release PR delivers the release without a manual dispatch.

Depends on grafana/data-sources-ci-workflows#29 for the release-event semantics in the shared workflow; mirrors grafana/grafana-elasticsearch-datasource#423. Release-triggered builds fail at plugin signing until grafana/plugin-ci-workflows#988 ships and the CI pin is bumped, because the release actor is the release-please app and the shared CI's bot trust list does not include it yet. Dispatch remains the fallback throughout.
