### PR TITLE
fix(autocomplete): show query macros instead of ClickHouse internal functions

### DIFF
--- a/src/components/suggestions.test.ts
+++ b/src/components/suggestions.test.ts
@@ -101,7 +101,11 @@ describe('Suggestions', () => {
         { label: 'query', type: 'String' } as TableColumn,
         { label: 'EventDate', type: 'DateTime' } as TableColumn,
       ],
-      functions: async (): Promise<SqlFunction[]> => [{ name: 'toDateTime' } as SqlFunction],
+      functions: async (): Promise<SqlFunction[]> => [
+        { name: 'toDateTime' } as SqlFunction,
+        { name: '__actionName', origin: 'System' } as SqlFunction,
+        { name: '__my_helper', origin: 'SQLUserDefined' } as SqlFunction,
+      ],
       defaultDatabase: 'default',
     };
 
@@ -130,6 +134,9 @@ describe('Suggestions', () => {
     for (let macro of pluginMacros) {
       const macroSuggestion = suggestionsByLabel.get(macro.name);
       expect(macroSuggestion).not.toBeUndefined();
+      // Monaco never includes `$` in the word it scores against, so macros must be
+      // filtered on their name without it.
+      expect(macroSuggestion?.filterText).toBe(macro.name.substring(1));
     }
 
     // Should have current columns in context
@@ -143,5 +150,9 @@ describe('Suggestions', () => {
     // Should show functions
     const functionToDateTime = suggestionsByLabel.get('toDateTime');
     expect(functionToDateTime).not.toBeUndefined();
+
+    // Should hide ClickHouse internal functions, but keep a user-defined one named like them
+    expect(suggestionsByLabel.get('__actionName')).toBeUndefined();
+    expect(suggestionsByLabel.get('__my_helper')).not.toBeUndefined();
   });
 });

--- a/src/components/suggestions.ts
+++ b/src/components/suggestions.ts
@@ -315,7 +315,11 @@ async function fetchFieldSuggestions(schema: Schema, range: Range, db: string, t
 }
 
 async function fetchFunctionSuggestions(schema: Schema, range: Range) {
-  const sqlFunctions = await schema.functions();
+  // ClickHouse's `__`-prefixed built-ins are query planner helpers, not user-facing SQL.
+  // `origin` keeps a user-defined function of the same shape, which reports SQLUserDefined.
+  // Matching on the name rather than `categories === 'Internal'` because that category only
+  // exists from 26.6, and older servers report it empty for the same functions.
+  const sqlFunctions = (await schema.functions()).filter((c) => !(c.name.startsWith('__') && c.origin === 'System'));
   return sqlFunctions.map((c) => ({
     label: c.name,
     kind: monaco.languages.CompletionItemKind.Function,
@@ -369,6 +373,10 @@ export function getMacroSuggestions(range: Range, prefix?: string) {
       kind: macro.isFunction
         ? monaco.languages.CompletionItemKind.Function
         : monaco.languages.CompletionItemKind.Variable,
+      // Monaco scores candidates against the word under the cursor, and `$` is a word
+      // separator, so typing `$__` is scored as `__`. Without this the label only matches
+      // at offset 1 and ClickHouse's own `__*` internal functions outrank every macro.
+      filterText: nameNoPrefix,
       sortText: `!!${macro.name.substring(3)}`,
       documentation: macro.documentation + (macro.example ? '\nExample output: ' + macro.example : ''),
       insertText: macro.isFunction


### PR DESCRIPTION
## Type of Change

- [x] 🐛 Bug Fix

---

## Bug Fix

### What is the bug?

Typing `$__` in the SQL editor shows ClickHouse internal functions instead of the plugin's query macros. On ClickHouse 26.8 and later, no macro is visible at all.

**User-facing impact:** autocomplete is the main way users discover macros such as `$__timeFilter` and `$__dateFilter`. On ClickHouse 26.8 and later, that discovery path is gone. Queries users already wrote are unaffected, and no query result changes.

**Why this needs to ship during the code freeze:**

1. It reaches every user on ClickHouse 26.8 or later. ClickHouse published 26.8 on 30 August 2026, and customers upgrade on their own schedule, so the affected population grows.
2. It gets worse without action. Each internal function ClickHouse adds keeps the macros hidden.
3. It blocks other work. Every PR whose CI has run since ClickHouse 26.8 became `latest-alpine` fails all six E2E matrix jobs, for example #2111 and #2108. PRs that still show a green matrix last ran before 30 August and fail on their next run. This PR is green because it carries the fix.

### Root cause

The ranking fault is ours and predates 26.8. Monaco excludes `$` from its word characters, so `$__` is scored against the word `__`. A function named `__actionName` is a prefix match and scores 9. The label `$__dateFilter` matches at offset 1 and scores 1. Every `__`-prefixed built-in therefore outranks every macro, back to at least ClickHouse 24.8.

ClickHouse 26.8 only changed the count. [ClickHouse#114950](https://github.com/ClickHouse/ClickHouse/pull/114950) registers four more internal functions, which takes the `__`-prefixed total in `system.functions` from 10 to 14. The suggestion list renders about 13 rows, so the macros are pushed off it completely.

### How to reproduce

1. Start the stack against ClickHouse 26.8 or later: `GRAFANA_VERSION=11.6.16 docker compose up -d`.
2. Open Explore and select the ClickHouse data source.
3. Type `SELECT * FROM t WHERE $__` into the SQL editor.
4. Read the suggestion list. It contains only `__`-prefixed ClickHouse internal functions.

Rendered suggestion rows on ClickHouse 26.8.2.7, before and after this change:

| Before | After |
| --- | --- |
| `__actionName`, `__applyFilter`, `__bitBoolMaskAnd`, ... (13 internal functions, 0 macros) | `$__adHocFilters`, `$__columns`, `$__conditionalAll`, `$__dateFilter`, ... (13 macros) |

On ClickHouse 26.5 the same list showed 9 internal functions first and only then 3 macros, which is the same fault in a less visible form.

### Related Issues

None open. Environment below.

### Environment (if no related issue)

- **ClickHouse version**: 26.8 and later for the total failure. The ranking fault goes back to at least 24.8.
- **Grafana version**: all supported versions. Reproduced on 11.6.16 and 12.2.0.
- **Plugin version**: 4.21.1.

---

## Please check that:

- [x] Tests for this change have been added/updated.
- [ ] Documentation has been added/updated (where applicable).

## Special notes for your reviewer

**Why `origin === 'System'` and not the name alone.** A ClickHouse user-defined function can also start with `__`. Verified on 26.8.2.7: `CREATE FUNCTION __my_helper AS (x) -> x + 1` reports `origin = 'SQLUserDefined'`. Filtering on the name alone hides it. The unit test covers both directions.

**Why not `categories = 'Internal'`.** ClickHouse marks these functions with that category, and it is a strict superset of the `__` prefix. It only exists from 26.6 though, and older servers report it empty for the same built-ins, so it does not give uniform behaviour across supported versions.

**Which lever is load-bearing.** The function filter is. It removes the competing candidates outright. `filterText` raises a macro from score 1 to 9 and widens the margin, and it corrects a genuine mismatch, because the plugin already hands Monaco a replacement range covering `__` and not `$__`.

**Verification.** Reproduced and fixed against Grafana 11.6.16 with ClickHouse 26.8.2.7. Before this change `sqlAutocomplete.spec.ts` failed 5 runs out of 5. After it, that spec passed 3 out of 3 and the full local e2e suite passed 83 tests. CI then passed the whole matrix, including Grafana 13.0.7, 13.2.0 and nightly, which covers the newer Monaco that Grafana 13 bundles.

**Two follow-ups, each getting its own PR.** Both predate this change and neither blocks it.

1. `NULL` is pushed with no prefix filter, so it is the top suggestion when a user types `$`, ahead of every macro. Columns are already filtered this way in `fetchFieldSuggestions`, and `NULL` cannot follow a `$`. Measured on 26.8.2.7, typing `$` renders `["NULL","$__adHocFilters","$__columns", ...]`.
2. `sqlAutocomplete.spec.ts` cannot fail for the regression it is named after. Proven by mutation: with the provider disposal removed from `SqlEditor.tsx`, the spec's `page.goto` round trip shows 0 duplicates and passes, while an in-document remount through Query Builder and back shows 6.
