### PR TITLE
fix(query-builder): keep Limit when changing table or database

### DIFF
--- a/src/hooks/useBuilderOptionsState.test.ts
+++ b/src/hooks/useBuilderOptionsState.test.ts
@@ -72,6 +72,7 @@ describe('reducer', () => {
       table: 'prev_table',
       queryType: QueryType.Logs,
       groupBy: ['will', 'be', 'reset'],
+      limit: 50,
     });
     const action = setDatabase('next_db');
 
@@ -80,6 +81,7 @@ describe('reducer', () => {
     expect(nextState.table).toEqual('');
     expect(nextState.queryType).toEqual(QueryType.Logs);
     expect(nextState.groupBy).toBeFalsy();
+    expect(nextState.limit).toEqual(50);
   });
   it('applies SetTable to reset settings but preserve db/queryType', async () => {
     const prevState = buildInitialState({
@@ -87,6 +89,7 @@ describe('reducer', () => {
       table: 'prev_table',
       queryType: QueryType.Logs,
       groupBy: ['will', 'be', 'reset'],
+      limit: 50,
     });
     const action = setTable('next_table');
 
@@ -95,6 +98,7 @@ describe('reducer', () => {
     expect(nextState.table).toEqual('next_table');
     expect(nextState.queryType).toEqual(QueryType.Logs);
     expect(nextState.groupBy).toBeFalsy();
+    expect(nextState.limit).toEqual(50);
   });
   it('applies SetOtelEnabled action', async () => {
     const prevState = buildInitialState({

--- a/src/hooks/useBuilderOptionsState.ts
+++ b/src/hooks/useBuilderOptionsState.ts
@@ -100,22 +100,24 @@ const actions = new Map<BuilderOptionsActionType, Reducer<QueryBuilderOptions, B
   [
     BuilderOptionsActionType.SetDatabase,
     (state: QueryBuilderOptions, action: BuilderOptionsReducerAction): QueryBuilderOptions => {
-      // Clear table and reset editor when database changes
+      // Clear table and reset editor when database changes, but keep limit
       return buildInitialState({
         database: action.payload.database,
         table: '',
         queryType: state.queryType,
+        limit: state.limit,
       });
     },
   ],
   [
     BuilderOptionsActionType.SetTable,
     (state: QueryBuilderOptions, action: BuilderOptionsReducerAction): QueryBuilderOptions => {
-      // Reset editor when table changes
+      // Reset editor when table changes, but keep limit
       return buildInitialState({
         database: state.database,
         table: action.payload.table,
         queryType: state.queryType,
+        limit: state.limit,
       });
     },
   ],


### PR DESCRIPTION
<!-- Please take time to fill out the below template appropriately, deleting sections where necessary. -->
<!-- Doing so will aid our reviewers in providing timely feedback and allow us to reach an outcome faster. Thanks! -->
<!-- Please delete all sections that do not apply. -->
<!-- To surface this PR in the changelog add the label: changelog -->
<!-- If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way: -->
<!-- Bad: fix state bug in hooks -->
<!-- Good: Fix crash when switching from Query Builder -->

## Type of Change

_Please check the relevant option._

- [ ] 🚀 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧹 Refactor / Chore

## Bug Fix

### What is the bug?

In the Query Builder, changing the Table or Database rebuilds the builder options from defaults, which reverts the effective row LIMIT back to the default 1000 in the generated query. However, the Limit input keeps displaying the previously entered value (e.g. 101). The result is a silent divergence: the input shows 101 while the query actually runs with LIMIT 1000.

This PR carries the existing limit through the SetTable and SetDatabase resets, so the query keeps the user's value and the input stays consistent with what is executed.

### How to reproduce

1. Add a ClickHouse panel and open the Query Builder (Query Type: Table). Pick a Database and Table.
2. Set Limit to 101 (click away to commit).
3. Change the Table (or Database) dropdown to another value.
4. The Limit input still shows 101, but the SQL Preview / executed query uses LIMIT 1000 — the displayed and executed limits no longer match.

### Related Issues

Closes #2162

### Environment (if no related issue)


- **ClickHouse version**: any
- **Grafana version**: 13.2.0
- **Plugin version**: 4.21.2 (reproduces on latest main)

---

## Screenshots / Videos

We set the limit on our query:
<img width="904" height="456" alt="image" src="https://github.com/user-attachments/assets/24c06824-f8ac-4633-97c9-034a3639e8c3" />

Switching table or database doesn't diverge the field and setting anymore:
<img width="990" height="473" alt="image" src="https://github.com/user-attachments/assets/6179bc90-f99f-4847-9e81-e0e23f0fe268" />


---

## Please check that:

- [x] Tests for this change have been added/updated.
- [ ] Documentation has been added/updated (where applicable).

## Special notes for your reviewer

I chose to preserve the limit rather than reset it because the Limit is not table-specific... unlike the selected columns, it has no dependency on which table or database is active, so there's no reason to clear it on a table/database change. It's an introduced annoyance having to consistently set it on table/db change.
