### PR TITLE
fix(pdc): apply TLS to native protocol connections made through PDC

### DIFF
--- a/pkg/plugin/driver.go
+++ b/pkg/plugin/driver.go
@@ -69,7 +69,13 @@ func getTLSConfig(settings Settings) (*tls.Config, error) {
 }
 
 // getPDCDialContext returns a dialer function for creating a connection to PDC if a secure SOCKS proxy is enabled.
-func getPDCDialContext(settings Settings) (func(context.Context, string) (net.Conn, error), error) {
+//
+// clickhouse-go applies Options.TLS only on its own dial path, and skips that
+// path once Options.DialContext is set. The native protocol therefore needs
+// this dialer to complete the TLS handshake itself. HTTP does not: net/http
+// applies Transport.TLSClientConfig over the dialed connection, and a second
+// handshake breaks it.
+func getPDCDialContext(settings Settings, tlsConfig *tls.Config, protocol clickhouse.Protocol) (func(context.Context, string) (net.Conn, error), error) {
 	p := sdkproxy.New(settings.ProxyOptions)
 
 	if !p.SecureSocksProxyEnabled() {
@@ -86,9 +92,38 @@ func getPDCDialContext(settings Settings) (func(context.Context, string) (net.Co
 		return nil, errors.New("unable to cast SOCKS proxy dialer to context proxy dialer")
 	}
 
+	return proxyDialContext(contextDialer, tlsConfig, protocol), nil
+}
+
+// proxyDialContext routes connections through base, adding TLS for the native protocol.
+func proxyDialContext(base proxy.ContextDialer, tlsConfig *tls.Config, protocol clickhouse.Protocol) func(context.Context, string) (net.Conn, error) {
+	wrapTLS := tlsConfig != nil && protocol == clickhouse.Native
+
 	return func(ctx context.Context, addr string) (net.Conn, error) {
-		return contextDialer.DialContext(ctx, "tcp", addr)
-	}, nil
+		conn, err := base.DialContext(ctx, "tcp", addr)
+		if err != nil || !wrapTLS {
+			return conn, err
+		}
+
+		// tls.Client does not derive the SNI name from the address, unlike
+		// tls.Dial, so an empty ServerName fails verification. The config is
+		// cloned because clickhouse.Options.TLS shares the same value.
+		cfg := tlsConfig.Clone()
+		if cfg.ServerName == "" {
+			host, _, splitErr := net.SplitHostPort(addr)
+			if splitErr != nil {
+				host = addr
+			}
+			cfg.ServerName = host
+		}
+
+		tlsConn := tls.Client(conn, cfg)
+		if err := tlsConn.HandshakeContext(ctx); err != nil {
+			_ = conn.Close()
+			return nil, fmt.Errorf("TLS handshake through the secure SOCKS proxy failed: %w", err)
+		}
+		return tlsConn, nil
+	}
 }
 
 func getClientInfoProducts(ctx context.Context) (products []struct{ Name, Version string }) {
@@ -278,7 +313,7 @@ func buildClickHouseOptions(ctx context.Context, settings Settings, message json
 	}
 
 	// dialCtx is used to create a connection to PDC, if it is enabled above
-	dialCtx, err := getPDCDialContext(settings)
+	dialCtx, err := getPDCDialContext(settings, tlsConfig, protocol)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/plugin/driver_pdc_tls_test.go
+++ b/pkg/plugin/driver_pdc_tls_test.go
@@ -1,0 +1,239 @@
+package plugin
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"fmt"
+	"io"
+	"math/big"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// tlsTestServer is a TLS listener that completes handshakes and records the
+// SNI name the client offered.
+type tlsTestServer struct {
+	port    string
+	certPEM *x509.Certificate
+
+	mu  sync.Mutex
+	sni string
+}
+
+// serverName returns the SNI name recorded from the last handshake.
+func (s *tlsTestServer) serverName() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.sni
+}
+
+// addr returns host:port for this server. crypto/tls omits SNI for IP
+// addresses, so tests pass a hostname.
+func (s *tlsTestServer) addr(host string) string {
+	return net.JoinHostPort(host, s.port)
+}
+
+// rootCAs returns a pool trusting only this server's self-signed certificate.
+func (s *tlsTestServer) rootCAs() *x509.CertPool {
+	pool := x509.NewCertPool()
+	pool.AddCert(s.certPEM)
+	return pool
+}
+
+func startTLSTestServer(t *testing.T) *tlsTestServer {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "localhost"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		DNSNames:     []string{"localhost"},
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &template, &template, &key.PublicKey, key)
+	require.NoError(t, err)
+
+	parsed, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+
+	srv := &tlsTestServer{certPEM: parsed}
+
+	cfg := &tls.Config{
+		Certificates: []tls.Certificate{{Certificate: [][]byte{der}, PrivateKey: key}},
+		GetConfigForClient: func(hello *tls.ClientHelloInfo) (*tls.Config, error) {
+			srv.mu.Lock()
+			srv.sni = hello.ServerName
+			srv.mu.Unlock()
+			return nil, nil
+		},
+	}
+
+	listener, err := tls.Listen("tcp", "127.0.0.1:0", cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = listener.Close() })
+
+	_, port, err := net.SplitHostPort(listener.Addr().String())
+	require.NoError(t, err)
+	srv.port = port
+
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			go func() {
+				defer func() { _ = conn.Close() }()
+				// Hold the connection open until the client hangs up, so the
+				// handshake is not torn down before the client observes it.
+				_, _ = io.Copy(io.Discard, conn)
+			}()
+		}
+	}()
+
+	return srv
+}
+
+// directContextDialer stands in for the PDC secure SOCKS dialer, which returns
+// a tunneled connection with no TLS of its own.
+type directContextDialer struct{}
+
+func (directContextDialer) Dial(network, addr string) (net.Conn, error) {
+	return net.Dial(network, addr)
+}
+
+func (directContextDialer) DialContext(ctx context.Context, network, addr string) (net.Conn, error) {
+	var d net.Dialer
+	return d.DialContext(ctx, network, addr)
+}
+
+// The native protocol needs the proxied connection returned already wrapped,
+// because clickhouse-go does not apply Options.TLS once a DialContext is set.
+// HTTP must stay unwrapped: net/http applies TLS over the dialer.
+func TestProxyDialContextTLSWrapping(t *testing.T) {
+	srv := startTLSTestServer(t)
+
+	tests := []struct {
+		name      string
+		tlsConfig *tls.Config
+		protocol  clickhouse.Protocol
+		wantTLS   bool
+	}{
+		{
+			name:      "native protocol with TLS is wrapped",
+			tlsConfig: &tls.Config{InsecureSkipVerify: true},
+			protocol:  clickhouse.Native,
+			wantTLS:   true,
+		},
+		{
+			name:      "http protocol is not wrapped",
+			tlsConfig: &tls.Config{InsecureSkipVerify: true},
+			protocol:  clickhouse.HTTP,
+			wantTLS:   false,
+		},
+		{
+			name:      "native protocol without TLS is not wrapped",
+			tlsConfig: nil,
+			protocol:  clickhouse.Native,
+			wantTLS:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dial := proxyDialContext(directContextDialer{}, tt.tlsConfig, tt.protocol)
+
+			conn, err := dial(t.Context(), srv.addr("localhost"))
+			require.NoError(t, err)
+			defer func() { _ = conn.Close() }()
+
+			_, isTLS := conn.(*tls.Conn)
+			assert.Equal(t, tt.wantTLS, isTLS, "connection TLS state must match the protocol and TLS settings")
+		})
+	}
+}
+
+// Verification must run for real, not just yield a *tls.Conn.
+func TestProxyDialContextVerifiesServer(t *testing.T) {
+	srv := startTLSTestServer(t)
+
+	t.Run("verification succeeds against a trusted CA", func(t *testing.T) {
+		dial := proxyDialContext(directContextDialer{}, &tls.Config{RootCAs: srv.rootCAs()}, clickhouse.Native)
+
+		conn, err := dial(t.Context(), srv.addr("localhost"))
+		require.NoError(t, err)
+		defer func() { _ = conn.Close() }()
+
+		assert.IsType(t, &tls.Conn{}, conn)
+	})
+
+	t.Run("verification fails against an untrusted CA", func(t *testing.T) {
+		dial := proxyDialContext(directContextDialer{}, &tls.Config{RootCAs: x509.NewCertPool()}, clickhouse.Native)
+
+		conn, err := dial(t.Context(), srv.addr("localhost"))
+		require.Error(t, err, "an untrusted server certificate must fail the handshake")
+		assert.Nil(t, conn)
+	})
+}
+
+// tls.Client does not derive SNI from the address, unlike tls.Dial.
+func TestProxyDialContextServerName(t *testing.T) {
+	t.Run("derived from the dial address when unset", func(t *testing.T) {
+		srv := startTLSTestServer(t)
+		tlsConfig := &tls.Config{InsecureSkipVerify: true}
+
+		dial := proxyDialContext(directContextDialer{}, tlsConfig, clickhouse.Native)
+		conn, err := dial(t.Context(), srv.addr("localhost"))
+		require.NoError(t, err)
+		defer func() { _ = conn.Close() }()
+
+		assert.Equal(t, "localhost", srv.serverName(), "SNI must be derived from the dial address")
+		assert.Empty(t, tlsConfig.ServerName, "the config shared with clickhouse.Options.TLS must not be mutated")
+	})
+
+	t.Run("configured server name is preserved", func(t *testing.T) {
+		srv := startTLSTestServer(t)
+		tlsConfig := &tls.Config{InsecureSkipVerify: true, ServerName: "clickhouse.example.com"}
+
+		dial := proxyDialContext(directContextDialer{}, tlsConfig, clickhouse.Native)
+		conn, err := dial(t.Context(), srv.addr("localhost"))
+		require.NoError(t, err)
+		defer func() { _ = conn.Close() }()
+
+		assert.Equal(t, "clickhouse.example.com", srv.serverName(), "an explicit ServerName must win over the dial address")
+	})
+}
+
+// A dial failure must surface rather than hide behind the TLS wrapping.
+func TestProxyDialContextDialErrorIsReturned(t *testing.T) {
+	dial := proxyDialContext(failingContextDialer{}, &tls.Config{InsecureSkipVerify: true}, clickhouse.Native)
+
+	conn, err := dial(t.Context(), "localhost:9440")
+	require.Error(t, err)
+	assert.Nil(t, conn)
+}
+
+type failingContextDialer struct{}
+
+func (failingContextDialer) Dial(network, addr string) (net.Conn, error) {
+	return nil, fmt.Errorf("proxy unavailable")
+}
+
+func (failingContextDialer) DialContext(_ context.Context, _, _ string) (net.Conn, error) {
+	return nil, fmt.Errorf("proxy unavailable")
+}


### PR DESCRIPTION
## Type of Change

- [x] 🐛 Bug Fix

---

## Bug Fix

### What is the bug?

A data source that uses the native protocol through Private data source connect ignores its TLS settings.

`clickhouse-go` applies `Options.TLS` only on its own dial path. It skips that path when `Options.DialContext` is set, which is how the proxy dialer works. The connection is dialled without TLS. A ClickHouse instance that requires TLS on its native port then refuses it.

The dialer now completes the TLS handshake itself for the native protocol. The HTTP protocol stays unwrapped, because `net/http` applies `Transport.TLSClientConfig` over a custom dialer and a second handshake breaks it.

Three decisions a reviewer cannot infer from the diff:

- The TLS config is cloned, because `clickhouse.Options.TLS` shares the same value.
- `tls.Client` does not derive the SNI name from the dial address. `tls.Dial` does. When `ServerName` is empty, the dialer fills it in. An explicit `ServerName` takes precedence.
- `proxyDialContext` takes the base dialer as a parameter. This seam makes the behaviour testable without a real SOCKS proxy and certificate material.

### How to reproduce

1. Enable TLS on the native port of a ClickHouse instance (`tcp_port_secure`, 9440).
2. Configure a secure SOCKS proxy that can reach that instance.
3. Add a ClickHouse data source.
4. Set Protocol to Native. Enable TLS and Private data source connect.
5. Select **Save & test**.

Before this change the test fails. After it the handshake completes.

### Related Issues

Related to #1258 for the TLS case. That issue collects several causes, so this PR does not close it.

---

## Please check that:

- [x] Tests for this change have been added/updated.
- [ ] Documentation has been added/updated (where applicable).
