### PR TITLE
feat(dashboards): let Query Analysis read any query_log source

### DIFF
--- a/src/dashboards/query-analysis.json
+++ b/src/dashboards/query-analysis.json
@@ -138,7 +138,7 @@
             }
           },
           "queryType": "sql",
-          "rawSql": "SELECT count() as \"Total queries\" FROM system.query_log WHERE type in ($type) AND initial_user IN ($user) AND query_kind IN ($query_kind) AND $__timeFilter(event_time) ",
+          "rawSql": "SELECT count() as \"Total queries\"\nFROM ${query_log}\nWHERE\n  $__conditionalAll(type IN (${type:singlequote}), $type)\n  AND $__conditionalAll(initial_user IN (${user:singlequote}), $user)\n  AND $__conditionalAll(query_kind IN (${query_kind:singlequote}), $query_kind)\n  AND $__timeFilter(event_time)",
           "refId": "A"
         }
       ],
@@ -220,7 +220,7 @@
             }
           },
           "queryType": "sql",
-          "rawSql": "SELECT avg(memory_usage) as \"Avg query memory\", $__timeInterval(query_start_time) as time FROM system.query_log WHERE type in ($type) AND initial_user IN ($user) AND query_kind IN ($query_kind) AND $__timeFilter(event_time) GROUP BY time ORDER BY time",
+          "rawSql": "SELECT\n  avg(memory_usage) as \"Avg query memory\",\n  $__timeInterval(query_start_time) as time\nFROM ${query_log}\nWHERE\n  $__conditionalAll(type IN (${type:singlequote}), $type)\n  AND $__conditionalAll(initial_user IN (${user:singlequote}), $user)\n  AND $__conditionalAll(query_kind IN (${query_kind:singlequote}), $query_kind)\n  AND $__timeFilter(event_time)\nGROUP BY time\nORDER BY time",
           "refId": "A"
         }
       ],
@@ -308,7 +308,7 @@
             }
           },
           "queryType": "sql",
-          "rawSql": "SELECT query_duration_ms as \"Query time\" FROM system.query_log WHERE type in ($type) AND initial_user IN ($user) AND query_kind IN ($query_kind) AND $__timeFilter(event_time) LIMIT 1000;",
+          "rawSql": "SELECT query_duration_ms as \"Query time\"\nFROM ${query_log}\nWHERE\n  $__conditionalAll(type IN (${type:singlequote}), $type)\n  AND $__conditionalAll(initial_user IN (${user:singlequote}), $user)\n  AND $__conditionalAll(query_kind IN (${query_kind:singlequote}), $query_kind)\n  AND $__timeFilter(event_time)\nLIMIT 1000",
           "refId": "A"
         }
       ],
@@ -380,7 +380,7 @@
             }
           },
           "queryType": "sql",
-          "rawSql": "SELECT initial_user, count() as c FROM system.query_log WHERE type in ($type) AND initial_user IN ($user) AND query_kind IN ($query_kind) GROUP BY initial_user LIMIT 100;\n",
+          "rawSql": "SELECT\n  initial_user,\n  count() as c\nFROM ${query_log}\nWHERE\n  $__conditionalAll(type IN (${type:singlequote}), $type)\n  AND $__conditionalAll(initial_user IN (${user:singlequote}), $user)\n  AND $__conditionalAll(query_kind IN (${query_kind:singlequote}), $query_kind)\n  AND $__timeFilter(event_time)\nGROUP BY initial_user\nLIMIT 100",
           "refId": "A"
         }
       ],
@@ -463,7 +463,7 @@
             }
           },
           "queryType": "sql",
-          "rawSql": "SELECT avg(query_duration_ms) as \"Avg query time\", $__timeInterval(query_start_time) as time FROM system.query_log WHERE type in ($type) AND initial_user IN ($user) AND query_kind IN ($query_kind) AND $__timeFilter(event_time) GROUP BY time ORDER BY time",
+          "rawSql": "SELECT\n  avg(query_duration_ms) as \"Avg query time\",\n  $__timeInterval(query_start_time) as time\nFROM ${query_log}\nWHERE\n  $__conditionalAll(type IN (${type:singlequote}), $type)\n  AND $__conditionalAll(initial_user IN (${user:singlequote}), $user)\n  AND $__conditionalAll(query_kind IN (${query_kind:singlequote}), $query_kind)\n  AND $__timeFilter(event_time)\nGROUP BY time\nORDER BY time",
           "refId": "A"
         }
       ],
@@ -562,7 +562,7 @@
             }
           },
           "queryType": "sql",
-          "rawSql": "SELECT $__timeInterval(query_start_time) as time,\n       any(normalizeQuery(query)) AS normalized_query,\n       count() as c\nFROM system.query_log\nWHERE type != 'QueryStart'\n  AND $__timeFilter(event_time)\n  AND initial_user IN ($user)\n   AND query_kind IN ($query_kind)\n  AND normalized_query_hash IN (SELECT normalized_query_hash\n                                FROM system.query_log\n                                WHERE type in ($type) AND $__timeFilter(event_time) AND query_kind IN ($query_kind)\n                                GROUP BY normalized_query_hash\n                                ORDER BY count() DESC\n                                LIMIT 5)\nGROUP BY normalized_query_hash, time\nORDER BY time",
+          "rawSql": "SELECT\n  $__timeInterval(query_start_time) as time,\n  any(normalizeQuery(query)) AS normalized_query,\n  count() as c\nFROM ${query_log}\nWHERE type != 'QueryStart'\n  AND $__conditionalAll(initial_user IN (${user:singlequote}), $user)\n  AND $__conditionalAll(query_kind IN (${query_kind:singlequote}), $query_kind)\n  AND $__timeFilter(event_time)\n  AND normalized_query_hash IN (\n    SELECT normalized_query_hash\n    FROM ${query_log}\n    WHERE\n      $__conditionalAll(type IN (${type:singlequote}), $type)\n      AND $__conditionalAll(initial_user IN (${user:singlequote}), $user)\n      AND $__conditionalAll(query_kind IN (${query_kind:singlequote}), $query_kind)\n      AND $__timeFilter(event_time)\n    GROUP BY normalized_query_hash\n    ORDER BY count() DESC\n    LIMIT 5\n  )\nGROUP BY normalized_query_hash, time\nORDER BY time",
           "refId": "A"
         }
       ],
@@ -670,7 +670,7 @@
             }
           },
           "queryType": "sql",
-          "rawSql": "SELECT $__timeInterval(query_start_time) as time,\n       any(normalizeQuery(query)) AS normalized_query,\n       avg(query_duration_ms) as avg_query_duration\nFROM system.query_log\nWHERE type != 'QueryStart'\n  AND $__timeFilter(event_time)\n  AND type in ($type) AND initial_user IN ($user) AND query_kind IN ($query_kind)\n  AND normalized_query_hash IN (SELECT normalized_query_hash\n                                FROM system.query_log\n                                WHERE type in ($type) AND initial_user IN ($user) AND query_kind IN ($query_kind) AND $__timeFilter(event_time)\n                                GROUP BY normalized_query_hash\n                                ORDER BY avg(query_duration_ms) DESC\n                                LIMIT 10)\nGROUP BY normalized_query_hash, time\nORDER BY time",
+          "rawSql": "SELECT\n  $__timeInterval(query_start_time) as time,\n  any(normalizeQuery(query)) AS normalized_query,\n  avg(query_duration_ms) as avg_query_duration\nFROM ${query_log}\nWHERE type != 'QueryStart'\n  AND $__conditionalAll(initial_user IN (${user:singlequote}), $user)\n  AND $__conditionalAll(query_kind IN (${query_kind:singlequote}), $query_kind)\n  AND $__timeFilter(event_time)\n  AND normalized_query_hash IN (\n    SELECT normalized_query_hash\n    FROM ${query_log}\n    WHERE\n      $__conditionalAll(type IN (${type:singlequote}), $type)\n      AND $__conditionalAll(initial_user IN (${user:singlequote}), $user)\n      AND $__conditionalAll(query_kind IN (${query_kind:singlequote}), $query_kind)\n      AND $__timeFilter(event_time)\n    GROUP BY normalized_query_hash\n    ORDER BY avg(query_duration_ms) DESC\n    LIMIT 10\n  )\nGROUP BY normalized_query_hash, time\nORDER BY time",
           "refId": "A"
         }
       ],
@@ -774,7 +774,7 @@
             }
           },
           "queryType": "sql",
-          "rawSql": "SELECT $__timeInterval(query_start_time) as time, initial_user as user, count() as \"number of queries by\"\nFROM system.query_log\nWHERE query_kind IN ($query_kind) AND type IN ($type) AND $__timeFilter(event_time) AND initial_user IN (\n  SELECT initial_user\nFROM system.query_log\nWHERE query_kind IN ($query_kind) AND type IN ($type) AND $__timeFilter(event_time)\nGROUP BY initial_user\nORDER BY count() as c DESC\nLIMIT 10\n)\nGROUP BY initial_user, time\nORDER BY time;",
+          "rawSql": "SELECT\n  $__timeInterval(query_start_time) as time,\n  initial_user as user,\n  count() as \"number of queries by\"\nFROM ${query_log}\nWHERE\n  $__conditionalAll(type IN (${type:singlequote}), $type)\n  AND $__conditionalAll(query_kind IN (${query_kind:singlequote}), $query_kind)\n  AND $__timeFilter(event_time)\n  AND initial_user IN (\n    SELECT initial_user\n    FROM ${query_log}\n    WHERE\n      $__conditionalAll(type IN (${type:singlequote}), $type)\n      AND $__conditionalAll(query_kind IN (${query_kind:singlequote}), $query_kind)\n      AND $__timeFilter(event_time)\n    GROUP BY initial_user\n    ORDER BY count() DESC\n    LIMIT 10\n  )\nGROUP BY initial_user, time\nORDER BY time",
           "refId": "A"
         }
       ],
@@ -890,7 +890,7 @@
             }
           },
           "queryType": "sql",
-          "rawSql": "SELECT $__timeInterval(query_start_time) as time, \n      max(memory_usage) as \"Max Memory Usage\"\nFROM system.query_log\nWHERE $__timeFilter(event_time)\nGROUP BY time\nORDER BY time DESC",
+          "rawSql": "SELECT\n  $__timeInterval(query_start_time) as time,\n  max(memory_usage) as \"Max Memory Usage\"\nFROM ${query_log}\nWHERE $__timeFilter(event_time)\nGROUP BY time\nORDER BY time DESC",
           "refId": "A"
         }
       ],
@@ -1018,7 +1018,7 @@
             }
           },
           "queryType": "sql",
-          "rawSql": "SELECT toStartOfInterval(toDateTime(event_time), INTERVAL 60 second),  sum(read_rows) read_rows, sum(written_rows) written_rows FROM system.query_log WHERE $__timeFilter(event_time) GROUP BY event_time ORDER BY event_time ASC",
+          "rawSql": "SELECT\n  toStartOfInterval(toDateTime(event_time), INTERVAL 60 second),\n  sum(read_rows) read_rows,\n  sum(written_rows) written_rows\nFROM ${query_log}\nWHERE $__timeFilter(event_time)\nGROUP BY event_time\nORDER BY event_time ASC",
           "refId": "A"
         }
       ],
@@ -1382,7 +1382,7 @@
             }
           },
           "queryType": "sql",
-          "rawSql": "SELECT query_start_time, type, query_duration_ms, initial_user, substring(query_id,1, 8) as query_id, query_kind, normalizeQuery(query) AS normalized_query, concat( toString(read_rows), ' rows / ', formatReadableSize(read_bytes) ) AS read, concat( toString(written_rows), ' rows / ', formatReadableSize(written_bytes) ) AS written, concat( toString(result_rows), ' rows / ', formatReadableSize(result_bytes) ) AS result, memory_usage FROM system.query_log WHERE type in ($type) AND initial_user IN ($user) AND query_kind IN ($query_kind) AND $__timeFilter(event_time) ORDER BY query_duration_ms DESC LIMIT  1000",
+          "rawSql": "SELECT\n  query_start_time,\n  type,\n  query_duration_ms,\n  initial_user,\n  substring(query_id, 1, 8) as query_id,\n  query_kind,\n  normalizeQuery(query) AS normalized_query,\n  concat(toString(read_rows), ' rows / ', formatReadableSize(read_bytes)) AS read,\n  concat(toString(written_rows), ' rows / ', formatReadableSize(written_bytes)) AS written,\n  concat(toString(result_rows), ' rows / ', formatReadableSize(result_bytes)) AS result,\n  memory_usage\nFROM ${query_log}\nWHERE\n  $__conditionalAll(type IN (${type:singlequote}), $type)\n  AND $__conditionalAll(initial_user IN (${user:singlequote}), $user)\n  AND $__conditionalAll(query_kind IN (${query_kind:singlequote}), $query_kind)\n  AND $__timeFilter(event_time)\nORDER BY query_duration_ms DESC\nLIMIT 1000",
           "refId": "A"
         }
       ],
@@ -1454,12 +1454,33 @@
         "type": "datasource"
       },
       {
+        "current": {
+          "selected": false,
+          "text": "system.query_log",
+          "value": "system.query_log"
+        },
+        "description": "Fully qualified query_log source. Point it at a premade view (for example obs_tools.query_log) to read a cluster-wide or rotation-aware query log instead of the local system table.",
+        "hide": 2,
+        "label": "Query log table",
+        "name": "query_log",
+        "options": [
+          {
+            "selected": true,
+            "text": "system.query_log",
+            "value": "system.query_log"
+          }
+        ],
+        "query": "system.query_log",
+        "skipUrlSync": false,
+        "type": "constant"
+      },
+      {
         "current": {},
         "datasource": {
           "type": "grafana-clickhouse-datasource",
           "uid": "${datasource}"
         },
-        "definition": "SELECT DISTINCT(query_kind) as query_kind FROM system.query_log WHERE query_kind != ''",
+        "definition": "SELECT DISTINCT(query_kind) as query_kind FROM ${query_log} WHERE query_kind != ''",
         "description": "",
         "hide": 0,
         "includeAll": true,
@@ -1467,7 +1488,7 @@
         "multi": true,
         "name": "query_kind",
         "options": [],
-        "query": "SELECT DISTINCT(query_kind) as query_kind FROM system.query_log WHERE query_kind != ''",
+        "query": "SELECT DISTINCT(query_kind) as query_kind FROM ${query_log} WHERE query_kind != ''",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -1480,14 +1501,14 @@
           "type": "grafana-clickhouse-datasource",
           "uid": "${datasource}"
         },
-        "definition": "SELECT type FROM system.query_log GROUP BY type",
+        "definition": "SELECT type FROM ${query_log} GROUP BY type",
         "hide": 0,
         "includeAll": true,
         "label": "Query status",
         "multi": true,
         "name": "type",
         "options": [],
-        "query": "SELECT type FROM system.query_log GROUP BY type",
+        "query": "SELECT type FROM ${query_log} GROUP BY type",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -1500,14 +1521,14 @@
           "type": "grafana-clickhouse-datasource",
           "uid": "${datasource}"
         },
-        "definition": "SELECT DISTINCT(initial_user) FROM system.query_log WHERE initial_user != '' LIMIT 100",
+        "definition": "SELECT DISTINCT(initial_user) FROM ${query_log} WHERE initial_user != '' LIMIT 100",
         "hide": 0,
         "includeAll": true,
         "label": "User",
         "multi": true,
         "name": "user",
         "options": [],
-        "query": "SELECT DISTINCT(initial_user) FROM system.query_log WHERE initial_user != '' LIMIT 100",
+        "query": "SELECT DISTINCT(initial_user) FROM ${query_log} WHERE initial_user != '' LIMIT 100",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -1524,6 +1545,6 @@
   "timezone": "",
   "title": "ClickHouse - Query Analysis",
   "uid": "w5Q2Otank",
-  "version": 1,
+  "version": 2,
   "weekStart": ""
 }


### PR DESCRIPTION
## Type of Change

- [x] 🚀 Feature

---

## Feature

### What is this feature?

The bundled **ClickHouse - Query Analysis** dashboard no longer hardcodes `system.query_log`. It reads the source from a new `query_log` constant variable that holds the fully qualified name and defaults to `system.query_log`, so the shipped behaviour is unchanged. Editing that one variable in dashboard settings repoints every panel *and* every filter variable (`Query kind`, `Query status`, `User`).

The "All" filters were also reworked to use the `$__conditionalAll` macro:

```sql
FROM ${query_log}
WHERE
  $__conditionalAll(type IN (${type:singlequote}), $type)
  AND $__conditionalAll(initial_user IN (${user:singlequote}), $user)
  AND $__conditionalAll(query_kind IN (${query_kind:singlequote}), $query_kind)
  AND $__timeFilter(event_time)
```

Variables are interpolated with `:singlequote` in the condition and passed as a plain `$var` in the macro's second argument, per [template-variables.md](https://github.com/grafana/clickhouse-datasource/blob/main/docs/sources/template-variables.md).

Three drive-by fixes in the same queries:

- **Top users** panel had no time filter, so it counted the whole retained log regardless of the picker.
- **Query requests by user** subquery had `ORDER BY count() as c DESC` (alias definition in `ORDER BY`).
- SQL was reflowed multi-line; it was previously unreadable single-line strings.

### Why is this feature needed?

`system.query_log` is local to whichever node Grafana's connection lands on, and it is truncated by the node's retention/rotation settings. Anyone with a cluster-wide or rotation-aware view over the query log (e.g. `clusterAllReplicas`-backed, or a merge over rotated tables) had to fork the dashboard to point it at that view — a fork that then has to be re-applied on every plugin release.

Separately, with `IN ($var)` the "All" selection expands into a full literal `IN` list of every value, which is both slower and breaks as soon as a value appears that was not in the variable's option list. `$__conditionalAll` drops the clause entirely instead.

### Who is this feature for?

Operators running multi-node/clustered ClickHouse who keep a curated query-log view, and anyone who currently sees partial data in this dashboard because the log rotated or lives on another replica.

### How to test this feature

1. Import (or re-import) the **ClickHouse - Query Analysis** dashboard and confirm every panel still works unchanged against `system.query_log`.
2. Set the **Query kind** / **Query status** / **User** variables to `All` and inspect a panel's query in the panel inspector — the clause should be `1=1`, not an expanded `IN (...)` list. Then select a single value and confirm it is quoted (`type IN ('QueryFinish')`).
3. Create a view, e.g. `CREATE VIEW default.query_log_all AS SELECT * FROM clusterAllReplicas(default, system.query_log)`, then set **Dashboard settings → Variables → Query log table** to `default.query_log_all`. Every panel and the three filter drop-downs should now read from the view.

---

## Behaviour changes worth calling out

- **"Top query types over time"** gains an `initial_user` filter in its top-5 hash subquery that main did not have, so the top-5 set now follows the User selection instead of being computed cluster-wide and then filtered.
- **"Query performance by type over time"** regains the outer `type` filter. On main it applied the Query status only inside the hash subquery, so the outer average still covered every type for those hashes.
- **"Memory usage over time"** and **"Read vs Write Rows"** now honour the Query status, User and query-kind variables; previously they read the whole `query_log` regardless. "Read vs Write Rows" also bucketed in its `SELECT` while grouping by the raw `event_time`, so the bucketing did nothing and the frame carried repeated timestamps — it now buckets with `$__timeInterval` and groups by that.

## Please check that:

- [x] Tests for this change have been added/updated.
- [ ] Documentation has been added/updated (where applicable).

`src/dashboards/__tests__/dashboards.test.ts` now also guards this dashboard directly: `query_log` stays a constant defaulting to the local system table, every panel reads through `${query_log}`, and each panel constrains `type`, `initial_user` and `query_kind` — either from the variable or, as "Query requests by user" does, with its own predicate. Both guards were checked by mutation (hard-coding one source, and dropping the filters from one panel) rather than only by passing. `docs/sources/dashboards.md` documents only the four OTel dashboards, so there is no page describing Query Analysis to update — happy to add one if you'd like it covered.

## Special notes for your reviewer

- The variable is a **constant** (`hide: 2`), not a query variable, so the dashboard makes no extra `system.tables` lookup on load and no new drop-down appears in the nav bar. It is changed in dashboard settings.
- It is named `query_log` rather than `database` because it holds `db.table`: a premade view is not necessarily named `query_log` in its own database.
- No screenshots: the rendered dashboard is visually identical with the default value, and the queries were verified by reading the interpolated SQL rather than against a live cluster.
- All commits are signed.
- Rebased onto #2083 (`fix/dashboards-multivalue-quoting`) as suggested, so the `${type:singlequote}` conversions are the base and this PR's `$__conditionalAll(... IN (${type:singlequote}), $type)` rewrites supersede them. The diff will shrink to this PR's own commits once #2083 lands.

