### PR TITLE
ci: forward the bundled pipeline's ref input on manual dispatch

### DIFF
--- a/.github/workflows/bundled-image.yml
+++ b/.github/workflows/bundled-image.yml
@@ -34,6 +34,14 @@ on:
       - tests/**
   workflow_dispatch:
     inputs:
+      ref:
+        description: >-
+          Tag or commit SHA to build. Leave empty to build the commit the run starts from. Set it
+          to the release tag when a release build is re-run, so the image matches the published
+          version and not the current main HEAD.
+        type: string
+        required: false
+        default: ""
       grafana-image:
         description: >-
           Grafana base image to bundle onto. Leave empty to read the first wave's current image.
@@ -73,6 +81,7 @@ jobs:
       contents: read
       id-token: write
     with:
+      ref: ${{ inputs.ref }}
       grafana-image: ${{ inputs.grafana-image }}
       push-image: ${{ inputs.push-image }}
       trigger-argo: ${{ inputs.trigger-argo }}


### PR DESCRIPTION
## What

Adds a \`ref\` input to the bundled-image dispatch form and forwards it to the shared pipeline (\`cd-bundled.yml\` already accepts it and defaults to the triggering SHA).

## Why

Without it, a manual full-rollout dispatch always builds the current main HEAD. If a commit lands after a release-please merge, the dispatched image claims the released version (package.json still carries it) but contains unreleased commits — the version gate passes on \`build_info\` while prod runs different code from the catalog zip published from the tag. Passing the release tag as \`ref\` makes the recovery dispatch build exactly what was released.

Dispatch stays the documented fallback path for a failed release build, so it has to be trustworthy. Same change goes to the other bundled callers so the file stays identical across repos.

Found in the 2026-08-27 release/bundled-images audit.