### PR TITLE
fix(headers): fix keepCookies cookie-forwarding on http protocol

### DIFF
--- a/docs/sources/configure.md
+++ b/docs/sources/configure.md
@@ -283,6 +283,12 @@ With header forwarding enabled, connections are keyed by the forwarded header se
 
 To forward headers other than the Grafana-set ones (for example, bearer tokens or tenant identifiers), add them as **Custom HTTP headers** in the same **Optional HTTP settings** panel. Custom headers are sent on every query regardless of the **Forward Grafana HTTP headers** toggle.
 
+### Skip connection pings behind a fail-closed proxy
+
+On every query, and once at data source creation, the plugin pings ClickHouse to catch connection errors early. That initial ping carries no forwarded headers.
+
+If ClickHouse sits behind a proxy that requires a forwarded header on every request and rejects requests that lack it, that ping fails even though real per-user queries would succeed. For example, proxy might require the presence of a cookie retained via Grafana's own **Forward cookies** data source option. Set `skipConnectionPings: true` (provisioning only; there is no UI toggle) to disable pings in this case. Real queries are unaffected: they always carry the forwarded headers, so ClickHouse connection errors are still caught on the first query.
+
 ## Forward OAuth Identity
 
 {{< admonition type="note" >}}
@@ -306,6 +312,7 @@ To enable it, turn on **Forward OAuth Identity** in the **Database credentials**
   Enabling **Allow service account fallback** lets alert rules and other backend queries fall back to the configured username and password. Those queries then authenticate as the shared service account and are **not** subject to the per-user [row policies](https://clickhouse.com/docs/en/operations/access-rights/#row-policies), quotas, or query-log attribution that OAuth pass-through enforces for interactive queries. As a result, an alert may read rows a given dashboard user could not see interactively. Scope the configured service account to the least privilege your alert queries require. The plugin emits a backend warning log each time this fallback is exercised.
   {{< /admonition >}}
 - **Connections are keyed per user.** Enabling JWT authentication automatically turns on header forwarding, so each Grafana user opens a separate ClickHouse connection. See [Connection pool implications](#connection-pool-implications) for sizing guidance.
+- **Uses ClickHouse's native JWT authentication, not a raw header pass-through.** The plugin hands the forwarded OAuth token to the ClickHouse client library's JWT auth mechanism, which ClickHouse [authenticates natively as a JWT](https://clickhouse.com/docs/en/operations/external-authenticators/jwt). Unlike other data sources (for example, Prometheus), it does **not** forward the unmodified `Authorization` header as-is over HTTP.
 
 ## Verify the connection
 
@@ -357,6 +364,7 @@ datasources:
       # forwardGrafanaHeaders: <bool>
       # oauthPassThru: <bool>  # forward the user's OAuth token as a JWT (ClickHouse Cloud only); requires secure: true
       # oauthPassThruAllowFallback: <bool>  # allow alerts/backend queries to fall back to username and password
+      # skipConnectionPings: <bool>  # see "Forward Grafana HTTP headers" for when this is needed
       # path: <string>  # HTTP URL path (HTTP protocol only)
       # httpHeaders:     # HTTP protocol only
       #   - name: X-Example-Header

--- a/pkg/plugin/driver.go
+++ b/pkg/plugin/driver.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/textproto"
 	"regexp"
 	"strconv"
 	"strings"
@@ -249,7 +250,14 @@ func buildClickHouseOptions(ctx context.Context, settings Settings, message json
 		customSettings["limit"] = settings.RowLimit
 	}
 
-	httpHeaders, err := extractForwardedHeadersFromMessage(message)
+	// When the operator has explicitly opted into arbitrary header
+	// forwarding (forwardGrafanaHeaders) or OAuth pass-through, we surface
+	// everything sqlds marshalled into the message. Otherwise we restrict
+	// the extractor to the SDK's unprefixed whitelist so that Cookie /
+	// Authorization / X-Id-Token can flow (matching Prometheus) without
+	// broadening the arbitrary-http_-headers pass-through contract.
+	restrictToSDKWhitelist := !settings.ForwardGrafanaHeaders && !settings.OAuthPassThru
+	httpHeaders, err := extractForwardedHeadersFromMessage(message, restrictToSDKWhitelist)
 	if err != nil {
 		return nil, err
 	}
@@ -372,12 +380,30 @@ func (h *Clickhouse) Connect(
 	// `sqlds` normally calls `db.PingContext()` to check if the connection is alive,
 	// however, as ClickHouse returns its own non-standard `Exception` type, we need
 	// to handle it here so that we can categorize and surface the error correctly.
-	if err := db.PingContext(ctx); err != nil {
-		if ctx.Err() != nil {
-			return nil, fmt.Errorf("the operation was cancelled during execution: %w", ctx.Err())
-		}
+	//
+	// sqlds calls Connect(ctx, settings, nil) at bootstrap (NewConnector) with no
+	// per-request headers, and again from GetConnectionFromQuery before dispatching
+	// to the per-args Connect that actually carries the user's Cookie / Authorization
+	// / X-Id-Token. For most data sources that nil-message bootstrap ping is exactly
+	// what we want: it catches a bad host/port/credentials eagerly, at data source
+	// creation time. But the result would be misleading if the backend or a proxy in
+	// front of it requires a header or cookie to be forwarded from the client HTTP
+	// context and fails-closed if it's absent; that's why we have the
+	// `skipConnectionPings` option. We can't just add the client http context to the
+	// ping as one may not exist at the time a ping is called for.
+	//
+	// The per-args Connect (message != nil) still pings here. That ping carries
+	// the forwarded headers so genuine wire-level errors on real queries are still
+	// reported.
+	shouldPing := message != nil || !settings.SkipConnectionPings
+	if shouldPing {
+		if err := db.PingContext(ctx); err != nil {
+			if ctx.Err() != nil {
+				return nil, fmt.Errorf("the operation was cancelled during execution: %w", ctx.Err())
+			}
 
-		return nil, wrapCategorizedConnectionError(err)
+			return nil, wrapCategorizedConnectionError(err)
+		}
 	}
 
 	// Honor the (nil-resource-on-error) contract so callers can rely on
@@ -472,7 +498,19 @@ func (h *Clickhouse) Settings(ctx context.Context, config backend.DataSourceInst
 		FillMode: &data.FillMissing{
 			Mode: data.FillModeNull,
 		},
-		ForwardHeaders:  settings.ForwardGrafanaHeaders || settings.OAuthPassThru,
+		// On the HTTP protocol we always route through the sqlds
+		// header-forwarding machinery. This enables the  subset of cookies
+		// listed in `keepCookies` to be propagated as a `Cookie` header
+		// on the outbound HTTP connection.
+		//
+		// The extractor (see extractForwardedHeadersFromMessage)
+		// applies an allow-list filter when forwardGrafanaHeaders is
+		// off so that arbitrary http_-prefixed headers still require
+		// the existing opt-in.
+		//
+		// Useless for the native protocol because clickhouse-go drops
+		// headers anyway.
+		ForwardHeaders:  settings.ForwardGrafanaHeaders || settings.OAuthPassThru || settings.Protocol == "http",
 		RowCapacityHint: settings.RowCapacityHint,
 	}
 }
@@ -670,7 +708,16 @@ func convertFieldToString(field *data.Field) (*data.Field, error) {
 	return newField, nil
 }
 
-func extractForwardedHeadersFromMessage(message json.RawMessage) (map[string]string, error) {
+// extractForwardedHeadersFromMessage decodes the grafana-http-headers blob
+// that sqlds writes into the query message's ConnectionArgs. When
+// restrictToSDKWhitelist is true, only the three unprefixed keys the
+// grafana-plugin-sdk-go http-header helper exposes to backend plugins —
+// Cookie, Authorization, and X-Id-Token — pass through, matching the
+// header-forwarding surface of the Grafana HTTP client (used by the
+// Prometheus plugin). This lets Cookie / OAuth flow on the HTTP protocol
+// without also broadening the pass-through to arbitrary http_-prefixed
+// headers, which remains gated behind forwardGrafanaHeaders.
+func extractForwardedHeadersFromMessage(message json.RawMessage, restrictToSDKWhitelist bool) (map[string]string, error) {
 	// An example of the message we're trying to parse:
 	// {
 	//   "grafana-http-headers": {
@@ -697,6 +744,15 @@ func extractForwardedHeadersFromMessage(message json.RawMessage) (map[string]str
 		}
 
 		for k, v := range fwdHeaders {
+			if restrictToSDKWhitelist {
+				canonical := textproto.CanonicalMIMEHeaderKey(k)
+				if canonical != backend.CookiesHeaderName &&
+					canonical != backend.OAuthIdentityTokenHeaderName &&
+					canonical != backend.OAuthIdentityIDTokenHeaderName {
+					continue
+				}
+			}
+
 			anyHeadersArr, ok := v.([]interface{})
 			if !ok {
 				return nil, fmt.Errorf("couldn't parse header %s as an array", k)

--- a/pkg/plugin/driver_integration_test.go
+++ b/pkg/plugin/driver_integration_test.go
@@ -1387,6 +1387,71 @@ func TestHTTPConnectWithHeaders(t *testing.T) {
 
 		assert.Equal(t, nil, err)
 	})
+
+	// Regression tests for Cookie and other HTTP header forwarding from
+	// client requests.
+	// The ClickHouse plugin used to only forward headers if forwardGrafanaHeaders
+	// or oauthPassThru were enabled, so an operator who configured keepCookies
+	// but not that toggle would see no cookies reach ClickHouse. On protocol: http
+	// the plugin now forwards the SDK's unprefixed whitelist unconditionally so
+	// keepCookies works out of the box.
+	// This aligns it with the Prometheus datasource, which routes queries through
+	// grafana-plugin-sdk-go's HTTP client to get cookie-forwarding automatically.
+	t.Run("should forward the Cookie header out of the box on http protocol (parity with Prometheus keepCookies)", func(t *testing.T) {
+		settings := backend.DataSourceInstanceSettings{JSONData: []byte(fmt.Sprintf(`{"server": "localhost", "port": %s, "username": "%s", "protocol": "http"}`, proxyPort, username)), DecryptedSecureJSONData: secure}
+		// Permissive handler during NewDatasource's ping. We only care
+		// about headers on the actual QueryData call below.
+		proxy.NonproxyHandler = proxyHandlerGenerator(t, map[string]string{})
+		dsInstance, err := NewDatasource(ctx, settings)
+		assert.Equal(t, nil, err)
+
+		ds, ok := dsInstance.(backend.QueryDataHandler)
+		require.True(t, ok, "instance must implement backend.QueryDataHandler")
+
+		cookieReq := &backend.QueryDataRequest{
+			PluginContext: backend.PluginContext{DataSourceInstanceSettings: &settings},
+			Headers: map[string]string{
+				// Cookie is one of the three unprefixed headers the SDK
+				// forwards; this is what Grafana's CookiesMiddleware emits
+				// after keepCookies filtering.
+				"Cookie": "x_authorized_project_ids=proj-a,proj-b",
+			},
+			Queries: []backend.DataQuery{{RefID: "A", JSON: []byte(`{"rawSql": "SELECT 1"}`)}},
+		}
+
+		proxy.NonproxyHandler = proxyHandlerGenerator(t, map[string]string{"Cookie": "x_authorized_project_ids=proj-a,proj-b"})
+		_, err = ds.QueryData(ctx, cookieReq)
+		assert.Equal(t, nil, err)
+	})
+
+	t.Run("should not forward arbitrary http_-prefixed headers when forwardGrafanaHeaders is off, even with a Cookie present", func(t *testing.T) {
+		// Confirms the parity fix does not broaden the existing
+		// arbitrary-header opt-in contract: X-Test must only be emitted when
+		// forwardGrafanaHeaders is true even on the HTTP protocol.
+		settings := backend.DataSourceInstanceSettings{JSONData: []byte(fmt.Sprintf(`{"server": "localhost", "port": %s, "username": "%s", "protocol": "http"}`, proxyPort, username)), DecryptedSecureJSONData: secure}
+		proxy.NonproxyHandler = proxyHandlerGenerator(t, map[string]string{})
+		dsInstance, err := NewDatasource(ctx, settings)
+		assert.Equal(t, nil, err)
+
+		ds, ok := dsInstance.(backend.QueryDataHandler)
+		require.True(t, ok, "instance must implement backend.QueryDataHandler")
+
+		mixedReq := &backend.QueryDataRequest{
+			PluginContext: backend.PluginContext{DataSourceInstanceSettings: &settings},
+			Headers: map[string]string{
+				"Cookie":      "x_authorized_project_ids=proj-a",
+				"http_X-Test": "Hello World!",
+			},
+			Queries: []backend.DataQuery{{RefID: "A", JSON: []byte(`{"rawSql": "SELECT 1"}`)}},
+		}
+
+		proxy.NonproxyHandler = proxyHandlerGenerator(t, map[string]string{
+			"Cookie": "x_authorized_project_ids=proj-a",
+			"X-Test": "",
+		})
+		_, err = ds.QueryData(ctx, mixedReq)
+		assert.Equal(t, nil, err)
+	})
 }
 
 // TestQueryDataMacroExpansion exercises the macropro-driven macro pipeline end to

--- a/pkg/plugin/driver_test.go
+++ b/pkg/plugin/driver_test.go
@@ -534,26 +534,95 @@ func TestSettingsForwardHeadersWithJWT(t *testing.T) {
 		ds := h.Settings(t.Context(), config)
 		assert.False(t, ds.ForwardHeaders)
 	})
+
+	t.Run("ForwardHeaders is true on the http protocol so keepCookies flows without forwardGrafanaHeaders", func(t *testing.T) {
+		// Cookie parity with the Prometheus data source: on protocol: http
+		// we route through the sqlds header-forwarding machinery so that
+		// Cookie / Authorization / X-Id-Token (populated by Grafana's
+		// CookiesMiddleware from keepCookies, or by oauthPassThru) reach
+		// the ClickHouse HTTP endpoint out of the box.
+		// buildClickHouseOptions still restricts what actually flows to
+		// the SDK's unprefixed whitelist so arbitrary http_-headers stay
+		// opt-in behind forwardGrafanaHeaders.
+		config := backend.DataSourceInstanceSettings{
+			JSONData:                []byte(`{"host": "test", "port": 443, "protocol": "http"}`),
+			DecryptedSecureJSONData: map[string]string{},
+		}
+		ds := h.Settings(t.Context(), config)
+		assert.True(t, ds.ForwardHeaders)
+	})
+
+	t.Run("ForwardHeaders remains false on the native protocol when no opt-in is set", func(t *testing.T) {
+		// clickhouse-go silently drops opts.HttpHeaders on Native, so we
+		// leave ForwardHeaders off to avoid per-user connection cache
+		// pressure with no wire-level benefit.
+		config := backend.DataSourceInstanceSettings{
+			JSONData:                []byte(`{"host": "test", "port": 443, "protocol": "native"}`),
+			DecryptedSecureJSONData: map[string]string{},
+		}
+		ds := h.Settings(t.Context(), config)
+		assert.False(t, ds.ForwardHeaders)
+	})
 }
 
 func TestExtractForwardedHeadersWithAuthorization(t *testing.T) {
-	t.Run("extracts Authorization header from message", func(t *testing.T) {
+	t.Run("unrestricted mode extracts Authorization and arbitrary headers", func(t *testing.T) {
 		message := json.RawMessage(`{
 			"grafana-http-headers": {
 				"Authorization": ["Bearer test-token-123"],
 				"X-Grafana-User": ["alice"]
 			}
 		}`)
-		headers, err := extractForwardedHeadersFromMessage(message)
+		headers, err := extractForwardedHeadersFromMessage(message, false)
 		assert.NoError(t, err)
 		assert.Equal(t, "Bearer test-token-123", headers["Authorization"])
 		assert.Equal(t, "alice", headers["X-Grafana-User"])
 	})
 
 	t.Run("returns empty map when message is nil", func(t *testing.T) {
-		headers, err := extractForwardedHeadersFromMessage(nil)
+		headers, err := extractForwardedHeadersFromMessage(nil, false)
 		assert.NoError(t, err)
 		assert.Empty(t, headers)
+	})
+
+	// Grafana's plugin SDK filters the headers plugins can see so most client
+	// headers never reach the plugin. At time of writing these were, depending
+	// on configuration options, Authorization, X-Id-Token, and a subset of
+	// entries in the Cookie header. This checks cookie forwarding.
+	// `sqlds` marshals the resulting `http.Header` verbatim.
+	t.Run("extracts Cookie header verbatim in unrestricted mode", func(t *testing.T) {
+		message := json.RawMessage(`{
+			"grafana-http-headers": {
+				"Cookie": ["x_authorized_project_ids=proj-a,proj-b"]
+			}
+		}`)
+		headers, err := extractForwardedHeadersFromMessage(message, false)
+		assert.NoError(t, err)
+		assert.Equal(t, "x_authorized_project_ids=proj-a,proj-b", headers["Cookie"])
+	})
+
+	// Restricted mode (forwardGrafanaHeaders off, oauthPassThru off) is what
+	// buildClickHouseOptions passes to give Cookie / OAuth pass-through
+	// parity with the Grafana HTTP client (as used by the Prometheus
+	// datasource) without also broadening arbitrary http_-prefixed
+	// forwarding, which remains opt-in via forwardGrafanaHeaders.
+	t.Run("restricted mode passes only the SDK whitelist and drops everything else", func(t *testing.T) {
+		message := json.RawMessage(`{
+			"grafana-http-headers": {
+				"Cookie":           ["x_authorized_project_ids=proj-a"],
+				"Authorization":    ["Bearer some-token"],
+				"X-Id-Token":       ["some-id-token"],
+				"X-Test":           ["hello"],
+				"X-Grafana-Org-Id": ["42"]
+			}
+		}`)
+		headers, err := extractForwardedHeadersFromMessage(message, true)
+		assert.NoError(t, err)
+		assert.Equal(t, "x_authorized_project_ids=proj-a", headers["Cookie"])
+		assert.Equal(t, "Bearer some-token", headers["Authorization"])
+		assert.Equal(t, "some-id-token", headers["X-Id-Token"])
+		assert.NotContains(t, headers, "X-Test", "arbitrary headers must not flow in restricted mode")
+		assert.NotContains(t, headers, "X-Grafana-Org-Id", "arbitrary headers must not flow in restricted mode")
 	})
 }
 
@@ -831,4 +900,36 @@ func TestMissingTableMacroIsDownstream(t *testing.T) {
 	got := resp.Responses["A"]
 	require.Error(t, got.Error)
 	assert.Equal(t, backend.ErrorSourceDownstream, got.ErrorSource)
+}
+
+// TestConnectPingsInForwardHeadersModeWithoutSkipOptIn asserts that
+// forwardGrafanaHeaders (or oauthPassThru) alone must NOT suppress
+// the bootstrap ping. Only the explicit skipConnectionPings opt-in
+// does that (see TestConnectSkipsBootstrapPingWithSkipConnectionPingsOptIn
+// below).
+func TestConnectPingsInForwardHeadersModeWithoutSkipOptIn(t *testing.T) {
+	h := &Clickhouse{}
+	settings := backend.DataSourceInstanceSettings{
+		JSONData:                []byte(`{"host": "127.0.0.1", "port": 1, "protocol": "http", "forwardGrafanaHeaders": true, "dialTimeout": "1", "queryTimeout": "1"}`),
+		DecryptedSecureJSONData: map[string]string{},
+	}
+	_, err := h.Connect(t.Context(), settings, nil)
+	require.Error(t, err, "forwardGrafanaHeaders alone, without skipConnectionPings, must still probe the wire on Connect")
+}
+
+// TestConnectSkipsBootstrapPingWithSkipConnectionPingsOptIn covers the case
+// where the downstream is a a data source that fails-closed if a required cookie
+// or header is missing. This relies solely on Grafana's own keepCookies
+// forwarding. The operator must opt in explicitly with skipConnectionPings
+// to allow this as there's no way to auto-detect it.
+func TestConnectSkipsBootstrapPingWithSkipConnectionPingsOptIn(t *testing.T) {
+	h := &Clickhouse{}
+	settings := backend.DataSourceInstanceSettings{
+		JSONData:                []byte(`{"host": "127.0.0.1", "port": 1, "protocol": "http", "skipConnectionPings": true, "dialTimeout": "1", "queryTimeout": "1"}`),
+		DecryptedSecureJSONData: map[string]string{},
+	}
+	db, err := h.Connect(t.Context(), settings, nil)
+	require.NoError(t, err, "skipConnectionPings must suppress the bootstrap ping")
+	require.NotNil(t, db)
+	_ = db.Close()
 }

--- a/pkg/plugin/settings.go
+++ b/pkg/plugin/settings.go
@@ -52,8 +52,16 @@ type Settings struct {
 	// Health checks and schema introspection always fall back regardless of
 	// this setting, since no user token is ever available for them.
 	OAuthPassThruAllowFallback bool `json:"oauthPassThruAllowFallback,omitempty"`
-	CustomSettings        []CustomSetting   `json:"customSettings"`
-	ProxyOptions          *proxy.Options
+	// SkipConnectionPings disables the bootstrap/health-check ping that
+	// Connect otherwise performs with no per-user forwarded headers. Use this
+	// when a proxy in front of the data source requires forwarded headers
+	// (for example Cookie via Grafana's keepCookies) on every request and
+	// fails closed on requests that lack them: the bootstrap ping carries no
+	// forwarded headers, so such a proxy would reject it even though real,
+	// per-user queries would be permitted.
+	SkipConnectionPings bool            `json:"skipConnectionPings,omitempty"`
+	CustomSettings      []CustomSetting `json:"customSettings"`
+	ProxyOptions        *proxy.Options
 
 	RowLimit       int64 `json:"rowLimit,omitempty"`
 	EnableRowLimit bool  `json:"enableRowLimit,omitempty"`
@@ -246,6 +254,17 @@ func LoadSettings(ctx context.Context, config backend.DataSourceInstanceSettings
 			}
 		} else {
 			settings.OAuthPassThruAllowFallback = jsonData["oauthPassThruAllowFallback"].(bool)
+		}
+	}
+
+	if jsonData["skipConnectionPings"] != nil {
+		if val, ok := jsonData["skipConnectionPings"].(string); ok {
+			settings.SkipConnectionPings, err = strconv.ParseBool(val)
+			if err != nil {
+				return settings, backend.DownstreamError(fmt.Errorf("could not parse skipConnectionPings value: %w", err))
+			}
+		} else {
+			settings.SkipConnectionPings = jsonData["skipConnectionPings"].(bool)
 		}
 	}
 


### PR DESCRIPTION
## Type of Change

- [x] 🐛 Bug Fix

## Bug Fix

### What is the bug?

Fixes: https://github.com/grafana/clickhouse-datasource/issues/2139 (cookie forwarding part only).

On the HTTP protocol, the plugin doesn't forward two headers that Grafana already makes available to it:

- `Cookie` (subset): populated from the data source's `keepCookies` list by Grafana's cookies middleware. Not forwarded at all, even with `keepCookies` set. Fixed by this PR.
- `Authorization` and `X-Id-Token`, populated when `oauthPassThru: true`. These do reach the plugin, but `Authorization` is diverted into ClickHouse's own JWT auth instead of forwarded as a plain header (see "OAuth forwarding" below). This PR doesn't change that part.

The cause is that `sqlds.DriverSettings.ForwardHeaders` was only set when `forwardGrafanaHeaders` or `oauthPassThru` was on. If a datasource just only set `keepCookies` no headers could be were forwarded.

Additionally, `Connect` pings ClickHouse unconditionally, including on the header-less call sqlds makes at data source startup. If a proxy in front of ClickHouse requires the cookie on every request it will reject these pings, so the data source never starts even once the first bug is fixed. This PR adds a new setting, `skipConnectionPings`, that an operator can turn on when they know their data source requires user header context (such as cookies) to permit a request to pass.

Note that the equivalent Prometheus data source forwards its cookie subset without any extra configuration.

### How to reproduce

#### Cookie forwarding

See https://github.com/grafana/clickhouse-datasource/issues/2139 for a self-contained test case. Manual steps:

Put a proxy in front of ClickHouse that requires a cookie named `my_auth_cookie` and returns 403 without it. Create a ClickHouse user `grafana_ds` with no other auth. Define a data source:

```yaml
type: grafana-clickhouse-datasource
jsonData:
  protocol: http
  host: <the proxy above>
  port: 8123
  username: grafana_ds
  keepCookies:
    - my_auth_cookie
  skipConnectionPings: true # the proxy would otherwise reject the header-less bootstrap ping
```

Grafana anonymous auth is fine for this test:

```
[auth.anonymous]
enabled = true
org_name = Main Org.
org_role = Viewer
```

Load a dashboard using this data source with a client request carrying `Cookie: my_auth_cookie=magicpermit`.

**Before this PR**: the data source fails to start, or every query fails with `[HTTP 403] "missing or invalid cookie"`.

**After this PR**: the cookie reaches ClickHouse, matching Prometheus data source behaviour.

#### OAuth forwarding

Not changed by this PR. See "OAuth forwarding" below.

### Related Issues

Fixes #2139 (cookie forwarding only)

Issue #2139 covers two things: (a) `Cookie` entries under `keepCookies` not forwarded, and (b) `Authorization`/`X-Id-Token` not usable the way Prometheus uses them under `oauthPassThru: true`. This PR resolves (a) only. Part (b) is a separate, pre-existing difference from Prometheus (see "OAuth forwarding" below) that this PR doesn't touch. It probably makes sense to split off #2139 into a separate bug for supporting prometheus-datasource-like OAuth forwarding that proxies can consume.

---

## Screenshots / Videos

Not applicable, this is a back-end fix. `skipConnectionPings` is not exposed on the UI, it's a provisioning-only setting since it's for fairly specialist use cases where auth-filtering reverse proxies are in use.

Tested with a real ClickHouse instance behind a header-capturing proxy, comparing the commit before this fix to this fix, for a `keepCookies`-only data source:

| case | before | after |
|---|---|---|
| cookie forwarding | fails, cookie not forwarded | passes |
| no forwarding configured | passes (unaffected) | passes |
| `forwardGrafanaHeaders` alone | passes (already worked) | passes |

---

## Please check that:

- [x] Tests for this change have been added/updated.
- [x] Documentation has been added/updated (where applicable).

## Special notes for your reviewer

### Grafana limitations

Due to https://github.com/grafana/grafana/issues/87364 Grafana does not support forwarding an arbitrary subset of HTTP headers from client through to a datasource plugin.

If this limitations is lifted (e.g. by https://github.com/grafana/grafana/pull/131747 and https://github.com/grafana/grafana/pull/131748) then this PR will also permit the clickhouse datasource to forward the permitted headers, in much the same way `keepCookies` currently works. In the mean time it fixes `keepCookies`.

### Changes in this PR

1. `Settings()` now sets `sqlds.ForwardHeaders` to true on `protocol: http`, regardless of `forwardGrafanaHeaders` or `oauthPassThru`. The Native protocol is unaffected: clickhouse-go never reads `Options.HttpHeaders` on that transport, so there's nothing to forward there either way.

2. `Connect` skips its own ping when called with no message (sqlds's bootstrap call) if the new `skipConnectionPings` setting is on. Nothing else affects this: `forwardGrafanaHeaders` and `oauthPassThru` alone still ping as before. A `keepCookies`-only data source can't be told apart from a plain one from inside the plugin (`keepCookies` isn't visible to it), so the operator has to opt in explicitly when their proxy needs it. "Save & Test" is unaffected either way, since it pings the cached bootstrap connection through a different code path that never re-enters `Connect`.

3. Header extraction gains a restricted mode: when neither `forwardGrafanaHeaders` nor `oauthPassThru` is set, only `Cookie`, `Authorization`, and `X-Id-Token` are forwarded. Forwarding arbitrary headers still requires `forwardGrafanaHeaders` so there's no change to the actual headers forwarded when `keepCookies` isn't involved.

### Effect

- `keepCookies` alone on `protocol: http` now forwards the named cookies on every query, matching Prometheus data source behaviour.
- `oauthPassThru: true` alone still forwards `Authorization` (into JWT auth, see below) and `X-Id-Token` (as a plain header), unchanged.
- `forwardGrafanaHeaders: true` still forwards arbitrary headers, unchanged.
- Native protocol is unchanged.
- If no forwarding configured no headers are forwarded and ping still runs.

### Backward compatibility

- No behaviour changes unless `keepCookies` is set on the plugin. This used to be silently ignored; with this fix, the listed cookies will be passed through.
- `skipConnectionPings` defaults to off, so it has no BC effect.

### OAuth forwarding (not addressed by this PR)

- **TLS is required for `oauthPassThru`.** The plugin rejects `oauthPassThru: true` without a secure connection, and rejects it combined with skipping TLS verification. Prometheus has no equivalent requirement. A separate PR, https://github.com/grafana/clickhouse-datasource/pull/2151, addresses this.
- **`Authorization` handling differs from Prometheus even with TLS.** Prometheus forwards `Authorization` and `X-Id-Token` as plain headers. This plugin instead takes the bearer token out of `Authorization` and passes it to ClickHouse's own JWT auth, so a proxy expecting a plain `Authorization: Bearer` header the way it would see from Prometheus won't see one here. `X-Id-Token` is unaffected and passes through as a plain header. This is existing behavior, unchanged by this PR. This breaks the use of a proxy between the datasource and clickhouse for extracting custom claims from a JWT to use to stamp a HTTP request with extra parameters (e.g. for automatic row-security setting stamping or dynamic clickhouse role assignment) but it's not a new issue. I didn't want to tackle it in the same scope as this PR.
