### PR TITLE
chore: align the plugin-ci-workflows pin on v11.1.1

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -30,7 +30,7 @@ jobs:
   ci:
     name: CI
     if: github.event_name == 'pull_request'
-    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@ci-cd-workflows/v10.1.0
+    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@ci-cd-workflows/v11.1.1
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
Aligns this repo's shared-CI pin with the version that builds the bundled image and the catalog artifact, so the commit validated in PR CI runs the same pipeline that packages what ships. Part of the fleet sweep with grafana/data-sources-ci-workflows#32; v11.1.1 also carries the signing trust fix the release-event paths need (plugin-ci-workflows#988).
